### PR TITLE
Sync libretto skill into .agents/skills on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		}
 	},
 	"scripts": {
+		"postinstall": "node ./scripts/postinstall.mjs",
 		"build": "tsup",
 		"type-check": "tsc --noEmit"
 	},

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,43 @@
+import { cpSync, existsSync, lstatSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function isDirectory(path) {
+	if (!existsSync(path)) return false;
+	return lstatSync(path).isDirectory();
+}
+
+function log(message) {
+	console.log(`[libretto postinstall] ${message}`);
+}
+
+function main() {
+	const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+	const initCwd = process.env.INIT_CWD ? resolve(process.env.INIT_CWD) : null;
+	const installRoot = initCwd ?? process.cwd();
+
+	const skillsRoot = join(installRoot, ".agents", "skills");
+	if (!isDirectory(skillsRoot)) {
+		log(`Skipped: "${skillsRoot}" does not exist.`);
+		return;
+	}
+
+	const sourceSkillDir = join(packageDir, "skill");
+	if (!isDirectory(sourceSkillDir)) {
+		log(`Skipped: source skill directory not found at "${sourceSkillDir}".`);
+		return;
+	}
+
+	const destinationSkillDir = join(skillsRoot, "libretto");
+	mkdirSync(destinationSkillDir, { recursive: true });
+	cpSync(sourceSkillDir, destinationSkillDir, { recursive: true, force: true });
+
+	log(`Synced skill to "${destinationSkillDir}".`);
+}
+
+try {
+	main();
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.warn(`[libretto postinstall] Warning: ${message}`);
+}


### PR DESCRIPTION
## Summary
- add a postinstall script for package consumers
- copy libretto skill files into .agents/skills/libretto when .agents/skills exists
- overwrite existing skill files on upgrade
- skip cleanly when .agents/skills is not present

## Notes
- uses INIT_CWD (fallback process.cwd()) to target the consumer project root
- does not fail installation if copy cannot run