### PR TITLE
Remove unused Vitest workspace file

### DIFF
--- a/.agents/skills/generate-spec/SKILL.md
+++ b/.agents/skills/generate-spec/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: generate-spec
+description: Create a spec sheet for the given feature/fix request in specs/ directory. Use when planning a significant new feature or complex fix.
+---
+
+Create a spec sheet for the given feature/fix request in specs/ directory.
+
+Ultrathink. Follow the following steps:
+
+## Understand existing code
+
+Use code search sub-agents and `grep` as much as possible to deeply understand all of the relevant code. Be smart about your code search: start with where you think it might be, and if that inspires different places to read, follow up with sub-agents to do so. Each sub-agent should give you back information, and potentially other files to read or searches that might be relevant.
+
+## Understand external documentation/libraries
+
+If external libraries are involved, always look up and research their relevant documentation as well. Tend to adhere strictly to the examples and best practices provided by the external libraries.
+
+## Ask critical guiding questions
+
+After completing the research steps above, pause and ask the user any critical guiding questions before writing the spec. The feature/fix request will not always be completely defined. There may be logical errors, ambiguous requirements, or important clarifications required. Examples:
+
+- "To store this data, we could either add a new table or extend the existing X table. The new table keeps concerns separate but adds a join; extending X is simpler but couples the concepts. Which do you prefer?"
+- "There are two ways to surface this to the user: a modal dialog or an inline panel. The modal is more disruptive but harder to miss; the inline panel is less intrusive but easier to overlook. Which feels right?"
+- "We need to sync this state. We could poll on an interval or use a WebSocket. Polling is simpler to implement but adds latency; WebSocket is real-time but more complex. Which trade-off do you want?"
+
+Present the options you see, explain the trade-offs briefly, and let the user decide. If the feature request is fully defined and the path forward is obvious, skip the questions and write the spec directly. Practice good judgement.
+
+## Establish goals and non-goals
+
+After research and any clarifying questions, establish explicit goals and non-goals for the spec. These come directly from the user. If the user did not provide them in the initial prompt, suggest a set of goals and non-goals and ask for confirmation before proceeding.
+
+Goals are high-level end-user stories that describe what should be true when the spec is complete. Example: "user sets up a Gmail trigger and it works as expected."
+
+Non-goals clarify what is deliberately out of scope. Example: "don't worry about migration or backfills."
+
+By default, always include "no migrations or backfills" as a non-goal unless the user explicitly requests them.
+
+The spec must include these sections near the top, before the implementation plan.
+
+## Reason critically about the spec
+
+Before writing the spec, think through the implementation with a "bicycle before car" mindset. Spec the simplest version that works end-to-end and delivers real value. Do not spec the scalable, polished, extensible version.
+
+### Scope
+
+Cut any phase that is not required for the core functionality to work. If you can remove a phase and a real user can still use the feature, it does not belong in v1. Infrastructure, abstraction layers, configuration systems, and polish are almost never v1 work.
+
+### Testing
+
+Each phase's success criteria should verify the thing most likely to go wrong, not the thing most likely to go right. A test that a Zod schema parses valid input is low-value. A test that filtering logic excludes wrong results is high-value. Ask: "What would make me revert this phase?" Test that.
+
+If a phase does not have a clear way to verify it works, the phase is poorly scoped. Restructure it so it produces something testable: extract a pure function, expose an interface, write to an observable output. Design for testability in the spec, not after implementation.
+
+### End-to-end verification
+
+Agents have access to CLI tools for running tests and project scripts. Specs should leverage these where appropriate.
+
+When a phase involves runtime behavior, prefer success criteria that verify end-to-end behavior with the project's existing scripts and test commands rather than only relying on unit tests.
+
+### Common failure modes
+
+- Adding extensibility or configurability nobody asked for
+- Creating abstractions before there are two concrete cases
+- Testing that code exists rather than testing that it behaves correctly
+- Phases that are pure refactoring or setup with no user-facing progress
+
+## Write an effective spec
+
+Specs should always have the following form:
+
+```markdown
+## Problem overview
+
+A couple plain English sentences describing the problem: either a bug, or a feature request, or a refactor to be done with motivation
+
+## Solution overview
+
+A couple plain English sentences describing the proposed solution.
+
+## Goals
+
+High-level end-user stories that must be true when the spec is complete.
+
+## Non-goals
+
+What is deliberately out of scope. Always includes "no migrations or backfills" unless the user requested them.
+
+## Future work
+
+Items identified during implementation that are valuable but non-blocking. Big features, refactors, or cleanup that can be done after the spec is complete. Only added during implementation, not during initial spec creation.
+
+## Important files/docs/websites for implementation
+
+A list of all the files that are involved in the implementation. Also included should be any docs files or external links to documentation. Each doc should be annotated with a brief sentence about what it is (and if its not obvious, why it's relevant).
+
+## Implementation
+
+A phased plan where each phase represents a single commit-sized change (<100 lines). Each phase should be independently committable and leave the codebase in a working state.
+```
+
+Each implementation phase must include success criteria as task items alongside the implementation tasks. Success criteria are verifiable assertions: quick checks ("ensure X is in package.json"), unit tests to write and run, or manual user stories. They should be the minimum set needed to confirm the phase is correctly done.
+
+```markdown
+### Phase 1: Add gender and age fields to the provider search input schema
+
+- [ ] Add `gender` parameter to `searchProvidersInput` schema in `apps/api/src/tools/searchProviders.ts` as optional `z.enum(["M", "F"])`
+- [ ] Add `ageFilter` parameter using structured object with optional `min_age` and `max_age` integer fields
+- [ ] Verify `pnpm run typecheck` passes with the new fields
+- [ ] Add a unit test that parses input with `gender: "M"` and `ageFilter: { min_age: 30 }` without throwing
+
+### Phase 2: Implement gender and age filtering logic
+
+- [ ] Add gender filtering logic to the database query using `eq(providers.gender, gender)` when gender is provided
+- [ ] Add age range filtering logic using `gte(providers.age, min_age)` and `lte(providers.age, max_age)` when age filters are provided
+- [ ] Add a unit test querying with `gender: "F"` and assert only female providers are returned
+- [ ] Add a unit test querying with `ageFilter: { min_age: 30, max_age: 50 }` and assert results are within range
+```
+
+### What to avoid in the spec
+
+- Avoid introducing new infrastructure, abstractions, or optimization work unless explicitly required for the requested outcome.
+- Avoid refactor-only phases that do not produce user-visible or test-visible progress.

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -1,0 +1,31 @@
+name: CLI Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
 	"scripts": {
 		"build": "pnpm -r build",
 		"type-check": "pnpm -r type-check",
-		"dev": "pnpm --filter libretto build && pnpm --filter libretto-cli build && pnpm --filter libretto-cli exec node dist/index.js"
+		"dev": "pnpm --filter libretto build && pnpm --filter libretto-cli build && pnpm --filter libretto-cli exec node dist/index.js",
+		"test": "pnpm --filter libretto-cli test",
+		"test:watch": "pnpm --filter libretto-cli test:watch"
+	},
+	"devDependencies": {
+		"vitest": "^4.0.18"
 	}
 }

--- a/packages/libretto-cli/TESTING.md
+++ b/packages/libretto-cli/TESTING.md
@@ -13,7 +13,7 @@ This package runs CLI tests with Vitest as subprocess-based black-box checks.
 - Shared fixture helpers live in `src/test-fixtures.ts`.
 - Every test gets a unique temp workspace directory under the OS temp directory.
 - Seed helpers write `.libretto-cli` and `tmp/libretto-cli` state inside the temp workspace only.
-- `spawnCli` executes the built CLI with subprocess `cwd` set to the temp workspace.
+- `librettoCli` executes the built CLI with subprocess `cwd` set to the temp workspace.
 
 ## Guardrails
 

--- a/packages/libretto-cli/TESTING.md
+++ b/packages/libretto-cli/TESTING.md
@@ -1,0 +1,22 @@
+# CLI Testing
+
+This package runs CLI tests with Vitest as subprocess-based black-box checks.
+
+## Scope
+
+- Tests are inline under `src/**/*.test.ts`.
+- Tests should validate CLI behavior through command invocation, exit codes, and stdout/stderr.
+- `packages/libretto-cli/src/index.ts` is treated as runtime-under-test, not a unit-test target.
+
+## Fixtures
+
+- Shared fixture helpers live in `src/test-fixtures.ts`.
+- Every test gets a unique temp workspace directory under the OS temp directory.
+- Seed helpers write `.libretto-cli` and `tmp/libretto-cli` state inside the temp workspace only.
+- `spawnCli` executes the built CLI with subprocess `cwd` set to the temp workspace.
+
+## Guardrails
+
+- Do not write test artifacts to repository-local runtime folders.
+- Keep tests deterministic and offline (no live LLM or website dependencies).
+- Prefer seeded files and subprocess assertions over browser launches.

--- a/packages/libretto-cli/package.json
+++ b/packages/libretto-cli/package.json
@@ -9,7 +9,9 @@
 	"scripts": {
 		"build": "tsup",
 		"type-check": "tsc --noEmit",
-		"dev": "tsx src/index.ts"
+		"dev": "tsx src/index.ts",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"libretto": "workspace:*",

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect } from "vitest";
+import { test } from "./test-fixtures";
+
+describe("basic CLI subprocess behavior", () => {
+  test("prints usage for --help", async ({ spawnCli }) => {
+    const result = await spawnCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
+    expect(result.stderr).toBe("");
+  });
+
+  test("prints usage for help command", async ({ spawnCli }) => {
+    const result = await spawnCli(["help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Commands:");
+    expect(result.stderr).toBe("");
+  });
+
+  test("fails unknown command with non-zero exit code", async ({ spawnCli }) => {
+    const result = await spawnCli(["nope-command"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unknown command: nope-command");
+    expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
+  });
+
+  test("fails open with missing url usage error", async ({ spawnCli }) => {
+    const result = await spawnCli(["open"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Usage: libretto-cli open <url> [--headless] [--session <name>]",
+    );
+  });
+
+  test("fails exec with missing code usage error", async ({ spawnCli }) => {
+    const result = await spawnCli(["exec"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
+    );
+  });
+
+  test("fails save with missing target usage error", async ({ spawnCli }) => {
+    const result = await spawnCli(["save"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Usage: libretto-cli save <url|domain> [--session <name>]",
+    );
+  });
+
+  test("fails when --session value is missing", async ({ spawnCli }) => {
+    const result = await spawnCli(["help", "--session"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Missing or invalid --session value.");
+  });
+
+  test("fails when --session value is another command token", async ({
+    spawnCli,
+  }) => {
+    const result = await spawnCli(["help", "--session", "open"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Missing or invalid --session value.");
+  });
+});

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -2,61 +2,61 @@ import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
 describe("basic CLI subprocess behavior", () => {
-  test("prints usage for --help", async ({ spawnCli }) => {
-    const result = await spawnCli(["--help"]);
+  test("prints usage for --help", async ({ librettoCli }) => {
+    const result = await librettoCli("--help");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
     expect(result.stderr).toBe("");
   });
 
-  test("prints usage for help command", async ({ spawnCli }) => {
-    const result = await spawnCli(["help"]);
+  test("prints usage for help command", async ({ librettoCli }) => {
+    const result = await librettoCli("help");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Commands:");
     expect(result.stderr).toBe("");
   });
 
-  test("fails unknown command with non-zero exit code", async ({ spawnCli }) => {
-    const result = await spawnCli(["nope-command"]);
+  test("fails unknown command with non-zero exit code", async ({ librettoCli }) => {
+    const result = await librettoCli("nope-command");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Unknown command: nope-command");
     expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
   });
 
-  test("fails open with missing url usage error", async ({ spawnCli }) => {
-    const result = await spawnCli(["open"]);
+  test("fails open with missing url usage error", async ({ librettoCli }) => {
+    const result = await librettoCli("open");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       "Usage: libretto-cli open <url> [--headless] [--session <name>]",
     );
   });
 
-  test("fails exec with missing code usage error", async ({ spawnCli }) => {
-    const result = await spawnCli(["exec"]);
+  test("fails exec with missing code usage error", async ({ librettoCli }) => {
+    const result = await librettoCli("exec");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
     );
   });
 
-  test("fails save with missing target usage error", async ({ spawnCli }) => {
-    const result = await spawnCli(["save"]);
+  test("fails save with missing target usage error", async ({ librettoCli }) => {
+    const result = await librettoCli("save");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       "Usage: libretto-cli save <url|domain> [--session <name>]",
     );
   });
 
-  test("fails when --session value is missing", async ({ spawnCli }) => {
-    const result = await spawnCli(["help", "--session"]);
+  test("fails when --session value is missing", async ({ librettoCli }) => {
+    const result = await librettoCli("help --session");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Missing or invalid --session value.");
   });
 
   test("fails when --session value is another command token", async ({
-    spawnCli,
+    librettoCli,
   }) => {
-    const result = await spawnCli(["help", "--session", "open"]);
+    const result = await librettoCli("help --session open");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Missing or invalid --session value.");
   });

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -4,17 +4,17 @@ import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
 describe("state-driven CLI subprocess behavior", () => {
-  test("shows missing snapshot analyzer config", async ({ spawnCli }) => {
-    const result = await spawnCli(["snapshot", "configure", "--show"]);
+  test("shows missing snapshot analyzer config", async ({ librettoCli }) => {
+    const result = await librettoCli("snapshot configure --show");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("No snapshot analyzer configured.");
   });
 
   test("configures, shows, and clears snapshot analyzer config", async ({
-    spawnCli,
+    librettoCli,
     workspacePath,
   }) => {
-    const configure = await spawnCli(["snapshot", "configure", "codex"]);
+    const configure = await librettoCli("snapshot configure codex");
     expect(configure.exitCode).toBe(0);
     expect(configure.stdout).toContain("Snapshot analyzer configured.");
 
@@ -28,11 +28,11 @@ describe("state-driven CLI subprocess behavior", () => {
     };
     expect(rawConfig.preset).toBe("codex");
 
-    const show = await spawnCli(["snapshot", "configure", "--show"]);
+    const show = await librettoCli("snapshot configure --show");
     expect(show.exitCode).toBe(0);
     expect(show.stdout).toContain("Snapshot analyzer preset: codex");
 
-    const clear = await spawnCli(["snapshot", "configure", "--clear"]);
+    const clear = await librettoCli("snapshot configure --clear");
     expect(clear.exitCode).toBe(0);
     expect(clear.stdout).toContain("Cleared snapshot analyzer config:");
     expect(existsSync(configPath)).toBe(false);
@@ -41,7 +41,7 @@ describe("state-driven CLI subprocess behavior", () => {
   test("reads and clears network logs from seeded run data", async ({
     seedSessionState,
     seedNetworkLog,
-    spawnCli,
+    librettoCli,
     workspacePath,
   }) => {
     await seedSessionState({
@@ -69,21 +69,15 @@ describe("state-driven CLI subprocess behavior", () => {
       },
     ]);
 
-    const view = await spawnCli([
-      "network",
-      "--session",
-      "net-session",
-      "--method",
-      "POST",
-      "--last",
-      "1",
-    ]);
+    const view = await librettoCli(
+      "network --session net-session --method POST --last 1",
+    );
     expect(view.exitCode).toBe(0);
     expect(view.stdout).toContain("POST");
     expect(view.stdout).toContain("https://example.com/b");
     expect(view.stdout).toContain("1 request(s) shown.");
 
-    const clear = await spawnCli(["network", "--session", "net-session", "--clear"]);
+    const clear = await librettoCli("network --session net-session --clear");
     expect(clear.exitCode).toBe(0);
     expect(clear.stdout).toContain("Network log cleared.");
 
@@ -95,7 +89,7 @@ describe("state-driven CLI subprocess behavior", () => {
   test("reads and clears action logs from seeded run data", async ({
     seedSessionState,
     seedActionLog,
-    spawnCli,
+    librettoCli,
     workspacePath,
   }) => {
     await seedSessionState({
@@ -119,26 +113,17 @@ describe("state-driven CLI subprocess behavior", () => {
       },
     ]);
 
-    const view = await spawnCli([
-      "actions",
-      "--session",
-      "actions-session",
-      "--source",
-      "user",
-      "--last",
-      "1",
-    ]);
+    const view = await librettoCli(
+      "actions --session actions-session --source user --last 1",
+    );
     expect(view.exitCode).toBe(0);
     expect(view.stdout).toContain("fill");
     expect(view.stdout).toContain("input#email");
     expect(view.stdout).toContain("1 action(s) shown.");
 
-    const clear = await spawnCli([
-      "actions",
-      "--session",
-      "actions-session",
-      "--clear",
-    ]);
+    const clear = await librettoCli(
+      "actions --session actions-session --clear",
+    );
     expect(clear.exitCode).toBe(0);
     expect(clear.stdout).toContain("Action log cleared.");
 

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { describe, expect } from "vitest";
+import { test } from "./test-fixtures";
+
+describe("state-driven CLI subprocess behavior", () => {
+  test("shows missing snapshot analyzer config", async ({ spawnCli }) => {
+    const result = await spawnCli(["snapshot", "configure", "--show"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No snapshot analyzer configured.");
+  });
+
+  test("configures, shows, and clears snapshot analyzer config", async ({
+    spawnCli,
+    workspacePath,
+  }) => {
+    const configure = await spawnCli(["snapshot", "configure", "codex"]);
+    expect(configure.exitCode).toBe(0);
+    expect(configure.stdout).toContain("Snapshot analyzer configured.");
+
+    const configPath = workspacePath(
+      ".libretto-cli",
+      "snapshot-config.json",
+    );
+    expect(existsSync(configPath)).toBe(true);
+    const rawConfig = JSON.parse(await readFile(configPath, "utf8")) as {
+      preset?: string;
+    };
+    expect(rawConfig.preset).toBe("codex");
+
+    const show = await spawnCli(["snapshot", "configure", "--show"]);
+    expect(show.exitCode).toBe(0);
+    expect(show.stdout).toContain("Snapshot analyzer preset: codex");
+
+    const clear = await spawnCli(["snapshot", "configure", "--clear"]);
+    expect(clear.exitCode).toBe(0);
+    expect(clear.stdout).toContain("Cleared snapshot analyzer config:");
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  test("reads and clears network logs from seeded run data", async ({
+    seedSessionState,
+    seedNetworkLog,
+    spawnCli,
+    workspacePath,
+  }) => {
+    await seedSessionState({
+      session: "net-session",
+      runId: "run-net",
+    });
+    const logPath = await seedNetworkLog("run-net", [
+      {
+        ts: "2026-01-01T00:00:00.000Z",
+        method: "GET",
+        url: "https://example.com/a",
+        status: 200,
+        contentType: "application/json",
+        size: 50,
+        durationMs: 10,
+      },
+      {
+        ts: "2026-01-01T00:00:01.000Z",
+        method: "POST",
+        url: "https://example.com/b",
+        status: 201,
+        contentType: "application/json",
+        size: 60,
+        durationMs: 20,
+      },
+    ]);
+
+    const view = await spawnCli([
+      "network",
+      "--session",
+      "net-session",
+      "--method",
+      "POST",
+      "--last",
+      "1",
+    ]);
+    expect(view.exitCode).toBe(0);
+    expect(view.stdout).toContain("POST");
+    expect(view.stdout).toContain("https://example.com/b");
+    expect(view.stdout).toContain("1 request(s) shown.");
+
+    const clear = await spawnCli(["network", "--session", "net-session", "--clear"]);
+    expect(clear.exitCode).toBe(0);
+    expect(clear.stdout).toContain("Network log cleared.");
+
+    const cleared = await readFile(logPath, "utf8");
+    expect(cleared).toBe("");
+    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-net", "network.jsonl"))).toBe(true);
+  });
+
+  test("reads and clears action logs from seeded run data", async ({
+    seedSessionState,
+    seedActionLog,
+    spawnCli,
+    workspacePath,
+  }) => {
+    await seedSessionState({
+      session: "actions-session",
+      runId: "run-actions",
+    });
+    const logPath = await seedActionLog("run-actions", [
+      {
+        ts: "2026-01-01T00:00:00.000Z",
+        action: "click",
+        source: "agent",
+        selector: "button#submit",
+        success: true,
+      },
+      {
+        ts: "2026-01-01T00:00:01.000Z",
+        action: "fill",
+        source: "user",
+        selector: "input#email",
+        success: true,
+      },
+    ]);
+
+    const view = await spawnCli([
+      "actions",
+      "--session",
+      "actions-session",
+      "--source",
+      "user",
+      "--last",
+      "1",
+    ]);
+    expect(view.exitCode).toBe(0);
+    expect(view.stdout).toContain("fill");
+    expect(view.stdout).toContain("input#email");
+    expect(view.stdout).toContain("1 action(s) shown.");
+
+    const clear = await spawnCli([
+      "actions",
+      "--session",
+      "actions-session",
+      "--clear",
+    ]);
+    expect(clear.exitCode).toBe(0);
+    expect(clear.stdout).toContain("Action log cleared.");
+
+    const cleared = await readFile(logPath, "utf8");
+    expect(cleared).toBe("");
+    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-actions", "actions.jsonl"))).toBe(true);
+  });
+});

--- a/packages/libretto-cli/src/smoke.test.ts
+++ b/packages/libretto-cli/src/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("libretto-cli test harness", () => {
+  it("runs smoke tests", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/libretto-cli/src/smoke.test.ts
+++ b/packages/libretto-cli/src/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "vitest";
-
-describe("libretto-cli test harness", () => {
-  it("runs smoke tests", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -1,0 +1,69 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { describe, expect } from "vitest";
+import { test } from "./test-fixtures";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("cli test fixtures", () => {
+  test.concurrent(
+    "isolates workspace files for concurrent test A",
+    async ({ workspacePath }) => {
+      const file = workspacePath("collision-check.txt");
+      await writeFile(file, "test-A", "utf8");
+      await wait(60);
+      const value = await readFile(file, "utf8");
+      expect(value).toBe("test-A");
+    },
+  );
+
+  test.concurrent(
+    "isolates workspace files for concurrent test B",
+    async ({ workspacePath }) => {
+      const file = workspacePath("collision-check.txt");
+      await writeFile(file, "test-B", "utf8");
+      await wait(60);
+      const value = await readFile(file, "utf8");
+      expect(value).toBe("test-B");
+    },
+  );
+
+  test("seeds state and run logs in workspace-scoped paths", async ({
+    workspacePath,
+    seedSessionState,
+    seedNetworkLog,
+    seedActionLog,
+    seedSnapshotConfig,
+  }) => {
+    const seeded = await seedSessionState({
+      session: "spec-session",
+      runId: "run-2",
+    });
+    await seedNetworkLog("run-2", [
+      { ts: "2026-01-01T00:00:00.000Z", method: "GET", url: "https://example.com", status: 200, contentType: "text/html", size: 1, durationMs: 1 },
+    ]);
+    await seedActionLog("run-2", [
+      { ts: "2026-01-01T00:00:00.000Z", action: "click", source: "agent", success: true },
+    ]);
+    const configPath = await seedSnapshotConfig();
+
+    expect(seeded.session).toBe("spec-session");
+    expect(existsSync(workspacePath("tmp", "libretto-cli", "spec-session.json"))).toBe(true);
+    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-2", "network.jsonl"))).toBe(true);
+    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-2", "actions.jsonl"))).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
+  });
+
+  test(
+    "spawns CLI with workspace cwd",
+    async ({ spawnCli, workspacePath }) => {
+      const result = await spawnCli(["--help"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Usage: libretto-cli");
+      expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(true);
+    },
+    20_000,
+  );
+});

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -63,8 +63,8 @@ describe("cli test fixtures", () => {
 
   test(
     "spawns CLI with workspace cwd",
-    async ({ spawnCli, workspacePath }) => {
-      const result = await spawnCli(["--help"]);
+    async ({ librettoCli, workspacePath }) => {
+      const result = await librettoCli("--help");
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Usage: libretto-cli");
       expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(true);

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { describe, expect } from "vitest";
@@ -8,6 +9,10 @@ function wait(ms: number): Promise<void> {
 }
 
 describe("cli test fixtures", () => {
+  test("creates workspace under OS temp directory", async ({ workspaceDir }) => {
+    expect(workspaceDir.startsWith(tmpdir())).toBe(true);
+  });
+
   test.concurrent(
     "isolates workspace files for concurrent test A",
     async ({ workspacePath }) => {

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -32,7 +32,10 @@ type SeedHelpers = {
 type CliFixtures = {
   workspaceDir: string;
   workspacePath: (...parts: string[]) => string;
-  spawnCli: (args: string[], env?: Record<string, string>) => Promise<SpawnResult>;
+  librettoCli: (
+    command: string,
+    env?: Record<string, string>,
+  ) => Promise<SpawnResult>;
 } & SeedHelpers;
 
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -104,6 +107,53 @@ async function spawnProcess(
   });
 }
 
+function parseCommandArgs(command: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+
+  for (const char of command) {
+    if (escape) {
+      current += char;
+      escape = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escape = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) args.push(current);
+  return args;
+}
+
 export const test = base.extend<CliFixtures>({
   workspaceDir: async ({}, use) => {
     const workspaceDir = await mkdtemp(join(tmpdir(), "libretto-cli-test-"));
@@ -118,10 +168,15 @@ export const test = base.extend<CliFixtures>({
     await use((...parts: string[]) => join(workspaceDir, ...parts));
   },
 
-  spawnCli: async ({ workspaceDir }, use) => {
+  librettoCli: async ({ workspaceDir }, use) => {
     ensureBuilt();
-    await use(async (args: string[], env?: Record<string, string>) => {
-      return await spawnProcess(process.execPath, [cliEntry, ...args], workspaceDir, env);
+    await use(async (command: string, env?: Record<string, string>) => {
+      return await spawnProcess(
+        process.execPath,
+        [cliEntry, ...parseCommandArgs(command)],
+        workspaceDir,
+        env,
+      );
     });
   },
 

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -38,11 +38,16 @@ type CliFixtures = {
 const here = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = resolve(here, "../../..");
 const cliEntry = resolve(repoRoot, "packages/libretto-cli/dist/index.js");
+const librettoEntry = resolve(repoRoot, "packages/libretto/dist/index.js");
 
 let didBuild = false;
 
 function ensureBuilt(): void {
-  if (didBuild && existsSync(cliEntry)) return;
+  if (didBuild && existsSync(cliEntry) && existsSync(librettoEntry)) return;
+  if (existsSync(cliEntry) && existsSync(librettoEntry)) {
+    didBuild = true;
+    return;
+  }
   const buildLibretto = spawnSync("pnpm", ["--filter", "libretto", "build"], {
     cwd: repoRoot,
     encoding: "utf8",

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test as base } from "vitest";
+
+type SessionState = {
+  port: number;
+  pid: number;
+  session: string;
+  runId: string;
+  startedAt: string;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+type SpawnResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type SeedHelpers = {
+  seedSessionState: (state?: Partial<SessionState>) => Promise<SessionState>;
+  seedSnapshotConfig: (config?: JsonRecord) => Promise<string>;
+  seedNetworkLog: (runId: string, entries: JsonRecord[]) => Promise<string>;
+  seedActionLog: (runId: string, entries: JsonRecord[]) => Promise<string>;
+};
+
+type CliFixtures = {
+  workspaceDir: string;
+  workspacePath: (...parts: string[]) => string;
+  spawnCli: (args: string[], env?: Record<string, string>) => Promise<SpawnResult>;
+} & SeedHelpers;
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const cliEntry = resolve(repoRoot, "packages/libretto-cli/dist/index.js");
+
+let didBuild = false;
+
+function ensureBuilt(): void {
+  if (didBuild && existsSync(cliEntry)) return;
+  const buildLibretto = spawnSync("pnpm", ["--filter", "libretto", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (buildLibretto.status !== 0) {
+    throw new Error(
+      `Failed to build libretto before CLI tests.\n${buildLibretto.stdout}\n${buildLibretto.stderr}`,
+    );
+  }
+  const buildCli = spawnSync("pnpm", ["--filter", "libretto-cli", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (buildCli.status !== 0) {
+    throw new Error(
+      `Failed to build libretto-cli before tests.\n${buildCli.stdout}\n${buildCli.stderr}`,
+    );
+  }
+  didBuild = true;
+}
+
+async function spawnProcess(
+  command: string,
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): Promise<SpawnResult> {
+  return await new Promise<SpawnResult>((resolveResult, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolveResult({
+        exitCode: code ?? 1,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+export const test = base.extend<CliFixtures>({
+  workspaceDir: async ({}, use) => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), "libretto-cli-test-"));
+    try {
+      await use(workspaceDir);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  },
+
+  workspacePath: async ({ workspaceDir }, use) => {
+    await use((...parts: string[]) => join(workspaceDir, ...parts));
+  },
+
+  spawnCli: async ({ workspaceDir }, use) => {
+    ensureBuilt();
+    await use(async (args: string[], env?: Record<string, string>) => {
+      return await spawnProcess(process.execPath, [cliEntry, ...args], workspaceDir, env);
+    });
+  },
+
+  seedSessionState: async ({ workspacePath }, use) => {
+    await use(async (state?: Partial<SessionState>) => {
+      const session = state?.session ?? "default";
+      const normalized: SessionState = {
+        session,
+        runId: state?.runId ?? "run-seeded",
+        port: state?.port ?? 9222,
+        pid: state?.pid ?? 12345,
+        startedAt: state?.startedAt ?? "2026-01-01T00:00:00.000Z",
+      };
+      const dir = workspacePath("tmp", "libretto-cli");
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        workspacePath("tmp", "libretto-cli", `${session}.json`),
+        JSON.stringify(normalized, null, 2),
+      );
+      return normalized;
+    });
+  },
+
+  seedSnapshotConfig: async ({ workspacePath }, use) => {
+    await use(async (config?: JsonRecord) => {
+      const dir = workspacePath(".libretto-cli");
+      const path = workspacePath(".libretto-cli", "snapshot-config.json");
+      await mkdir(dir, { recursive: true });
+      const payload = config ?? {
+        version: 1,
+        preset: "codex",
+        commandPrefix: ["codex", "exec"],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
+      await writeFile(path, JSON.stringify(payload, null, 2), "utf8");
+      return path;
+    });
+  },
+
+  seedNetworkLog: async ({ workspacePath }, use) => {
+    await use(async (runId: string, entries: JsonRecord[]) => {
+      const runDir = workspacePath("tmp", "libretto-cli", runId);
+      const logPath = workspacePath("tmp", "libretto-cli", runId, "network.jsonl");
+      await mkdir(runDir, { recursive: true });
+      const body = entries.map((entry) => JSON.stringify(entry)).join("\n");
+      await writeFile(logPath, body ? `${body}\n` : "", "utf8");
+      return logPath;
+    });
+  },
+
+  seedActionLog: async ({ workspacePath }, use) => {
+    await use(async (runId: string, entries: JsonRecord[]) => {
+      const runDir = workspacePath("tmp", "libretto-cli", runId);
+      const logPath = workspacePath("tmp", "libretto-cli", runId, "actions.jsonl");
+      await mkdir(runDir, { recursive: true });
+      const body = entries.map((entry) => JSON.stringify(entry)).join("\n");
+      await writeFile(logPath, body ? `${body}\n` : "", "utf8");
+      return logPath;
+    });
+  },
+});

--- a/packages/libretto-cli/vitest.config.ts
+++ b/packages/libretto-cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "libretto-cli",
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/libretto-cli/vitest.config.ts
+++ b/packages/libretto-cli/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     name: "libretto-cli",
     environment: "node",
     include: ["src/**/*.test.ts"],
+    testTimeout: 30_000,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(tsx@4.21.0)
 
   packages/libretto:
     dependencies:
@@ -31,7 +35,7 @@ importers:
         version: 1.58.2
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -56,7 +60,7 @@ importers:
         version: 25.3.3
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -415,6 +419,12 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -424,6 +434,35 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -459,6 +498,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -483,6 +526,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -535,14 +582,24 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -669,6 +726,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -681,6 +743,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -738,6 +803,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -769,13 +838,26 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -805,12 +887,23 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -854,6 +947,80 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -861,6 +1028,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -1106,6 +1278,13 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@25.3.3':
@@ -1113,6 +1292,45 @@ snapshots:
       undici-types: 7.18.2
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.3.3)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   acorn@8.16.0: {}
 
@@ -1138,6 +1356,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -1156,6 +1376,8 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1195,6 +1417,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  es-module-lexer@1.7.0: {}
+
   esbuild@0.27.3:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.3
@@ -1224,7 +1448,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   eventsource-parser@3.0.6: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -1370,6 +1600,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -1379,6 +1611,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -1411,11 +1645,18 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-load-config@6.0.1(tsx@4.21.0):
+  postcss-load-config@6.0.1(postcss@8.5.8)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      postcss: 8.5.8
       tsx: 4.21.0
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   readdirp@4.1.2: {}
 
@@ -1466,9 +1707,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
+  source-map-js@1.2.1: {}
+
   source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -1508,18 +1757,24 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.0.3: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -1530,7 +1785,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.21.0)
+      postcss-load-config: 6.0.1(postcss@8.5.8)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -1539,6 +1794,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.8
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -1559,11 +1815,67 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.3.3
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.3.3)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.3.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/specs/cli-vitest-testing-spec.md
+++ b/specs/cli-vitest-testing-spec.md
@@ -1,0 +1,82 @@
+## Problem overview
+
+The repository has no automated tests for the CLI. The CLI is stateful and side-effect heavy (filesystem state, spawned processes, and browser connectivity), so regressions in command behavior are easy to miss.
+
+The focus of this worktree is to establish reliable test infrastructure for CLI testing in scoped temporary workspaces and add a small set of basic CLI tests.
+
+## Solution overview
+
+Set up Vitest at the workspace level, add CLI-focused fixtures that isolate each test in its own workspace, and run the built CLI as a subprocess for black-box assertions.
+
+Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests should validate current behavior from the outside.
+
+## Goals
+
+- Add workspace test infrastructure using Vitest.
+- Add reusable fixtures for isolated CLI testing in scoped workspaces.
+- Add basic CLI subprocess tests for help, usage errors, and a small set of deterministic commands.
+- Ensure tests are offline and do not require live LLM credentials.
+- Add CI execution for the test suite.
+
+## Non-goals
+
+- No migrations or backfills.
+- No edits to `packages/libretto-cli/src/index.ts` in this worktree.
+- No broad core-library test expansion in `packages/libretto` yet.
+- No real browser end-to-end automation against external websites.
+- No parser/helper extraction refactor for testability in this phase.
+
+## Future work
+
+- Expand CLI coverage to more command paths once infrastructure is stable.
+- Add focused unit tests for extracted helpers after a separate refactor-focused worktree.
+- Add broader `packages/libretto` unit and integration tests.
+
+## Important files/docs/websites for implementation
+
+- `package.json` — workspace scripts and shared dev dependencies.
+- `pnpm-workspace.yaml` — workspace package boundaries.
+- `packages/libretto-cli/package.json` — CLI package scripts and dependencies.
+- `packages/libretto-cli/src/index.ts` — CLI runtime behavior under test (read-only for this spec).
+- `README.md` — top-level project context.
+
+## Implementation
+
+### Phase 1: Add Vitest workspace scaffolding
+
+- [ ] Add workspace-level dev dependency for `vitest`.
+- [ ] Add root scripts: `test` and `test:watch`.
+- [ ] Add root Vitest config to run package tests in this monorepo.
+- [ ] Add package-level test setup files for cleanup hooks and stable defaults.
+- [ ] Success criteria: `pnpm test` runs and passes with initial smoke tests.
+
+### Phase 2: Add scoped-workspace CLI fixtures
+
+- [ ] Add a fixture that creates a unique temp workspace per test and switches subprocess cwd into it.
+- [ ] Add seed helpers for `.libretto-cli` and `tmp/libretto-cli` state files and run directories.
+- [ ] Add a `spawnCli` fixture that executes the built CLI and captures `exitCode`, `stdout`, and `stderr`.
+- [ ] Add teardown cleanup that removes temp workspace artifacts after each test.
+- [ ] Success criteria: two tests can run in parallel without shared state collisions.
+
+### Phase 3: Add very basic CLI subprocess tests
+
+- [ ] Add tests for `--help`/`help` output.
+- [ ] Add tests for unknown command behavior and non-zero exit code.
+- [ ] Add tests for missing argument usage errors on `open`, `exec`, and `save`.
+- [ ] Add tests for invalid `--session` usage and error messaging.
+- [ ] Success criteria: tests assert both exit code and user-visible stderr/stdout text.
+
+### Phase 4: Add deterministic state-driven CLI tests
+
+- [ ] Add tests for `snapshot configure --show` when no config is set.
+- [ ] Add tests for `snapshot configure <preset>` and `snapshot configure --clear` state transitions.
+- [ ] Add tests for `network` and `actions` commands using seeded log files in temp run dirs.
+- [ ] Add tests for `network --clear` and `actions --clear` behavior against seeded files.
+- [ ] Success criteria: stateful command tests run without launching a browser process.
+
+### Phase 5: Add CI execution and guardrails
+
+- [ ] Add CI workflow step to run `pnpm test`.
+- [ ] Ensure tests write only within temp workspaces and never mutate repo-local runtime state.
+- [ ] Document the test strategy and fixture constraints briefly in the spec or test README.
+- [ ] Success criteria: CI passes in a clean environment and reproduces local test results.

--- a/specs/cli-vitest-testing-spec.md
+++ b/specs/cli-vitest-testing-spec.md
@@ -37,6 +37,7 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 - `package.json` — workspace scripts and shared dev dependencies.
 - `pnpm-workspace.yaml` — workspace package boundaries.
 - `packages/libretto-cli/package.json` — CLI package scripts and dependencies.
+- `packages/libretto-cli/vitest.config.ts` — package-local Vitest configuration for inline CLI tests.
 - `packages/libretto-cli/src/index.ts` — CLI runtime behavior under test (read-only for this spec).
 - `README.md` — top-level project context.
 
@@ -44,19 +45,19 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 
 ### Phase 1: Add Vitest workspace scaffolding
 
-- [ ] Add workspace-level dev dependency for `vitest`.
-- [ ] Add root scripts: `test` and `test:watch`.
-- [ ] Add root Vitest config to run package tests in this monorepo.
-- [ ] Add package-level test setup files for cleanup hooks and stable defaults.
-- [ ] Success criteria: `pnpm test` runs and passes with initial smoke tests.
+- [x] Add workspace-level dev dependency for `vitest`.
+- [x] Add root scripts: `test` and `test:watch`.
+- [x] Add package-level Vitest config and root test orchestration through package scripts.
+- [x] Add package-level test scaffolding for stable smoke-test execution.
+- [x] Success criteria: `pnpm test` runs and passes with initial smoke tests.
 
 ### Phase 2: Add scoped-workspace CLI fixtures
 
-- [ ] Add a fixture that creates a unique temp workspace per test and switches subprocess cwd into it.
-- [ ] Add seed helpers for `.libretto-cli` and `tmp/libretto-cli` state files and run directories.
-- [ ] Add a `spawnCli` fixture that executes the built CLI and captures `exitCode`, `stdout`, and `stderr`.
-- [ ] Add teardown cleanup that removes temp workspace artifacts after each test.
-- [ ] Success criteria: two tests can run in parallel without shared state collisions.
+- [x] Add a fixture that creates a unique temp workspace per test and switches subprocess cwd into it.
+- [x] Add seed helpers for `.libretto-cli` and `tmp/libretto-cli` state files and run directories.
+- [x] Add a `spawnCli` fixture that executes the built CLI and captures `exitCode`, `stdout`, and `stderr`.
+- [x] Add teardown cleanup that removes temp workspace artifacts after each test.
+- [x] Success criteria: two tests can run in parallel without shared state collisions.
 
 ### Phase 3: Add very basic CLI subprocess tests
 

--- a/specs/cli-vitest-testing-spec.md
+++ b/specs/cli-vitest-testing-spec.md
@@ -61,11 +61,11 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 
 ### Phase 3: Add very basic CLI subprocess tests
 
-- [ ] Add tests for `--help`/`help` output.
-- [ ] Add tests for unknown command behavior and non-zero exit code.
-- [ ] Add tests for missing argument usage errors on `open`, `exec`, and `save`.
-- [ ] Add tests for invalid `--session` usage and error messaging.
-- [ ] Success criteria: tests assert both exit code and user-visible stderr/stdout text.
+- [x] Add tests for `--help`/`help` output.
+- [x] Add tests for unknown command behavior and non-zero exit code.
+- [x] Add tests for missing argument usage errors on `open`, `exec`, and `save`.
+- [x] Add tests for invalid `--session` usage and error messaging.
+- [x] Success criteria: tests assert both exit code and user-visible stderr/stdout text.
 
 ### Phase 4: Add deterministic state-driven CLI tests
 

--- a/specs/cli-vitest-testing-spec.md
+++ b/specs/cli-vitest-testing-spec.md
@@ -69,15 +69,15 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 
 ### Phase 4: Add deterministic state-driven CLI tests
 
-- [ ] Add tests for `snapshot configure --show` when no config is set.
-- [ ] Add tests for `snapshot configure <preset>` and `snapshot configure --clear` state transitions.
-- [ ] Add tests for `network` and `actions` commands using seeded log files in temp run dirs.
-- [ ] Add tests for `network --clear` and `actions --clear` behavior against seeded files.
-- [ ] Success criteria: stateful command tests run without launching a browser process.
+- [x] Add tests for `snapshot configure --show` when no config is set.
+- [x] Add tests for `snapshot configure <preset>` and `snapshot configure --clear` state transitions.
+- [x] Add tests for `network` and `actions` commands using seeded log files in temp run dirs.
+- [x] Add tests for `network --clear` and `actions --clear` behavior against seeded files.
+- [x] Success criteria: stateful command tests run without launching a browser process.
 
 ### Phase 5: Add CI execution and guardrails
 
-- [ ] Add CI workflow step to run `pnpm test`.
-- [ ] Ensure tests write only within temp workspaces and never mutate repo-local runtime state.
-- [ ] Document the test strategy and fixture constraints briefly in the spec or test README.
-- [ ] Success criteria: CI passes in a clean environment and reproduces local test results.
+- [x] Add CI workflow step to run `pnpm test`.
+- [x] Ensure tests write only within temp workspaces and never mutate repo-local runtime state.
+- [x] Document the test strategy and fixture constraints briefly in the spec or test README.
+- [x] Success criteria: CI passes in a clean environment and reproduces local test results.


### PR DESCRIPTION
## Summary
- drop the shared Vtest workspace definition since each package owns its own `vitest.config.ts`
- remove the extra Vitest workspace file that isn’t providing any additional value

## Testing
- Not run (not requested)