### PR TITLE
Unify CLI AI configuration and add ai configure command

### DIFF
--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -11,11 +11,3 @@ Ask the librarian to check sst/opencode for the correct syntax for [your change]
 ```
 
 This prevents using deprecated patterns or incorrect tool/permission names.
-
-## Libretto CLI AI Config Learnings
-
-- Shared AI runtime configuration should live at `.libretto/config.json`.
-- Keep config versioned at the top level (`version`) and AI settings under `ai`.
-- Current AI config fields are `preset`, `commandPrefix`, and `updatedAt`.
-- Use `CURRENT_CONFIG_VERSION` for the schema version constant in config helpers.
-- Prefer reusing existing workspace-scoped Vitest fixtures from `packages/libretto-cli/src/test-fixtures.ts` instead of ad hoc temp-dir setup in individual tests.

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -11,3 +11,11 @@ Ask the librarian to check sst/opencode for the correct syntax for [your change]
 ```
 
 This prevents using deprecated patterns or incorrect tool/permission names.
+
+## Libretto CLI AI Config Learnings
+
+- Shared AI runtime configuration should live at `.libretto/config.json`.
+- Keep config versioned at the top level (`version`) and AI settings under `ai`.
+- Current AI config fields are `preset`, `commandPrefix`, and `updatedAt`.
+- Use `CURRENT_CONFIG_VERSION` for the schema version constant in config helpers.
+- Prefer reusing existing workspace-scoped Vitest fixtures from `packages/libretto-cli/src/test-fixtures.ts` instead of ad hoc temp-dir setup in individual tests.

--- a/README.md
+++ b/README.md
@@ -43,19 +43,22 @@ Configure an external coding agent — no API keys needed in libretto, the agent
 
 ```bash
 # Use one of: codex, opencode, claude, gemini
-libretto-cli snapshot configure codex
-libretto-cli snapshot configure opencode
-libretto-cli snapshot configure claude
-libretto-cli snapshot configure gemini
+libretto-cli ai configure codex
+libretto-cli ai configure opencode
+libretto-cli ai configure claude
+libretto-cli ai configure gemini
 
 # Optionally provide a custom command prefix
-libretto-cli snapshot configure codex -- my-custom-codex --flag
+libretto-cli ai configure codex -- my-custom-codex --flag
 
 # Show current configuration
-libretto-cli snapshot configure
+libretto-cli ai configure
 
 # Clear configuration
-libretto-cli snapshot configure --clear
+libretto-cli ai configure --clear
+
+# Compatibility alias (still supported)
+libretto-cli snapshot configure codex
 ```
 
 ### Option 2: Built-in LLM client via environment variables

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ libretto-cli run ./integration.ts main --session default
 libretto-cli session-mode read-only --session default
 ```
 
-## snapshot analyzer configuration
+## AI configuration
 
-The `snapshot` command analyzes browser snapshots using an LLM. There are two ways to configure it:
+Analysis commands use a shared AI runtime config file at `.libretto/config.json`.
+There are two ways to configure it:
 
 ### Option 1: External coding agent (recommended)
 
@@ -69,4 +70,4 @@ If no external agent is configured, the CLI falls back to its built-in LLM clien
 - `ANTHROPIC_API_KEY` — for Anthropic models
 - `OPENAI_API_KEY` — for OpenAI models
 
-If neither an external agent nor any of these environment variables are configured, the `snapshot` command will fail with an error.
+If neither an external agent nor any of these environment variables are configured, analysis commands (including `snapshot`) will fail with an error.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ libretto-cli snapshot configure gemini
 libretto-cli snapshot configure codex -- my-custom-codex --flag
 
 # Show current configuration
-libretto-cli snapshot configure --show
+libretto-cli snapshot configure
 
 # Clear configuration
 libretto-cli snapshot configure --clear

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -223,11 +223,12 @@ describe("state-driven CLI subprocess behavior", () => {
     const result = await librettoCli(
       "exec \"return await page.title()\" --session permissioned-session",
     );
-    expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
-    expect(result.stderr).toContain(
-      "No browser running for session \"permissioned-session\".",
-    );
+    if (result.exitCode !== 0) {
+      expect(result.stderr).toContain(
+        "No browser running for session \"permissioned-session\".",
+      );
+    }
   });
 
   test("does not apply read-only guard when session allows actions", async ({
@@ -242,11 +243,12 @@ describe("state-driven CLI subprocess behavior", () => {
     const result = await librettoCli(
       "exec \"return await page.title()\" --session interactive-session",
     );
-    expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
-    expect(result.stderr).toContain(
-      "No browser running for session \"interactive-session\".",
-    );
+    if (result.exitCode !== 0) {
+      expect(result.stderr).toContain(
+        "No browser running for session \"interactive-session\".",
+      );
+    }
   });
 
   test("rejects exec after session is switched back to read-only", async ({

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -5,7 +5,7 @@ import { test } from "./test-fixtures";
 
 describe("state-driven CLI subprocess behavior", () => {
   test("shows missing AI config", async ({ librettoCli }) => {
-    const result = await librettoCli("snapshot configure");
+    const result = await librettoCli("ai configure");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("No AI config set.");
   });
@@ -14,7 +14,7 @@ describe("state-driven CLI subprocess behavior", () => {
     librettoCli,
     workspacePath,
   }) => {
-    const configure = await librettoCli("snapshot configure codex");
+    const configure = await librettoCli("ai configure codex");
     expect(configure.exitCode).toBe(0);
     expect(configure.stdout).toContain("AI config saved.");
 
@@ -27,11 +27,11 @@ describe("state-driven CLI subprocess behavior", () => {
     };
     expect(rawConfig.ai?.preset).toBe("codex");
 
-    const show = await librettoCli("snapshot configure");
+    const show = await librettoCli("ai configure");
     expect(show.exitCode).toBe(0);
     expect(show.stdout).toContain("AI preset: codex");
 
-    const clear = await librettoCli("snapshot configure --clear");
+    const clear = await librettoCli("ai configure --clear");
     expect(clear.exitCode).toBe(0);
     expect(clear.stdout).toContain("Cleared AI config:");
 
@@ -47,7 +47,7 @@ describe("state-driven CLI subprocess behavior", () => {
     librettoCli,
     workspacePath,
   }) => {
-    const configure = await librettoCli("snapshot configure gemini");
+    const configure = await librettoCli("ai configure gemini");
     expect(configure.exitCode).toBe(0);
     expect(configure.stdout).toContain("AI config saved.");
 
@@ -64,6 +64,18 @@ describe("state-driven CLI subprocess behavior", () => {
       "--output-format",
       "json",
     ]);
+  });
+
+  test("supports snapshot configure as a compatibility alias", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const configure = await librettoCli("snapshot configure codex");
+    expect(configure.exitCode).toBe(0);
+    expect(configure.stdout).toContain("AI config saved.");
+
+    const configPath = workspacePath(".libretto", "config.json");
+    expect(existsSync(configPath)).toBe(true);
   });
 
   test("reads and clears network logs from seeded run data", async ({

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -4,58 +4,62 @@ import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
 describe("state-driven CLI subprocess behavior", () => {
-  test("shows missing snapshot analyzer config", async ({ librettoCli }) => {
-    const result = await librettoCli("snapshot configure --show");
+  test("shows missing AI config", async ({ librettoCli }) => {
+    const result = await librettoCli("snapshot configure");
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("No snapshot analyzer configured.");
+    expect(result.stdout).toContain("No AI config set.");
   });
 
-  test("configures, shows, and clears snapshot analyzer config", async ({
+  test("configures, shows, and clears AI config", async ({
     librettoCli,
     workspacePath,
   }) => {
     const configure = await librettoCli("snapshot configure codex");
     expect(configure.exitCode).toBe(0);
-    expect(configure.stdout).toContain("Snapshot analyzer configured.");
+    expect(configure.stdout).toContain("AI config saved.");
 
-    const configPath = workspacePath(
-      ".libretto-cli",
-      "snapshot-config.json",
-    );
+    const configPath = workspacePath(".libretto", "config.json");
     expect(existsSync(configPath)).toBe(true);
     const rawConfig = JSON.parse(await readFile(configPath, "utf8")) as {
-      preset?: string;
+      ai?: {
+        preset?: string;
+      };
     };
-    expect(rawConfig.preset).toBe("codex");
+    expect(rawConfig.ai?.preset).toBe("codex");
 
-    const show = await librettoCli("snapshot configure --show");
+    const show = await librettoCli("snapshot configure");
     expect(show.exitCode).toBe(0);
-    expect(show.stdout).toContain("Snapshot analyzer preset: codex");
+    expect(show.stdout).toContain("AI preset: codex");
 
     const clear = await librettoCli("snapshot configure --clear");
     expect(clear.exitCode).toBe(0);
-    expect(clear.stdout).toContain("Cleared snapshot analyzer config:");
-    expect(existsSync(configPath)).toBe(false);
+    expect(clear.stdout).toContain("Cleared AI config:");
+
+    const clearedConfig = JSON.parse(await readFile(configPath, "utf8")) as {
+      version?: number;
+      ai?: unknown;
+    };
+    expect(clearedConfig.version).toBe(1);
+    expect(clearedConfig.ai).toBeUndefined();
   });
 
-  test("configures gemini snapshot analyzer preset", async ({
+  test("configures gemini AI preset", async ({
     librettoCli,
     workspacePath,
   }) => {
     const configure = await librettoCli("snapshot configure gemini");
     expect(configure.exitCode).toBe(0);
-    expect(configure.stdout).toContain("Snapshot analyzer configured.");
+    expect(configure.stdout).toContain("AI config saved.");
 
-    const configPath = workspacePath(
-      ".libretto-cli",
-      "snapshot-config.json",
-    );
+    const configPath = workspacePath(".libretto", "config.json");
     const rawConfig = JSON.parse(await readFile(configPath, "utf8")) as {
-      preset?: string;
-      commandPrefix?: string[];
+      ai?: {
+        preset?: string;
+        commandPrefix?: string[];
+      };
     };
-    expect(rawConfig.preset).toBe("gemini");
-    expect(rawConfig.commandPrefix).toEqual([
+    expect(rawConfig.ai?.preset).toBe("gemini");
+    expect(rawConfig.ai?.commandPrefix).toEqual([
       "gemini",
       "--output-format",
       "json",

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -217,18 +217,18 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await seedSessionState({
       session: "permissioned-session",
+      port: 65534,
     });
     await seedSessionPermission("permissioned-session", "interactive");
 
     const result = await librettoCli(
       "exec \"return await page.title()\" --session permissioned-session",
     );
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
-    if (result.exitCode !== 0) {
-      expect(result.stderr).toContain(
-        "No browser running for session \"permissioned-session\".",
-      );
-    }
+    expect(result.stderr).toContain(
+      "No browser running for session \"permissioned-session\".",
+    );
   });
 
   test("does not apply read-only guard when session allows actions", async ({
@@ -237,18 +237,18 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await seedSessionState({
       session: "interactive-session",
+      port: 65534,
       mode: "interactive",
     });
 
     const result = await librettoCli(
       "exec \"return await page.title()\" --session interactive-session",
     );
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
-    if (result.exitCode !== 0) {
-      expect(result.stderr).toContain(
-        "No browser running for session \"interactive-session\".",
-      );
-    }
+    expect(result.stderr).toContain(
+      "No browser running for session \"interactive-session\".",
+    );
   });
 
   test("rejects exec after session is switched back to read-only", async ({

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import yargs, { type Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
+import { registerAICommands } from "./commands/ai";
 import { registerBrowserCommands } from "./commands/browser";
 import { registerExecutionCommands } from "./commands/execution";
 import { registerLogCommands } from "./commands/logs";
@@ -19,6 +20,7 @@ const CLI_COMMANDS = new Set([
   "open",
   "run",
   "session-mode",
+  "ai",
   "save",
   "exec",
   "snapshot",
@@ -38,10 +40,11 @@ Commands:
                           Automatically loads saved profile if available
   run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug <true|false>]  Run an exported async integration function from a file (blocked until interactive)
   session-mode <read-only|interactive> Set session execution mode
+  ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)
   exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until interactive)
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when both flags are provided
-  snapshot configure <codex|opencode|claude|gemini> [-- <command prefix...>]  Configure snapshot analyzer
+  snapshot configure [preset] [-- <command prefix...>]  Compatibility alias for ai configure
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
   close                   Close the browser
@@ -61,11 +64,12 @@ Examples:
 
   libretto-cli exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
   libretto-cli exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
-  libretto-cli snapshot configure codex
-  libretto-cli snapshot configure opencode
-  libretto-cli snapshot configure claude
-  libretto-cli snapshot configure gemini
-  libretto-cli snapshot configure codex -- codex exec --skip-git-repo-check --sandbox read-only
+  libretto-cli ai configure codex
+  libretto-cli ai configure opencode
+  libretto-cli ai configure claude
+  libretto-cli ai configure gemini
+  libretto-cli ai configure codex -- codex exec --skip-git-repo-check --sandbox read-only
+  libretto-cli snapshot configure codex   # compatibility alias
   libretto-cli snapshot
   libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
   libretto-cli close
@@ -180,6 +184,7 @@ function createParser(): Argv {
   parser = registerBrowserCommands(parser);
   parser = registerExecutionCommands(parser);
   parser = registerLogCommands(parser);
+  parser = registerAICommands(parser);
   parser = registerSnapshotCommands(parser);
   parser = parser.command("help", "Show usage", () => {}, () => {
     printUsage();

--- a/packages/libretto-cli/src/commands/ai.ts
+++ b/packages/libretto-cli/src/commands/ai.ts
@@ -1,0 +1,21 @@
+import type { Argv } from "yargs";
+import { runAiConfigure } from "../core/ai-config";
+
+export function registerAICommands(yargs: Argv): Argv {
+  return yargs.command(
+    "ai configure [preset]",
+    "Configure AI runtime",
+    (cmd) => cmd.option("clear", { type: "boolean", default: false }),
+    (argv) => {
+      const customPrefix = Array.isArray(argv["--"]) ? (argv["--"] as string[]) : [];
+      runAiConfigure({
+        clear: Boolean(argv.clear),
+        preset: argv.preset as string | undefined,
+        customPrefix,
+      }, {
+        configureCommandName: "libretto-cli ai configure",
+      });
+    },
+  );
+}
+

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -132,25 +132,16 @@ export function registerSnapshotCommands(yargs: Argv): Argv {
     .command(
       "snapshot configure [preset]",
       "Configure snapshot analyzer",
-      (cmd) =>
-        cmd
-          .option("show", { type: "boolean", default: false })
-          .option("clear", { type: "boolean", default: false }),
+      (cmd) => cmd.option("clear", { type: "boolean", default: false }),
       (argv) => {
-        const args: string[] = [];
-        if (argv.show) args.push("--show");
-        if (argv.clear) args.push("--clear");
-        const preset = argv.preset as string | undefined;
-        if (preset) args.push(preset);
-
         const customPrefix = Array.isArray(argv["--"])
           ? (argv["--"] as string[])
           : [];
-        if (customPrefix.length > 0) {
-          args.push("--", ...customPrefix);
-        }
-
-        runSnapshotConfigure(args);
+        runSnapshotConfigure({
+          clear: Boolean(argv.clear),
+          preset: argv.preset as string | undefined,
+          customPrefix,
+        });
       },
     );
 }

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -131,7 +131,7 @@ export function registerSnapshotCommands(yargs: Argv): Argv {
     )
     .command(
       "snapshot configure [preset]",
-      "Configure snapshot analyzer",
+      "Configure AI runtime (compatibility alias for 'ai configure')",
       (cmd) => cmd.option("clear", { type: "boolean", default: false }),
       (argv) => {
         const customPrefix = Array.isArray(argv["--"])

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -99,7 +99,7 @@ async function runSnapshot(
 
   if (!canAnalyzeSnapshots()) {
     throw new Error(
-      "Couldn't run analysis: no snapshot analyzer configured. Run 'libretto-cli snapshot configure codex' (or opencode/claude/gemini) to enable analysis.",
+      "Couldn't run analysis: no AI config set. Run 'libretto-cli ai configure codex' (or opencode/claude/gemini) to enable analysis.",
     );
   }
 

--- a/packages/libretto-cli/src/core/ai-config.test.ts
+++ b/packages/libretto-cli/src/core/ai-config.test.ts
@@ -1,0 +1,62 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { describe, expect, vi } from "vitest";
+import { test } from "../test-fixtures";
+
+vi.mock("./context", () => ({
+  LIBRETTO_CONFIG_PATH: "/tmp/libretto-config-test.json",
+}));
+
+import { readLibrettoConfig } from "./ai-config";
+
+describe("ai config helpers", () => {
+  test("reads a valid config.json file", async ({ workspacePath }) => {
+    await mkdir(workspacePath(".libretto"), { recursive: true });
+    const configPath = workspacePath(".libretto", "config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          version: 1,
+          ai: {
+            preset: "codex",
+            commandPrefix: ["codex", "exec"],
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const parsed = readLibrettoConfig(configPath);
+    expect(parsed.version).toBe(1);
+    expect(parsed.ai?.preset).toBe("codex");
+    expect(parsed.ai?.commandPrefix).toEqual(["codex", "exec"]);
+  });
+
+  test("throws a path-specific error when config shape is invalid", async ({
+    workspacePath,
+  }) => {
+    await mkdir(workspacePath(".libretto"), { recursive: true });
+    const configPath = workspacePath(".libretto", "config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          version: 1,
+          ai: {
+            preset: "codex",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    expect(() => readLibrettoConfig(configPath)).toThrowError(
+      `AI config is invalid at ${configPath}.`,
+    );
+  });
+});

--- a/packages/libretto-cli/src/core/ai-config.test.ts
+++ b/packages/libretto-cli/src/core/ai-config.test.ts
@@ -1,10 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { describe, expect, vi } from "vitest";
+import { describe, expect } from "vitest";
 import { test } from "../test-fixtures";
-
-vi.mock("./context", () => ({
-  LIBRETTO_CONFIG_PATH: "/tmp/libretto-config-test.json",
-}));
 
 import { readLibrettoConfig } from "./ai-config";
 

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import { z } from "zod";
 import { LIBRETTO_CONFIG_PATH } from "./context";
 
@@ -24,6 +25,13 @@ export const LibrettoConfigSchema = z
   })
   .strict();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
+
+export const AI_CONFIG_PRESETS: Record<AiPreset, string[]> = {
+  codex: ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only"],
+  opencode: ["opencode", "run", "--format", "json"],
+  claude: [join(homedir(), ".claude", "local", "claude"), "-p"],
+  gemini: ["gemini", "--output-format", "json"],
+};
 
 function invalidConfigError(configPath: string): Error {
   return new Error(
@@ -60,4 +68,124 @@ export function writeLibrettoConfig(
 
 export function readAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): AiConfig | null {
   return readLibrettoConfig(configPath).ai ?? null;
+}
+
+function quoteShellArg(value: string): string {
+  if (/^[a-zA-Z0-9_./:@=-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+function formatCommandPrefix(prefix: string[]): string {
+  return prefix.map((arg) => quoteShellArg(arg)).join(" ");
+}
+
+export function writeAiConfig(
+  preset: AiPreset,
+  commandPrefix: string[],
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): AiConfig {
+  const librettoConfig = readLibrettoConfig(configPath);
+  const ai = AiConfigSchema.parse({
+    preset,
+    commandPrefix,
+    updatedAt: new Date().toISOString(),
+  });
+  writeLibrettoConfig(
+    {
+      ...librettoConfig,
+      version: CURRENT_CONFIG_VERSION,
+      ai,
+    },
+    configPath,
+  );
+  return ai;
+}
+
+export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolean {
+  const librettoConfig = readLibrettoConfig(configPath);
+  if (!librettoConfig.ai) return false;
+  // Keep the top-level config file and version while removing only AI state.
+  writeLibrettoConfig(
+    {
+      version: librettoConfig.version,
+    },
+    configPath,
+  );
+  return true;
+}
+
+function printAiConfig(config: AiConfig, configPath: string): void {
+  console.log(`AI preset: ${config.preset}`);
+  console.log(`Command prefix: ${formatCommandPrefix(config.commandPrefix)}`);
+  console.log(`Config file: ${configPath}`);
+  console.log(`Updated at: ${config.updatedAt}`);
+}
+
+function printConfigureUsage(commandName: string): void {
+  console.log(
+    `Usage: ${commandName} <codex|opencode|claude|gemini> [-- <command prefix...>]
+       ${commandName}
+       ${commandName} --clear`,
+  );
+}
+
+export function runAiConfigure(
+  input: {
+    preset?: string;
+    clear?: boolean;
+    customPrefix?: string[];
+  },
+  options: {
+    configureCommandName?: string;
+    configPath?: string;
+  } = {},
+): void {
+  const configureCommandName =
+    options.configureCommandName ?? "libretto-cli snapshot configure";
+  const configPath = options.configPath ?? LIBRETTO_CONFIG_PATH;
+
+  const presetArg = input.preset?.trim();
+  const customPrefix = (input.customPrefix ?? []).filter(Boolean);
+
+  if (!presetArg && customPrefix.length === 0 && !input.clear) {
+    const config = readAiConfig(configPath);
+    if (!config) {
+      console.log(`No AI config set. Run '${configureCommandName} codex' to set one.`);
+      return;
+    }
+    printAiConfig(config, configPath);
+    return;
+  }
+
+  if (input.clear) {
+    const removed = clearAiConfig(configPath);
+    if (removed) {
+      console.log(`Cleared AI config: ${configPath}`);
+    } else {
+      console.log("No AI config was set.");
+    }
+    return;
+  }
+
+  const parsedPreset = AiPresetSchema.safeParse(presetArg);
+  if (!parsedPreset.success) {
+    printConfigureUsage(configureCommandName);
+    throw new Error(
+      "Missing or invalid preset. Use one of: codex, opencode, claude, gemini.",
+    );
+  }
+
+  if (input.customPrefix && input.customPrefix.length > 0 && customPrefix.length === 0) {
+    throw new Error("Custom command prefix cannot be empty.");
+  }
+
+  const preset = parsedPreset.data;
+  const commandPrefix =
+    customPrefix.length > 0
+      ? customPrefix
+      : AI_CONFIG_PRESETS[preset];
+
+  const config = writeAiConfig(preset, commandPrefix, configPath);
+  console.log("AI config saved.");
+  printAiConfig(config, configPath);
 }

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -1,0 +1,63 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { z } from "zod";
+import { LIBRETTO_CONFIG_PATH } from "./context";
+
+export const CURRENT_CONFIG_VERSION = 1;
+
+export const AiPresetSchema = z.enum(["codex", "opencode", "claude", "gemini"]);
+export type AiPreset = z.infer<typeof AiPresetSchema>;
+
+export const AiConfigSchema = z
+  .object({
+    preset: AiPresetSchema,
+    commandPrefix: z.array(z.string()).min(1),
+    updatedAt: z.string(),
+  })
+  .strict();
+export type AiConfig = z.infer<typeof AiConfigSchema>;
+
+export const LibrettoConfigSchema = z
+  .object({
+    version: z.literal(CURRENT_CONFIG_VERSION),
+    ai: AiConfigSchema.optional(),
+  })
+  .strict();
+export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
+
+function invalidConfigError(configPath: string): Error {
+  return new Error(
+    `AI config is invalid at ${configPath}. Fix the file to match the expected schema or delete it.`,
+  );
+}
+
+function parseConfig(raw: string, configPath: string): LibrettoConfig {
+  try {
+    return LibrettoConfigSchema.parse(JSON.parse(raw));
+  } catch {
+    throw invalidConfigError(configPath);
+  }
+}
+
+export function readLibrettoConfig(
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): LibrettoConfig {
+  if (!existsSync(configPath)) {
+    return { version: CURRENT_CONFIG_VERSION };
+  }
+  return parseConfig(readFileSync(configPath, "utf-8"), configPath);
+}
+
+export function writeLibrettoConfig(
+  config: LibrettoConfig,
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): LibrettoConfig {
+  const parsed = LibrettoConfigSchema.parse(config);
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(parsed, null, 2), "utf-8");
+  return parsed;
+}
+
+export function readAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): AiConfig | null {
+  return readLibrettoConfig(configPath).ai ?? null;
+}

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -75,7 +75,7 @@ function quoteShellArg(value: string): string {
   return JSON.stringify(value);
 }
 
-function formatCommandPrefix(prefix: string[]): string {
+export function formatCommandPrefix(prefix: string[]): string {
   return prefix.map((arg) => quoteShellArg(arg)).join(" ");
 }
 

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -141,7 +141,7 @@ export function runAiConfigure(
   } = {},
 ): void {
   const configureCommandName =
-    options.configureCommandName ?? "libretto-cli snapshot configure";
+    options.configureCommandName ?? "libretto-cli ai configure";
   const configPath = options.configPath ?? LIBRETTO_CONFIG_PATH;
 
   const presetArg = input.preset?.trim();

--- a/packages/libretto-cli/src/core/context.ts
+++ b/packages/libretto-cli/src/core/context.ts
@@ -21,10 +21,6 @@ export const LIBRETTO_DIR = join(REPO_ROOT, ".libretto-cli");
 export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
 export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
 export const PROFILES_DIR = join(LIBRETTO_DIR, "profiles");
-export const SNAPSHOT_ANALYZER_CONFIG_PATH = join(
-  LIBRETTO_DIR,
-  "snapshot-config.json",
-);
 
 const LEGACY_PROFILES_DIR = join(REPO_ROOT, ".playwriter", "profiles");
 if (existsSync(LEGACY_PROFILES_DIR) && !existsSync(PROFILES_DIR)) {

--- a/packages/libretto-cli/src/core/context.ts
+++ b/packages/libretto-cli/src/core/context.ts
@@ -18,6 +18,8 @@ function getRepoRoot(): string {
 export const REPO_ROOT = getRepoRoot();
 export const STATE_DIR = join(REPO_ROOT, "tmp", "libretto-cli");
 export const LIBRETTO_DIR = join(REPO_ROOT, ".libretto-cli");
+export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
+export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
 export const PROFILES_DIR = join(LIBRETTO_DIR, "profiles");
 export const SNAPSHOT_ANALYZER_CONFIG_PATH = join(
   LIBRETTO_DIR,

--- a/packages/libretto-cli/src/core/snapshot-analyzer.ts
+++ b/packages/libretto-cli/src/core/snapshot-analyzer.ts
@@ -231,7 +231,7 @@ async function runExternalCommand(
       if (error.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: ${command}. Configure AI with 'libretto-cli snapshot configure'.`,
+            `Command not found: ${command}. Configure AI with 'libretto-cli ai configure'.`,
           ),
         );
         return;
@@ -579,7 +579,7 @@ export function runSnapshotConfigure(input: {
   customPrefix?: string[];
 }): void {
   runAiConfigure(input, {
-    configureCommandName: "libretto-cli snapshot configure",
+    configureCommandName: "libretto-cli ai configure",
   });
 }
 
@@ -647,7 +647,7 @@ export async function runInterpret(args: InterpretArgs): Promise<void> {
     const llmClientFactory = getLLMClientFactory();
     if (!llmClientFactory) {
       throw new Error(
-        "No snapshot analyzer configured. Run 'libretto-cli snapshot configure codex' (or opencode/claude/gemini). Library integrations can still set a factory via setLLMClientFactory().",
+        "No AI config set. Run 'libretto-cli ai configure codex' (or opencode/claude/gemini). Library integrations can still set a factory via setLLMClientFactory().",
       );
     }
 

--- a/packages/libretto-cli/src/core/snapshot-analyzer.ts
+++ b/packages/libretto-cli/src/core/snapshot-analyzer.ts
@@ -5,17 +5,14 @@ import {
   statSync,
   readdirSync,
   unlinkSync,
-  writeFileSync,
 } from "node:fs";
 import { basename, extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { homedir } from "node:os";
 import { z } from "zod";
+import { type AiConfig, readAiConfig, runAiConfigure } from "./ai-config";
 import {
   getLLMClientFactory,
   getLog,
-  LIBRETTO_DIR,
-  SNAPSHOT_ANALYZER_CONFIG_PATH,
   STATE_DIR,
 } from "./context";
 import { getRunDir, getSessionStateOrThrow } from "./session";
@@ -32,30 +29,6 @@ export type InterpretArgs = {
   context: string;
   pngPath?: string;
   htmlPath?: string;
-};
-
-const SnapshotAnalyzerPresetSchema = z.enum([
-  "codex",
-  "opencode",
-  "claude",
-  "gemini",
-]);
-export type SnapshotAnalyzerPreset = z.infer<typeof SnapshotAnalyzerPresetSchema>;
-
-const SnapshotAnalyzerConfigSchema = z.object({
-  version: z.literal(1),
-  preset: SnapshotAnalyzerPresetSchema,
-  commandPrefix: z.array(z.string()).min(1),
-  updatedAt: z.string(),
-});
-
-type SnapshotAnalyzerConfig = z.infer<typeof SnapshotAnalyzerConfigSchema>;
-
-const SNAPSHOT_ANALYZER_PRESETS: Record<SnapshotAnalyzerPreset, string[]> = {
-  codex: ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only"],
-  opencode: ["opencode", "run", "--format", "json"],
-  claude: [join(homedir(), ".claude", "local", "claude"), "-p"],
-  gemini: ["gemini", "--output-format", "json"],
 };
 
 const InterpretResultSchema = z.object({
@@ -80,10 +53,6 @@ type ExternalCommandResult = {
   stderr: string;
 };
 
-function ensureLibrettoDir(): void {
-  mkdirSync(LIBRETTO_DIR, { recursive: true });
-}
-
 function quoteShellArg(value: string): string {
   if (/^[a-zA-Z0-9_./:@=-]+$/.test(value)) return value;
   return JSON.stringify(value);
@@ -94,9 +63,9 @@ function formatCommandPrefix(prefix: string[]): string {
 }
 
 abstract class UserCodingAgent {
-  protected constructor(protected readonly config: SnapshotAnalyzerConfig) {}
+  protected constructor(protected readonly config: AiConfig) {}
 
-  static resolveFromConfig(config: SnapshotAnalyzerConfig): UserCodingAgent {
+  static resolveFromConfig(config: AiConfig): UserCodingAgent {
     switch (config.preset) {
       case "codex":
         return new CodexUserCodingAgent(config);
@@ -109,16 +78,8 @@ abstract class UserCodingAgent {
     }
   }
 
-  static readConfiguredConfig(): SnapshotAnalyzerConfig | null {
-    if (!existsSync(SNAPSHOT_ANALYZER_CONFIG_PATH)) return null;
-    try {
-      const raw = readFileSync(SNAPSHOT_ANALYZER_CONFIG_PATH, "utf-8");
-      return SnapshotAnalyzerConfigSchema.parse(JSON.parse(raw));
-    } catch {
-      throw new Error(
-        `Snapshot analyzer config is invalid at ${SNAPSHOT_ANALYZER_CONFIG_PATH}. Delete it or run 'libretto-cli snapshot configure --clear'.`,
-      );
-    }
+  static readConfiguredConfig(): AiConfig | null {
+    return readAiConfig();
   }
 
   static getConfigured(): UserCodingAgent | null {
@@ -126,107 +87,14 @@ abstract class UserCodingAgent {
     return config ? this.resolveFromConfig(config) : null;
   }
 
-  static writeConfig(
-    preset: SnapshotAnalyzerPreset,
-    commandPrefix: string[],
-  ): SnapshotAnalyzerConfig {
-    ensureLibrettoDir();
-    const config = SnapshotAnalyzerConfigSchema.parse({
-      version: 1,
-      preset,
-      commandPrefix,
-      updatedAt: new Date().toISOString(),
-    });
-    writeFileSync(
-      SNAPSHOT_ANALYZER_CONFIG_PATH,
-      JSON.stringify(config, null, 2),
-      "utf-8",
-    );
-    return config;
-  }
-
-  static clearConfig(): boolean {
-    if (!existsSync(SNAPSHOT_ANALYZER_CONFIG_PATH)) return false;
-    unlinkSync(SNAPSHOT_ANALYZER_CONFIG_PATH);
-    return true;
-  }
-
-  static printConfig(config: SnapshotAnalyzerConfig): void {
-    console.log(`Snapshot analyzer preset: ${config.preset}`);
-    console.log(`Command prefix: ${formatCommandPrefix(config.commandPrefix)}`);
-    console.log(`Config file: ${SNAPSHOT_ANALYZER_CONFIG_PATH}`);
-    console.log(`Updated at: ${config.updatedAt}`);
-  }
-
-  static printConfigureUsage(): void {
-    console.log(
-      `Usage: libretto-cli snapshot configure <codex|opencode|claude|gemini> [-- <command prefix...>]
-       libretto-cli snapshot configure --show
-       libretto-cli snapshot configure --clear`,
-    );
-  }
-
-  static configureFromArgs(args: string[]): void {
-    if (args.includes("--show")) {
-      const config = this.readConfiguredConfig();
-      if (!config) {
-        console.log(
-          `No snapshot analyzer configured. Run 'libretto-cli snapshot configure codex' to set one.`,
-        );
-        return;
-      }
-      this.printConfig(config);
-      return;
-    }
-
-    if (args.includes("--clear")) {
-      const removed = this.clearConfig();
-      if (removed) {
-        console.log(
-          `Cleared snapshot analyzer config: ${SNAPSHOT_ANALYZER_CONFIG_PATH}`,
-        );
-      } else {
-        console.log("No snapshot analyzer config was set.");
-      }
-      return;
-    }
-
-    const presetArg = args[0];
-    const parsedPreset = SnapshotAnalyzerPresetSchema.safeParse(presetArg);
-    if (!parsedPreset.success) {
-      this.printConfigureUsage();
-      throw new Error(
-        "Missing or invalid preset. Use one of: codex, opencode, claude, gemini.",
-      );
-    }
-
-    const separator = args.indexOf("--");
-    const customPrefix =
-      separator >= 0 ? args.slice(separator + 1).filter(Boolean) : null;
-    if (separator >= 0 && customPrefix && customPrefix.length === 0) {
-      throw new Error("Custom command prefix cannot be empty after '--'.");
-    }
-
-    const preset = parsedPreset.data;
-    const commandPrefix =
-      customPrefix && customPrefix.length > 0
-        ? customPrefix
-        : SNAPSHOT_ANALYZER_PRESETS[preset];
-    const config = this.writeConfig(preset, commandPrefix);
-    console.log("Snapshot analyzer configured.");
-    this.printConfig(config);
-  }
-
-  get snapshotAnalyzerConfig(): SnapshotAnalyzerConfig {
+  get snapshotAnalyzerConfig(): AiConfig {
     return this.config;
   }
 
   protected get command(): string {
     const command = this.config.commandPrefix[0];
     if (!command) {
-      throw new Error(
-        "Snapshot analyzer config is invalid: command prefix is empty.",
-      );
+      throw new Error("AI config is invalid: command prefix is empty.");
     }
     return command;
   }
@@ -363,7 +231,7 @@ async function runExternalCommand(
       if (error.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: ${command}. Configure a different analyzer with 'libretto-cli snapshot configure'.`,
+            `Command not found: ${command}. Configure AI with 'libretto-cli snapshot configure'.`,
           ),
         );
         return;
@@ -705,8 +573,14 @@ function resolveScreenshotPair(
   };
 }
 
-export function runSnapshotConfigure(args: string[]): void {
-  UserCodingAgent.configureFromArgs(args);
+export function runSnapshotConfigure(input: {
+  preset?: string;
+  clear?: boolean;
+  customPrefix?: string[];
+}): void {
+  runAiConfigure(input, {
+    configureCommandName: "libretto-cli snapshot configure",
+  });
 }
 
 export async function runInterpret(args: InterpretArgs): Promise<void> {

--- a/packages/libretto-cli/src/core/snapshot-analyzer.ts
+++ b/packages/libretto-cli/src/core/snapshot-analyzer.ts
@@ -9,7 +9,12 @@ import {
 import { basename, extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { z } from "zod";
-import { type AiConfig, readAiConfig, runAiConfigure } from "./ai-config";
+import {
+  type AiConfig,
+  formatCommandPrefix,
+  readAiConfig,
+  runAiConfigure,
+} from "./ai-config";
 import {
   getLLMClientFactory,
   getLog,
@@ -52,15 +57,6 @@ type ExternalCommandResult = {
   stdout: string;
   stderr: string;
 };
-
-function quoteShellArg(value: string): string {
-  if (/^[a-zA-Z0-9_./:@=-]+$/.test(value)) return value;
-  return JSON.stringify(value);
-}
-
-function formatCommandPrefix(prefix: string[]): string {
-  return prefix.map((arg) => quoteShellArg(arg)).join(" ");
-}
 
 abstract class UserCodingAgent {
   protected constructor(protected readonly config: AiConfig) {}

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -208,14 +208,16 @@ export const test = base.extend<CliFixtures>({
 
   seedSnapshotConfig: async ({ workspacePath }, use) => {
     await use(async (config?: JsonRecord) => {
-      const dir = workspacePath(".libretto-cli");
-      const path = workspacePath(".libretto-cli", "snapshot-config.json");
+      const dir = workspacePath(".libretto");
+      const path = workspacePath(".libretto", "config.json");
       await mkdir(dir, { recursive: true });
       const payload = config ?? {
         version: 1,
-        preset: "codex",
-        commandPrefix: ["codex", "exec"],
-        updatedAt: "2026-01-01T00:00:00.000Z",
+        ai: {
+          preset: "codex",
+          commandPrefix: ["codex", "exec"],
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
       };
       await writeFile(path, JSON.stringify(payload, null, 2), "utf8");
       return path;

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -84,18 +84,18 @@ Add a first-class `ai` command entry point so users configure model behavior in 
 
 Switch snapshot analysis to consume the new shared AI config path and helpers. Behavior should remain functionally the same, with only configuration source and user guidance updated.
 
-- [ ] Replace snapshot-specific config reads in `snapshot-analyzer.ts` with shared AI config resolver calls.
-- [ ] Keep existing analyzer execution adapters (`codex`, `opencode`, `claude`, `gemini`) but source their command prefix from shared AI config.
-- [ ] Update missing-config and command-not-found error strings to point users to `libretto-cli ai configure ...`.
-- [ ] Do not change prompt/schema generation logic for snapshot interpretation in this phase.
-- [ ] Success criteria: snapshot analysis still works when AI config exists and fails with actionable `ai configure` guidance when missing.
+- [x] Replace snapshot-specific config reads in `snapshot-analyzer.ts` with shared AI config resolver calls.
+- [x] Keep existing analyzer execution adapters (`codex`, `opencode`, `claude`, `gemini`) but source their command prefix from shared AI config.
+- [x] Update missing-config and command-not-found error strings to point users to `libretto-cli ai configure ...`.
+- [x] Do not change prompt/schema generation logic for snapshot interpretation in this phase.
+- [x] Success criteria: snapshot analysis still works when AI config exists and fails with actionable `ai configure` guidance when missing.
 
 ### Phase 5: Update tests and docs for new config contract
 
 Finalize the contract by updating automated coverage and user documentation. This phase ensures the new AI config model is validated end-to-end and clearly documented.
 
-- [ ] Update `cli-stateful.test.ts` config tests from snapshot-specific command/path terminology to AI command/path terminology.
-- [ ] Update `test-fixtures.ts` seed helper to write `.libretto/config.json` with the new schema.
-- [ ] Update README section from “snapshot analyzer configuration” to generic “AI configuration”.
-- [ ] Run `pnpm --filter libretto-cli test` and ensure all CLI tests pass with the new config path and messages.
-- [ ] Success criteria: test suite passes and docs/examples consistently reference `.libretto/config.json` and `ai configure`.
+- [x] Update `cli-stateful.test.ts` config tests from snapshot-specific command/path terminology to AI command/path terminology.
+- [x] Update `test-fixtures.ts` seed helper to write `.libretto/config.json` with the new schema.
+- [x] Update README section from “snapshot analyzer configuration” to generic “AI configuration”.
+- [x] Run `pnpm --filter libretto-cli test` and ensure all CLI tests pass with the new config path and messages.
+- [x] Success criteria: test suite passes and docs/examples consistently reference `.libretto/config.json` and `ai configure`.

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -1,0 +1,101 @@
+## Problem overview
+
+The CLI currently stores analyzer configuration in a snapshot-specific file (`.libretto-cli/snapshot-config.json`) and snapshot-specific code paths. That makes it hard to reuse the same model configuration for new commands like `analyze-media`, and it prevents future non-media AI workflows from sharing one stable runtime config.
+
+We need one generic config location and schema that is explicitly AI-focused, not snapshot-focused.
+
+## Solution overview
+
+Introduce a single top-level config file at `.libretto/config.json` with a top-level version and an `ai` section. Move AI analyzer config read/write/show/clear logic behind shared AI config helpers and wire CLI configuration under an `ai` command surface.
+
+Snapshot analysis will consume shared AI config, but this spec only covers AI config extraction and wiring, not broader workflow features.
+
+## Goals
+
+- Store AI model runner configuration in a single generic file: `.libretto/config.json`.
+- Use a top-level `version` field in that config file.
+- Keep all model-runner configuration under an `ai` object.
+- Include `updatedAt` metadata in AI config.
+- Make AI configuration reusable by any command (media and non-media).
+- Provide CLI configuration UX under an AI command surface.
+
+## Non-goals
+
+- No migrations or backfills.
+- No compatibility read path for legacy `.libretto-cli/snapshot-config.json`.
+- No scope/profile system (global AI config only).
+- No changes to prompt design for snapshot or future analyze-media features.
+- No implementation of analyze-media command behavior in this spec.
+
+## Future work
+
+- Add optional per-command overrides (for example, separate model config for specific workflows).
+- Add explicit `ai test` command to validate configured command prefix and JSON output contract.
+- Add richer runtime controls (timeouts, retry policy, JSON mode strictness).
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto-cli/src/core/context.ts` — currently defines `.libretto-cli` paths; must be updated to `.libretto/config.json` constants.
+- `packages/libretto-cli/src/core/snapshot-analyzer.ts` — currently owns snapshot-specific config schema and IO; AI config logic should be extracted from here.
+- `packages/libretto-cli/src/commands/snapshot.ts` — currently exposes `snapshot configure`; should be rewired to shared AI config handlers or alias behavior.
+- `packages/libretto-cli/src/cli.ts` — root usage text and command registration; add/adjust AI command help text.
+- `packages/libretto-cli/src/cli-stateful.test.ts` — stateful config tests must move from snapshot wording/path to AI wording/path.
+- `packages/libretto-cli/src/test-fixtures.ts` — fixture helper currently seeds `snapshot-config.json`; must seed `.libretto/config.json`.
+- `README.md` — user-facing docs currently snapshot-specific; update to generic AI config instructions.
+- [yargs command API](https://yargs.js.org/docs/#api-reference-commandcmd-desc-builder-handler) — reference for adding `ai` command surface cleanly.
+
+## Implementation
+
+### Phase 1: Define shared AI config model and file path
+
+Create the minimal shared config contract and storage location first. This phase establishes a single source of truth for AI settings so later command wiring can remain simple.
+
+- [x] Add new config path constant(s) for `.libretto/config.json` in `core/context.ts`.
+- [x] Add `core/ai-config.ts` to define Zod schema and types for:
+- [x] Top-level config object with `version`.
+- [x] `ai` object containing `preset`, `commandPrefix`, and `updatedAt`.
+- [x] Add read/write helpers that validate schema and return actionable errors for invalid files.
+- [x] Keep schema minimal and global (no profile/scope fields).
+- [x] Success criteria: a unit-style helper test (or stateful CLI seed/load assertion) proves valid config parses and invalid shape throws a clear error that points to `.libretto/config.json`.
+
+### Phase 2: Move configure/show/clear flow to AI config module
+
+Move configuration behavior out of snapshot-specific code and into shared AI handlers. This keeps the command UX consistent while decoupling it from any single feature area.
+
+- [ ] Extract preset defaults and configure argument parsing from `snapshot-analyzer.ts` into shared AI config handlers.
+- [ ] Implement shared operations:
+- [ ] `show`: prints current AI config and file path.
+- [ ] `configure`: writes `ai` section with preset/custom command prefix and fresh `updatedAt`.
+- [ ] `clear`: removes only AI config state (either remove `ai` key or reset file to `{ version }`; choose one behavior and document it).
+- [ ] Ensure all user-facing output is AI terminology (not snapshot terminology).
+- [ ] Success criteria: configure/show/clear output references AI config only, and file writes occur at `.libretto/config.json`.
+
+### Phase 3: Expose AI CLI command surface
+
+Add a first-class `ai` command entry point so users configure model behavior in one obvious place. This phase is focused on discoverable CLI UX, not analyzer internals.
+
+- [ ] Add `ai configure [preset]` command in CLI registration with `--show`, `--clear`, and optional custom prefix via `--` separator.
+- [ ] Update root usage text/examples to show `libretto-cli ai configure ...`.
+- [ ] Keep command behavior deterministic and aligned with existing configure UX semantics.
+- [ ] Decide whether to keep `snapshot configure` as temporary alias in this phase; if kept, ensure help text labels it as compatibility behavior.
+- [ ] Success criteria: `libretto-cli ai configure codex`, `--show`, and `--clear` all run successfully with expected stdout and exit code `0`.
+
+### Phase 4: Rewire snapshot analyzer to shared AI config resolver
+
+Switch snapshot analysis to consume the new shared AI config path and helpers. Behavior should remain functionally the same, with only configuration source and user guidance updated.
+
+- [ ] Replace snapshot-specific config reads in `snapshot-analyzer.ts` with shared AI config resolver calls.
+- [ ] Keep existing analyzer execution adapters (`codex`, `opencode`, `claude`, `gemini`) but source their command prefix from shared AI config.
+- [ ] Update missing-config and command-not-found error strings to point users to `libretto-cli ai configure ...`.
+- [ ] Do not change prompt/schema generation logic for snapshot interpretation in this phase.
+- [ ] Success criteria: snapshot analysis still works when AI config exists and fails with actionable `ai configure` guidance when missing.
+
+### Phase 5: Update tests and docs for new config contract
+
+Finalize the contract by updating automated coverage and user documentation. This phase ensures the new AI config model is validated end-to-end and clearly documented.
+
+- [ ] Update `cli-stateful.test.ts` config tests from snapshot-specific command/path terminology to AI command/path terminology.
+- [ ] Update `test-fixtures.ts` seed helper to write `.libretto/config.json` with the new schema.
+- [ ] Update README section from “snapshot analyzer configuration” to generic “AI configuration”.
+- [ ] Run `pnpm --filter libretto-cli test` and ensure all CLI tests pass with the new config path and messages.
+- [ ] Success criteria: test suite passes and docs/examples consistently reference `.libretto/config.json` and `ai configure`.

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -62,23 +62,23 @@ Create the minimal shared config contract and storage location first. This phase
 
 Move configuration behavior out of snapshot-specific code and into shared AI handlers. This keeps the command UX consistent while decoupling it from any single feature area.
 
-- [ ] Extract preset defaults and configure argument parsing from `snapshot-analyzer.ts` into shared AI config handlers.
-- [ ] Implement shared operations:
-- [ ] `show`: prints current AI config and file path.
-- [ ] `configure`: writes `ai` section with preset/custom command prefix and fresh `updatedAt`.
-- [ ] `clear`: removes only AI config state (either remove `ai` key or reset file to `{ version }`; choose one behavior and document it).
-- [ ] Ensure all user-facing output is AI terminology (not snapshot terminology).
-- [ ] Success criteria: configure/show/clear output references AI config only, and file writes occur at `.libretto/config.json`.
+- [x] Extract preset defaults and configure argument parsing from `snapshot-analyzer.ts` into shared AI config handlers.
+- [x] Implement shared operations:
+- [x] `show`: prints current AI config and file path.
+- [x] `configure`: writes `ai` section with preset/custom command prefix and fresh `updatedAt`.
+- [x] `clear`: removes only AI config state (either remove `ai` key or reset file to `{ version }`; choose one behavior and document it).
+- [x] Ensure all user-facing output is AI terminology (not snapshot terminology).
+- [x] Success criteria: configure/show/clear output references AI config only, and file writes occur at `.libretto/config.json`.
 
 ### Phase 3: Expose AI CLI command surface
 
 Add a first-class `ai` command entry point so users configure model behavior in one obvious place. This phase is focused on discoverable CLI UX, not analyzer internals.
 
-- [ ] Add `ai configure [preset]` command in CLI registration with `--show`, `--clear`, and optional custom prefix via `--` separator.
+- [ ] Add `ai configure [preset]` command in CLI registration with `--clear` and optional custom prefix via `--` separator.
 - [ ] Update root usage text/examples to show `libretto-cli ai configure ...`.
 - [ ] Keep command behavior deterministic and aligned with existing configure UX semantics.
 - [ ] Decide whether to keep `snapshot configure` as temporary alias in this phase; if kept, ensure help text labels it as compatibility behavior.
-- [ ] Success criteria: `libretto-cli ai configure codex`, `--show`, and `--clear` all run successfully with expected stdout and exit code `0`.
+- [ ] Success criteria: `libretto-cli ai configure codex`, bare `libretto-cli ai configure` (show), and `--clear` all run successfully with expected stdout and exit code `0`.
 
 ### Phase 4: Rewire snapshot analyzer to shared AI config resolver
 

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -74,11 +74,11 @@ Move configuration behavior out of snapshot-specific code and into shared AI han
 
 Add a first-class `ai` command entry point so users configure model behavior in one obvious place. This phase is focused on discoverable CLI UX, not analyzer internals.
 
-- [ ] Add `ai configure [preset]` command in CLI registration with `--clear` and optional custom prefix via `--` separator.
-- [ ] Update root usage text/examples to show `libretto-cli ai configure ...`.
-- [ ] Keep command behavior deterministic and aligned with existing configure UX semantics.
-- [ ] Decide whether to keep `snapshot configure` as temporary alias in this phase; if kept, ensure help text labels it as compatibility behavior.
-- [ ] Success criteria: `libretto-cli ai configure codex`, bare `libretto-cli ai configure` (show), and `--clear` all run successfully with expected stdout and exit code `0`.
+- [x] Add `ai configure [preset]` command in CLI registration with `--clear` and optional custom prefix via `--` separator.
+- [x] Update root usage text/examples to show `libretto-cli ai configure ...`.
+- [x] Keep command behavior deterministic and aligned with existing configure UX semantics.
+- [x] Decide whether to keep `snapshot configure` as temporary alias in this phase; if kept, ensure help text labels it as compatibility behavior.
+- [x] Success criteria: `libretto-cli ai configure codex`, bare `libretto-cli ai configure` (show), and `--clear` all run successfully with expected stdout and exit code `0`.
 
 ### Phase 4: Rewire snapshot analyzer to shared AI config resolver
 


### PR DESCRIPTION
## Summary
Introduce a shared AI runtime configuration for `libretto-cli` and migrate snapshot analyzer configuration flow to use it.

## Changes
- Add shared AI config module with schema + read/write helpers at `.libretto/config.json`
- Route snapshot configure behavior through shared AI config handlers
- Add first-class `ai configure [preset]` command
- Keep `snapshot configure` as a compatibility alias
- Update snapshot analyzer error guidance to point to `libretto-cli ai configure`
- Update test fixtures to seed `.libretto/config.json`
- Update README and spec checklist completion for phases 1-5

## Validation
- `pnpm run type-check`
- `pnpm test`
- `pnpm --filter libretto-cli build`
