### PR TITLE
Add Libretto workflow auth profile handling for run

### DIFF
--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -17,4 +17,26 @@ If on a non-main branch where the existing PR is already merged, the uncommitted
 
 Commit the changes. Use gh cli to check if a PR exists for this branch. If no PR exists, create one with an appropriate title and description. If a PR exists, query its current title and description and update them if the new changes warrant it. Push the changes.
 
+### PR body formatting
+
+When the PR body contains Markdown code spans/backticks, parentheses, angle brackets, or shell-sensitive characters, do not pass it directly via `--body "..."` because shells can mangle it.
+
+Use `--body-file` with stdin/heredoc instead:
+
+```bash
+cat <<'EOF' | gh pr create --base main --head <branch> --title "<title>" --body-file -
+## Summary
+- item with `code`
+EOF
+```
+
+Use the same pattern for updates:
+
+```bash
+cat <<'EOF' | gh pr edit <branch-or-number> --body-file -
+## Updated Summary
+- item with `code`
+EOF
+```
+
 For follow-up edits in this session, continue to commit, push, and update the PR as needed.

--- a/.libretto/config.json
+++ b/.libretto/config.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "ai": {
+    "preset": "codex",
+    "commandPrefix": [
+      "codex",
+      "exec",
+      "--skip-git-repo-check",
+      "--sandbox",
+      "read-only"
+    ],
+    "updatedAt": "2026-03-06T04:10:02.651Z"
+  }
+}

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
@@ -71,6 +71,27 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
     expect(result.stderr).toContain("Integration file does not exist:");
+  });
+
+  test("fails run when export is not a Libretto workflow instance", async ({
+    librettoCli,
+    seedSessionPermission,
+    workspacePath,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    await writeFile(
+      workspacePath("integration.ts"),
+      `
+export async function main() {
+  return "ok";
+}
+`,
+      "utf8",
+    );
+
+    const result = await librettoCli("run ./integration.ts main");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("must be a Libretto workflow instance");
   });
 
   test("fails open when deprecated --allow-actions flag is passed", async ({

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
@@ -134,6 +134,69 @@ export const main = workflow(
       "libretto-cli open https://app.example.com --headed --session default",
     );
     expect(result.stderr).toContain("libretto-cli save app.example.com --session default");
+  });
+
+  test("does not require local auth profile when auth metadata is absent", async ({
+    librettoCli,
+    seedSessionPermission,
+    workspacePath,
+  }) => {
+    const librettoEntryUrl = new URL(
+      "../../libretto/dist/index.js",
+      import.meta.url,
+    ).href;
+    await seedSessionPermission("default", "interactive");
+    await writeFile(
+      workspacePath("integration.ts"),
+      `
+import { workflow } from "${librettoEntryUrl}";
+
+export const main = workflow({}, async () => "ok");
+`,
+      "utf8",
+    );
+
+    const result = await librettoCli("run ./integration.ts main", {
+      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toContain("Local auth profile not found for domain");
+  });
+
+  test("proceeds when declared local auth profile file exists", async ({
+    librettoCli,
+    seedSessionPermission,
+    workspacePath,
+  }) => {
+    const librettoEntryUrl = new URL(
+      "../../libretto/dist/index.js",
+      import.meta.url,
+    ).href;
+    await seedSessionPermission("default", "interactive");
+    await writeFile(
+      workspacePath("integration.ts"),
+      `
+import { workflow } from "${librettoEntryUrl}";
+
+export const main = workflow(
+  { authProfile: { type: "local", domain: "app.example.com" } },
+  async () => "ok",
+);
+`,
+      "utf8",
+    );
+    await mkdir(workspacePath(".libretto-cli", "profiles"), { recursive: true });
+    await writeFile(
+      workspacePath(".libretto-cli", "profiles", "app.example.com.json"),
+      JSON.stringify({ cookies: [], origins: [] }),
+      "utf8",
+    );
+
+    const result = await librettoCli("run ./integration.ts main", {
+      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toContain("Local auth profile not found for domain");
   });
 
   test("fails open when deprecated --allow-actions flag is passed", async ({

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -94,13 +94,42 @@ export async function main() {
     expect(result.stderr).toContain("must be a Libretto workflow instance");
   });
 
+  test("accepts branded Libretto workflow contract across module boundaries", async ({
+    librettoCli,
+    seedSessionPermission,
+    workspacePath,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    await writeFile(
+      workspacePath("integration.ts"),
+      `
+const brand = Symbol.for("libretto.workflow");
+
+export const main = {
+  [brand]: true,
+  metadata: {},
+  async run() {
+    return "ok";
+  },
+};
+`,
+      "utf8",
+    );
+
+    const result = await librettoCli("run ./integration.ts main", {
+      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toContain("must be a Libretto workflow instance");
+  });
+
   test("fails run when local auth profile is declared but missing", async ({
     librettoCli,
     seedSessionPermission,
     workspacePath,
   }) => {
     const librettoEntryUrl = new URL(
-      "../../libretto/dist/index.js",
+      "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
     await seedSessionPermission("default", "interactive");
@@ -142,7 +171,7 @@ export const main = workflow(
     workspacePath,
   }) => {
     const librettoEntryUrl = new URL(
-      "../../libretto/dist/index.js",
+      "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
     await seedSessionPermission("default", "interactive");
@@ -169,7 +198,7 @@ export const main = workflow({}, async () => "ok");
     workspacePath,
   }) => {
     const librettoEntryUrl = new URL(
-      "../../libretto/dist/index.js",
+      "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
     await seedSessionPermission("default", "interactive");

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -94,6 +94,48 @@ export async function main() {
     expect(result.stderr).toContain("must be a Libretto workflow instance");
   });
 
+  test("fails run when local auth profile is declared but missing", async ({
+    librettoCli,
+    seedSessionPermission,
+    workspacePath,
+  }) => {
+    const librettoEntryUrl = new URL(
+      "../../libretto/dist/index.js",
+      import.meta.url,
+    ).href;
+    await seedSessionPermission("default", "interactive");
+    await writeFile(
+      workspacePath("integration.ts"),
+      `
+import { workflow } from "${librettoEntryUrl}";
+
+export const main = workflow(
+  { authProfile: { type: "local", domain: "app.example.com" } },
+  async () => {
+    return "ok";
+  },
+);
+`,
+      "utf8",
+    );
+
+    const result = await librettoCli("run ./integration.ts main");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      'Local auth profile not found for domain "app.example.com".',
+    );
+    expect(result.stderr).toContain(
+      "Expected profile file:",
+    );
+    expect(result.stderr).toContain(
+      ".libretto-cli/profiles/app.example.com.json",
+    );
+    expect(result.stderr).toContain(
+      "libretto-cli open https://app.example.com --headed --session default",
+    );
+    expect(result.stderr).toContain("libretto-cli save app.example.com --session default");
+  });
+
   test("fails open when deprecated --allow-actions flag is passed", async ({
     librettoCli,
   }) => {

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -38,7 +38,7 @@ function printUsage(): void {
 Commands:
   open <url> [--headless] Launch browser and open URL (headed by default)
                           Automatically loads saved profile if available
-  run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug <true|false>]  Run an exported async integration function from a file (blocked until interactive)
+  run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug <true|false>]  Run an exported Libretto workflow from a file (blocked until interactive)
   session-mode <read-only|interactive> Set session execution mode
   ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -85,6 +85,8 @@ Available in exec:
 Profiles:
   Profiles are saved to .libretto-cli/profiles/<domain>.json (git-ignored)
   They persist cookies, localStorage, and session data across browser launches.
+  Local profiles are machine-local and are not shared with other users/environments.
+  Sessions can expire; if run fails auth, log in again and re-save the profile.
 
 Sessions:
   Session state is stored in tmp/libretto-cli/<session>.json

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -235,6 +235,22 @@ function resolveWorkflowStorageStatePath(workflow: LibrettoWorkflow): string | u
   return resolveLocalAuthProfilePath(authProfile.domain);
 }
 
+function getMissingLocalAuthProfileError(args: {
+  domain: string;
+  profilePath: string;
+  session: string;
+}): string {
+  const normalizedDomain = normalizeDomain(args.domain);
+  return [
+    `Local auth profile not found for domain "${normalizedDomain}".`,
+    `Expected profile file: ${args.profilePath}`,
+    "To create it:",
+    `  1. libretto-cli open https://${normalizedDomain} --headed --session ${args.session}`,
+    "  2. Log in manually in the browser window.",
+    `  3. libretto-cli save ${normalizedDomain} --session ${args.session}`,
+  ].join("\n");
+}
+
 async function runIntegrationFromFile(args: {
   integrationPath: string;
   exportName: string;
@@ -290,7 +306,17 @@ async function runIntegrationFromFile(args: {
     session: args.session,
   });
   const workflow = targetExport;
+  const authProfile = workflow.metadata.authProfile;
   const storageStatePath = resolveWorkflowStorageStatePath(workflow);
+  if (authProfile?.type === "local" && storageStatePath && !existsSync(storageStatePath)) {
+    throw new Error(
+      getMissingLocalAuthProfileError({
+        domain: authProfile.domain,
+        profilePath: storageStatePath,
+        session: args.session,
+      }),
+    );
+  }
   const browserSession = await launchBrowser({
     sessionName: args.session,
     headless: args.headless,

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -4,11 +4,20 @@ import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Argv } from "yargs";
-import type { Browser, BrowserContext, Page } from "playwright";
 import { installInstrumentation } from "libretto/instrumentation";
 import { setDebugMode } from "libretto/config";
 import { launchBrowser } from "libretto/run";
-import { connect, disconnectBrowser } from "../core/browser";
+import {
+  LibrettoWorkflow,
+  type LibrettoAuthProfile,
+  type LibrettoWorkflowContext,
+} from "libretto";
+import {
+  connect,
+  disconnectBrowser,
+  getProfilePath,
+  normalizeDomain,
+} from "../core/browser";
 import { getLog } from "../core/context";
 import {
   getSessionPermissionMode,
@@ -214,24 +223,16 @@ async function runExec(
   }
 }
 
-type ExportedIntegrationFunction = (
-  ctx: {
-    logger: unknown;
-    page: Page;
-    context: BrowserContext;
-    browser: Browser;
-    session: string;
-    integrationPath: string;
-    exportName: string;
-    headless: boolean;
-  },
-  input: unknown,
-) => Promise<unknown>;
+function resolveLocalAuthProfilePath(domain: string): string {
+  return getProfilePath(normalizeDomain(domain));
+}
 
-function isExportedIntegrationFunction(
-  value: unknown,
-): value is ExportedIntegrationFunction {
-  return typeof value === "function";
+function resolveWorkflowStorageStatePath(workflow: LibrettoWorkflow): string | undefined {
+  const authProfile: LibrettoAuthProfile | undefined = workflow.metadata.authProfile;
+  if (authProfile?.type !== "local") {
+    return undefined;
+  }
+  return resolveLocalAuthProfilePath(authProfile.domain);
 }
 
 async function runIntegrationFromFile(args: {
@@ -273,9 +274,9 @@ async function runIntegrationFromFile(args: {
     );
   }
 
-  if (!isExportedIntegrationFunction(targetExport)) {
+  if (!(targetExport instanceof LibrettoWorkflow)) {
     throw new Error(
-      `Export "${args.exportName}" in ${absolutePath} must be an async function with signature (ctx, input).`,
+      `Export "${args.exportName}" in ${absolutePath} must be a Libretto workflow instance. Use workflow(...) from "libretto".`,
     );
   }
 
@@ -288,25 +289,27 @@ async function runIntegrationFromFile(args: {
     integrationExport: args.exportName,
     session: args.session,
   });
+  const workflow = targetExport;
+  const storageStatePath = resolveWorkflowStorageStatePath(workflow);
   const browserSession = await launchBrowser({
     sessionName: args.session,
     headless: args.headless,
+    storageStatePath,
   });
 
+  const workflowContext: LibrettoWorkflowContext = {
+    logger: integrationLogger,
+    page: browserSession.page,
+    context: browserSession.context,
+    browser: browserSession.browser,
+    session: args.session,
+    integrationPath: absolutePath,
+    exportName: args.exportName,
+    headless: args.headless,
+  };
+
   try {
-    await targetExport(
-      {
-        logger: integrationLogger,
-        page: browserSession.page,
-        context: browserSession.context,
-        browser: browserSession.browser,
-        session: args.session,
-        integrationPath: absolutePath,
-        exportName: args.exportName,
-        headless: args.headless,
-      },
-      args.params ?? {},
-    );
+    await workflow.run(workflowContext, args.params ?? {});
     console.log("Integration completed.");
   } finally {
     await browserSession.close();
@@ -346,7 +349,7 @@ export function registerExecutionCommands(yargs: Argv): Argv {
     )
     .command(
       "run [integrationFile] [integrationExport]",
-      "Run an exported async integration function from a file",
+      "Run an exported Libretto workflow from a file",
       (cmd) =>
         cmd
           .option("params", { type: "string" })

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -8,7 +8,6 @@ import { installInstrumentation } from "libretto/instrumentation";
 import { setDebugMode } from "libretto/config";
 import { launchBrowser } from "libretto/run";
 import {
-  LibrettoWorkflow,
   type LibrettoAuthProfile,
   type LibrettoWorkflowContext,
 } from "libretto";
@@ -32,6 +31,7 @@ import {
 } from "../core/telemetry";
 
 type ExecFunction = (...args: unknown[]) => Promise<unknown>;
+const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
 type StripTypeScriptTypesFn = (
   code: string,
@@ -227,8 +227,26 @@ function resolveLocalAuthProfilePath(domain: string): string {
   return getProfilePath(normalizeDomain(domain));
 }
 
-function resolveWorkflowStorageStatePath(workflow: LibrettoWorkflow): string | undefined {
-  const authProfile: LibrettoAuthProfile | undefined = workflow.metadata.authProfile;
+type LoadedLibrettoWorkflow = {
+  metadata: {
+    authProfile?: LibrettoAuthProfile;
+  };
+  run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
+};
+
+function isLoadedLibrettoWorkflow(value: unknown): value is LoadedLibrettoWorkflow {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<PropertyKey, unknown>;
+  return (
+    candidate[LIBRETTO_WORKFLOW_BRAND] === true &&
+    typeof candidate.run === "function" &&
+    !!candidate.metadata &&
+    typeof candidate.metadata === "object"
+  );
+}
+
+function resolveWorkflowStorageStatePath(workflow: LoadedLibrettoWorkflow): string | undefined {
+  const authProfile = workflow.metadata.authProfile;
   if (authProfile?.type !== "local") {
     return undefined;
   }
@@ -290,7 +308,7 @@ async function runIntegrationFromFile(args: {
     );
   }
 
-  if (!(targetExport instanceof LibrettoWorkflow)) {
+  if (!isLoadedLibrettoWorkflow(targetExport)) {
     throw new Error(
       `Export "${args.exportName}" in ${absolutePath} must be a Libretto workflow instance. Use workflow(...) from "libretto".`,
     );

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -608,11 +608,6 @@ await new Promise(() => {});
   let childSpawnError: Error | null = null;
   let childEarlyExit: { code: number | null; signal: NodeJS.Signals | null } | null =
     null;
-  const readChildSpawnError = (): Error | null => childSpawnError;
-  const readChildEarlyExit = (): {
-    code: number | null;
-    signal: NodeJS.Signals | null;
-  } | null => childEarlyExit;
 
   child.on("error", (err) => {
     childSpawnError = err;
@@ -635,8 +630,8 @@ await new Promise(() => {});
   const cdpStartupTimeoutMs = cdpPollIntervalMs * cdpMaxAttempts;
 
   for (let i = 0; i < cdpMaxAttempts; i++) {
-    const spawnError = readChildSpawnError();
-    if (spawnError) {
+    const spawnError = childSpawnError as Error | null;
+    if (spawnError !== null) {
       const errWithCode = spawnError as Error & { code?: string };
       const hint =
         errWithCode.code === "ENOENT"
@@ -647,8 +642,11 @@ await new Promise(() => {});
       );
     }
 
-    const earlyExit = readChildEarlyExit();
-    if (earlyExit) {
+    const earlyExit = childEarlyExit as {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    } | null;
+    if (earlyExit !== null) {
       const status = earlyExit.code ?? earlyExit.signal ?? "unknown";
       throw new Error(
         `Browser child process exited before startup (status: ${status}). Check logs: ${runLogPath}`,

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -608,6 +608,11 @@ await new Promise(() => {});
   let childSpawnError: Error | null = null;
   let childEarlyExit: { code: number | null; signal: NodeJS.Signals | null } | null =
     null;
+  const readChildSpawnError = (): Error | null => childSpawnError;
+  const readChildEarlyExit = (): {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  } | null => childEarlyExit;
 
   child.on("error", (err) => {
     childSpawnError = err;
@@ -630,19 +635,21 @@ await new Promise(() => {});
   const cdpStartupTimeoutMs = cdpPollIntervalMs * cdpMaxAttempts;
 
   for (let i = 0; i < cdpMaxAttempts; i++) {
-    if (childSpawnError) {
-      const errWithCode = childSpawnError as Error & { code?: string };
+    const spawnError = readChildSpawnError();
+    if (spawnError) {
+      const errWithCode = spawnError as Error & { code?: string };
       const hint =
         errWithCode.code === "ENOENT"
           ? " Ensure Node.js is available in PATH for child processes."
           : "";
       throw new Error(
-        `Failed to launch browser child process: ${childSpawnError.message}.${hint} Check logs: ${runLogPath}`,
+        `Failed to launch browser child process: ${spawnError.message}.${hint} Check logs: ${runLogPath}`,
       );
     }
 
-    if (childEarlyExit) {
-      const status = childEarlyExit.code ?? childEarlyExit.signal ?? "unknown";
+    const earlyExit = readChildEarlyExit();
+    if (earlyExit) {
+      const status = earlyExit.code ?? earlyExit.signal ?? "unknown";
       throw new Error(
         `Browser child process exited before startup (status: ${status}). Check logs: ${runLogPath}`,
       );

--- a/packages/libretto-cli/tsconfig.json
+++ b/packages/libretto-cli/tsconfig.json
@@ -10,11 +10,12 @@
 		"sourceMap": true,
 		"outDir": "./dist",
 		"baseUrl": ".",
-		"paths": {
-			"libretto/logger": ["../libretto/src/logger/index.ts"],
-			"libretto/llm": ["../libretto/src/llm/index.ts"],
-			"libretto/instrumentation": ["../libretto/src/instrumentation/index.ts"],
-			"libretto/config": ["../libretto/src/config/index.ts"],
+	"paths": {
+		"libretto": ["../libretto/src/index.ts"],
+		"libretto/logger": ["../libretto/src/logger/index.ts"],
+		"libretto/llm": ["../libretto/src/llm/index.ts"],
+		"libretto/instrumentation": ["../libretto/src/instrumentation/index.ts"],
+		"libretto/config": ["../libretto/src/config/index.ts"],
 			"libretto/run": ["../libretto/src/run/api.ts"]
 		}
 	},

--- a/packages/libretto-cli/vitest.config.ts
+++ b/packages/libretto-cli/vitest.config.ts
@@ -1,6 +1,32 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^libretto$/, replacement: resolve(__dirname, "../libretto/src/index.ts") },
+      {
+        find: /^libretto\/logger$/,
+        replacement: resolve(__dirname, "../libretto/src/logger/index.ts"),
+      },
+      {
+        find: /^libretto\/llm$/,
+        replacement: resolve(__dirname, "../libretto/src/llm/index.ts"),
+      },
+      {
+        find: /^libretto\/instrumentation$/,
+        replacement: resolve(__dirname, "../libretto/src/instrumentation/index.ts"),
+      },
+      {
+        find: /^libretto\/config$/,
+        replacement: resolve(__dirname, "../libretto/src/config/index.ts"),
+      },
+      {
+        find: /^libretto\/run$/,
+        replacement: resolve(__dirname, "../libretto/src/run/api.ts"),
+      },
+    ],
+  },
   test: {
     name: "libretto-cli",
     environment: "node",

--- a/packages/libretto/skills/libretto-network-skill/SKILL.md
+++ b/packages/libretto/skills/libretto-network-skill/SKILL.md
@@ -290,7 +290,12 @@ These can surface at any point — the first endpoint you try or the fifteenth. 
 
 The browser stays open indefinitely until explicitly closed with `npx libretto close` or by the user closing the window. **Do not** set any timeouts, auto-close timers, or call `close` until the user says the workflow session is done. Ensure that you open the browser in `--headed` mode so the user can see what's happening.
 
-**Do NOT ask the user about saved login sessions.** Do not ask if they have a saved session or if they need to log in. Always open the page in `--headed` mode and let the user log in manually in the browser window. Do not use `npx libretto save` during workflow creation.
+If the site requires login, ask the user how auth should work in the generated workflow:
+
+1. Save a local profile (recommended for local runs): open in `--headed`, have the user log in manually, run `npx libretto save <domain>`, and generate workflow metadata with `authProfile: { type: "local", domain: "<hostname>" }`.
+2. Use user-managed credential logic in Playwright code (no local profile dependency).
+
+If local profile is chosen, include this warning in your generated workflow guidance: local profiles are machine-local (other users/environments will not have them), and sessions can expire so re-login/re-save may be required.
 
 ### Integration Approaches
 

--- a/packages/libretto/skills/original-skill/SKILL.md
+++ b/packages/libretto/skills/original-skill/SKILL.md
@@ -263,7 +263,12 @@ Use Libretto CLI interactively to build a brand new workflow file from scratch. 
 
 The browser stays open indefinitely until explicitly closed with `libretto-cli close` or by the user closing the window. **Do not** set any timeouts, auto-close timers, or call `close` until the user says the workflow session is done. Ensure that you open the browser in `--headed` mode so the user can see what's happening.
 
-**Do NOT ask the user about saved login sessions.** Do not ask if they have a saved session or if they need to log in. Always open the page in `--headed` mode and let the user log in manually in the browser window. Do not use `libretto-cli save` during workflow creation.
+If the site requires login, ask the user how auth should work in the generated workflow:
+
+1. Save a local profile (recommended for local runs): open in `--headed`, have the user log in manually, run `libretto-cli save <domain>`, and generate workflow metadata with `authProfile: { type: "local", domain: "<hostname>" }`.
+2. Use user-managed credential logic in Playwright code (no local profile dependency).
+
+If local profile is chosen, include this warning in your generated workflow guidance: local profiles are machine-local (other users/environments will not have them), and sessions can expire so re-login/re-save may be required.
 
 ### Choosing Between Playwright and Network Requests
 

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -99,6 +99,7 @@ export {
 // Workflow helpers
 export {
 	LibrettoWorkflow,
+	LIBRETTO_WORKFLOW_BRAND,
 	workflow,
 	type LibrettoAuthProfile,
 	type LibrettoWorkflowMetadata,

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -95,3 +95,13 @@ export {
 	type LaunchBrowserArgs,
 	type BrowserSession,
 } from "./run/api.js";
+
+// Workflow helpers
+export {
+	LibrettoWorkflow,
+	workflow,
+	type LibrettoAuthProfile,
+	type LibrettoWorkflowMetadata,
+	type LibrettoWorkflowContext,
+	type LibrettoWorkflowHandler,
+} from "./workflow/workflow.js";

--- a/packages/libretto/src/run/browser.ts
+++ b/packages/libretto/src/run/browser.ts
@@ -23,6 +23,7 @@ export type LaunchBrowserArgs = {
   sessionName: string;
   headless?: boolean;
   viewport?: { width: number; height: number };
+  storageStatePath?: string;
 };
 
 export type BrowserSession = {
@@ -38,6 +39,7 @@ export async function launchBrowser({
   sessionName,
   headless = false,
   viewport = { width: 1366, height: 768 },
+  storageStatePath,
 }: LaunchBrowserArgs): Promise<BrowserSession> {
   const debugPort = await pickFreePort();
   const browser = await chromium.launch({
@@ -49,7 +51,10 @@ export async function launchBrowser({
     ],
   });
 
-  const context = await browser.newContext({ viewport });
+  const context = await browser.newContext({
+    viewport,
+    ...(storageStatePath ? { storageState: storageStatePath } : {}),
+  });
   const page = await context.newPage();
   page.setDefaultTimeout(30_000);
   page.setDefaultNavigationTimeout(45_000);

--- a/packages/libretto/src/workflow/workflow.ts
+++ b/packages/libretto/src/workflow/workflow.ts
@@ -1,5 +1,7 @@
 import type { Browser, BrowserContext, Page } from "playwright";
 
+export const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
+
 export type LibrettoAuthProfile = {
 	type: "local";
 	domain: string;
@@ -26,6 +28,7 @@ export type LibrettoWorkflowHandler<Input = unknown, Output = unknown> = (
 ) => Promise<Output>;
 
 export class LibrettoWorkflow<Input = unknown, Output = unknown> {
+	public readonly [LIBRETTO_WORKFLOW_BRAND] = true;
 	public readonly metadata: LibrettoWorkflowMetadata;
 	private readonly handler: LibrettoWorkflowHandler<Input, Output>;
 
@@ -38,7 +41,7 @@ export class LibrettoWorkflow<Input = unknown, Output = unknown> {
 	}
 
 	async run(ctx: LibrettoWorkflowContext, input: Input): Promise<Output> {
-		return await this.handler(ctx, input);
+		return this.handler(ctx, input);
 	}
 }
 

--- a/packages/libretto/src/workflow/workflow.ts
+++ b/packages/libretto/src/workflow/workflow.ts
@@ -1,0 +1,50 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+
+export type LibrettoAuthProfile = {
+	type: "local";
+	domain: string;
+};
+
+export type LibrettoWorkflowMetadata = {
+	authProfile?: LibrettoAuthProfile;
+};
+
+export type LibrettoWorkflowContext = {
+	logger: unknown;
+	page: Page;
+	context: BrowserContext;
+	browser: Browser;
+	session: string;
+	integrationPath: string;
+	exportName: string;
+	headless: boolean;
+};
+
+export type LibrettoWorkflowHandler<Input = unknown, Output = unknown> = (
+	ctx: LibrettoWorkflowContext,
+	input: Input,
+) => Promise<Output>;
+
+export class LibrettoWorkflow<Input = unknown, Output = unknown> {
+	public readonly metadata: LibrettoWorkflowMetadata;
+	private readonly handler: LibrettoWorkflowHandler<Input, Output>;
+
+	constructor(
+		metadata: LibrettoWorkflowMetadata,
+		handler: LibrettoWorkflowHandler<Input, Output>,
+	) {
+		this.metadata = metadata;
+		this.handler = handler;
+	}
+
+	async run(ctx: LibrettoWorkflowContext, input: Input): Promise<Output> {
+		return await this.handler(ctx, input);
+	}
+}
+
+export function workflow<Input = unknown, Output = unknown>(
+	metadata: LibrettoWorkflowMetadata,
+	handler: LibrettoWorkflowHandler<Input, Output>,
+): LibrettoWorkflow<Input, Output> {
+	return new LibrettoWorkflow(metadata, handler);
+}

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -69,7 +69,7 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 
 ### Phase 4: End-to-end verification and docs alignment
 
-- [ ] Add/adjust tests for: metadata present + missing profile error, metadata absent default behavior, and storageState handoff path.
-- [ ] Run `pnpm --filter libretto-cli test`.
-- [ ] Run `pnpm --filter libretto-cli type-check` and `pnpm --filter libretto type-check`.
-- [ ] Success criteria: all listed test/type-check commands pass and spec changes are reflected in relevant usage docs.
+- [x] Add/adjust tests for: metadata present + missing profile error, metadata absent default behavior, and storageState handoff path.
+- [x] Run `pnpm --filter libretto-cli test`.
+- [x] Run `pnpm --filter libretto-cli type-check` and `pnpm --filter libretto type-check`.
+- [x] Success criteria: all listed test/type-check commands pass and spec changes are reflected in relevant usage docs.

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -62,10 +62,10 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 
 ### Phase 3: Authoring and prompt guidance updates
 
-- [ ] Update integration generation/prompt guidance to ask for auth handling when login is required.
-- [ ] Replace current guidance that forbids discussing saved sessions; instruct agents to offer local profile saving when appropriate.
-- [ ] Require warning text in generated workflow guidance: local profiles are machine-local and may expire, requiring re-login.
-- [ ] Success criteria: skill docs and CLI/help text include the new local-profile warning and no longer conflict with the runtime behavior.
+- [x] Update integration generation/prompt guidance to ask for auth handling when login is required.
+- [x] Replace current guidance that forbids discussing saved sessions; instruct agents to offer local profile saving when appropriate.
+- [x] Require warning text in generated workflow guidance: local profiles are machine-local and may expire, requiring re-login.
+- [x] Success criteria: skill docs and CLI/help text include the new local-profile warning and no longer conflict with the runtime behavior.
 
 ### Phase 4: End-to-end verification and docs alignment
 

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -55,10 +55,10 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 
 ### Phase 2: Enforce fail-fast runtime behavior for declared local auth
 
-- [ ] In `run`, when `authProfile.type === "local"` is declared, verify the corresponding profile file exists before launching the browser.
-- [ ] Return a clear error that includes the expected profile path and next action (`open` -> manual login -> `save`).
-- [ ] Keep behavior unchanged for integrations with no `authProfile` metadata.
-- [ ] Success criteria: subprocess CLI test with interactive session permission and an integration that declares local auth fails before browser launch when profile file is missing, with deterministic error text.
+- [x] In `run`, when `authProfile.type === "local"` is declared, verify the corresponding profile file exists before launching the browser.
+- [x] Return a clear error that includes the expected profile path and next action (`open` -> manual login -> `save`).
+- [x] Keep behavior unchanged for integrations with no `authProfile` metadata.
+- [x] Success criteria: subprocess CLI test with interactive session permission and an integration that declares local auth fails before browser launch when profile file is missing, with deterministic error text.
 
 ### Phase 3: Authoring and prompt guidance updates
 

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -1,0 +1,75 @@
+## Problem overview
+
+Integration creation can involve a manual login during browser exploration, but `libretto run` currently launches a fresh browser context that does not reuse the saved login profile. This causes integrations that worked during setup to fail at runtime due to missing authenticated state.
+
+## Solution overview
+
+Add an explicit `LibrettoWorkflow` class to carry integration metadata and run logic together, with `authProfile.type = "local"` support in v1. When `libretto run` executes a `LibrettoWorkflow` that declares a local auth profile domain, it resolves `.libretto-cli/profiles/<hostname>.json` and loads it as Playwright `storageState` before creating the browser context. If the profile is declared but missing, fail fast with an actionable error.
+
+## Goals
+
+- Integrations can declare `authProfile` metadata with `type: "local"` and `domain` through a typed `LibrettoWorkflow` export.
+- `libretto run` automatically loads `.libretto-cli/profiles/<domain>.json` when local auth metadata is present.
+- Runtime fails early with a clear error when declared local auth profile data is unavailable.
+- Authoring/generation guidance prompts for auth handling and records local auth metadata when a saved profile is chosen.
+- User-facing guidance clearly warns that local profiles are machine-local and may expire/re-authenticate.
+
+## Non-goals
+
+- No migrations or backfills.
+- No support for optional auth profiles (`required` flag).
+- No multi-account profile keying beyond hostname domain in v1.
+- No integration with external credential managers in this spec.
+- No `authProfile.type = "cloud"` implementation in this spec.
+
+## Future work
+
+- Add `authProfile.type = "cloud"` backed by Libretto Cloud / Kernel auth.
+- Add multi-account profile aliases for multiple identities on the same hostname.
+- Add tooling to refresh/validate stale local profiles proactively.
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto-cli/src/commands/execution.ts` - `run` command/module loading path; add auth metadata resolution and fail-fast behavior.
+- `packages/libretto/src/run/browser.ts` - browser context creation; accept optional `storageState` input so runtime can preload auth state.
+- `packages/libretto/src/run/api.ts` - export surface for updated browser launch args.
+- `packages/libretto/src/index.ts` - export workflow/auth metadata helper if introduced for integration authoring ergonomics.
+- `packages/libretto-cli/src/core/context.ts` - source of `.libretto-cli/profiles` location and path conventions.
+- `packages/libretto-cli/src/cli.ts` - usage/help text updates for `run` auth profile behavior.
+- `packages/libretto-cli/src/cli-basic.test.ts` - subprocess-level guard and usage behavior assertions.
+- `packages/libretto-cli/src/test-fixtures.ts` - fixture helpers for creating integration/profile files in isolated workspaces.
+- `packages/libretto/skills/libretto-network-skill/SKILL.md` - update auth prompt guidance during workflow creation.
+- `packages/libretto/skills/original-skill/SKILL.md` - keep legacy skill variant aligned with new auth flow.
+
+## Implementation
+
+### Phase 1: Add local auth profile contract and loader plumbing
+
+- [ ] Add a `LibrettoWorkflow` class that stores `{ authProfile?: { type: "local"; domain: string } }` metadata and a `run(ctx, input)` handler.
+- [ ] Add/extend a `workflow(meta, fn)` helper that returns a `LibrettoWorkflow` instance.
+- [ ] Update `libretto run` loader to require that the selected export is a `LibrettoWorkflow` instance.
+- [ ] Read auth metadata only from the `LibrettoWorkflow` instance.
+- [ ] Extend `launchBrowser` args to accept optional `storageStatePath` and pass it to `browser.newContext({ storageState })` when provided.
+- [ ] Ensure domain normalization uses hostname (e.g., `app.example.com`) and maps to `.libretto-cli/profiles/<domain>.json`.
+- [ ] Success criteria: focused tests confirm (1) the resolver maps declared domain metadata to the expected profile path and (2) `run` returns a clear error when the export is not a `LibrettoWorkflow` instance.
+
+### Phase 2: Enforce fail-fast runtime behavior for declared local auth
+
+- [ ] In `run`, when `authProfile.type === "local"` is declared, verify the corresponding profile file exists before launching the browser.
+- [ ] Return a clear error that includes the expected profile path and next action (`open` -> manual login -> `save`).
+- [ ] Keep behavior unchanged for integrations with no `authProfile` metadata.
+- [ ] Success criteria: subprocess CLI test with interactive session permission and an integration that declares local auth fails before browser launch when profile file is missing, with deterministic error text.
+
+### Phase 3: Authoring and prompt guidance updates
+
+- [ ] Update integration generation/prompt guidance to ask for auth handling when login is required.
+- [ ] Replace current guidance that forbids discussing saved sessions; instruct agents to offer local profile saving when appropriate.
+- [ ] Require warning text in generated workflow guidance: local profiles are machine-local and may expire, requiring re-login.
+- [ ] Success criteria: skill docs and CLI/help text include the new local-profile warning and no longer conflict with the runtime behavior.
+
+### Phase 4: End-to-end verification and docs alignment
+
+- [ ] Add/adjust tests for: metadata present + missing profile error, metadata absent default behavior, and storageState handoff path.
+- [ ] Run `pnpm --filter libretto-cli test`.
+- [ ] Run `pnpm --filter libretto-cli type-check` and `pnpm --filter libretto type-check`.
+- [ ] Success criteria: all listed test/type-check commands pass and spec changes are reflected in relevant usage docs.

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -45,13 +45,13 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 
 ### Phase 1: Add local auth profile contract and loader plumbing
 
-- [ ] Add a `LibrettoWorkflow` class that stores `{ authProfile?: { type: "local"; domain: string } }` metadata and a `run(ctx, input)` handler.
-- [ ] Add/extend a `workflow(meta, fn)` helper that returns a `LibrettoWorkflow` instance.
-- [ ] Update `libretto run` loader to require that the selected export is a `LibrettoWorkflow` instance.
-- [ ] Read auth metadata only from the `LibrettoWorkflow` instance.
-- [ ] Extend `launchBrowser` args to accept optional `storageStatePath` and pass it to `browser.newContext({ storageState })` when provided.
-- [ ] Ensure domain normalization uses hostname (e.g., `app.example.com`) and maps to `.libretto-cli/profiles/<domain>.json`.
-- [ ] Success criteria: focused tests confirm (1) the resolver maps declared domain metadata to the expected profile path and (2) `run` returns a clear error when the export is not a `LibrettoWorkflow` instance.
+- [x] Add a `LibrettoWorkflow` class that stores `{ authProfile?: { type: "local"; domain: string } }` metadata and a `run(ctx, input)` handler.
+- [x] Add/extend a `workflow(meta, fn)` helper that returns a `LibrettoWorkflow` instance.
+- [x] Update `libretto run` loader to require that the selected export is a `LibrettoWorkflow` instance.
+- [x] Read auth metadata only from the `LibrettoWorkflow` instance.
+- [x] Extend `launchBrowser` args to accept optional `storageStatePath` and pass it to `browser.newContext({ storageState })` when provided.
+- [x] Ensure domain normalization uses hostname (e.g., `app.example.com`) and maps to `.libretto-cli/profiles/<domain>.json`.
+- [x] Success criteria: subprocess tests confirm `run` returns a clear error when the export is not a Libretto workflow instance, and type checks pass for the new workflow + storage-state plumbing.
 
 ### Phase 2: Enforce fail-fast runtime behavior for declared local auth
 


### PR DESCRIPTION
## Summary
- add a typed `LibrettoWorkflow` + `workflow(...)` helper and require `libretto run` exports to use it
- plumb optional Playwright `storageState` into browser launch and map local auth domains to `.libretto-cli/profiles/<domain>.json`
- fail fast when a declared local auth profile is missing with actionable `open -> login -> save` guidance
- update CLI/help and integration skills to include local-profile machine-local + expiry warnings
- update spec progress and CLI subprocess tests for missing/non-missing auth-profile runtime paths

## Testing
- `pnpm run type-check`
- `pnpm test`
- `pnpm --filter libretto-cli build`
- `pnpm --filter libretto-cli test -- src/cli-basic.test.ts`
