### PR TITLE
feat: centralize libretto-cli state under .libretto

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ There are two ways to configure it:
 Configure an external coding agent — no API keys needed in libretto, the agent handles its own authentication:
 
 ```bash
-# Use one of: codex, opencode, claude, gemini
+# Use one of: codex, claude, gemini
 libretto-cli ai configure codex
-libretto-cli ai configure opencode
 libretto-cli ai configure claude
 libretto-cli ai configure gemini
 
@@ -57,9 +56,6 @@ libretto-cli ai configure
 
 # Clear configuration
 libretto-cli ai configure --clear
-
-# Compatibility alias (still supported)
-libretto-cli snapshot configure codex
 ```
 
 ### Option 2: Built-in LLM client via environment variables

--- a/packages/libretto-cli/TESTING.md
+++ b/packages/libretto-cli/TESTING.md
@@ -12,7 +12,7 @@ This package runs CLI tests with Vitest as subprocess-based black-box checks.
 
 - Shared fixture helpers live in `src/test-fixtures.ts`.
 - Every test gets a unique temp workspace directory under the OS temp directory.
-- Seed helpers write `.libretto` and legacy `.libretto-cli` state inside the temp workspace only.
+- Seed helpers write `.libretto` state inside the temp workspace only.
 - `librettoCli` executes the built CLI with subprocess `cwd` set to the temp workspace.
 
 ## Guardrails

--- a/packages/libretto-cli/TESTING.md
+++ b/packages/libretto-cli/TESTING.md
@@ -12,7 +12,7 @@ This package runs CLI tests with Vitest as subprocess-based black-box checks.
 
 - Shared fixture helpers live in `src/test-fixtures.ts`.
 - Every test gets a unique temp workspace directory under the OS temp directory.
-- Seed helpers write `.libretto-cli` and `tmp/libretto-cli` state inside the temp workspace only.
+- Seed helpers write `.libretto` and legacy `.libretto-cli` state inside the temp workspace only.
 - `librettoCli` executes the built CLI with subprocess `cwd` set to the temp workspace.
 
 ## Guardrails

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -174,7 +174,7 @@ export const main = workflow(
       "Expected profile file:",
     );
     expect(result.stderr).toContain(
-      ".libretto-cli/profiles/app.example.com.json",
+      ".libretto/profiles/app.example.com.json",
     );
     expect(result.stderr).toContain(
       "libretto-cli open https://app.example.com --headed --session default",
@@ -231,9 +231,9 @@ export const main = workflow(
 `,
       "utf8",
     );
-    await mkdir(workspacePath(".libretto-cli", "profiles"), { recursive: true });
+    await mkdir(workspacePath(".libretto", "profiles"), { recursive: true });
     await writeFile(
-      workspacePath(".libretto-cli", "profiles", "app.example.com.json"),
+      workspacePath(".libretto", "profiles", "app.example.com.json"),
       JSON.stringify({ cookies: [], origins: [] }),
       "utf8",
     );
@@ -275,11 +275,15 @@ export const main = workflow(
 
     const raw = JSON.parse(
       await readFile(
-        workspacePath(".libretto-cli", "session-permissions.json"),
+        workspacePath(".libretto", "config.json"),
         "utf8",
       ),
-    ) as { sessions?: Record<string, string> };
-    expect(raw.sessions?.consented).toBe("interactive");
+    ) as {
+      permissions?: {
+        sessions?: Record<string, string>;
+      };
+    };
+    expect(raw.permissions?.sessions?.consented).toBe("interactive");
   });
 
   test("session-mode read-only removes interactive permission", async ({
@@ -293,11 +297,15 @@ export const main = workflow(
 
     const raw = JSON.parse(
       await readFile(
-        workspacePath(".libretto-cli", "session-permissions.json"),
+        workspacePath(".libretto", "config.json"),
         "utf8",
       ),
-    ) as { sessions?: Record<string, string> };
-    expect(raw.sessions?.toggled).toBeUndefined();
+    ) as {
+      permissions?: {
+        sessions?: Record<string, string>;
+      };
+    };
+    expect(raw.permissions?.sessions?.toggled).toBeUndefined();
   });
 
   test("fails session-mode with invalid mode", async ({ librettoCli }) => {

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
@@ -8,6 +9,22 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
     expect(result.stderr).toBe("");
+  });
+
+  test("bootstraps .libretto state on --help without creating legacy dirs", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const result = await librettoCli("--help");
+    expect(result.exitCode).toBe(0);
+
+    expect(existsSync(workspacePath(".libretto"))).toBe(true);
+    expect(existsSync(workspacePath(".libretto", ".gitignore"))).toBe(true);
+    expect(existsSync(workspacePath(".libretto", "sessions"))).toBe(true);
+    expect(existsSync(workspacePath(".libretto", "profiles"))).toBe(true);
+
+    expect(existsSync(workspacePath(".libretto-cli"))).toBe(false);
+    expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(false);
   });
 
   test("prints usage for help command", async ({ librettoCli }) => {

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -66,18 +66,6 @@ describe("state-driven CLI subprocess behavior", () => {
     ]);
   });
 
-  test("supports snapshot configure as a compatibility alias", async ({
-    librettoCli,
-    workspacePath,
-  }) => {
-    const configure = await librettoCli("snapshot configure codex");
-    expect(configure.exitCode).toBe(0);
-    expect(configure.stdout).toContain("AI config saved.");
-
-    const configPath = workspacePath(".libretto", "config.json");
-    expect(existsSync(configPath)).toBe(true);
-  });
-
   test("reads and clears network logs from seeded run data", async ({
     seedSessionState,
     seedNetworkLog,
@@ -88,7 +76,7 @@ describe("state-driven CLI subprocess behavior", () => {
       session: "net-session",
       runId: "run-net",
     });
-    const logPath = await seedNetworkLog("run-net", [
+    const logPath = await seedNetworkLog("net-session", [
       {
         ts: "2026-01-01T00:00:00.000Z",
         method: "GET",
@@ -123,7 +111,9 @@ describe("state-driven CLI subprocess behavior", () => {
 
     const cleared = await readFile(logPath, "utf8");
     expect(cleared).toBe("");
-    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-net", "network.jsonl"))).toBe(true);
+    expect(
+      existsSync(workspacePath(".libretto", "sessions", "net-session", "network.jsonl")),
+    ).toBe(true);
   });
 
   test("reads and clears action logs from seeded run data", async ({
@@ -136,7 +126,7 @@ describe("state-driven CLI subprocess behavior", () => {
       session: "actions-session",
       runId: "run-actions",
     });
-    const logPath = await seedActionLog("run-actions", [
+    const logPath = await seedActionLog("actions-session", [
       {
         ts: "2026-01-01T00:00:00.000Z",
         action: "click",
@@ -169,7 +159,11 @@ describe("state-driven CLI subprocess behavior", () => {
 
     const cleared = await readFile(logPath, "utf8");
     expect(cleared).toBe("");
-    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-actions", "actions.jsonl"))).toBe(true);
+    expect(
+      existsSync(
+        workspacePath(".libretto", "sessions", "actions-session", "actions.jsonl"),
+      ),
+    ).toBe(true);
   });
 
   test("blocks exec in read-only open sessions", async ({

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -81,7 +81,7 @@ Available in exec:
   page, context, state, browser, networkLog, actionLog
 
 Profiles:
-  Profiles are saved to .libretto-cli/profiles/<domain>.json (git-ignored)
+  Profiles are saved to .libretto/profiles/<domain>.json (git-ignored)
   They persist cookies, localStorage, and session data across browser launches.
   Local profiles are machine-local and are not shared with other users/environments.
   Sessions can expire; if run fails auth, log in again and re-save the profile.

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -7,7 +7,13 @@ import { registerBrowserCommands } from "./commands/browser";
 import { registerExecutionCommands } from "./commands/execution";
 import { registerLogCommands } from "./commands/logs";
 import { registerSnapshotCommands } from "./commands/snapshot";
-import { flushLog, getLog, setLogFile, STATE_DIR } from "./core/context";
+import {
+  ensureLibrettoSetup,
+  flushLog,
+  getLog,
+  setLogFile,
+  STATE_DIR,
+} from "./core/context";
 import {
   getStateFilePath,
   logFileForRun,
@@ -195,16 +201,14 @@ function createParser(): Argv {
 
 export async function runLibrettoCLI(): Promise<void> {
   const rawArgs = process.argv.slice(2);
-  initializeLogger(rawArgs);
-  const log = getLog();
+  ensureLibrettoSetup();
+  let loggerInitialized = false;
 
   try {
     validateLegacySessionArg(rawArgs);
 
     const args = filterSessionArgs(rawArgs);
     const command = args[0];
-
-    log.info("cli-command", { command, args });
 
     if (!command || command === "--help" || command === "-h" || command === "help") {
       printUsage();
@@ -219,14 +223,21 @@ export async function runLibrettoCLI(): Promise<void> {
       process.exit(1);
     }
 
+    initializeLogger(rawArgs);
+    loggerInitialized = true;
+    const log = getLog();
     const parser = createParser();
+    log.info("cli-command", { command, args });
     await parser.parseAsync();
 
     await flushLog();
     process.exit(0);
   } catch (err) {
-    log.error("cli-error", { error: err, args: rawArgs });
-    await flushLog();
+    if (loggerInitialized) {
+      const log = getLog();
+      log.error("cli-error", { error: err, args: rawArgs });
+      await flushLog();
+    }
     const message = err instanceof Error ? err.message : String(err);
     console.error(message);
     process.exit(1);

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -1,5 +1,3 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import yargs, { type Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
 import { registerAICommands } from "./commands/ai";
@@ -12,14 +10,11 @@ import {
   flushLog,
   getLog,
   setLogFile,
-  STATE_DIR,
 } from "./core/context";
 import {
-  getStateFilePath,
-  logFileForRun,
+  logFileForSession,
   SESSION_DEFAULT,
   validateSessionName,
-  type SessionState,
 } from "./core/session";
 
 const CLI_COMMANDS = new Set([
@@ -50,7 +45,6 @@ Commands:
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)
   exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until interactive)
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when both flags are provided
-  snapshot configure [preset] [-- <command prefix...>]  Compatibility alias for ai configure
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
   close                   Close the browser
@@ -71,11 +65,9 @@ Examples:
   libretto-cli exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
   libretto-cli exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
   libretto-cli ai configure codex
-  libretto-cli ai configure opencode
   libretto-cli ai configure claude
   libretto-cli ai configure gemini
-  libretto-cli ai configure codex -- codex exec --skip-git-repo-check --sandbox read-only
-  libretto-cli snapshot configure codex   # compatibility alias
+  libretto-cli ai configure <codex|claude|gemini> -- <command prefix...>
   libretto-cli snapshot
   libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
   libretto-cli close
@@ -93,7 +85,8 @@ Profiles:
   They persist cookies, localStorage, and session data across browser launches.
 
 Sessions:
-  Session state is stored in tmp/libretto-cli/<session>.json
+  Session state is stored in .libretto/sessions/<session>/state.json
+  CLI logs are stored in .libretto/sessions/<session>/logs.jsonl
   Each session runs an isolated browser instance on a dynamic port.
 `);
 }
@@ -139,30 +132,13 @@ function validateLegacySessionArg(rawArgs: string[]): void {
 
 function initializeLogger(rawArgs: string[]): void {
   const sessionForLog = parseSessionForLog(rawArgs);
-
-  const runIdForLog = (() => {
-    try {
-      const stateFile = getStateFilePath(sessionForLog);
-      if (existsSync(stateFile)) {
-        const state = JSON.parse(readFileSync(stateFile, "utf-8")) as SessionState;
-        if (state?.runId) return state.runId;
-      }
-    } catch {}
-    return null;
-  })();
-
-  const logFilePath = (() => {
-    if (runIdForLog) return logFileForRun(runIdForLog);
-    mkdirSync(STATE_DIR, { recursive: true });
-    return join(STATE_DIR, "cli.log");
-  })();
+  const logFilePath = logFileForSession(sessionForLog);
 
   setLogFile(logFilePath);
   getLog().info("cli-start", {
     args: rawArgs,
     cwd: process.cwd(),
     session: sessionForLog,
-    runId: runIdForLog,
   });
 }
 
@@ -202,7 +178,8 @@ function createParser(): Argv {
 export async function runLibrettoCLI(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   ensureLibrettoSetup();
-  let loggerInitialized = false;
+  initializeLogger(rawArgs);
+  const log = getLog();
 
   try {
     validateLegacySessionArg(rawArgs);
@@ -223,9 +200,6 @@ export async function runLibrettoCLI(): Promise<void> {
       process.exit(1);
     }
 
-    initializeLogger(rawArgs);
-    loggerInitialized = true;
-    const log = getLog();
     const parser = createParser();
     log.info("cli-command", { command, args });
     await parser.parseAsync();
@@ -233,11 +207,8 @@ export async function runLibrettoCLI(): Promise<void> {
     await flushLog();
     process.exit(0);
   } catch (err) {
-    if (loggerInitialized) {
-      const log = getLog();
-      log.error("cli-error", { error: err, args: rawArgs });
-      await flushLog();
-    }
+    log.error("cli-error", { error: err, args: rawArgs });
+    await flushLog();
     const message = err instanceof Error ? err.message : String(err);
     console.error(message);
     process.exit(1);

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -12,7 +12,7 @@ import { connect, disconnectBrowser } from "../core/browser";
 import { getLog } from "../core/context";
 import {
   getSessionPermissionMode,
-  getSessionStateOrThrow,
+  readSessionStateOrThrow,
   readOnlySessionError,
   resolveSessionMode,
 } from "../core/session";
@@ -103,7 +103,7 @@ async function runExec(
   visualize = false,
 ): Promise<void> {
   const log = getLog();
-  const sessionState = getSessionStateOrThrow(session);
+  const sessionState = readSessionStateOrThrow(session);
   const mode = resolveSessionMode(session, sessionState);
   if (mode !== "interactive") {
     throw new Error(readOnlySessionError(session));
@@ -147,7 +147,7 @@ async function runExec(
   };
   process.on("SIGINT", sigintHandler);
 
-  wrapPageForActionLogging(page, sessionState.runId, onActivity);
+  wrapPageForActionLogging(page, session, onActivity);
 
   if (visualize) {
     await installInstrumentation(page, { visualize: true, logger: log });

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -2,10 +2,7 @@ import { mkdirSync } from "node:fs";
 import type { Argv } from "yargs";
 import { connect, disconnectBrowser } from "../core/browser";
 import { getLog, getSessionSnapshotRunDir } from "../core/context";
-import {
-  generateRunId,
-  assertSessionStateExistsOrThrow,
-} from "../core/session";
+import { generateRunId } from "../core/session";
 import {
   canAnalyzeSnapshots,
   runInterpret,
@@ -15,7 +12,6 @@ import {
 async function captureScreenshot(session: string): Promise<ScreenshotPair> {
   const log = getLog();
   log.info("screenshot-start", { session });
-  assertSessionStateExistsOrThrow(session);
   const snapshotRunId = `snapshot-${generateRunId()}-${Math.random()
     .toString(36)
     .slice(2, 8)}`;

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -1,37 +1,33 @@
 import { mkdirSync } from "node:fs";
 import type { Argv } from "yargs";
 import { connect, disconnectBrowser } from "../core/browser";
-import { getLog } from "../core/context";
-import { getRunDir, getSessionStateOrThrow } from "../core/session";
+import { getLog, getSessionSnapshotRunDir } from "../core/context";
+import {
+  generateRunId,
+  assertSessionStateExistsOrThrow,
+} from "../core/session";
 import {
   canAnalyzeSnapshots,
   runInterpret,
-  runSnapshotConfigure,
   type ScreenshotPair,
 } from "../core/snapshot-analyzer";
 
 async function captureScreenshot(session: string): Promise<ScreenshotPair> {
   const log = getLog();
   log.info("screenshot-start", { session });
-  const state = getSessionStateOrThrow(session);
-  const runDir = getRunDir(state.runId);
-  mkdirSync(runDir, { recursive: true });
+  assertSessionStateExistsOrThrow(session);
+  const snapshotRunId = `snapshot-${generateRunId()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  const snapshotRunDir = getSessionSnapshotRunDir(session, snapshotRunId);
+  mkdirSync(snapshotRunDir, { recursive: true });
   const { browser, page } = await connect(session);
 
   try {
     const title = await page.title();
     const pageUrl = page.url();
-    const sanitizedTitle = title
-      .replace(/[^a-zA-Z0-9\s-]/g, "")
-      .replace(/\s+/g, "-")
-      .toLowerCase()
-      .slice(0, 50);
-
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const baseName = `${sanitizedTitle}-${timestamp}`;
-
-    const pngPath = `${runDir}/${baseName}.png`;
-    const htmlPath = `${runDir}/${baseName}.html`;
+    const pngPath = `${snapshotRunDir}/page.png`;
+    const htmlPath = `${snapshotRunDir}/page.html`;
 
     await page.screenshot({ path: pngPath });
 
@@ -45,8 +41,9 @@ async function captureScreenshot(session: string): Promise<ScreenshotPair> {
       title,
       pngPath,
       htmlPath,
+      snapshotRunId,
     });
-    return { pngPath, htmlPath, baseName };
+    return { pngPath, htmlPath, baseName: snapshotRunId };
   } catch (err) {
     let pageAlive = false;
     let browserConnected = false;
@@ -99,7 +96,7 @@ async function runSnapshot(
 
   if (!canAnalyzeSnapshots()) {
     throw new Error(
-      "Couldn't run analysis: no AI config set. Run 'libretto-cli ai configure codex' (or opencode/claude/gemini) to enable analysis.",
+      "Couldn't run analysis: no AI config set. Run 'libretto-cli ai configure codex' (or claude/gemini) to enable analysis.",
     );
   }
 
@@ -113,35 +110,19 @@ async function runSnapshot(
 }
 
 export function registerSnapshotCommands(yargs: Argv): Argv {
-  return yargs
-    .command(
-      "snapshot",
-      "Capture PNG + HTML; analyze when objective/context provided",
-      (cmd) =>
-        cmd
-          .option("objective", { type: "string" })
-          .option("context", { type: "string" }),
-      async (argv) => {
-        await runSnapshot(
-          String(argv.session),
-          argv.objective as string | undefined,
-          argv.context as string | undefined,
-        );
-      },
-    )
-    .command(
-      "snapshot configure [preset]",
-      "Configure AI runtime (compatibility alias for 'ai configure')",
-      (cmd) => cmd.option("clear", { type: "boolean", default: false }),
-      (argv) => {
-        const customPrefix = Array.isArray(argv["--"])
-          ? (argv["--"] as string[])
-          : [];
-        runSnapshotConfigure({
-          clear: Boolean(argv.clear),
-          preset: argv.preset as string | undefined,
-          customPrefix,
-        });
-      },
-    );
+  return yargs.command(
+    "snapshot",
+    "Capture PNG + HTML; analyze when objective/context provided",
+    (cmd) =>
+      cmd
+        .option("objective", { type: "string" })
+        .option("context", { type: "string" }),
+    async (argv) => {
+      await runSnapshot(
+        String(argv.session),
+        argv.objective as string | undefined,
+        argv.context as string | undefined,
+      );
+    },
+  );
 }

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -31,10 +31,18 @@ export const AiConfigSchema = z
   .strict();
 export type AiConfig = z.infer<typeof AiConfigSchema>;
 
+const SessionModeSchema = z.enum(["read-only", "interactive"]);
+const SessionPermissionsSchema = z
+  .object({
+    sessions: z.record(SessionModeSchema),
+  })
+  .strict();
+
 export const LibrettoConfigSchema = z
   .object({
     version: z.literal(CURRENT_CONFIG_VERSION),
     ai: AiConfigSchema.optional(),
+    permissions: SessionPermissionsSchema.optional(),
   })
   .strict();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
@@ -120,6 +128,7 @@ export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolea
   writeLibrettoConfig(
     {
       version: librettoConfig.version,
+      permissions: librettoConfig.permissions,
     },
     configPath,
   );

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -1,21 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import { cwd } from "node:process";
 import { z } from "zod";
-
-function getRepoRoot(): string {
-  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
-    encoding: "utf-8",
-  });
-  if (result.status === 0 && result.stdout) {
-    return result.stdout.trim();
-  }
-  return cwd();
-}
-
-const LIBRETTO_CONFIG_PATH = join(getRepoRoot(), ".libretto", "config.json");
+import { LIBRETTO_CONFIG_PATH } from "./context";
 
 export const CURRENT_CONFIG_VERSION = 1;
 

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -19,7 +19,7 @@ const LIBRETTO_CONFIG_PATH = join(getRepoRoot(), ".libretto", "config.json");
 
 export const CURRENT_CONFIG_VERSION = 1;
 
-export const AiPresetSchema = z.enum(["codex", "opencode", "claude", "gemini"]);
+export const AiPresetSchema = z.enum(["codex", "claude", "gemini"]);
 export type AiPreset = z.infer<typeof AiPresetSchema>;
 
 export const AiConfigSchema = z
@@ -41,7 +41,6 @@ export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
 
 export const AI_CONFIG_PRESETS: Record<AiPreset, string[]> = {
   codex: ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only"],
-  opencode: ["opencode", "run", "--format", "json"],
   claude: [join(homedir(), ".claude", "local", "claude"), "-p"],
   gemini: ["gemini", "--output-format", "json"],
 };
@@ -136,7 +135,7 @@ function printAiConfig(config: AiConfig, configPath: string): void {
 
 function printConfigureUsage(commandName: string): void {
   console.log(
-    `Usage: ${commandName} <codex|opencode|claude|gemini> [-- <command prefix...>]
+    `Usage: ${commandName} <codex|claude|gemini> [-- <command prefix...>]
        ${commandName}
        ${commandName} --clear`,
   );
@@ -184,7 +183,7 @@ export function runAiConfigure(
   if (!parsedPreset.success) {
     printConfigureUsage(configureCommandName);
     throw new Error(
-      "Missing or invalid preset. Use one of: codex, opencode, claude, gemini.",
+      "Missing or invalid preset. Use one of: codex, claude, gemini.",
     );
   }
 

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -1,8 +1,21 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
+import { cwd } from "node:process";
 import { z } from "zod";
-import { LIBRETTO_CONFIG_PATH } from "./context";
+
+function getRepoRoot(): string {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+  });
+  if (result.status === 0 && result.stdout) {
+    return result.stdout.trim();
+  }
+  return cwd();
+}
+
+const LIBRETTO_CONFIG_PATH = join(getRepoRoot(), ".libretto", "config.json");
 
 export const CURRENT_CONFIG_VERSION = 1;
 

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -1,6 +1,6 @@
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { openSync, existsSync, writeFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createServer } from "node:net";
 import { spawn } from "node:child_process";
 import {
@@ -769,6 +769,7 @@ export async function runSave(urlOrDomain: string, session: string): Promise<voi
 
     const state = { cookies, origins };
     const fs = await import("node:fs/promises");
+    await fs.mkdir(dirname(profilePath), { recursive: true });
     await fs.writeFile(profilePath, JSON.stringify(state, null, 2));
 
     log.info("save-success", {

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -3,14 +3,20 @@ import { openSync, existsSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { createServer } from "node:net";
 import { spawn } from "node:child_process";
-import { getLog, PROFILES_DIR, REPO_ROOT, setLogFile } from "./context";
+import {
+  getLog,
+  getSessionActionsLogPath,
+  getSessionNetworkLogPath,
+  PROFILES_DIR,
+  REPO_ROOT,
+  setLogFile,
+} from "./context";
 import {
   clearSessionState,
   generateRunId,
   getSessionPermissionMode,
-  getRunDir,
-  getSessionStateOrThrow,
-  logFileForRun,
+  readSessionStateOrThrow,
+  logFileForSession,
   readSessionState,
   writeSessionState,
 } from "./session";
@@ -128,7 +134,7 @@ export async function connect(
 }> {
   const log = getLog();
   log.info("connect", { session, timeoutMs });
-  const state = getSessionStateOrThrow(session);
+  const state = readSessionStateOrThrow(session);
   const browser = await tryConnectToPort(state.port, timeoutMs);
   if (!browser) {
     log.error("connect-no-browser", {
@@ -229,7 +235,9 @@ export async function runOpen(
 
   const port = await pickFreePort();
   const runId = generateRunId();
-  const runLogPath = logFileForRun(runId);
+  const runLogPath = logFileForSession(session);
+  const networkLogPath = getSessionNetworkLogPath(session);
+  const actionsLogPath = getSessionActionsLogPath(session);
 
   setLogFile(runLogPath);
   log = getLog();
@@ -267,14 +275,20 @@ export async function runOpen(
     : "";
 
   const escapedLogPath = runLogPath.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+  const escapedNetworkLogPath = networkLogPath
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'");
+  const escapedActionsLogPath = actionsLogPath
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'");
 
   const launcherCode = `
 import { chromium } from 'playwright';
 import { appendFileSync, mkdirSync } from 'node:fs';
 
 const LOG_FILE = '${escapedLogPath}';
-const NETWORK_LOG = '${escapedLogPath}'.replace('session.log', 'network.jsonl');
-const ACTIONS_LOG = NETWORK_LOG.replace('network.jsonl', 'actions.jsonl');
+const NETWORK_LOG = '${escapedNetworkLogPath}';
+const ACTIONS_LOG = '${escapedActionsLogPath}';
 mkdirSync(NETWORK_LOG.replace(/\\/[^\\/]+$/, ''), { recursive: true });
 
 const STATIC_EXT_RE = /\\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\\?|$)/i;

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -630,19 +630,24 @@ await new Promise(() => {});
   const cdpStartupTimeoutMs = cdpPollIntervalMs * cdpMaxAttempts;
 
   for (let i = 0; i < cdpMaxAttempts; i++) {
-    if (childSpawnError) {
-      const errWithCode = childSpawnError as Error & { code?: string };
+    const spawnError = childSpawnError as (Error & { code?: string }) | null;
+    if (spawnError) {
+      const errWithCode = spawnError;
       const hint =
         errWithCode.code === "ENOENT"
           ? " Ensure Node.js is available in PATH for child processes."
           : "";
       throw new Error(
-        `Failed to launch browser child process: ${childSpawnError.message}.${hint} Check logs: ${runLogPath}`,
+        `Failed to launch browser child process: ${spawnError.message}.${hint} Check logs: ${runLogPath}`,
       );
     }
 
-    if (childEarlyExit) {
-      const status = childEarlyExit.code ?? childEarlyExit.signal ?? "unknown";
+    const earlyExit = childEarlyExit as {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    } | null;
+    if (earlyExit) {
+      const status = earlyExit.code ?? earlyExit.signal ?? "unknown";
       throw new Error(
         `Browser child process exited before startup (status: ${status}). Check logs: ${runLogPath}`,
       );

--- a/packages/libretto-cli/src/core/context.ts
+++ b/packages/libretto-cli/src/core/context.ts
@@ -2,7 +2,7 @@ import { Logger, createFileLogSink } from "libretto/logger";
 import type { LLMClient } from "libretto/llm";
 import { spawnSync } from "node:child_process";
 import { cwd } from "node:process";
-import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 function getRepoRoot(): string {
@@ -21,17 +21,56 @@ export const LIBRETTO_DIR = join(REPO_ROOT, ".libretto-cli");
 export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
 export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
 export const PROFILES_DIR = join(LIBRETTO_DIR, "profiles");
+export const LIBRETTO_SESSIONS_DIR = join(LIBRETTO_CONFIG_DIR, "sessions");
+export const LIBRETTO_PROFILES_DIR = join(LIBRETTO_CONFIG_DIR, "profiles");
+export const LIBRETTO_GITIGNORE_PATH = join(LIBRETTO_CONFIG_DIR, ".gitignore");
 
-const LEGACY_PROFILES_DIR = join(REPO_ROOT, ".playwriter", "profiles");
-if (existsSync(LEGACY_PROFILES_DIR) && !existsSync(PROFILES_DIR)) {
-  mkdirSync(LIBRETTO_DIR, { recursive: true });
-  renameSync(LEGACY_PROFILES_DIR, PROFILES_DIR);
+const LIBRETTO_GITIGNORE_CONTENT = [
+  "# Local libretto runtime state",
+  "*",
+  "!.gitignore",
+  "",
+].join("\n");
+
+export function getSessionDir(session: string): string {
+  return join(LIBRETTO_SESSIONS_DIR, session);
 }
 
-const LEGACY_BT_PROFILES_DIR = join(REPO_ROOT, ".browser-tap", "profiles");
-if (existsSync(LEGACY_BT_PROFILES_DIR) && !existsSync(PROFILES_DIR)) {
-  mkdirSync(LIBRETTO_DIR, { recursive: true });
-  renameSync(LEGACY_BT_PROFILES_DIR, PROFILES_DIR);
+export function getSessionStatePath(session: string): string {
+  return join(getSessionDir(session), "state.json");
+}
+
+export function getSessionLogsPath(session: string): string {
+  return join(getSessionDir(session), "logs.jsonl");
+}
+
+export function getSessionNetworkLogPath(session: string): string {
+  return join(getSessionDir(session), "network.jsonl");
+}
+
+export function getSessionActionsLogPath(session: string): string {
+  return join(getSessionDir(session), "actions.jsonl");
+}
+
+export function getSessionSnapshotsDir(session: string): string {
+  return join(getSessionDir(session), "snapshots");
+}
+
+export function getSessionSnapshotRunDir(
+  session: string,
+  snapshotRunId: string,
+): string {
+  return join(getSessionSnapshotsDir(session), snapshotRunId);
+}
+
+export function ensureLibrettoSetup(): void {
+  mkdirSync(LIBRETTO_CONFIG_DIR, { recursive: true });
+  mkdirSync(LIBRETTO_SESSIONS_DIR, { recursive: true });
+  mkdirSync(LIBRETTO_PROFILES_DIR, { recursive: true });
+
+  if (!existsSync(LIBRETTO_GITIGNORE_PATH)) {
+    writeFileSync(LIBRETTO_GITIGNORE_PATH, LIBRETTO_GITIGNORE_CONTENT, "utf-8");
+  }
 }
 
 let log: Logger | null = null;
@@ -42,6 +81,7 @@ export function setLogFile(filePath: string): void {
 
 export function ensureLog(): void {
   if (log) return;
+  ensureLibrettoSetup();
   mkdirSync(STATE_DIR, { recursive: true });
   setLogFile(join(STATE_DIR, "cli.log"));
 }

--- a/packages/libretto-cli/src/core/context.ts
+++ b/packages/libretto-cli/src/core/context.ts
@@ -16,12 +16,10 @@ function getRepoRoot(): string {
 }
 
 export const REPO_ROOT = getRepoRoot();
-export const LIBRETTO_DIR = join(REPO_ROOT, ".libretto-cli");
 export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
 export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
-export const PROFILES_DIR = join(LIBRETTO_DIR, "profiles");
+export const PROFILES_DIR = join(LIBRETTO_CONFIG_DIR, "profiles");
 export const LIBRETTO_SESSIONS_DIR = join(LIBRETTO_CONFIG_DIR, "sessions");
-export const LIBRETTO_PROFILES_DIR = join(LIBRETTO_CONFIG_DIR, "profiles");
 export const LIBRETTO_GITIGNORE_PATH = join(LIBRETTO_CONFIG_DIR, ".gitignore");
 
 const LIBRETTO_GITIGNORE_CONTENT = [
@@ -65,7 +63,7 @@ export function getSessionSnapshotRunDir(
 export function ensureLibrettoSetup(): void {
   mkdirSync(LIBRETTO_CONFIG_DIR, { recursive: true });
   mkdirSync(LIBRETTO_SESSIONS_DIR, { recursive: true });
-  mkdirSync(LIBRETTO_PROFILES_DIR, { recursive: true });
+  mkdirSync(PROFILES_DIR, { recursive: true });
 
   if (!existsSync(LIBRETTO_GITIGNORE_PATH)) {
     writeFileSync(LIBRETTO_GITIGNORE_PATH, LIBRETTO_GITIGNORE_CONTENT, "utf-8");

--- a/packages/libretto-cli/src/core/context.ts
+++ b/packages/libretto-cli/src/core/context.ts
@@ -16,7 +16,6 @@ function getRepoRoot(): string {
 }
 
 export const REPO_ROOT = getRepoRoot();
-export const STATE_DIR = join(REPO_ROOT, "tmp", "libretto-cli");
 export const LIBRETTO_DIR = join(REPO_ROOT, ".libretto-cli");
 export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
 export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
@@ -27,8 +26,8 @@ export const LIBRETTO_GITIGNORE_PATH = join(LIBRETTO_CONFIG_DIR, ".gitignore");
 
 const LIBRETTO_GITIGNORE_CONTENT = [
   "# Local libretto runtime state",
-  "*",
-  "!.gitignore",
+  "sessions/",
+  "profiles/",
   "",
 ].join("\n");
 
@@ -79,16 +78,13 @@ export function setLogFile(filePath: string): void {
   log = new Logger(["libretto-cli"], [createFileLogSink({ filePath })]);
 }
 
-export function ensureLog(): void {
-  if (log) return;
-  ensureLibrettoSetup();
-  mkdirSync(STATE_DIR, { recursive: true });
-  setLogFile(join(STATE_DIR, "cli.log"));
-}
-
 export function getLog(): Logger {
-  ensureLog();
-  return log as Logger;
+  if (!log) {
+    throw new Error(
+      "Logger is not initialized. Call setLogFile(...) before calling getLog().",
+    );
+  }
+  return log;
 }
 
 export async function flushLog(): Promise<void> {

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -6,18 +6,17 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
 import {
   getLog,
   getSessionDir,
   getSessionLogsPath,
   getSessionStatePath,
-  LIBRETTO_DIR,
+  LIBRETTO_CONFIG_DIR,
+  LIBRETTO_CONFIG_PATH,
   LIBRETTO_SESSIONS_DIR,
 } from "./context";
 
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
-const SESSION_PERMISSIONS_PATH = join(LIBRETTO_DIR, "session-permissions.json");
 
 export const SESSION_DEFAULT = "default";
 export const SESSION_DEV_SERVER = "dev-server";
@@ -34,7 +33,6 @@ export type SessionState = {
 };
 
 type SessionPermissions = {
-  version: 1;
   sessions: Record<string, SessionMode>;
 };
 
@@ -169,7 +167,7 @@ export function clearSessionState(session: string): void {
 }
 
 function ensureLibrettoDir(): void {
-  mkdirSync(LIBRETTO_DIR, { recursive: true });
+  mkdirSync(LIBRETTO_CONFIG_DIR, { recursive: true });
 }
 
 function isSessionMode(value: unknown): value is SessionMode {
@@ -177,27 +175,41 @@ function isSessionMode(value: unknown): value is SessionMode {
 }
 
 export function readSessionPermissions(): SessionPermissions {
-  if (!existsSync(SESSION_PERMISSIONS_PATH)) {
-    return { version: 1, sessions: {} };
+  if (!existsSync(LIBRETTO_CONFIG_PATH)) {
+    return { sessions: {} };
   }
 
   try {
-    const raw = JSON.parse(
-      readFileSync(SESSION_PERMISSIONS_PATH, "utf-8"),
+    const rawConfig = JSON.parse(
+      readFileSync(LIBRETTO_CONFIG_PATH, "utf-8"),
     ) as Record<string, unknown>;
 
-    if (raw.version !== 1) {
+    if (rawConfig.version !== 1) {
       throw new Error("unsupported version");
     }
+
+    const rawPermissions = rawConfig.permissions;
+    if (rawPermissions === undefined) {
+      return { sessions: {} };
+    }
     if (
-      typeof raw.sessions !== "object" ||
-      raw.sessions === null ||
-      Array.isArray(raw.sessions)
+      typeof rawPermissions !== "object" ||
+      rawPermissions === null ||
+      Array.isArray(rawPermissions)
+    ) {
+      throw new Error("permissions must be an object");
+    }
+
+    const typedPermissions = rawPermissions as Record<string, unknown>;
+    if (
+      typeof typedPermissions.sessions !== "object" ||
+      typedPermissions.sessions === null ||
+      Array.isArray(typedPermissions.sessions)
     ) {
       throw new Error("sessions must be an object");
     }
 
-    const sessions = raw.sessions as Record<string, unknown>;
+    const sessions = typedPermissions.sessions as Record<string, unknown>;
     const normalized: Record<string, SessionMode> = {};
     for (const [session, mode] of Object.entries(sessions)) {
       if (!isSessionMode(mode)) {
@@ -206,19 +218,49 @@ export function readSessionPermissions(): SessionPermissions {
       normalized[session] = mode;
     }
 
-    return { version: 1, sessions: normalized };
+    return { sessions: normalized };
   } catch {
     throw new Error(
-      `Session permissions are invalid at ${SESSION_PERMISSIONS_PATH}.`,
+      `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
     );
   }
 }
 
 export function writeSessionPermissions(permissions: SessionPermissions): void {
   ensureLibrettoDir();
+  let rawConfig: Record<string, unknown> = { version: 1 };
+
+  if (existsSync(LIBRETTO_CONFIG_PATH)) {
+    try {
+      const parsed = JSON.parse(
+        readFileSync(LIBRETTO_CONFIG_PATH, "utf-8"),
+      ) as Record<string, unknown>;
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error("config must be an object");
+      }
+      rawConfig = parsed;
+    } catch {
+      throw new Error(
+        `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
+      );
+    }
+  }
+
+  if (rawConfig.version !== undefined && rawConfig.version !== 1) {
+    throw new Error(
+      `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
+    );
+  }
+
+  rawConfig.version = 1;
+  rawConfig.permissions = permissions;
   writeFileSync(
-    SESSION_PERMISSIONS_PATH,
-    JSON.stringify(permissions, null, 2),
+    LIBRETTO_CONFIG_PATH,
+    JSON.stringify(rawConfig, null, 2),
     "utf-8",
   );
 }

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -7,7 +7,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { getLog, LIBRETTO_DIR, STATE_DIR } from "./context";
+import {
+  getLog,
+  getSessionDir,
+  getSessionLogsPath,
+  getSessionStatePath,
+  LIBRETTO_DIR,
+  LIBRETTO_SESSIONS_DIR,
+} from "./context";
 
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
 const SESSION_PERMISSIONS_PATH = join(LIBRETTO_DIR, "session-permissions.json");
@@ -39,14 +46,11 @@ export function generateRunId(): string {
     .replace(/^(\d{8})(\d{6})$/, "$1-$2");
 }
 
-export function getRunDir(runId: string): string {
-  return join(STATE_DIR, runId);
-}
-
-export function logFileForRun(runId: string): string {
-  const dir = getRunDir(runId);
+export function logFileForSession(session: string): string {
+  validateSessionName(session);
+  const dir = getSessionDir(session);
   mkdirSync(dir, { recursive: true });
-  return join(dir, "session.log");
+  return getSessionLogsPath(session);
 }
 
 export function validateSessionName(session: string): void {
@@ -64,8 +68,9 @@ export function validateSessionName(session: string): void {
 
 export function getStateFilePath(session: string): string {
   validateSessionName(session);
-  mkdirSync(STATE_DIR, { recursive: true });
-  return join(STATE_DIR, `${session}.json`);
+  const sessionDir = getSessionDir(session);
+  mkdirSync(sessionDir, { recursive: true });
+  return getSessionStatePath(session);
 }
 
 export function readSessionState(session: string): SessionState | null {
@@ -92,31 +97,42 @@ export function readSessionState(session: string): SessionState | null {
 }
 
 function listActiveSessions(): string[] {
-  if (!existsSync(STATE_DIR)) return [];
-  return readdirSync(STATE_DIR)
-    .filter((f) => f.endsWith(".json"))
-    .map((f) => f.replace(/\.json$/, ""));
+  if (!existsSync(LIBRETTO_SESSIONS_DIR)) return [];
+  return readdirSync(LIBRETTO_SESSIONS_DIR).filter((session) =>
+    existsSync(getSessionStatePath(session)),
+  );
 }
 
-export function getSessionStateOrThrow(session: string): SessionState {
+function throwSessionNotFoundError(session: string): never {
+  const active = listActiveSessions();
+  const lines = [`No session "${session}" found.`];
+  if (active.length > 0) {
+    lines.push("");
+    lines.push("Active sessions:");
+    for (const name of active) {
+      lines.push(`  ${name}`);
+    }
+  } else {
+    lines.push("");
+    lines.push("No active sessions.");
+  }
+  lines.push("");
+  lines.push("Start one with:");
+  lines.push(`  libretto-cli open <url> --session ${session}`);
+  throw new Error(lines.join("\n"));
+}
+
+export function assertSessionStateExistsOrThrow(session: string): void {
   const stateFile = getStateFilePath(session);
   if (!existsSync(stateFile)) {
-    const active = listActiveSessions();
-    const lines = [`No session "${session}" found.`];
-    if (active.length > 0) {
-      lines.push("");
-      lines.push("Active sessions:");
-      for (const name of active) {
-        lines.push(`  ${name}`);
-      }
-    } else {
-      lines.push("");
-      lines.push("No active sessions.");
-    }
-    lines.push("");
-    lines.push(`Start one with:`);
-    lines.push(`  libretto-cli open <url> --session ${session}`);
-    throw new Error(lines.join("\n"));
+    throwSessionNotFoundError(session);
+  }
+}
+
+export function readSessionStateOrThrow(session: string): SessionState {
+  const stateFile = getStateFilePath(session);
+  if (!existsSync(stateFile)) {
+    throwSessionNotFoundError(session);
   }
 
   try {

--- a/packages/libretto-cli/src/core/snapshot-analyzer.ts
+++ b/packages/libretto-cli/src/core/snapshot-analyzer.ts
@@ -1,26 +1,22 @@
 import {
   existsSync,
-  mkdirSync,
+  mkdtempSync,
   readFileSync,
-  statSync,
-  readdirSync,
-  unlinkSync,
+  rmSync,
 } from "node:fs";
-import { basename, extname, isAbsolute, join, resolve } from "node:path";
+import { extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
 import { z } from "zod";
 import {
   type AiConfig,
   formatCommandPrefix,
   readAiConfig,
-  runAiConfigure,
 } from "./ai-config";
 import {
   getLLMClientFactory,
   getLog,
-  STATE_DIR,
 } from "./context";
-import { getRunDir, getSessionStateOrThrow } from "./session";
 
 export type ScreenshotPair = {
   pngPath: string;
@@ -32,8 +28,8 @@ export type InterpretArgs = {
   objective: string;
   session: string;
   context: string;
-  pngPath?: string;
-  htmlPath?: string;
+  pngPath: string;
+  htmlPath: string;
 };
 
 const InterpretResultSchema = z.object({
@@ -65,8 +61,6 @@ abstract class UserCodingAgent {
     switch (config.preset) {
       case "codex":
         return new CodexUserCodingAgent(config);
-      case "opencode":
-        return new OpencodeUserCodingAgent(config);
       case "claude":
         return new ClaudeUserCodingAgent(config);
       case "gemini":
@@ -138,9 +132,9 @@ class CodexUserCodingAgent extends UserCodingAgent {
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    mkdirSync(STATE_DIR, { recursive: true });
+    const tempDir = mkdtempSync(join(tmpdir(), "libretto-cli-analyzer-"));
     const outputPath = join(
-      STATE_DIR,
+      tempDir,
       `snapshot-analyzer-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
     );
     const args = [
@@ -159,25 +153,8 @@ class CodexUserCodingAgent extends UserCodingAgent {
       }
       return parseInterpretResultFromText(outputText);
     } finally {
-      if (existsSync(outputPath)) {
-        unlinkSync(outputPath);
-      }
+      rmSync(tempDir, { recursive: true, force: true });
     }
-  }
-}
-
-class OpencodeUserCodingAgent extends UserCodingAgent {
-  async analyzeSnapshot(
-    prompt: string,
-    pngPath: string,
-  ): Promise<InterpretResult> {
-    const args = [
-      ...this.baseArgs,
-      `${prompt}${this.screenshotHint(pngPath)}`,
-      "-f",
-      pngPath,
-    ];
-    return await this.runAndParse(args);
   }
 }
 
@@ -464,121 +441,6 @@ function collectSelectorHints(html: string, limit = 120): string[] {
   return candidates;
 }
 
-function findLatestScreenshotPair(screenshotsDir: string): ScreenshotPair {
-  if (!existsSync(screenshotsDir)) {
-    throw new Error(
-      `No snapshots directory found: ${screenshotsDir}. Run 'libretto-cli snapshot' first.`,
-    );
-  }
-
-  const entries = readdirSync(screenshotsDir, { withFileTypes: true });
-  const pairs = new Map<
-    string,
-    { pngPath?: string; htmlPath?: string; mtimeMs: number }
-  >();
-
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    const ext = extname(entry.name);
-    if (ext !== ".png" && ext !== ".html") continue;
-    const baseName = basename(entry.name, ext);
-    const fullPath = join(screenshotsDir, entry.name);
-    const stat = statSync(fullPath);
-    const current = pairs.get(baseName) || { mtimeMs: 0 };
-    const next = {
-      ...current,
-      mtimeMs: Math.max(current.mtimeMs, stat.mtimeMs),
-    };
-    if (ext === ".png") next.pngPath = fullPath;
-    if (ext === ".html") next.htmlPath = fullPath;
-    pairs.set(baseName, next);
-  }
-
-  let latestBaseName: string | null = null;
-  let latestPngPath: string | null = null;
-  let latestHtmlPath: string | null = null;
-  let latestMtime = 0;
-
-  pairs.forEach((pair, baseName) => {
-    if (!pair.pngPath || !pair.htmlPath) return;
-    if (!latestBaseName || pair.mtimeMs > latestMtime) {
-      latestBaseName = baseName;
-      latestPngPath = pair.pngPath;
-      latestHtmlPath = pair.htmlPath;
-      latestMtime = pair.mtimeMs;
-    }
-  });
-
-  if (!latestBaseName || !latestPngPath || !latestHtmlPath) {
-    throw new Error(
-      `No snapshot + HTML pair found in ${screenshotsDir}. Run 'libretto-cli snapshot' first.`,
-    );
-  }
-
-  return {
-    baseName: latestBaseName,
-    pngPath: latestPngPath,
-    htmlPath: latestHtmlPath,
-  };
-}
-
-function resolveScreenshotPair(
-  session: string,
-  pngPath?: string,
-  htmlPath?: string,
-): ScreenshotPair {
-  const state = getSessionStateOrThrow(session);
-  const runDir = getRunDir(state.runId);
-  let resolvedPng = pngPath ? resolvePath(pngPath) : undefined;
-  let resolvedHtml = htmlPath ? resolvePath(htmlPath) : undefined;
-
-  if (resolvedPng && !existsSync(resolvedPng)) {
-    throw new Error(`PNG file not found: ${resolvedPng}`);
-  }
-  if (resolvedHtml && !existsSync(resolvedHtml)) {
-    throw new Error(`HTML file not found: ${resolvedHtml}`);
-  }
-
-  if (resolvedPng && !resolvedHtml) {
-    const candidate = resolvedPng.replace(/\.[^.]+$/, ".html");
-    if (existsSync(candidate)) {
-      resolvedHtml = candidate;
-    }
-  }
-
-  if (resolvedHtml && !resolvedPng) {
-    const candidate = resolvedHtml.replace(/\.[^.]+$/, ".png");
-    if (existsSync(candidate)) {
-      resolvedPng = candidate;
-    }
-  }
-
-  if (!resolvedPng || !resolvedHtml) {
-    if (!resolvedPng && !resolvedHtml) {
-      return findLatestScreenshotPair(runDir);
-    }
-    throw new Error(
-      "Both PNG and HTML paths are required if one is provided (or ensure matching .png/.html exists).",
-    );
-  }
-
-  return {
-    baseName: basename(resolvedPng, extname(resolvedPng)),
-    pngPath: resolvedPng,
-    htmlPath: resolvedHtml,
-  };
-}
-
-export function runSnapshotConfigure(input: {
-  preset?: string;
-  clear?: boolean;
-  customPrefix?: string[];
-}): void {
-  runAiConfigure(input, {
-    configureCommandName: "libretto-cli ai configure",
-  });
-}
-
 export async function runInterpret(args: InterpretArgs): Promise<void> {
   const log = getLog();
   log.info("interpret-start", {
@@ -588,11 +450,15 @@ export async function runInterpret(args: InterpretArgs): Promise<void> {
   });
   process.env.NODE_ENV = "development";
 
-  const { pngPath, htmlPath } = resolveScreenshotPair(
-    args.session,
-    args.pngPath,
-    args.htmlPath,
-  );
+  const pngPath = resolvePath(args.pngPath);
+  const htmlPath = resolvePath(args.htmlPath);
+  if (!existsSync(pngPath)) {
+    throw new Error(`PNG file not found: ${pngPath}`);
+  }
+  if (!existsSync(htmlPath)) {
+    throw new Error(`HTML file not found: ${htmlPath}`);
+  }
+
   const htmlContent = readFileSync(htmlPath, "utf-8");
   const htmlCharLimit = 500_000;
   const { text: trimmedHtml, truncated } = truncateText(
@@ -643,7 +509,7 @@ export async function runInterpret(args: InterpretArgs): Promise<void> {
     const llmClientFactory = getLLMClientFactory();
     if (!llmClientFactory) {
       throw new Error(
-        "No AI config set. Run 'libretto-cli ai configure codex' (or opencode/claude/gemini). Library integrations can still set a factory via setLLMClientFactory().",
+        "No AI config set. Run 'libretto-cli ai configure codex' (or claude/gemini). Library integrations can still set a factory via setLLMClientFactory().",
       );
     }
 

--- a/packages/libretto-cli/src/core/telemetry.ts
+++ b/packages/libretto-cli/src/core/telemetry.ts
@@ -1,7 +1,10 @@
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { Page } from "playwright";
-import { join } from "node:path";
-import { getRunDir, getSessionStateOrThrow } from "./session";
+import {
+  getSessionActionsLogPath,
+  getSessionNetworkLogPath,
+} from "./context";
+import { assertSessionStateExistsOrThrow } from "./session";
 
 export type NetworkLogEntry = {
   ts: string;
@@ -15,16 +18,12 @@ export type NetworkLogEntry = {
   durationMs: number | null;
 };
 
-export function getNetworkLogPath(runId: string): string {
-  return join(getRunDir(runId), "network.jsonl");
-}
-
 export function readNetworkLog(
   session: string,
   opts: { last?: number; filter?: string; method?: string } = {},
 ): NetworkLogEntry[] {
-  const state = getSessionStateOrThrow(session);
-  const logPath = getNetworkLogPath(state.runId);
+  assertSessionStateExistsOrThrow(session);
+  const logPath = getSessionNetworkLogPath(session);
   if (!existsSync(logPath)) return [];
 
   const lines = readFileSync(logPath, "utf-8")
@@ -72,8 +71,8 @@ export function formatNetworkEntry(e: NetworkLogEntry): string {
 }
 
 export function clearNetworkLog(session: string): void {
-  const state = getSessionStateOrThrow(session);
-  const logPath = getNetworkLogPath(state.runId);
+  assertSessionStateExistsOrThrow(session);
+  const logPath = getSessionNetworkLogPath(session);
   writeFileSync(logPath, "");
 }
 
@@ -89,17 +88,13 @@ export type ActionLogEntry = {
   error?: string;
 };
 
-export function getActionLogPath(runId: string): string {
-  return join(getRunDir(runId), "actions.jsonl");
-}
-
 export function parentLogAction(
-  runId: string,
+  session: string,
   entry: Record<string, unknown>,
 ): void {
   try {
     const record = { ts: new Date().toISOString(), ...entry };
-    appendFileSync(getActionLogPath(runId), JSON.stringify(record) + "\n");
+    appendFileSync(getSessionActionsLogPath(session), JSON.stringify(record) + "\n");
   } catch {}
 }
 
@@ -112,8 +107,8 @@ export function readActionLog(
     source?: string;
   } = {},
 ): ActionLogEntry[] {
-  const state = getSessionStateOrThrow(session);
-  const logPath = getActionLogPath(state.runId);
+  assertSessionStateExistsOrThrow(session);
+  const logPath = getSessionActionsLogPath(session);
   if (!existsSync(logPath)) return [];
 
   const lines = readFileSync(logPath, "utf-8")
@@ -164,8 +159,8 @@ export function formatActionEntry(e: ActionLogEntry): string {
 }
 
 export function clearActionLog(session: string): void {
-  const state = getSessionStateOrThrow(session);
-  const logPath = getActionLogPath(state.runId);
+  assertSessionStateExistsOrThrow(session);
+  const logPath = getSessionActionsLogPath(session);
   writeFileSync(logPath, "");
 }
 
@@ -231,7 +226,7 @@ function formatHint(method: string, args: any[]): string {
 function wrapLocator(
   locator: any,
   hint: string,
-  runId: string,
+  session: string,
   page: Page,
   onActivity?: () => void,
 ): any {
@@ -250,7 +245,7 @@ function wrapLocator(
       } catch {}
       try {
         const result = await origAct(...actArgs);
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: actMethod,
           source: "agent",
           selector: hint,
@@ -264,7 +259,7 @@ function wrapLocator(
         onActivity?.();
         return result;
       } catch (err: any) {
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: actMethod,
           source: "agent",
           selector: hint,
@@ -293,7 +288,7 @@ function wrapLocator(
         args.length > 0
           ? `${hint}.${formatHint(method, args)}`
           : `${hint}.${method}()`;
-      return wrapLocator(child, childHint, runId, page, onActivity);
+      return wrapLocator(child, childHint, session, page, onActivity);
     };
   }
 
@@ -302,7 +297,7 @@ function wrapLocator(
     locator.nth = (index: number) => {
       const child = origNth(index);
       const childHint = `${hint}.nth(${index})`;
-      return wrapLocator(child, childHint, runId, page, onActivity);
+      return wrapLocator(child, childHint, session, page, onActivity);
     };
   }
 
@@ -312,7 +307,7 @@ function wrapLocator(
       const items: any[] = await origAll();
       return items.map((item: any, i: number) => {
         const childHint = `${hint}.all()[${i}]`;
-        return wrapLocator(item, childHint, runId, page, onActivity);
+        return wrapLocator(item, childHint, session, page, onActivity);
       });
     };
   }
@@ -322,7 +317,7 @@ function wrapLocator(
 
 export function wrapPageForActionLogging(
   page: Page,
-  runId: string,
+  session: string,
   onActivity?: () => void,
 ): void {
   const PAGE_ACTIONS = [
@@ -350,7 +345,7 @@ export function wrapPageForActionLogging(
       } catch {}
       try {
         const result = await orig(...args);
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: method,
           source: "agent",
           selector: typeof args[0] === "string" ? args[0] : undefined,
@@ -362,7 +357,7 @@ export function wrapPageForActionLogging(
         onActivity?.();
         return result;
       } catch (err: any) {
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: method,
           source: "agent",
           selector: typeof args[0] === "string" ? args[0] : undefined,
@@ -388,7 +383,7 @@ export function wrapPageForActionLogging(
       const start = Date.now();
       try {
         const result = await orig(...args);
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: method,
           source: "agent",
           url: typeof args[0] === "string" ? args[0] : page.url(),
@@ -398,7 +393,7 @@ export function wrapPageForActionLogging(
         onActivity?.();
         return result;
       } catch (err: any) {
-        parentLogAction(runId, {
+        parentLogAction(session, {
           action: method,
           source: "agent",
           url: typeof args[0] === "string" ? args[0] : undefined,
@@ -428,7 +423,7 @@ export function wrapPageForActionLogging(
     (page as any)[factory] = (...factoryArgs: any[]) => {
       const locator = orig(...factoryArgs);
       const hint = formatHint(factory, factoryArgs);
-      return wrapLocator(locator, hint, runId, page, onActivity);
+      return wrapLocator(locator, hint, session, page, onActivity);
     };
   }
 }

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -46,18 +46,24 @@ describe("cli test fixtures", () => {
       session: "spec-session",
       runId: "run-2",
     });
-    await seedNetworkLog("run-2", [
+    await seedNetworkLog("spec-session", [
       { ts: "2026-01-01T00:00:00.000Z", method: "GET", url: "https://example.com", status: 200, contentType: "text/html", size: 1, durationMs: 1 },
     ]);
-    await seedActionLog("run-2", [
+    await seedActionLog("spec-session", [
       { ts: "2026-01-01T00:00:00.000Z", action: "click", source: "agent", success: true },
     ]);
     const configPath = await seedSnapshotConfig();
 
     expect(seeded.session).toBe("spec-session");
-    expect(existsSync(workspacePath("tmp", "libretto-cli", "spec-session.json"))).toBe(true);
-    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-2", "network.jsonl"))).toBe(true);
-    expect(existsSync(workspacePath("tmp", "libretto-cli", "run-2", "actions.jsonl"))).toBe(true);
+    expect(
+      existsSync(workspacePath(".libretto", "sessions", "spec-session", "state.json")),
+    ).toBe(true);
+    expect(
+      existsSync(workspacePath(".libretto", "sessions", "spec-session", "network.jsonl")),
+    ).toBe(true);
+    expect(
+      existsSync(workspacePath(".libretto", "sessions", "spec-session", "actions.jsonl")),
+    ).toBe(true);
     expect(existsSync(configPath)).toBe(true);
   });
 

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -67,7 +67,9 @@ describe("cli test fixtures", () => {
       const result = await librettoCli("--help");
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Usage: libretto-cli");
-      expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(true);
+      expect(existsSync(workspacePath(".libretto"))).toBe(true);
+      expect(existsSync(workspacePath(".libretto", ".gitignore"))).toBe(true);
+      expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(false);
     },
     20_000,
   );

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -226,11 +226,15 @@ export const test = base.extend<CliFixtures>({
 
   seedSessionPermission: async ({ workspacePath }, use) => {
     await use(async (session: string, mode: "read-only" | "interactive") => {
-      const dir = workspacePath(".libretto-cli");
-      const path = workspacePath(".libretto-cli", "session-permissions.json");
+      const dir = workspacePath(".libretto");
+      const path = workspacePath(".libretto", "config.json");
       await mkdir(dir, { recursive: true });
-      const payload = {
-        version: 1,
+      let payload: Record<string, unknown> = { version: 1 };
+      if (existsSync(path)) {
+        payload = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+      }
+      payload.version = 1;
+      payload.permissions = {
         sessions: {
           [session]: mode,
         },

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -30,8 +30,8 @@ type SeedHelpers = {
     mode: "read-only" | "interactive",
   ) => Promise<string>;
   seedSnapshotConfig: (config?: JsonRecord) => Promise<string>;
-  seedNetworkLog: (runId: string, entries: JsonRecord[]) => Promise<string>;
-  seedActionLog: (runId: string, entries: JsonRecord[]) => Promise<string>;
+  seedNetworkLog: (session: string, entries: JsonRecord[]) => Promise<string>;
+  seedActionLog: (session: string, entries: JsonRecord[]) => Promise<string>;
 };
 
 type CliFixtures = {
@@ -196,10 +196,10 @@ export const test = base.extend<CliFixtures>({
         startedAt: state?.startedAt ?? "2026-01-01T00:00:00.000Z",
         mode: state?.mode,
       };
-      const dir = workspacePath("tmp", "libretto-cli");
+      const dir = workspacePath(".libretto", "sessions", session);
       await mkdir(dir, { recursive: true });
       await writeFile(
-        workspacePath("tmp", "libretto-cli", `${session}.json`),
+        workspacePath(".libretto", "sessions", session, "state.json"),
         JSON.stringify(normalized, null, 2),
       );
       return normalized;
@@ -241,10 +241,10 @@ export const test = base.extend<CliFixtures>({
   },
 
   seedNetworkLog: async ({ workspacePath }, use) => {
-    await use(async (runId: string, entries: JsonRecord[]) => {
-      const runDir = workspacePath("tmp", "libretto-cli", runId);
-      const logPath = workspacePath("tmp", "libretto-cli", runId, "network.jsonl");
-      await mkdir(runDir, { recursive: true });
+    await use(async (session: string, entries: JsonRecord[]) => {
+      const sessionDir = workspacePath(".libretto", "sessions", session);
+      const logPath = workspacePath(".libretto", "sessions", session, "network.jsonl");
+      await mkdir(sessionDir, { recursive: true });
       const body = entries.map((entry) => JSON.stringify(entry)).join("\n");
       await writeFile(logPath, body ? `${body}\n` : "", "utf8");
       return logPath;
@@ -252,10 +252,10 @@ export const test = base.extend<CliFixtures>({
   },
 
   seedActionLog: async ({ workspacePath }, use) => {
-    await use(async (runId: string, entries: JsonRecord[]) => {
-      const runDir = workspacePath("tmp", "libretto-cli", runId);
-      const logPath = workspacePath("tmp", "libretto-cli", runId, "actions.jsonl");
-      await mkdir(runDir, { recursive: true });
+    await use(async (session: string, entries: JsonRecord[]) => {
+      const sessionDir = workspacePath(".libretto", "sessions", session);
+      const logPath = workspacePath(".libretto", "sessions", session, "actions.jsonl");
+      await mkdir(sessionDir, { recursive: true });
       const body = entries.map((entry) => JSON.stringify(entry)).join("\n");
       await writeFile(logPath, body ? `${body}\n` : "", "utf8");
       return logPath;

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -77,21 +77,21 @@ Target layout:
 
 ### Phase 2: Move CLI session state and logs into per-session directories
 
-- [ ] Move session state file from `tmp/libretto-cli/<session>.json` to `.libretto/sessions/<session>/state.json`.
-- [ ] Replace run-directory/per-run log helpers with session-directory helpers and `logs.jsonl`.
-- [ ] Update logger initialization in `cli.ts` to write to per-session `logs.jsonl`.
-- [ ] After logger defaults move off `tmp/libretto-cli`, allow early `getLog()` usage on help/error paths without recreating legacy dirs.
-- [ ] Update `open` child process logging path to append JSONL entries to `.libretto/sessions/<session>/logs.jsonl`.
-- [ ] Success criteria: session commands (`open`, `close`, `exec` guard paths) operate using only `.libretto/sessions/<session>/state.json` + `logs.jsonl`.
+- [x] Move session state file from `tmp/libretto-cli/<session>.json` to `.libretto/sessions/<session>/state.json`.
+- [x] Replace run-directory/per-run log helpers with session-directory helpers and `logs.jsonl`.
+- [x] Update logger initialization in `cli.ts` to write to per-session `logs.jsonl`.
+- [x] After logger defaults move off `tmp/libretto-cli`, allow early `getLog()` usage on help/error paths without recreating legacy dirs.
+- [x] Update `open` child process logging path to append JSONL entries to `.libretto/sessions/<session>/logs.jsonl`.
+- [x] Success criteria: session commands (`open`, `close`, `exec` guard paths) operate using only `.libretto/sessions/<session>/state.json` + `logs.jsonl`.
 
 ### Phase 3: Move telemetry and snapshots to session-scoped `.libretto` paths
 
-- [ ] Move network/action telemetry files to `.libretto/sessions/<session>/network.jsonl` and `.libretto/sessions/<session>/actions.jsonl`.
-- [ ] Update `network` and `actions` read/clear commands to use the new per-session files.
-- [ ] Move snapshot captures to `.libretto/sessions/<session>/snapshots/<snapshot-run-id>/page.png` and `page.html`.
-- [ ] Update snapshot pair discovery and `runInterpret` defaults to find the latest pair in the new snapshot tree.
-- [ ] Keep temporary analyzer output under `.libretto` (not `tmp/`) and delete it after parse as today.
-- [ ] Success criteria: stateful tests prove network/actions/snapshot files are created under `.libretto/sessions/<session>/...` and no files are created in `tmp/libretto-cli/`.
+- [x] Move network/action telemetry files to `.libretto/sessions/<session>/network.jsonl` and `.libretto/sessions/<session>/actions.jsonl`.
+- [x] Update `network` and `actions` read/clear commands to use the new per-session files.
+- [x] Move snapshot captures to `.libretto/sessions/<session>/snapshots/<snapshot-run-id>/page.png` and `page.html`.
+- [x] Require explicit snapshot PNG/HTML paths from the current `snapshot` command flow; remove implicit latest-pair lookup from previous runs.
+- [x] Remove repository-scoped analyzer temp directories; use transient OS temp files and delete them after parse.
+- [x] Success criteria: stateful tests prove network/actions/snapshot files are created under `.libretto/sessions/<session>/...` and no files are created in `tmp/libretto-cli/`.
 
 ### Phase 4: Consolidate session permission state into `.libretto/config.json`
 

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -1,0 +1,118 @@
+## Problem overview
+
+Libretto runtime state is currently split across multiple roots: `.libretto-cli/`, `tmp/libretto-cli/`, and `tmp/libretto/`. This makes state hard to inspect, hard to clean up, and inconsistent between CLI and library runtime behavior.
+
+`main` already moved AI/snapshot analyzer config into `.libretto/config.json`, but session metadata, profiles, logs, telemetry, debug signals, and snapshot artifacts are still spread across the legacy locations.
+
+## Solution overview
+
+Centralize all runtime and persistent state under a single `.libretto/` root with a stable per-session layout. Add a setup script that creates `.libretto/`, required subdirectories, and `.libretto/.gitignore` when missing. Remove legacy path migration code and update all writers/readers to the new paths.
+
+Target layout:
+
+```text
+.libretto/
+  .gitignore
+  config.json
+  profiles/
+  sessions/
+    <session-name>/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+        <snapshot-run-id>/
+          page.png
+          page.html
+```
+
+## Goals
+
+- All runtime/persistent state used by `libretto-cli` and default `libretto` runtime helpers is stored under `.libretto/`.
+- Each session has an isolated directory at `.libretto/sessions/<session-name>/`.
+- Per-session logging uses `logs.jsonl` instead of per-run `session.log`.
+- Profiles are stored under `.libretto/profiles/`.
+- `.libretto/config.json` remains the single config file and also holds session permission state.
+- Legacy `.playwriter` and `.browser-tap` migration code is removed.
+- A setup script creates `.libretto/` structure and `.libretto/.gitignore` automatically when missing.
+
+## Non-goals
+
+- No migrations or backfills of old state from `.libretto-cli/` or `tmp/`.
+- No compatibility shims that continue writing to old paths in parallel.
+- No schema/versioning redesign beyond what is needed to add session permission data to existing `.libretto/config.json`.
+- No changes to Playwright behavior, browser launch semantics, or command UX beyond path and storage location updates.
+
+## Future work
+
+- None yet. Add follow-ups only if discovered during implementation.
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto-cli/src/core/context.ts` — defines global state roots and currently contains legacy profile migration logic.
+- `packages/libretto-cli/src/core/session.ts` — session state read/write, run directory helpers, and session permission persistence.
+- `packages/libretto-cli/src/core/telemetry.ts` — network/actions log paths and read/clear behavior.
+- `packages/libretto-cli/src/core/browser.ts` — `open/save/close` flow and child browser logging file paths.
+- `packages/libretto-cli/src/commands/snapshot.ts` — snapshot PNG/HTML capture locations.
+- `packages/libretto-cli/src/core/snapshot-analyzer.ts` — temporary analyzer output file handling and snapshot pair discovery.
+- `packages/libretto-cli/src/core/ai-config.ts` — `.libretto/config.json` schema and read/write helpers to extend with session permissions.
+- `packages/libretto-cli/src/cli.ts` — logger initialization path and usage text that currently documents legacy paths.
+- `packages/libretto/src/run/browser.ts` — writes browser metadata to `tmp/libretto`.
+- `packages/libretto/src/debug/pause.ts` — default pause/resume signal directory under `tmp/libretto`.
+- `packages/libretto/src/step/runner.ts` — default `logDir` under `tmp/libretto/logs`.
+- `packages/libretto-cli/src/test-fixtures.ts` and `packages/libretto-cli/src/cli-stateful.test.ts` — fixture seeding and assertions that encode current filesystem layout.
+- `README.md` and `packages/libretto/README.md` — user-facing documentation of state file locations.
+- `.gitignore` — root ignore policy that currently ignores `.libretto-cli/` and `tmp/`.
+
+## Implementation
+
+### Phase 1: Add `.libretto` setup bootstrap and canonical path helpers
+
+- [x] Add a setup bootstrap helper that ensures `.libretto/`, `.libretto/sessions/`, `.libretto/profiles/`, and `.libretto/.gitignore` exist.
+- [x] Define canonical helpers for `.libretto` root, session directory resolution, and per-session file paths (`state.json`, `logs.jsonl`, `network.jsonl`, `actions.jsonl`, snapshot root).
+- [x] Invoke setup bootstrap from CLI startup and any runtime entry points that can write state before command handlers execute.
+- [x] Remove `.playwriter` and `.browser-tap` migration code from startup path handling.
+- [x] Success criteria: running `libretto-cli --help` in a fresh repo creates `.libretto/.gitignore` and subdirectories without creating `.libretto-cli/` or `tmp/libretto-cli/`.
+
+### Phase 2: Move CLI session state and logs into per-session directories
+
+- [ ] Move session state file from `tmp/libretto-cli/<session>.json` to `.libretto/sessions/<session>/state.json`.
+- [ ] Replace run-directory/per-run log helpers with session-directory helpers and `logs.jsonl`.
+- [ ] Update logger initialization in `cli.ts` to write to per-session `logs.jsonl`.
+- [ ] After logger defaults move off `tmp/libretto-cli`, allow early `getLog()` usage on help/error paths without recreating legacy dirs.
+- [ ] Update `open` child process logging path to append JSONL entries to `.libretto/sessions/<session>/logs.jsonl`.
+- [ ] Success criteria: session commands (`open`, `close`, `exec` guard paths) operate using only `.libretto/sessions/<session>/state.json` + `logs.jsonl`.
+
+### Phase 3: Move telemetry and snapshots to session-scoped `.libretto` paths
+
+- [ ] Move network/action telemetry files to `.libretto/sessions/<session>/network.jsonl` and `.libretto/sessions/<session>/actions.jsonl`.
+- [ ] Update `network` and `actions` read/clear commands to use the new per-session files.
+- [ ] Move snapshot captures to `.libretto/sessions/<session>/snapshots/<snapshot-run-id>/page.png` and `page.html`.
+- [ ] Update snapshot pair discovery and `runInterpret` defaults to find the latest pair in the new snapshot tree.
+- [ ] Keep temporary analyzer output under `.libretto` (not `tmp/`) and delete it after parse as today.
+- [ ] Success criteria: stateful tests prove network/actions/snapshot files are created under `.libretto/sessions/<session>/...` and no files are created in `tmp/libretto-cli/`.
+
+### Phase 4: Consolidate session permission state into `.libretto/config.json`
+
+- [ ] Extend `LibrettoConfigSchema` to include a `sessionPermissions` object keyed by session name with `read-only|interactive` values.
+- [ ] Replace `.libretto-cli/session-permissions.json` reads/writes with config-backed reads/writes in `ai-config.ts` + `session.ts`.
+- [ ] Ensure `session-mode` command behavior remains unchanged from a user perspective.
+- [ ] Remove any remaining references to `.libretto-cli/session-permissions.json` from code and tests.
+- [ ] Success criteria: `session-mode interactive --session <name>` persists mode in `.libretto/config.json` and `run/exec` guards still enforce the same rules.
+
+### Phase 5: Move default `libretto` package runtime state out of `tmp/libretto`
+
+- [ ] Change `launchBrowser` metadata path default to `.libretto/sessions/<session>/state.json`-compatible location (or sibling metadata file in the same session dir).
+- [ ] Change `debugPause` default signal directory from `tmp/libretto` to `.libretto/sessions/<session>/`.
+- [ ] Change runner default `logDir` from `tmp/libretto/logs` to a `.libretto/sessions/<session>/`-scoped logs location.
+- [ ] Ensure these defaults remain overridable by explicit options.
+- [ ] Success criteria: library defaults no longer create `tmp/libretto/*` in a fresh run.
+
+### Phase 6: Tests, docs, and cleanup
+
+- [ ] Update CLI fixtures/tests to seed/assert the new `.libretto` layout.
+- [ ] Add regression coverage that asserts commands do not create `.libretto-cli/` or `tmp/libretto-cli/` paths.
+- [ ] Update usage/help text and README references from old paths to `.libretto`.
+- [ ] Update root `.gitignore` policy to stop relying on `.libretto-cli/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
+- [ ] Success criteria: `pnpm --filter libretto-cli test`, `pnpm --filter libretto-cli type-check`, and `pnpm --filter libretto type-check` pass with updated path expectations.

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -95,11 +95,11 @@ Target layout:
 
 ### Phase 4: Consolidate session permission state into `.libretto/config.json`
 
-- [ ] Extend `LibrettoConfigSchema` to include a `sessionPermissions` object keyed by session name with `read-only|interactive` values.
-- [ ] Replace `.libretto-cli/session-permissions.json` reads/writes with config-backed reads/writes in `ai-config.ts` + `session.ts`.
-- [ ] Ensure `session-mode` command behavior remains unchanged from a user perspective.
-- [ ] Remove any remaining references to `.libretto-cli/session-permissions.json` from code and tests.
-- [ ] Success criteria: `session-mode interactive --session <name>` persists mode in `.libretto/config.json` and `run/exec` guards still enforce the same rules.
+- [x] Extend `LibrettoConfigSchema` to include a `permissions` object keyed by session name with `read-only|interactive` values.
+- [x] Replace `.libretto-cli/session-permissions.json` reads/writes with config-backed reads/writes in `ai-config.ts` + `session.ts`.
+- [x] Ensure `session-mode` command behavior remains unchanged from a user perspective.
+- [x] Remove any remaining references to `.libretto-cli/session-permissions.json` from code and tests.
+- [x] Success criteria: `session-mode interactive --session <name>` persists mode in `.libretto/config.json` and `run/exec` guards still enforce the same rules.
 
 ### Phase 5: Move default `libretto` package runtime state out of `tmp/libretto`
 
@@ -113,6 +113,6 @@ Target layout:
 
 - [ ] Update CLI fixtures/tests to seed/assert the new `.libretto` layout.
 - [ ] Add regression coverage that asserts commands do not create `.libretto-cli/` or `tmp/libretto-cli/` paths.
-- [ ] Update usage/help text and README references from old paths to `.libretto`.
+- [x] Update usage/help text and README references from old paths to `.libretto`.
 - [ ] Update root `.gitignore` policy to stop relying on `.libretto-cli/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
 - [ ] Success criteria: `pnpm --filter libretto-cli test`, `pnpm --filter libretto-cli type-check`, and `pnpm --filter libretto type-check` pass with updated path expectations.


### PR DESCRIPTION
## Summary
- centralize libretto-cli runtime state under `.libretto/` with session-scoped paths
- migrate session files to `.libretto/sessions/<session>/` (`state.json`, `logs.jsonl`, `network.jsonl`, `actions.jsonl`, `snapshots/`)
- remove `snapshot configure` compatibility alias and keep AI config under `ai configure`
- remove OpenCode preset support and clean analyzer/provider wiring
- remove repository-scoped analyzer temp dir usage and rely on transient OS temp files
- tighten logger initialization and session-state helper naming (`assertSessionStateExistsOrThrow` / `readSessionStateOrThrow`)
- update docs/spec/tests to match new state layout

## Validation
- `pnpm --filter libretto-cli type-check`
- `pnpm --filter libretto-cli build`
- `pnpm --filter libretto-cli test`
