### PR TITLE
Fix postinstall skill sync and run guard ordering

### DIFF
--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -411,6 +411,11 @@ export function registerExecutionCommands(yargs: Argv): Argv {
           .option("params-file", { type: "string" })
           .option("headed", { type: "boolean", default: false })
           .option("headless", { type: "boolean", default: false })
+          .option("allow-actions", {
+            type: "boolean",
+            default: false,
+            hidden: true,
+          })
           .option("debug", { type: "string" }),
       async (argv) => {
         const usage =
@@ -422,6 +427,17 @@ export function registerExecutionCommands(yargs: Argv): Argv {
         }
 
         const session = String(argv.session);
+        const allowActions = Boolean(
+          argv["allow-actions"] ?? (argv as { allowActions?: boolean }).allowActions,
+        );
+        if (allowActions) {
+          throw new Error(
+            `--allow-actions is not supported for run. ${readOnlySessionError(session)}`,
+          );
+        }
+        if (getSessionPermissionMode(session) !== "interactive") {
+          throw new Error(readOnlySessionError(session));
+        }
 
         const rawInlineParams = argv.params as string | undefined;
         const paramsFile = argv["params-file"] as string | undefined;

--- a/packages/libretto/scripts/postinstall.mjs
+++ b/packages/libretto/scripts/postinstall.mjs
@@ -22,38 +22,16 @@ function main() {
 		return;
 	}
 
-	const sourceSkillsDir = join(packageDir, "skills");
-	if (!isDirectory(sourceSkillsDir)) {
-		log(`Skipped: source skills directory not found at "${sourceSkillsDir}".`);
+	const sourceSkillDir = join(packageDir, "skill");
+	if (!isDirectory(sourceSkillDir)) {
+		log(`Skipped: source skill directory not found at "${sourceSkillDir}".`);
 		return;
 	}
 
-	const skillCopies = [
-		{ source: "original-skill", destination: "libretto" },
-		{
-			source: "libretto-network-skill",
-			destination: "libretto-network-skill"
-		}
-	];
-
-	let syncedCount = 0;
-	for (const { source, destination } of skillCopies) {
-		const sourceSkillDir = join(sourceSkillsDir, source);
-		if (!isDirectory(sourceSkillDir)) {
-			log(`Skipped: source skill directory not found at "${sourceSkillDir}".`);
-			continue;
-		}
-
-		const destinationSkillDir = join(skillsRoot, destination);
-		mkdirSync(destinationSkillDir, { recursive: true });
-		cpSync(sourceSkillDir, destinationSkillDir, { recursive: true, force: true });
-		log(`Synced skill "${destination}" to "${destinationSkillDir}".`);
-		syncedCount += 1;
-	}
-
-	if (syncedCount === 0) {
-		log("Skipped: no source skill directories were synced.");
-	}
+	const destinationSkillDir = join(skillsRoot, "libretto-network-skill");
+	mkdirSync(destinationSkillDir, { recursive: true });
+	cpSync(sourceSkillDir, destinationSkillDir, { recursive: true, force: true });
+	log(`Synced skill "libretto-network-skill" to "${destinationSkillDir}".`);
 }
 
 try {


### PR DESCRIPTION
## Summary
- fix `packages/libretto/scripts/postinstall.mjs` to sync from `packages/libretto/skill` (singular), matching the current package layout
- remove legacy multi-source copy logic and sync only `libretto-network-skill`
- fix `libretto-cli run` guard ordering so read-only/deprecated-flag errors are emitted before integration file validation
- add hidden `--allow-actions` parsing for `run` and return the intended deprecation error

## Validation
- `INIT_CWD=$(mktemp -d) node packages/libretto/scripts/postinstall.mjs`
- `pnpm --filter libretto-cli build`
- `pnpm --filter libretto-cli test`
