### PR TITLE
fix(postinstall): sync skill into libretto directory

### DIFF
--- a/packages/libretto/scripts/postinstall.mjs
+++ b/packages/libretto/scripts/postinstall.mjs
@@ -28,10 +28,10 @@ function main() {
 		return;
 	}
 
-	const destinationSkillDir = join(skillsRoot, "libretto-network-skill");
+	const destinationSkillDir = join(skillsRoot, "libretto");
 	mkdirSync(destinationSkillDir, { recursive: true });
 	cpSync(sourceSkillDir, destinationSkillDir, { recursive: true, force: true });
-	log(`Synced skill "libretto-network-skill" to "${destinationSkillDir}".`);
+	log(`Synced skill "libretto" to ".agents/skills/libretto".`);
 }
 
 try {


### PR DESCRIPTION
## Summary
- update postinstall to sync skill files into `.agents/skills/libretto`
- keep recursive copy behavior and update postinstall log message to the new destination path text
