### PR TITLE
Refine CLI session handling and remove run-id state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ pnpm --filter libretto-cli dev
 # default: read-only session (exec blocked)
 libretto-cli open https://example.com
 
+# open prints a generated 5-char session id (for example: abc12)
 # user explicitly approves this session for actions
-libretto-cli session-mode interactive --session default
+libretto-cli session-mode interactive --session abc12
 
 # now action commands can run in that session
-libretto-cli exec "return await page.url()" --session default
-libretto-cli run ./integration.ts main --session default
+libretto-cli exec "return await page.url()" --session abc12
+libretto-cli run ./integration.ts main --session abc12
 
 # lock it back down afterward
-libretto-cli session-mode read-only --session default
+libretto-cli session-mode read-only --session abc12
 ```
 
 ## AI configuration

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -9,7 +9,7 @@ describe("basic CLI subprocess behavior", () => {
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("libretto-cli [command]");
+    expect(result.stdout).toMatch(/libretto-cli [<\[]command[>\]]/);
     expect(result.stderr).toBe("");
   });
 
@@ -48,10 +48,18 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("fails when only global options are passed without a command", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("--session abc12");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Not enough non-option arguments");
+  });
+
   test("fails unknown command with non-zero exit code", async ({ librettoCli }) => {
     const result = await librettoCli("nope-command");
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("libretto-cli [command]");
+    expect(result.stderr).toMatch(/libretto-cli [<\[]command[>\]]/);
     expect(result.stderr).toContain("Unknown command: nope-command");
     expect(result.stdout).toBe("");
   });
@@ -82,7 +90,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("exec --session test1");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
+      "Usage: libretto-cli exec <code> --session <name> [--visualize]",
     );
   });
 
@@ -346,7 +354,7 @@ export const main = workflow(
     const result = await librettoCli("session-mode maybe --session default");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Usage: libretto-cli session-mode <read-only|interactive> [--session <name>]",
+      "Usage: libretto-cli session-mode <read-only|interactive> --session <name>",
     );
   });
 
@@ -354,7 +362,7 @@ export const main = workflow(
     const result = await librettoCli("save --session test1");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Usage: libretto-cli save <url|domain> [--session <name>]",
+      "Usage: libretto-cli save <url|domain> --session <name>",
     );
   });
 

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -296,14 +296,14 @@ export const main = workflow(
     );
   });
 
-  test("ignores deprecated --allow-actions flag for run", async ({
+  test("fails run when deprecated --allow-actions flag is passed", async ({
     librettoCli,
   }) => {
     const result = await librettoCli(
       "run ./integration.ts main --allow-actions --session test1",
     );
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Integration file does not exist:");
+    expect(result.stderr).toContain("--allow-actions is not supported for run.");
   });
 
   test("session-mode interactive writes session permission", async ({

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -27,6 +27,18 @@ describe("basic CLI subprocess behavior", () => {
     expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(false);
   });
 
+  test("auto-generates a 5-char session id for open without --session", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("open https://example.com", {
+      PATH: "/definitely-not-real",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toMatch(
+      /Launching headed browser \(session: [a-z0-9]{5}\)\.\.\./,
+    );
+  });
+
   test("prints usage for help command", async ({ librettoCli }) => {
     const result = await librettoCli("help");
     expect(result.exitCode).toBe(0);
@@ -64,27 +76,31 @@ describe("basic CLI subprocess behavior", () => {
   });
 
   test("fails exec with missing code usage error", async ({ librettoCli }) => {
-    const result = await librettoCli("exec");
+    const result = await librettoCli("exec --session test1");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
     );
   });
 
-  test("fails run by default in read-only session", async ({ librettoCli }) => {
+  test("fails run when --session is not provided", async ({ librettoCli }) => {
     const result = await librettoCli("run ./integration.ts main");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"default\" is read-only. Only a human can authorize interactive mode.",
+      'Missing --session for "run".',
     );
   });
 
   test("allows run guard when session is permissioned interactive", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
   }) => {
-    await seedSessionPermission("default", "interactive");
-    const result = await librettoCli("run ./integration.ts main");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
     expect(result.stderr).toContain("Integration file does not exist:");
@@ -92,10 +108,12 @@ describe("basic CLI subprocess behavior", () => {
 
   test("fails run when export is not a Libretto workflow instance", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
-    await seedSessionPermission("default", "interactive");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -106,17 +124,21 @@ export async function main() {
       "utf8",
     );
 
-    const result = await librettoCli("run ./integration.ts main");
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("must be a Libretto workflow instance");
   });
 
   test("accepts branded Libretto workflow contract across module boundaries", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
-    await seedSessionPermission("default", "interactive");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -133,15 +155,19 @@ export const main = {
       "utf8",
     );
 
-    const result = await librettoCli("run ./integration.ts main", {
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+      {
       PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
-    });
+      },
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("must be a Libretto workflow instance");
   });
 
   test("fails run when local auth profile is declared but missing", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -149,7 +175,8 @@ export const main = {
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    await seedSessionPermission("default", "interactive");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -165,7 +192,9 @@ export const main = workflow(
       "utf8",
     );
 
-    const result = await librettoCli("run ./integration.ts main");
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       'Local auth profile not found for domain "app.example.com".',
@@ -177,13 +206,16 @@ export const main = workflow(
       ".libretto/profiles/app.example.com.json",
     );
     expect(result.stderr).toContain(
-      "libretto-cli open https://app.example.com --headed --session default",
+      `libretto-cli open https://app.example.com --headed --session ${defaultSession}`,
     );
-    expect(result.stderr).toContain("libretto-cli save app.example.com --session default");
+    expect(result.stderr).toContain(
+      `libretto-cli save app.example.com --session ${defaultSession}`,
+    );
   });
 
   test("does not require local auth profile when auth metadata is absent", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -191,7 +223,8 @@ export const main = workflow(
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    await seedSessionPermission("default", "interactive");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -202,15 +235,19 @@ export const main = workflow({}, async () => "ok");
       "utf8",
     );
 
-    const result = await librettoCli("run ./integration.ts main", {
-      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
-    });
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+      {
+        PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+      },
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("Local auth profile not found for domain");
   });
 
   test("proceeds when declared local auth profile file exists", async ({
     librettoCli,
+    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -218,7 +255,8 @@ export const main = workflow({}, async () => "ok");
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    await seedSessionPermission("default", "interactive");
+    const defaultSession = await seedDefaultSession();
+    await seedSessionPermission(defaultSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -238,9 +276,12 @@ export const main = workflow(
       "utf8",
     );
 
-    const result = await librettoCli("run ./integration.ts main", {
-      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
-    });
+    const result = await librettoCli(
+      `run ./integration.ts main --session ${defaultSession}`,
+      {
+        PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+      },
+    );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("Local auth profile not found for domain");
   });
@@ -255,12 +296,14 @@ export const main = workflow(
     );
   });
 
-  test("fails run when deprecated --allow-actions flag is passed", async ({
+  test("ignores deprecated --allow-actions flag for run", async ({
     librettoCli,
   }) => {
-    const result = await librettoCli("run ./integration.ts main --allow-actions");
+    const result = await librettoCli(
+      "run ./integration.ts main --allow-actions --session test1",
+    );
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("--allow-actions is not supported for run.");
+    expect(result.stderr).toContain("Integration file does not exist:");
   });
 
   test("session-mode interactive writes session permission", async ({
@@ -317,7 +360,7 @@ export const main = workflow(
   });
 
   test("fails save with missing target usage error", async ({ librettoCli }) => {
-    const result = await librettoCli("save");
+    const result = await librettoCli("save --session test1");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
       "Usage: libretto-cli save <url|domain> [--session <name>]",

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -3,11 +3,13 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
+const testSession = "abc12";
+
 describe("basic CLI subprocess behavior", () => {
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
+    expect(result.stdout).toContain("libretto-cli [command]");
     expect(result.stderr).toBe("");
   });
 
@@ -49,8 +51,9 @@ describe("basic CLI subprocess behavior", () => {
   test("fails unknown command with non-zero exit code", async ({ librettoCli }) => {
     const result = await librettoCli("nope-command");
     expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("libretto-cli [command]");
     expect(result.stderr).toContain("Unknown command: nope-command");
-    expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
+    expect(result.stdout).toBe("");
   });
 
   test("fails open with missing url usage error", async ({ librettoCli }) => {
@@ -93,13 +96,11 @@ describe("basic CLI subprocess behavior", () => {
 
   test("allows run guard when session is permissioned interactive", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
   }) => {
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).not.toContain("is read-only");
@@ -108,12 +109,10 @@ describe("basic CLI subprocess behavior", () => {
 
   test("fails run when export is not a Libretto workflow instance", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -125,7 +124,7 @@ export async function main() {
     );
 
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("must be a Libretto workflow instance");
@@ -133,12 +132,10 @@ export async function main() {
 
   test("accepts branded Libretto workflow contract across module boundaries", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -156,9 +153,9 @@ export const main = {
     );
 
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
       {
-      PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
+        PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
       },
     );
     expect(result.exitCode).toBe(1);
@@ -167,7 +164,6 @@ export const main = {
 
   test("fails run when local auth profile is declared but missing", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -175,8 +171,7 @@ export const main = {
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -193,7 +188,7 @@ export const main = workflow(
     );
 
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
@@ -206,16 +201,15 @@ export const main = workflow(
       ".libretto/profiles/app.example.com.json",
     );
     expect(result.stderr).toContain(
-      `libretto-cli open https://app.example.com --headed --session ${defaultSession}`,
+      `libretto-cli open https://app.example.com --headed --session ${testSession}`,
     );
     expect(result.stderr).toContain(
-      `libretto-cli save app.example.com --session ${defaultSession}`,
+      `libretto-cli save app.example.com --session ${testSession}`,
     );
   });
 
   test("does not require local auth profile when auth metadata is absent", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -223,8 +217,7 @@ export const main = workflow(
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -236,7 +229,7 @@ export const main = workflow({}, async () => "ok");
     );
 
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
       {
         PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
       },
@@ -247,7 +240,6 @@ export const main = workflow({}, async () => "ok");
 
   test("proceeds when declared local auth profile file exists", async ({
     librettoCli,
-    seedDefaultSession,
     seedSessionPermission,
     workspacePath,
   }) => {
@@ -255,8 +247,7 @@ export const main = workflow({}, async () => "ok");
       "../../libretto/src/workflow/workflow.ts",
       import.meta.url,
     ).href;
-    const defaultSession = await seedDefaultSession();
-    await seedSessionPermission(defaultSession, "interactive");
+    await seedSessionPermission(testSession, "interactive");
     await writeFile(
       workspacePath("integration.ts"),
       `
@@ -277,7 +268,7 @@ export const main = workflow(
     );
 
     const result = await librettoCli(
-      `run ./integration.ts main --session ${defaultSession}`,
+      `run ./integration.ts main --session ${testSession}`,
       {
         PLAYWRIGHT_BROWSERS_PATH: workspacePath("missing-playwright-browsers"),
       },
@@ -368,9 +359,9 @@ export const main = workflow(
   });
 
   test("fails when --session value is missing", async ({ librettoCli }) => {
-    const result = await librettoCli("help --session");
+    const result = await librettoCli("open --session");
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Missing or invalid --session value.");
+    expect(result.stderr).toContain("Not enough arguments following: session");
   });
 
   test("fails when --session value is another command token", async ({

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -74,7 +74,6 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await seedSessionState({
       session: "net-session",
-      runId: "run-net",
     });
     const logPath = await seedNetworkLog("net-session", [
       {
@@ -124,7 +123,6 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await seedSessionState({
       session: "actions-session",
-      runId: "run-actions",
     });
     const logPath = await seedActionLog("actions-session", [
       {

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -284,7 +284,6 @@ describe("state-driven CLI subprocess behavior", () => {
         {
           version: 2,
           session,
-          runId: "run-invalid-version",
           port: 65534,
           pid: 12345,
           startedAt: "2026-01-01T00:00:00.000Z",

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -1,5 +1,4 @@
-import yargs, { type Argv } from "yargs";
-import { hideBin } from "yargs/helpers";
+import yargs, { type Argv, type ArgumentsCamelCase } from "yargs";
 import { registerAICommands } from "./commands/ai";
 import { registerBrowserCommands } from "./commands/browser";
 import { registerExecutionCommands } from "./commands/execution";
@@ -44,98 +43,6 @@ const SESSION_REQUIRED_COMMANDS = new Set([
   "close",
 ]);
 
-function printUsage(): void {
-  console.log(`Usage: libretto-cli <command> [--session <name>]
-
-Commands:
-  open <url> [--headless] Launch browser and open URL (headed by default)
-                          Automatically loads saved profile if available
-  run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug <true|false>]  Run an exported Libretto workflow from a file (blocked until interactive)
-  session-mode <read-only|interactive> Set session execution mode
-  ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
-  save <url|domain>       Save current browser session (cookies, localStorage, etc.)
-  exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until interactive)
-  snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when both flags are provided
-  network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
-  actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
-  close                   Close the browser
-
-Options:
-  --session <name>        Use a named session
-                          Required for: run, session-mode, save, exec, snapshot, network, actions, close
-                          If omitted for open, a 5-character id is auto-generated
-
-Examples:
-  libretto-cli open https://linkedin.com
-  # open prints the generated session id (for example: abc12)
-  libretto-cli session-mode interactive --session abc12
-
-  # ... manually log in ...
-  libretto-cli save linkedin.com --session abc12
-  # Next time you open linkedin.com, you'll be logged in automatically
-
-  libretto-cli exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
-  libretto-cli exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
-  libretto-cli ai configure codex
-  libretto-cli ai configure claude
-  libretto-cli ai configure gemini
-  libretto-cli ai configure <codex|claude|gemini> -- <command prefix...>
-  libretto-cli snapshot
-  libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
-  libretto-cli close
-
-  # Multiple sessions
-  libretto-cli open https://site1.com --session test1
-  libretto-cli open https://site2.com --session test2
-  libretto-cli exec "return await page.title()" --session test1
-
-Available in exec:
-  page, context, state, browser, networkLog, actionLog
-
-Profiles:
-  Profiles are saved to .libretto/profiles/<domain>.json (git-ignored)
-  They persist cookies, localStorage, and session data across browser launches.
-  Local profiles are machine-local and are not shared with other users/environments.
-  Sessions can expire; if run fails auth, log in again and re-save the profile.
-
-Sessions:
-  Session state is stored in .libretto/sessions/<session>/state.json
-  CLI logs are stored in .libretto/sessions/<session>/logs.jsonl
-  Each session runs an isolated browser instance on a dynamic port.
-`);
-}
-
-function filterSessionArgs(args: string[]): string[] {
-  const result: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--session") {
-      i++;
-    } else {
-      result.push(args[i]!);
-    }
-  }
-  return result;
-}
-
-function getExplicitSession(rawArgs: string[]): string | undefined {
-  const idx = rawArgs.indexOf("--session");
-  if (idx < 0) return undefined;
-  const value = rawArgs[idx + 1];
-  return value;
-}
-
-function validateLegacySessionArg(rawArgs: string[]): void {
-  const idx = rawArgs.indexOf("--session");
-  if (idx < 0) return;
-  const value = rawArgs[idx + 1];
-  if (!value || value.startsWith("--") || CLI_COMMANDS.has(value)) {
-    throw new Error(
-      "Usage: libretto-cli <command> [--session <name>]\nMissing or invalid --session value.",
-    );
-  }
-  validateSessionName(value);
-}
-
 function initializeLogger(rawArgs: string[], session: string): void {
   const logFilePath = logFileForSession(session);
 
@@ -147,35 +54,95 @@ function initializeLogger(rawArgs: string[], session: string): void {
   });
 }
 
-function createParser(defaultSession: string): Argv {
-  let parser: Argv = (yargs(hideBin(process.argv)) as Argv)
+function invalidSessionValueMessage(): string {
+  return "Usage: libretto-cli <command> [--session <name>]\nMissing or invalid --session value.";
+}
+
+function getCommand(argv: ArgumentsCamelCase): string | null {
+  const commandValue = argv._[0];
+  return typeof commandValue === "string" ? commandValue : null;
+}
+
+function getCommandArgs(argv: ArgumentsCamelCase): string[] {
+  return argv._.filter((item): item is string => typeof item === "string");
+}
+
+function getRawSession(argv: ArgumentsCamelCase): unknown {
+  return (argv as { session?: unknown }).session;
+}
+
+function autoCreateSessionForOpen(argv: ArgumentsCamelCase): void {
+  const command = getCommand(argv);
+  const rawSession = getRawSession(argv);
+  if (command === "open" && rawSession === undefined) {
+    (argv as { session?: string }).session = generateSessionName();
+  }
+}
+
+function assertSession(argv: ArgumentsCamelCase): string | undefined {
+  const command = getCommand(argv);
+  const rawSession = getRawSession(argv);
+
+  if (rawSession !== undefined) {
+    if (typeof rawSession !== "string") {
+      return invalidSessionValueMessage();
+    }
+    if (!rawSession || rawSession.startsWith("--")) {
+      return invalidSessionValueMessage();
+    }
+    if (CLI_COMMANDS.has(rawSession)) {
+      return invalidSessionValueMessage();
+    }
+    try {
+      validateSessionName(rawSession);
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  if (!command || command === "help") {
+    return undefined;
+  }
+
+  if (SESSION_REQUIRED_COMMANDS.has(command) && rawSession === undefined) {
+    return `Missing --session for "${command}". Start with 'libretto-cli open <url>' and use the returned session id.`;
+  }
+
+  return undefined;
+}
+
+function createParser(
+  rawArgs: string[],
+  onArgvResolved: (argv: ArgumentsCamelCase) => void,
+): Argv {
+  let parser: Argv = (yargs(rawArgs) as Argv)
     .scriptName("libretto-cli")
     .parserConfiguration({ "populate--": true })
+    .strictCommands()
     .option("session", {
       type: "string",
-      default: defaultSession,
       describe: "Use a named session",
       global: true,
     })
+    .requiresArg("session")
     .middleware((argv) => {
-      validateSessionName(String(argv.session));
+      autoCreateSessionForOpen(argv);
+    }, true)
+    .check((argv) => {
+      const error = assertSession(argv);
+      if (error) return error;
+      return true;
     })
+    .middleware((argv) => onArgvResolved(argv))
     .exitProcess(false)
-    .help(false)
-    .version(false)
-    .fail((msg, err) => {
-      if (err) throw err;
-      throw new Error(msg || "Command failed");
-    });
+    .showHelpOnFail(true)
+    .version(false);
 
   parser = registerBrowserCommands(parser);
   parser = registerExecutionCommands(parser);
   parser = registerLogCommands(parser);
   parser = registerAICommands(parser);
   parser = registerSnapshotCommands(parser);
-  parser = parser.command("help", "Show usage", () => {}, () => {
-    printUsage();
-  });
 
   return parser;
 }
@@ -183,51 +150,46 @@ function createParser(defaultSession: string): Argv {
 export async function runLibrettoCLI(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   ensureLibrettoSetup();
-  let log: ReturnType<typeof getLog> | null = null;
+  let loggerInitialized = false;
 
   try {
-    validateLegacySessionArg(rawArgs);
+    const parser = createParser(rawArgs, (argv) => {
+      if (loggerInitialized) {
+        return;
+      }
+      const command = getCommand(argv);
+      const session = getRawSession(argv);
+      if (!command || command === "help" || typeof session !== "string") {
+        return;
+      }
+      initializeLogger(rawArgs, session);
+      const logger = getLog();
+      logger.info("cli-command", {
+        command,
+        args: getCommandArgs(argv),
+      });
+      loggerInitialized = true;
+    });
 
-    const args = filterSessionArgs(rawArgs);
-    const command = args[0];
-
-    if (!command || command === "--help" || command === "-h" || command === "help") {
-      printUsage();
+    if (rawArgs.length === 0) {
+      parser.showHelp();
       await flushLog();
       process.exit(0);
     }
 
-    if (!CLI_COMMANDS.has(command)) {
-      console.error(`Unknown command: ${command}\n`);
-      printUsage();
-      await flushLog();
-      process.exit(1);
-    }
-
-    const explicitSession = getExplicitSession(rawArgs);
-    if (SESSION_REQUIRED_COMMANDS.has(command) && !explicitSession) {
-      throw new Error(
-        `Missing --session for "${command}". Start with 'libretto-cli open <url>' and use the returned session id.`,
-      );
-    }
-
-    const sessionId = explicitSession ?? generateSessionName();
-    initializeLogger(rawArgs, sessionId);
-    log = getLog();
-
-    const parser = createParser(sessionId);
-    log.info("cli-command", { command, args });
     await parser.parseAsync();
 
     await flushLog();
     process.exit(0);
   } catch (err) {
-    if (log) {
-      log.error("cli-error", { error: err, args: rawArgs });
+    if (loggerInitialized) {
+      getLog().error("cli-error", { error: err, args: rawArgs });
     }
     await flushLog();
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(message);
+    if (!(err instanceof Error && err.name === "YError")) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(message);
+    }
     process.exit(1);
   }
 }

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -12,8 +12,8 @@ import {
   setLogFile,
 } from "./core/context";
 import {
+  generateSessionName,
   logFileForSession,
-  SESSION_DEFAULT,
   validateSessionName,
 } from "./core/session";
 
@@ -33,6 +33,17 @@ const CLI_COMMANDS = new Set([
   "help",
 ]);
 
+const SESSION_REQUIRED_COMMANDS = new Set([
+  "run",
+  "session-mode",
+  "save",
+  "exec",
+  "snapshot",
+  "network",
+  "actions",
+  "close",
+]);
+
 function printUsage(): void {
   console.log(`Usage: libretto-cli <command> [--session <name>]
 
@@ -50,16 +61,17 @@ Commands:
   close                   Close the browser
 
 Options:
-  --session <name>        Use a named session (default: "default")
-                          Built-in sessions: default, dev-server, browser-agent
+  --session <name>        Use a named session
+                          Required for: run, session-mode, save, exec, snapshot, network, actions, close
+                          If omitted for open, a 5-character id is auto-generated
 
 Examples:
   libretto-cli open https://linkedin.com
-  # default sessions are read-only; enable actions only after explicit human approval
-  libretto-cli session-mode interactive --session default
+  # open prints the generated session id (for example: abc12)
+  libretto-cli session-mode interactive --session abc12
 
   # ... manually log in ...
-  libretto-cli save linkedin.com
+  libretto-cli save linkedin.com --session abc12
   # Next time you open linkedin.com, you'll be logged in automatically
 
   libretto-cli exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
@@ -105,19 +117,11 @@ function filterSessionArgs(args: string[]): string[] {
   return result;
 }
 
-function parseSessionForLog(rawArgs: string[]): string {
+function getExplicitSession(rawArgs: string[]): string | undefined {
   const idx = rawArgs.indexOf("--session");
-  if (idx < 0) return SESSION_DEFAULT;
+  if (idx < 0) return undefined;
   const value = rawArgs[idx + 1];
-  if (!value || value.startsWith("--") || CLI_COMMANDS.has(value)) {
-    return SESSION_DEFAULT;
-  }
-  try {
-    validateSessionName(value);
-    return value;
-  } catch {
-    return SESSION_DEFAULT;
-  }
+  return value;
 }
 
 function validateLegacySessionArg(rawArgs: string[]): void {
@@ -132,25 +136,24 @@ function validateLegacySessionArg(rawArgs: string[]): void {
   validateSessionName(value);
 }
 
-function initializeLogger(rawArgs: string[]): void {
-  const sessionForLog = parseSessionForLog(rawArgs);
-  const logFilePath = logFileForSession(sessionForLog);
+function initializeLogger(rawArgs: string[], session: string): void {
+  const logFilePath = logFileForSession(session);
 
   setLogFile(logFilePath);
   getLog().info("cli-start", {
     args: rawArgs,
     cwd: process.cwd(),
-    session: sessionForLog,
+    session,
   });
 }
 
-function createParser(): Argv {
+function createParser(defaultSession: string): Argv {
   let parser: Argv = (yargs(hideBin(process.argv)) as Argv)
     .scriptName("libretto-cli")
     .parserConfiguration({ "populate--": true })
     .option("session", {
       type: "string",
-      default: SESSION_DEFAULT,
+      default: defaultSession,
       describe: "Use a named session",
       global: true,
     })
@@ -180,8 +183,7 @@ function createParser(): Argv {
 export async function runLibrettoCLI(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   ensureLibrettoSetup();
-  initializeLogger(rawArgs);
-  const log = getLog();
+  let log: ReturnType<typeof getLog> | null = null;
 
   try {
     validateLegacySessionArg(rawArgs);
@@ -202,14 +204,27 @@ export async function runLibrettoCLI(): Promise<void> {
       process.exit(1);
     }
 
-    const parser = createParser();
+    const explicitSession = getExplicitSession(rawArgs);
+    if (SESSION_REQUIRED_COMMANDS.has(command) && !explicitSession) {
+      throw new Error(
+        `Missing --session for "${command}". Start with 'libretto-cli open <url>' and use the returned session id.`,
+      );
+    }
+
+    const sessionId = explicitSession ?? generateSessionName();
+    initializeLogger(rawArgs, sessionId);
+    log = getLog();
+
+    const parser = createParser(sessionId);
     log.info("cli-command", { command, args });
     await parser.parseAsync();
 
     await flushLog();
     process.exit(0);
   } catch (err) {
-    log.error("cli-error", { error: err, args: rawArgs });
+    if (log) {
+      log.error("cli-error", { error: err, args: rawArgs });
+    }
     await flushLog();
     const message = err instanceof Error ? err.message : String(err);
     console.error(message);

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -119,6 +119,7 @@ function createParser(
     .scriptName("libretto-cli")
     .parserConfiguration({ "populate--": true })
     .strictCommands()
+    .demandCommand(1)
     .option("session", {
       type: "string",
       describe: "Use a named session",

--- a/packages/libretto-cli/src/commands/browser.ts
+++ b/packages/libretto-cli/src/commands/browser.ts
@@ -72,7 +72,7 @@ export function registerBrowserCommands(yargs: Argv): Argv {
         const mode = argv.mode;
         if (mode !== "read-only" && mode !== "interactive") {
           throw new Error(
-            "Usage: libretto-cli session-mode <read-only|interactive> [--session <name>]",
+            "Usage: libretto-cli session-mode <read-only|interactive> --session <name>",
           );
         }
         runSessionMode(String(argv.session), mode);
@@ -85,7 +85,7 @@ export function registerBrowserCommands(yargs: Argv): Argv {
       async (argv) => {
         const urlOrDomain = argv.urlOrDomain as string | undefined;
         if (!urlOrDomain) {
-          throw new Error("Usage: libretto-cli save <url|domain> [--session <name>]");
+          throw new Error("Usage: libretto-cli save <url|domain> --session <name>");
         }
         await runSave(urlOrDomain, String(argv.session));
       },

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -26,6 +26,7 @@ import {
 } from "../core/browser";
 import { getLog } from "../core/context";
 import {
+  getSessionPermissionMode,
   readSessionStateOrThrow,
   readOnlySessionError,
   resolveSessionMode,
@@ -410,6 +411,11 @@ export function registerExecutionCommands(yargs: Argv): Argv {
           .option("params-file", { type: "string" })
           .option("headed", { type: "boolean", default: false })
           .option("headless", { type: "boolean", default: false })
+          .option("allow-actions", {
+            type: "boolean",
+            default: false,
+            hidden: true,
+          })
           .option("debug", { type: "string" }),
       async (argv) => {
         const usage =
@@ -421,6 +427,17 @@ export function registerExecutionCommands(yargs: Argv): Argv {
         }
 
         const session = String(argv.session);
+        const allowActions = Boolean(
+          argv["allow-actions"] ?? (argv as { allowActions?: boolean }).allowActions,
+        );
+        if (allowActions) {
+          throw new Error(
+            `--allow-actions is not supported for run. ${readOnlySessionError(session)}`,
+          );
+        }
+        if (getSessionPermissionMode(session) !== "interactive") {
+          throw new Error(readOnlySessionError(session));
+        }
 
         const rawInlineParams = argv.params as string | undefined;
         const paramsFile = argv["params-file"] as string | undefined;

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -395,7 +395,7 @@ export function registerExecutionCommands(yargs: Argv): Argv {
         const code = codeParts.join(" ");
         if (!code) {
           throw new Error(
-            "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
+            "Usage: libretto-cli exec <code> --session <name> [--visualize]",
           );
         }
         await runExec(code, String(argv.session), Boolean(argv.visualize));

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -26,7 +26,6 @@ import {
 } from "../core/browser";
 import { getLog } from "../core/context";
 import {
-  getSessionPermissionMode,
   readSessionStateOrThrow,
   readOnlySessionError,
   resolveSessionMode,

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -2,17 +2,24 @@ import { mkdirSync } from "node:fs";
 import type { Argv } from "yargs";
 import { connect, disconnectBrowser } from "../core/browser";
 import { getLog, getSessionSnapshotRunDir } from "../core/context";
-import { generateRunId } from "../core/session";
 import {
   canAnalyzeSnapshots,
   runInterpret,
   type ScreenshotPair,
 } from "../core/snapshot-analyzer";
 
+function generateSnapshotTimestampId(): string {
+  return new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .replace(/\..+/, "")
+    .replace(/^(\d{8})(\d{6})$/, "$1-$2");
+}
+
 async function captureScreenshot(session: string): Promise<ScreenshotPair> {
   const log = getLog();
   log.info("screenshot-start", { session });
-  const snapshotRunId = `snapshot-${generateRunId()}-${Math.random()
+  const snapshotRunId = `snapshot-${generateSnapshotTimestampId()}-${Math.random()
     .toString(36)
     .slice(2, 8)}`;
   const snapshotRunDir = getSessionSnapshotRunDir(session, snapshotRunId);

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -13,7 +13,6 @@ import {
 } from "./context";
 import {
   clearSessionState,
-  generateRunId,
   getSessionPermissionMode,
   readSessionStateOrThrow,
   logFileForSession,
@@ -234,7 +233,6 @@ export async function runOpen(
   }
 
   const port = await pickFreePort();
-  const runId = generateRunId();
   const runLogPath = logFileForSession(session);
   const networkLogPath = getSessionNetworkLogPath(session);
   const actionsLogPath = getSessionActionsLogPath(session);
@@ -253,7 +251,6 @@ export async function runOpen(
     sessionMode,
     session,
     port,
-    runId,
     domain,
     useProfile,
     profilePath: useProfile ? profilePath : undefined,
@@ -263,7 +260,7 @@ export async function runOpen(
     console.log(`Loading saved profile for ${domain}`);
   }
   console.log(
-    `Launching ${browserMode} browser (session: ${session}, run: ${runId})...`,
+    `Launching ${browserMode} browser (session: ${session})...`,
   );
 
   const escapedProfilePath = profilePath
@@ -679,7 +676,6 @@ await new Promise(() => {});
         port,
         pid: child.pid!,
         session,
-        runId,
         startedAt: new Date().toISOString(),
         mode: sessionMode,
       });
@@ -689,7 +685,6 @@ await new Promise(() => {});
         sessionMode,
         session,
         port,
-        runId,
         pid: child.pid,
       });
       console.log(`Browser open (${browserMode}): ${url}`);

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -27,6 +27,7 @@ import {
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
 const AUTO_SESSION_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
 const AUTO_SESSION_LENGTH = 5;
+const MAX_AUTO_SESSION_GENERATION_ATTEMPTS = 128;
 
 export const SESSION_DEV_SERVER = "dev-server";
 export const SESSION_BROWSER_AGENT = "browser-agent";
@@ -37,13 +38,30 @@ type SessionPermissions = {
   sessions: Record<string, SessionMode>;
 };
 
-export function generateSessionName(): string {
+function generateSessionNameCandidate(): string {
   let value = "";
   for (let i = 0; i < AUTO_SESSION_LENGTH; i += 1) {
     const index = Math.floor(Math.random() * AUTO_SESSION_CHARS.length);
     value += AUTO_SESSION_CHARS[index];
   }
   return value;
+}
+
+function hasSessionState(session: string): boolean {
+  return existsSync(getSessionStatePath(session));
+}
+
+export function generateSessionName(
+  sessionExists: (session: string) => boolean = hasSessionState,
+): string {
+  for (let attempt = 0; attempt < MAX_AUTO_SESSION_GENERATION_ATTEMPTS; attempt += 1) {
+    const candidate = generateSessionNameCandidate();
+    if (!sessionExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Failed to generate a unique session id.");
 }
 
 export function logFileForSession(session: string): string {

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -17,8 +17,9 @@ import {
 } from "./context";
 
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
+const AUTO_SESSION_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+const AUTO_SESSION_LENGTH = 5;
 
-export const SESSION_DEFAULT = "default";
 export const SESSION_DEV_SERVER = "dev-server";
 export const SESSION_BROWSER_AGENT = "browser-agent";
 export type SessionMode = "read-only" | "interactive";
@@ -27,7 +28,6 @@ export type SessionState = {
   port: number;
   pid: number;
   session: string;
-  runId: string;
   startedAt: string;
   mode?: SessionMode;
 };
@@ -36,12 +36,13 @@ type SessionPermissions = {
   sessions: Record<string, SessionMode>;
 };
 
-export function generateRunId(): string {
-  return new Date()
-    .toISOString()
-    .replace(/[-:T]/g, "")
-    .replace(/\..+/, "")
-    .replace(/^(\d{8})(\d{6})$/, "$1-$2");
+export function generateSessionName(): string {
+  let value = "";
+  for (let i = 0; i < AUTO_SESSION_LENGTH; i += 1) {
+    const index = Math.floor(Math.random() * AUTO_SESSION_CHARS.length);
+    value += AUTO_SESSION_CHARS[index];
+  }
+  return value;
 }
 
 export function logFileForSession(session: string): string {
@@ -151,7 +152,6 @@ export function writeSessionState(state: SessionState): void {
     stateFile,
     port: state.port,
     pid: state.pid,
-    runId: state.runId,
   });
 }
 

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -71,7 +71,7 @@ describe("cli test fixtures", () => {
     async ({ librettoCli, workspacePath }) => {
       const result = await librettoCli("--help");
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("libretto-cli [command]");
+      expect(result.stdout).toMatch(/libretto-cli [<\[]command[>\]]/);
       expect(existsSync(workspacePath(".libretto"))).toBe(true);
       expect(existsSync(workspacePath(".libretto", ".gitignore"))).toBe(true);
       expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(false);

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -44,7 +44,6 @@ describe("cli test fixtures", () => {
   }) => {
     const seeded = await seedSessionState({
       session: "spec-session",
-      runId: "run-2",
     });
     await seedNetworkLog("spec-session", [
       { ts: "2026-01-01T00:00:00.000Z", method: "GET", url: "https://example.com", status: 200, contentType: "text/html", size: 1, durationMs: 1 },

--- a/packages/libretto-cli/src/test-fixtures.test.ts
+++ b/packages/libretto-cli/src/test-fixtures.test.ts
@@ -71,7 +71,7 @@ describe("cli test fixtures", () => {
     async ({ librettoCli, workspacePath }) => {
       const result = await librettoCli("--help");
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("Usage: libretto-cli");
+      expect(result.stdout).toContain("libretto-cli [command]");
       expect(existsSync(workspacePath(".libretto"))).toBe(true);
       expect(existsSync(workspacePath(".libretto", ".gitignore"))).toBe(true);
       expect(existsSync(workspacePath("tmp", "libretto-cli"))).toBe(false);

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -23,7 +23,6 @@ type SpawnResult = {
 };
 
 type SeedHelpers = {
-  seedDefaultSession: (session?: string) => Promise<string>;
   seedSessionState: (state?: Partial<SessionState>) => Promise<SessionState>;
   seedSessionPermission: (
     session: string,
@@ -203,13 +202,6 @@ export const test = base.extend<CliFixtures>({
         JSON.stringify(normalized, null, 2),
       );
       return normalized;
-    });
-  },
-
-  seedDefaultSession: async ({}, use) => {
-    await use(async (session?: string) => {
-      const value = session ?? testDefaultSession;
-      return value;
     });
   },
 

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -10,7 +10,6 @@ type SessionState = {
   port: number;
   pid: number;
   session: string;
-  runId: string;
   startedAt: string;
   mode?: "read-only" | "interactive";
 };
@@ -24,6 +23,7 @@ type SpawnResult = {
 };
 
 type SeedHelpers = {
+  seedDefaultSession: (session?: string) => Promise<string>;
   seedSessionState: (state?: Partial<SessionState>) => Promise<SessionState>;
   seedSessionPermission: (
     session: string,
@@ -47,6 +47,7 @@ const here = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = resolve(here, "../../..");
 const cliEntry = resolve(repoRoot, "packages/libretto-cli/dist/index.js");
 const librettoEntry = resolve(repoRoot, "packages/libretto/dist/index.js");
+const testDefaultSession = "abc12";
 
 let didBuild = false;
 
@@ -187,10 +188,9 @@ export const test = base.extend<CliFixtures>({
 
   seedSessionState: async ({ workspacePath }, use) => {
     await use(async (state?: Partial<SessionState>) => {
-      const session = state?.session ?? "default";
+      const session = state?.session ?? testDefaultSession;
       const normalized: SessionState = {
         session,
-        runId: state?.runId ?? "run-seeded",
         port: state?.port ?? 9222,
         pid: state?.pid ?? 12345,
         startedAt: state?.startedAt ?? "2026-01-01T00:00:00.000Z",
@@ -203,6 +203,13 @@ export const test = base.extend<CliFixtures>({
         JSON.stringify(normalized, null, 2),
       );
       return normalized;
+    });
+  },
+
+  seedDefaultSession: async ({}, use) => {
+    await use(async (session?: string) => {
+      const value = session ?? testDefaultSession;
+      return value;
     });
   },
 

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -15,18 +15,19 @@ If it's not obvious which element to click or what value to enter, **ask the use
 
 ```bash
 npx libretto open <url> [--headed]     # Launch browser and navigate (headless by default)
-npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
-npx libretto run <integrationFile> <integrationExport> # Execute integration actions
-npx libretto session-mode <read-only|interactive> [--session <name>] # Set session mode explicitly
-npx libretto snapshot --objective "<what to find>" --context "<situational info>"
-npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto/profiles/
-npx libretto network                   # Show last 20 captured network requests
-npx libretto actions                   # Show last 20 captured user/agent actions
-npx libretto close                     # Close the browser
+npx libretto exec <code> --session <name> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
+npx libretto run <integrationFile> <integrationExport> --session <name> # Execute integration actions
+npx libretto session-mode <read-only|interactive> --session <name> # Set session mode explicitly
+npx libretto snapshot --session <name> --objective "<what to find>" --context "<situational info>"
+npx libretto save <url|domain> --session <name> # Save session (cookies, localStorage) to .libretto/profiles/
+npx libretto network --session <name>  # Show last 20 captured network requests
+npx libretto actions --session <name>  # Show last 20 captured user/agent actions
+npx libretto close --session <name>    # Close the browser
 ```
 
-All commands accept `--session <name>` for isolated browser instances.
-If `--session` is omitted on `open`, Libretto auto-generates a 5-character session id and prints it.
+`open` accepts optional `--session <name>`.
+If omitted on `open`, Libretto auto-generates a 5-character session id and prints it.
+All other session-bound commands require `--session <name>`.
 Built-in sessions: `dev-server`, `browser-agent`.
 
 ## Session Mode: Read-Only by Default
@@ -59,26 +60,26 @@ npx libretto open https://example.com
 npx libretto session-mode interactive --session abc12
 
 # Interact with elements
-npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
-npx libretto exec "await page.fill('input[name=\"email\"]', 'user@example.com')"
+npx libretto exec --session abc12 "await page.locator('button:has-text(\"Sign in\")').click()"
+npx libretto exec --session abc12 "await page.fill('input[name=\"email\"]', 'user@example.com')"
 
 # Understand the page — always provide objective and context
-npx libretto snapshot \
+npx libretto snapshot --session abc12 \
   --objective "Find the sign-in form fields and submit button" \
   --context "Navigated to example.com login page. Expecting email/password inputs and a submit button."
 
 # Include relevant network calls in context when debugging API interactions
-npx libretto snapshot \
+npx libretto snapshot --session abc12 \
   --objective "Find why the referral list is empty" \
   --context "Logged into eClinicalWorks. Clicked Open Referrals tab. Table appears but shows no rows. Recent POST to /servlet/AjaxServlet returned 200 but with empty body."
 
 # Done
-npx libretto close
+npx libretto close --session abc12
 ```
 
 ## Workflow: Save and Restore Login Sessions
 
-Profiles persist cookies and localStorage across browser launches. They are saved to `.libretto-cli/profiles/<domain>.json` (git-ignored) and loaded automatically on `open`.
+Profiles persist cookies and localStorage across browser launches. They are saved to `.libretto/profiles/<domain>.json` (git-ignored) and loaded automatically on `open`.
 
 ```bash
 # Open a site in headed mode so you can log in manually
@@ -87,7 +88,7 @@ npx libretto open https://portal.example.com --headed
 # ... manually log in in the browser window ...
 
 # Save the session
-npx libretto save portal.example.com
+npx libretto save portal.example.com --session abc12
 
 # Next time you open this domain, you'll be logged in automatically
 npx libretto open https://portal.example.com

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -14,7 +14,7 @@ If it's not obvious which element to click or what value to enter, **ask the use
 ## Commands
 
 ```bash
-npx libretto open <url> [--headed]     # Launch browser and navigate (headless by default)
+npx libretto open <url> [--headed]     # Launch browser and navigate (headed by default)
 npx libretto exec <code> --session <name> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> --session <name> # Execute integration actions
 npx libretto session-mode <read-only|interactive> --session <name> # Set session mode explicitly

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -19,14 +19,15 @@ npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--v
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
 npx libretto session-mode <read-only|interactive> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" --context "<situational info>"
-npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto-cli/profiles/
+npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto/profiles/
 npx libretto network                   # Show last 20 captured network requests
 npx libretto actions                   # Show last 20 captured user/agent actions
 npx libretto close                     # Close the browser
 ```
 
-All commands accept `--session <name>` for isolated browser instances (default: `default`).
-Built-in sessions: `default`, `dev-server`, `browser-agent`.
+All commands accept `--session <name>` for isolated browser instances.
+If `--session` is omitted on `open`, Libretto auto-generates a 5-character session id and prints it.
+Built-in sessions: `dev-server`, `browser-agent`.
 
 ## Session Mode: Read-Only by Default
 
@@ -54,8 +55,8 @@ The `state` object persists across `exec` calls within the same session — use 
 # Open a page (starts in read-only mode)
 npx libretto open https://example.com
 
-# When user grants interactive access:
-npx libretto session-mode interactive --session default
+# When user grants interactive access (replace abc12 with the id printed by open):
+npx libretto session-mode interactive --session abc12
 
 # Interact with elements
 npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
@@ -187,7 +188,7 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 ## Network Logging
 
-Network requests are captured automatically when a browser is opened via `npx libretto open`. All non-static HTTP responses (excluding `.css`, `.js`, `.png`, `.jpg`, `.gif`, `.woff`, `.ico`, `.svg`, and `chrome-extension://` URLs) are logged to `tmp/libretto-cli/<runId>/network.jsonl`.
+Network requests are captured automatically when a browser is opened via `npx libretto open`. All non-static HTTP responses (excluding `.css`, `.js`, `.png`, `.jpg`, `.gif`, `.woff`, `.ico`, `.svg`, and `chrome-extension://` URLs) are logged to `.libretto/sessions/<session>/network.jsonl`.
 
 ### CLI: `npx libretto network`
 
@@ -213,7 +214,7 @@ Returns an array of objects with: `ts`, `method`, `url`, `status`, `contentType`
 
 ## Action Logging
 
-Browser actions are captured automatically when a browser is opened via `npx libretto open`. Both user interactions (manual clicks, typing in the headed browser window) and agent actions (programmatic Playwright API calls via `exec`) are logged to `tmp/libretto-cli/<runId>/actions.jsonl` with a `source` field of `'user'` or `'agent'` to distinguish the two.
+Browser actions are captured automatically when a browser is opened via `npx libretto open`. Both user interactions (manual clicks, typing in the headed browser window) and agent actions (programmatic Playwright API calls via `exec`) are logged to `.libretto/sessions/<session>/actions.jsonl` with a `source` field of `'user'` or `'agent'` to distinguish the two.
 
 ### CLI: `npx libretto actions`
 

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -130,7 +130,7 @@ npx libretto exec --session browser-agent "await page.locator('.dropdown-trigger
 
 ## Snapshot — The Primary Observation Tool
 
-The `snapshot` command captures a PNG screenshot + HTML, sends both to a vision model (Gemini Flash), and returns an analysis with Playwright-ready selectors. **Both `--objective` and `--context` are required.** This is the single way to understand what's on the page — use it any time you need to inspect page structure, find elements, or debug what's happening.
+The `snapshot` command captures a PNG screenshot + HTML, sends both to a vision model (Gemini Flash), and returns an analysis with Playwright-ready selectors when analysis flags are provided. If both `--objective` and `--context` are omitted, it still captures PNG + HTML without analysis. If one is provided, the other is required. This is the single way to understand what's on the page — use it any time you need to inspect page structure, find elements, or debug what's happening.
 
 **Never use `page.screenshot()` via `exec` to understand the page.** Use the `snapshot` command instead — it captures the screenshot, HTML, and sends both to a vision model that returns actionable selectors. Raw screenshots give you an image with no analysis; `snapshot` gives you the answer.
 
@@ -194,11 +194,11 @@ Network requests are captured automatically when a browser is opened via `npx li
 ### CLI: `npx libretto network`
 
 ```bash
-npx libretto network                              # show last 20 requests
-npx libretto network --last 50                    # show last 50
-npx libretto network --filter 'referral|patient'  # regex filter on URL
-npx libretto network --method POST                # filter by HTTP method
-npx libretto network --clear                      # truncate the log file
+npx libretto network --session <name>                              # show last 20 requests
+npx libretto network --session <name> --last 50                    # show last 50
+npx libretto network --session <name> --filter 'referral|patient'  # regex filter on URL
+npx libretto network --session <name> --method POST                # filter by HTTP method
+npx libretto network --session <name> --clear                      # truncate the log file
 ```
 
 ### In exec: `networkLog()`
@@ -220,13 +220,13 @@ Browser actions are captured automatically when a browser is opened via `npx lib
 ### CLI: `npx libretto actions`
 
 ```bash
-npx libretto actions                              # show last 20 actions
-npx libretto actions --last 50                    # show last 50
-npx libretto actions --filter 'button|input'      # regex filter on selector/value
-npx libretto actions --action click                # filter by action type
-npx libretto actions --source user                 # only manual user actions
-npx libretto actions --source agent                # only programmatic agent actions
-npx libretto actions --clear                       # truncate the log file
+npx libretto actions --session <name>                              # show last 20 actions
+npx libretto actions --session <name> --last 50                    # show last 50
+npx libretto actions --session <name> --filter 'button|input'      # regex filter on selector/value
+npx libretto actions --session <name> --action click               # filter by action type
+npx libretto actions --session <name> --source user                # only manual user actions
+npx libretto actions --session <name> --source agent               # only programmatic agent actions
+npx libretto actions --session <name> --clear                      # truncate the log file
 ```
 
 ### In exec: `actionLog()`

--- a/packages/libretto/src/run/browser.ts
+++ b/packages/libretto/src/run/browser.ts
@@ -77,9 +77,6 @@ export async function launchBrowser({
         session: sessionName,
         port: debugPort,
         pid: process.pid,
-        runId: parsedExistingState.success
-          ? parsedExistingState.data.runId
-          : `runtime-${Date.now()}`,
         startedAt: new Date().toISOString(),
         ...(parsedExistingState.success && parsedExistingState.data.mode
           ? { mode: parsedExistingState.data.mode }

--- a/packages/libretto/src/state/session-state.ts
+++ b/packages/libretto/src/state/session-state.ts
@@ -8,7 +8,6 @@ export const SessionStateFileSchema = z.object({
 	port: z.number().int().min(0).max(65535),
 	pid: z.number().int(),
 	session: z.string().min(1),
-	runId: z.string().min(1),
 	startedAt: z.string().datetime({ offset: true }),
 	mode: SessionModeSchema.optional(),
 });


### PR DESCRIPTION
## Summary
- remove `runId` from CLI session state and launch output
- switch session flow so `open` auto-generates a short 5-char session id when `--session` is omitted
- require explicit `--session` for session-bound commands (`run`, `exec`, `snapshot`, `network`, `actions`, `save`, `close`, `session-mode`)
- move session validation/defaulting to yargs middleware + `check` and simplify CLI parser flow
- rely on yargs default help/fail output for parser errors and top-level usage
- initialize logging only after session id resolution
- update CLI docs/skill docs and tests to match the new session model

## Validation
- `pnpm --filter libretto-cli build`
- `pnpm --filter libretto-cli type-check`
- `pnpm --filter libretto-cli test`
