### PR TITLE
Simplify tsup configs and fix non-bundled CLI runtime

### DIFF
--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -1,21 +1,21 @@
 import yargs, { type Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
-import { registerAICommands } from "./commands/ai";
-import { registerBrowserCommands } from "./commands/browser";
-import { registerExecutionCommands } from "./commands/execution";
-import { registerLogCommands } from "./commands/logs";
-import { registerSnapshotCommands } from "./commands/snapshot";
+import { registerAICommands } from "./commands/ai.js";
+import { registerBrowserCommands } from "./commands/browser.js";
+import { registerExecutionCommands } from "./commands/execution.js";
+import { registerLogCommands } from "./commands/logs.js";
+import { registerSnapshotCommands } from "./commands/snapshot.js";
 import {
   ensureLibrettoSetup,
   flushLog,
   getLog,
   setLogFile,
-} from "./core/context";
+} from "./core/context.js";
 import {
   logFileForSession,
   SESSION_DEFAULT,
   validateSessionName,
-} from "./core/session";
+} from "./core/session.js";
 
 const CLI_COMMANDS = new Set([
   "open",

--- a/packages/libretto-cli/src/commands/ai.ts
+++ b/packages/libretto-cli/src/commands/ai.ts
@@ -1,5 +1,5 @@
 import type { Argv } from "yargs";
-import { runAiConfigure } from "../core/ai-config";
+import { runAiConfigure } from "../core/ai-config.js";
 
 export function registerAICommands(yargs: Argv): Argv {
   return yargs.command(

--- a/packages/libretto-cli/src/commands/browser.ts
+++ b/packages/libretto-cli/src/commands/browser.ts
@@ -1,12 +1,12 @@
 import type { Argv } from "yargs";
-import { runClose, runOpen, runSave } from "../core/browser";
+import { runClose, runOpen, runSave } from "../core/browser.js";
 import {
   readOnlySessionError,
   readSessionState,
   setSessionPermissionMode,
   writeSessionState,
   type SessionMode,
-} from "../core/session";
+} from "../core/session.js";
 
 function runSessionMode(session: string, mode: SessionMode): void {
   setSessionPermissionMode(session, mode);
@@ -95,4 +95,4 @@ export function registerBrowserCommands(yargs: Argv): Argv {
     });
 }
 
-export { runClose } from "../core/browser";
+export { runClose } from "../core/browser.js";

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -23,18 +23,18 @@ import {
   disconnectBrowser,
   getProfilePath,
   normalizeDomain,
-} from "../core/browser";
-import { getLog } from "../core/context";
+} from "../core/browser.js";
+import { getLog } from "../core/context.js";
 import {
   getSessionPermissionMode,
   readSessionStateOrThrow,
   readOnlySessionError,
-} from "../core/session";
+} from "../core/session.js";
 import {
   readActionLog,
   readNetworkLog,
   wrapPageForActionLogging,
-} from "../core/telemetry";
+} from "../core/telemetry.js";
 
 type ExecFunction = (...args: unknown[]) => Promise<unknown>;
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");

--- a/packages/libretto-cli/src/commands/logs.ts
+++ b/packages/libretto-cli/src/commands/logs.ts
@@ -6,7 +6,7 @@ import {
   formatNetworkEntry,
   readActionLog,
   readNetworkLog,
-} from "../core/telemetry";
+} from "../core/telemetry.js";
 
 export function registerLogCommands(yargs: Argv): Argv {
   return yargs

--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -1,13 +1,13 @@
 import { mkdirSync } from "node:fs";
 import type { Argv } from "yargs";
-import { connect, disconnectBrowser } from "../core/browser";
-import { getLog, getSessionSnapshotRunDir } from "../core/context";
-import { generateRunId } from "../core/session";
+import { connect, disconnectBrowser } from "../core/browser.js";
+import { getLog, getSessionSnapshotRunDir } from "../core/context.js";
+import { generateRunId } from "../core/session.js";
 import {
   canAnalyzeSnapshots,
   runInterpret,
   type ScreenshotPair,
-} from "../core/snapshot-analyzer";
+} from "../core/snapshot-analyzer.js";
 
 async function captureScreenshot(session: string): Promise<ScreenshotPair> {
   const log = getLog();

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { z } from "zod";
-import { LIBRETTO_CONFIG_PATH } from "./context";
+import { LIBRETTO_CONFIG_PATH } from "./context.js";
 
 export const CURRENT_CONFIG_VERSION = 1;
 

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -10,7 +10,7 @@ import {
   PROFILES_DIR,
   REPO_ROOT,
   setLogFile,
-} from "./context";
+} from "./context.js";
 import {
   clearSessionState,
   generateRunId,
@@ -19,7 +19,7 @@ import {
   logFileForSession,
   readSessionState,
   writeSessionState,
-} from "./session";
+} from "./session.js";
 
 async function pickFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -14,7 +14,7 @@ import {
   LIBRETTO_CONFIG_DIR,
   LIBRETTO_CONFIG_PATH,
   LIBRETTO_SESSIONS_DIR,
-} from "./context";
+} from "./context.js";
 import {
   SESSION_STATE_VERSION,
   SessionModeSchema,

--- a/packages/libretto-cli/src/core/snapshot-analyzer.ts
+++ b/packages/libretto-cli/src/core/snapshot-analyzer.ts
@@ -12,11 +12,11 @@ import {
   type AiConfig,
   formatCommandPrefix,
   readAiConfig,
-} from "./ai-config";
+} from "./ai-config.js";
 import {
   getLLMClientFactory,
   getLog,
-} from "./context";
+} from "./context.js";
 
 export type ScreenshotPair = {
   pngPath: string;

--- a/packages/libretto-cli/src/core/telemetry.ts
+++ b/packages/libretto-cli/src/core/telemetry.ts
@@ -3,8 +3,8 @@ import type { Page } from "playwright";
 import {
   getSessionActionsLogPath,
   getSessionNetworkLogPath,
-} from "./context";
-import { assertSessionStateExistsOrThrow } from "./session";
+} from "./context.js";
+import { assertSessionStateExistsOrThrow } from "./session.js";
 
 export type NetworkLogEntry = {
   ts: string;

--- a/packages/libretto-cli/src/index.ts
+++ b/packages/libretto-cli/src/index.ts
@@ -1,11 +1,11 @@
-import { runLibrettoCLI } from "./cli";
+import { runLibrettoCLI } from "./cli.js";
 import {
   maybeConfigureLLMClientFactoryFromEnv,
   setLLMClientFactory,
-} from "./core/context";
+} from "./core/context.js";
 
 export { setLLMClientFactory };
-export { runClose } from "./commands/browser";
+export { runClose } from "./commands/browser.js";
 export { runLibrettoCLI };
 
 maybeConfigureLLMClientFactoryFromEnv();

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { test as base } from "vitest";
-import { SESSION_STATE_VERSION, type SessionState } from "./core/session";
+import { SESSION_STATE_VERSION, type SessionState } from "./core/session.js";
 
 type JsonRecord = Record<string, unknown>;
 

--- a/packages/libretto-cli/tsup.config.ts
+++ b/packages/libretto-cli/tsup.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: {
-		index: "src/index.ts",
-	},
+	entry: ["src/**/*.ts", "!src/**/*.test.ts", "!src/test-fixtures.ts"],
 	format: ["esm"],
 	dts: false,
 	clean: true,

--- a/packages/libretto-cli/tsup.config.ts
+++ b/packages/libretto-cli/tsup.config.ts
@@ -7,8 +7,7 @@ export default defineConfig({
 	format: ["esm"],
 	dts: false,
 	clean: true,
-	bundle: true,
-	splitting: false,
+	bundle: false,
 	minify: false,
 	banner: {
 		js: "#!/usr/bin/env node",

--- a/packages/libretto/tsup.config.ts
+++ b/packages/libretto/tsup.config.ts
@@ -1,22 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: {
-		index: "src/index.ts",
-		"step/index": "src/step/index.ts",
-		"logger/index": "src/logger/index.ts",
-		"recovery/index": "src/recovery/index.ts",
-		"extract/index": "src/extract/index.ts",
-		"network/index": "src/network/index.ts",
-		"download/index": "src/download/index.ts",
-		"debug/index": "src/debug/index.ts",
-		"config/index": "src/config/index.ts",
-		"instrumentation/index": "src/instrumentation/index.ts",
-		"visualization/index": "src/visualization/index.ts",
-		"llm/index": "src/llm/index.ts",
-		"state/index": "src/state/index.ts",
-		"run/api": "src/run/api.ts",
-	},
+	entry: ["src/**/*.ts", "!src/**/*.test.ts"],
 	format: ["esm", "cjs"],
 	dts: true,
 	bundle: false,

--- a/packages/libretto/tsup.config.ts
+++ b/packages/libretto/tsup.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 	},
 	format: ["esm", "cjs"],
 	dts: true,
-	splitting: false,
+	bundle: false,
 	minify: false,
 	clean: true,
 	outDir: "dist",


### PR DESCRIPTION
## Summary
- keep `bundle: false` and `minify: false` for both `libretto` and `libretto-cli`
- expand `tsup` entries to emit all runtime modules for non-bundled output
- update CLI internal relative imports to explicit `.js` specifiers so Node ESM resolves compiled files correctly

## Why
- with non-bundled output, runtime imports must reference emitted files
- extensionless relative ESM imports fail under Node when running `dist` directly

## Testing
- `pnpm --filter libretto build`
- `pnpm --filter libretto-cli build`
- `pnpm --filter libretto-cli test` (40/40 passing)
