### PR TITLE
Improve pause/resume and fail fast on active sessions

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -17,25 +17,25 @@ Sessions start in **read-only mode** by default. **Every time you launch a brows
 >
 > I've opened the browser in **read-only mode**. I can observe the page, take snapshots, and inspect network traffic, but I **cannot** click, type, fill forms, submit, or execute any actions that modify the page.
 >
-> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **full-access mode**.
+> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **interactive mode**.
 
 **Rules:**
 - Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants full access.
 - Do NOT proceed with any `exec` or `run` commands until the user explicitly grants full access.
 
-### Full-access mode (user-approved)
+### Interactive mode (user-approved)
 
-> **Session mode: FULL-ACCESS**
+> **Session mode: INTERACTIVE**
 >
-> I've opened the browser in **full-access mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
+> I've opened the browser in **interactive mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
 >
 > If you'd like me to switch to **read-only mode** (observe only, no page modifications), let me know.
 
 ### Switching modes
 
-- When the user requests full-access mode, run `npx libretto session-mode full-access --session <name>` and then proceed with `exec`/`run`.
+- When the user requests interactive mode, run `npx libretto session-mode interactive --session <name>` and then proceed with `exec`/`run`.
 - Never change session mode unless the user explicitly approves.
-- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting full access. Switch the mode and confirm.
+- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting interactive access. Switch the mode and confirm.
 
 ## Ask, Don't Guess
 
@@ -47,7 +47,8 @@ If it's not obvious which element to click or what value to enter, **ask the use
 npx libretto open <url> [--headed]     # Launch browser and navigate (headless by default)
 npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
-npx libretto session-mode <read-only|full-access> [--session <name>] # Set session mode explicitly
+npx libretto resume                    # Resume a paused workflow in the current session
+npx libretto session-mode <read-only|interactive> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" --context "<situational info>"
 npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto-cli/profiles/
 npx libretto network                   # Show last 20 captured network requests
@@ -62,6 +63,16 @@ Built-in sessions: `default`, `dev-server`, `browser-agent`.
 
 Add `--visualize` to any `exec` command to show a ghost cursor and element highlight before each action executes. Use it when the user wants to see what will be clicked/filled before it happens.
 
+## Workflow Pause/Resume (`ctx.pause()`)
+
+Workflows pause from inside the workflow function by calling `await ctx.pause()`.
+
+- There are no pause options to pass at call sites. Pause is always session-scoped and resolved from the active session.
+- `npx libretto run ...` waits until the workflow either completes or hits the next `ctx.pause()`.
+- On pause, the workflow process stays alive and keeps browser/session state.
+- `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
+- `resume` should be called repeatedly for multi-pause workflows until completion.
+
 ## Globals Available in `exec`
 
 `page`, `context`, `state`, `browser`, `networkLog({ last?, filter?, method? })`, `actionLog({ last?, filter?, action?, source? })`, `console`, `fetch`, `Buffer`, `URL`, `setTimeout`
@@ -74,8 +85,8 @@ The `state` object persists across `exec` calls within the same session — use 
 # Open a page (starts in read-only mode)
 npx libretto open https://example.com
 
-# When user grants full access:
-npx libretto session-mode full-access --session default
+# When user grants interactive access:
+npx libretto session-mode interactive --session default
 
 # Interact with elements
 npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
@@ -119,8 +130,8 @@ When browser automation jobs fail (selectors timing out, clicks not working), us
 1. Add `page.pause()` before the problematic code section
 2. Start the job with `npx browser-agent start` (debug mode is always enabled locally)
 3. Wait ~60 seconds for the browser to hit the breakpoint
-4. Ask user if they approve full-access mode for `browser-agent`
-5. If approved, run `npx libretto session-mode full-access --session browser-agent`
+4. Ask user if they approve interactive mode for `browser-agent`
+5. If approved, run `npx libretto session-mode interactive --session browser-agent`
 6. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
 7. Once the fix works, codify it in source files
 8. Restart the job to verify end-to-end
@@ -133,7 +144,7 @@ npx browser-agent start \
   --params '{"vendorName":"eClinicalWorks"}'
 
 # Inspect page state
-npx libretto session-mode full-access --session browser-agent
+npx libretto session-mode interactive --session browser-agent
 npx libretto exec --session browser-agent "return await page.url();"
 npx libretto snapshot --session browser-agent \
   --objective "Find dropdown menus and their current selections" \
@@ -200,7 +211,7 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 - **Never use `page.screenshot()` via `exec`.** Use `npx libretto snapshot` instead — it captures the viewport, sends the screenshot + HTML to a vision model, and returns actionable selectors. The `fullPage` option is especially dangerous — it scrolls the entire page to stitch a screenshot, which can crash JavaScript-heavy pages (especially EMR portals like eClinicalWorks).
 - **Never run `exec` commands in parallel.** Always wait for one `exec` to finish before starting the next. Do not use `run_in_background` for `exec` calls. Running simultaneous `exec` calls opens multiple CDP connections to the same page, which corrupts the page state and kills the browser.
-- If `open` is called when a session already has a browser running, it navigates the existing browser to the new URL instead of launching a new one.
+- `open` and `run` take control of the session. If the session already has an owner PID, it is terminated first and a warning is printed.
 - Use `return <value>` in `exec` to print results. Strings print raw; objects print as JSON.
 - For iframe content, access via `page.locator('iframe[name="..."]').contentFrame()`.
 - Multiple sessions allow parallel browser instances: `--session test1`, `--session test2`.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -20,8 +20,8 @@ Sessions start in **read-only mode** by default. **Every time you launch a brows
 > If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **interactive mode**.
 
 **Rules:**
-- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants full access.
-- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants full access.
+- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants interactive access.
+- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants interactive access.
 
 ### Interactive mode (user-approved)
 
@@ -47,7 +47,7 @@ If it's not obvious which element to click or what value to enter, **ask the use
 npx libretto open <url> [--headed]     # Launch browser and navigate (headless by default)
 npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
-npx libretto resume                    # Resume a paused workflow in the current session
+npx libretto resume                    # Resume a paused workflow for the current session
 npx libretto session-mode <read-only|interactive> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" --context "<situational info>"
 npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto-cli/profiles/
@@ -67,11 +67,11 @@ Add `--visualize` to any `exec` command to show a ghost cursor and element highl
 
 Workflows pause from inside the workflow function by calling `await ctx.pause()`.
 
-- There are no pause options to pass at call sites. Pause is always session-scoped and resolved from the active session.
+- There are no pause options to pass at call sites. Pause is session-scoped and resolved from the active session.
 - `npx libretto run ...` waits until the workflow either completes or hits the next `ctx.pause()`.
 - On pause, the workflow process stays alive and keeps browser/session state.
 - `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
-- `resume` should be called repeatedly for multi-pause workflows until completion.
+- For multi-pause workflows, call `resume` repeatedly until the workflow completes.
 
 ## Globals Available in `exec`
 
@@ -211,7 +211,7 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 - **Never use `page.screenshot()` via `exec`.** Use `npx libretto snapshot` instead — it captures the viewport, sends the screenshot + HTML to a vision model, and returns actionable selectors. The `fullPage` option is especially dangerous — it scrolls the entire page to stitch a screenshot, which can crash JavaScript-heavy pages (especially EMR portals like eClinicalWorks).
 - **Never run `exec` commands in parallel.** Always wait for one `exec` to finish before starting the next. Do not use `run_in_background` for `exec` calls. Running simultaneous `exec` calls opens multiple CDP connections to the same page, which corrupts the page state and kills the browser.
-- `open` and `run` take control of the session. If the session already has an owner PID, it is terminated first and a warning is printed.
+- `open` and `run` take control of the session. If a session already has an owner PID, Libretto terminates it first and prints a warning.
 - Use `return <value>` in `exec` to print results. Strings print raw; objects print as JSON.
 - For iframe content, access via `page.locator('iframe[name="..."]').contentFrame()`.
 - Multiple sessions allow parallel browser instances: `--session test1`, `--session test2`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent Guidelines
+
+## Background Context
+
+This repository is a pnpm monorepo for Libretto.
+
+- `packages/libretto` contains the runtime library.
+- `packages/libretto-cli` contains the CLI and its integration-style test suites.
+- The CLI depends on the local runtime package via workspace linking.
+
+## Package Structure
+
+- Root scripts orchestrate package-level workflows.
+- Runtime build/type-check live in `packages/libretto/package.json`.
+- CLI build/type-check/test live in `packages/libretto-cli/package.json`.
+- CLI tests are in `packages/libretto-cli/src/*.test.ts`.
+
+## Important Commands
+
+Root:
+
+```bash
+pnpm i
+pnpm build
+pnpm type-check
+pnpm test
+```
+
+Targeted (most common during CLI work):
+
+```bash
+pnpm --filter libretto-cli type-check
+pnpm --filter libretto-cli test -- src/cli-basic.test.ts
+pnpm --filter libretto-cli test -- src/cli-pause.test.ts
+pnpm --filter libretto-cli test -- src/cli-stateful.test.ts
+```
+
+Local CLI invocation:
+
+```bash
+pnpm cli -- --help
+```
+
+## Skill Documentation Source of Truth
+
+- Edit `packages/libretto/skill/SKILL.md`.
+- Run `pnpm i` to sync generated copy to `.agents/skills/libretto/SKILL.md`.
+- Do not manually edit `.agents/skills/libretto/SKILL.md`.

--- a/packages/libretto-cli/package.json
+++ b/packages/libretto-cli/package.json
@@ -10,7 +10,7 @@
 		"build": "tsup",
 		"type-check": "tsc --noEmit",
 		"dev": "tsx src/index.ts",
-		"test": "vitest run",
+		"test": "pnpm --filter libretto build && pnpm --filter libretto-cli build && vitest run",
 		"test:watch": "vitest"
 	},
 	"dependencies": {

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -13,15 +13,6 @@ function isPidRunning(pid: number): boolean {
   }
 }
 
-async function waitForPidToExit(pid: number, timeoutMs: number = 4_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isPidRunning(pid)) return;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
-  }
-  throw new Error(`Timed out waiting for pid ${pid} to exit.`);
-}
-
 describe("basic CLI subprocess behavior", () => {
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
@@ -94,16 +85,16 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("run ./integration.ts main");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"default\" is read-only. Only a human can authorize interactive mode.",
+      "Session \"default\" is read-only. Only a human can authorize full-access mode.",
     );
   });
 
-  test("run takes over existing session owner pid", async ({
+  test("run fails when session name is already active", async ({
     librettoCli,
     seedSessionPermission,
     seedSessionState,
   }) => {
-    await seedSessionPermission("default", "interactive");
+    await seedSessionPermission("default", "full-access");
     const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
       stdio: "ignore",
     });
@@ -115,7 +106,7 @@ describe("basic CLI subprocess behavior", () => {
 
     await seedSessionState({
       session: "default",
-      mode: "interactive",
+      mode: "full-access",
       pid,
     });
 
@@ -123,9 +114,12 @@ describe("basic CLI subprocess behavior", () => {
       const result = await librettoCli("run ./integration.ts main");
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(
-        `Warning: session \"default\" is currently owned by pid ${pid}; terminating it before run.`,
+        `Session "default" is already open and connected to http://127.0.0.1:9222 (pid ${pid}).`,
       );
-      await waitForPidToExit(pid);
+      expect(result.stderr).toContain(
+        "Create a new session or close the current one with: libretto-cli close --session default",
+      );
+      expect(isPidRunning(pid)).toBe(true);
     } finally {
       if (isPidRunning(pid)) {
         process.kill(pid, "SIGKILL");
@@ -133,7 +127,36 @@ describe("basic CLI subprocess behavior", () => {
     }
   });
 
-  test("allows run guard when session is permissioned interactive", async ({
+  test("close clears active session lock so run can be retried", async ({
+    librettoCli,
+    seedSessionPermission,
+    seedSessionState,
+  }) => {
+    await seedSessionPermission("default", "full-access");
+    await seedSessionState({
+      session: "default",
+      mode: "full-access",
+      pid: 54321,
+      port: 9222,
+    });
+
+    const blockedRun = await librettoCli("run ./integration.ts main");
+    expect(blockedRun.exitCode).toBe(1);
+    expect(blockedRun.stderr).toContain(
+      'Session "default" is already open and connected to http://127.0.0.1:9222 (pid 54321).',
+    );
+
+    const closeResult = await librettoCli("close --session default");
+    expect(closeResult.exitCode).toBe(0);
+    expect(closeResult.stdout).toContain('Browser closed (session: default).');
+
+    const retriedRun = await librettoCli("run ./integration.ts main");
+    expect(retriedRun.exitCode).toBe(1);
+    expect(retriedRun.stderr).not.toContain("already open and connected");
+    expect(retriedRun.stderr).toContain("Integration file does not exist:");
+  });
+
+  test("allows run guard when session is permissioned full-access", async ({
     librettoCli,
     seedSessionPermission,
   }) => {
@@ -165,7 +188,7 @@ export async function main() {
     expect(result.stderr).toContain("must be a Libretto workflow instance");
   });
 
-  test("open takes over existing session owner pid", async ({
+  test("open fails when session name is already active", async ({
     librettoCli,
     seedSessionState,
   }) => {
@@ -180,7 +203,7 @@ export async function main() {
 
     await seedSessionState({
       session: "default",
-      mode: "interactive",
+      mode: "full-access",
       pid,
     });
 
@@ -190,10 +213,12 @@ export async function main() {
       });
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(
-        `Warning: session \"default\" is currently owned by pid ${pid}; terminating it before open.`,
+        `Session "default" is already open and connected to http://127.0.0.1:9222 (pid ${pid}).`,
       );
-      expect(result.stderr).toContain("Failed to launch browser child process:");
-      await waitForPidToExit(pid);
+      expect(result.stderr).toContain(
+        "Create a new session or close the current one with: libretto-cli close --session default",
+      );
+      expect(isPidRunning(pid)).toBe(true);
     } finally {
       if (isPidRunning(pid)) {
         process.kill(pid, "SIGKILL");
@@ -353,15 +378,15 @@ export const main = workflow(
     expect(result.stderr).toContain("--allow-actions is not supported for run.");
   });
 
-  test("session-mode interactive writes session permission", async ({
+  test("session-mode full-access writes session permission", async ({
     librettoCli,
     workspacePath,
   }) => {
     const result = await librettoCli(
-      "session-mode interactive --session consented",
+      "session-mode full-access --session consented",
     );
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("Session \"consented\" is now interactive.");
+    expect(result.stdout).toContain("Session \"consented\" is now full-access.");
 
     const raw = JSON.parse(
       await readFile(
@@ -376,11 +401,11 @@ export const main = workflow(
     expect(raw.permissions?.sessions?.consented).toBe("full-access");
   });
 
-  test("session-mode read-only removes interactive permission", async ({
+  test("session-mode read-only removes full-access permission", async ({
     librettoCli,
     workspacePath,
   }) => {
-    await librettoCli("session-mode interactive --session toggled");
+    await librettoCli("session-mode full-access --session toggled");
     const result = await librettoCli("session-mode read-only --session toggled");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Session \"toggled\" is now read-only.");
@@ -402,7 +427,7 @@ export const main = workflow(
     const result = await librettoCli("session-mode maybe --session default");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Usage: libretto-cli session-mode <read-only|interactive> [--session <name>]",
+      "Usage: libretto-cli session-mode <read-only|full-access> [--session <name>]",
     );
   });
 

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -245,67 +245,6 @@ export const main = workflow(
     expect(result.stderr).not.toContain("Local auth profile not found for domain");
   });
 
-  test("returns paused status when workflow hits debugPause", async ({
-    librettoCli,
-    librettoRuntimePath,
-    seedSessionPermission,
-    writeWorkflowScript,
-  }) => {
-    await seedSessionPermission("default", "interactive");
-    const integrationFilePath = await writeWorkflowScript(
-      "integration-pause.mjs",
-      `
-import { workflow, debugPause } from "${
-  librettoRuntimePath
-}";
-
-export const main = workflow({}, async (ctx) => {
-  console.log("WORKFLOW_BEFORE_PAUSE");
-  await debugPause(ctx.page, { enabled: ctx.debug, sessionName: ctx.session });
-  console.log("WORKFLOW_AFTER_PAUSE");
-});
-`,
-    );
-
-    const result = await librettoCli(
-      `run "${integrationFilePath}" main --session default --headless --debug`,
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("WORKFLOW_BEFORE_PAUSE");
-    expect(result.stdout).toContain("Workflow paused.");
-    expect(result.stdout).not.toContain("WORKFLOW_AFTER_PAUSE");
-    expect(result.stdout).not.toContain("Integration completed.");
-  }, 45_000);
-
-  test("completes workflow run when no pause is triggered", async ({
-    librettoCli,
-    librettoRuntimePath,
-    seedSessionPermission,
-    writeWorkflowScript,
-  }) => {
-    await seedSessionPermission("default", "interactive");
-    const integrationFilePath = await writeWorkflowScript(
-      "integration-complete.mjs",
-      `
-import { workflow } from "${
-  librettoRuntimePath
-}";
-
-export const main = workflow({}, async () => {
-  console.log("WORKFLOW_COMPLETES");
-});
-`,
-    );
-
-    const result = await librettoCli(
-      `run "${integrationFilePath}" main --session default --headless`,
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("WORKFLOW_COMPLETES");
-    expect(result.stdout).toContain("Integration completed.");
-    expect(result.stdout).not.toContain("Workflow paused.");
-  }, 45_000);
-
   test("fails open when deprecated --allow-actions flag is passed", async ({
     librettoCli,
   }) => {

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -1,7 +1,26 @@
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
+
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPidToExit(pid: number, timeoutMs: number = 4_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidRunning(pid)) return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`Timed out waiting for pid ${pid} to exit.`);
+}
 
 describe("basic CLI subprocess behavior", () => {
   test("prints usage for --help", async ({ librettoCli }) => {
@@ -79,6 +98,41 @@ describe("basic CLI subprocess behavior", () => {
     );
   });
 
+  test("run takes over existing session owner pid", async ({
+    librettoCli,
+    seedSessionPermission,
+    seedSessionState,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const pid = owner.pid;
+    expect(pid).toBeTypeOf("number");
+    if (!pid) {
+      throw new Error("Failed to spawn takeover test process.");
+    }
+
+    await seedSessionState({
+      session: "default",
+      mode: "interactive",
+      pid,
+    });
+
+    try {
+      const result = await librettoCli("run ./integration.ts main");
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        `Warning: session \"default\" is currently owned by pid ${pid}; terminating it before run.`,
+      );
+      await waitForPidToExit(pid);
+    } finally {
+      if (isPidRunning(pid)) {
+        process.kill(pid, "SIGKILL");
+      }
+    }
+  });
+
   test("allows run guard when session is permissioned interactive", async ({
     librettoCli,
     seedSessionPermission,
@@ -109,6 +163,42 @@ export async function main() {
     const result = await librettoCli("run ./integration.ts main");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("must be a Libretto workflow instance");
+  });
+
+  test("open takes over existing session owner pid", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const pid = owner.pid;
+    expect(pid).toBeTypeOf("number");
+    if (!pid) {
+      throw new Error("Failed to spawn takeover test process.");
+    }
+
+    await seedSessionState({
+      session: "default",
+      mode: "interactive",
+      pid,
+    });
+
+    try {
+      const result = await librettoCli("open https://example.com", {
+        PATH: "/definitely-not-real",
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        `Warning: session \"default\" is currently owned by pid ${pid}; terminating it before open.`,
+      );
+      expect(result.stderr).toContain("Failed to launch browser child process:");
+      await waitForPidToExit(pid);
+    } finally {
+      if (isPidRunning(pid)) {
+        process.kill(pid, "SIGKILL");
+      }
+    }
   });
 
   test("accepts branded Libretto workflow contract across module boundaries", async ({

--- a/packages/libretto-cli/src/cli-basic.test.ts
+++ b/packages/libretto-cli/src/cli-basic.test.ts
@@ -18,6 +18,10 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("--help");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Usage: libretto-cli <command> [--session <name>]");
+    expect(result.stdout).toContain(
+      "session-mode <read-only|full-access> Set session execution mode",
+    );
+    expect(result.stdout).not.toContain("session-mode <read-only|interactive>");
     expect(result.stderr).toBe("");
   });
 
@@ -133,27 +137,43 @@ describe("basic CLI subprocess behavior", () => {
     seedSessionState,
   }) => {
     await seedSessionPermission("default", "full-access");
+    const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    const pid = owner.pid;
+    expect(pid).toBeTypeOf("number");
+    if (!pid) {
+      throw new Error("Failed to spawn lock-owner test process.");
+    }
+
     await seedSessionState({
       session: "default",
       mode: "full-access",
-      pid: 54321,
+      pid,
       port: 9222,
+      status: "active",
     });
 
-    const blockedRun = await librettoCli("run ./integration.ts main");
-    expect(blockedRun.exitCode).toBe(1);
-    expect(blockedRun.stderr).toContain(
-      'Session "default" is already open and connected to http://127.0.0.1:9222 (pid 54321).',
-    );
+    try {
+      const blockedRun = await librettoCli("run ./integration.ts main");
+      expect(blockedRun.exitCode).toBe(1);
+      expect(blockedRun.stderr).toContain(
+        `Session "default" is already open and connected to http://127.0.0.1:9222 (pid ${pid}).`,
+      );
 
-    const closeResult = await librettoCli("close --session default");
-    expect(closeResult.exitCode).toBe(0);
-    expect(closeResult.stdout).toContain('Browser closed (session: default).');
+      const closeResult = await librettoCli("close --session default");
+      expect(closeResult.exitCode).toBe(0);
+      expect(closeResult.stdout).toContain('Browser closed (session: default).');
 
-    const retriedRun = await librettoCli("run ./integration.ts main");
-    expect(retriedRun.exitCode).toBe(1);
-    expect(retriedRun.stderr).not.toContain("already open and connected");
-    expect(retriedRun.stderr).toContain("Integration file does not exist:");
+      const retriedRun = await librettoCli("run ./integration.ts main");
+      expect(retriedRun.exitCode).toBe(1);
+      expect(retriedRun.stderr).not.toContain("already open and connected");
+      expect(retriedRun.stderr).toContain("Integration file does not exist:");
+    } finally {
+      if (isPidRunning(pid)) {
+        process.kill(pid, "SIGKILL");
+      }
+    }
   });
 
   test("allows run guard when session is permissioned full-access", async ({

--- a/packages/libretto-cli/src/cli-pause.test.ts
+++ b/packages/libretto-cli/src/cli-pause.test.ts
@@ -95,6 +95,68 @@ export const main = workflow({}, async (ctx) => {
     }
   }, 45_000);
 
+  test("handles multiple pause and resume cycles", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    seedSessionState,
+    writeWorkflowScript,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    await seedSessionState({ session: "default", mode: "interactive" });
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-pause-multiple.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async (ctx) => {
+  console.log("CHECKPOINT_0");
+  await ctx.pause();
+  console.log("CHECKPOINT_1");
+  await ctx.pause();
+  console.log("CHECKPOINT_2");
+  await ctx.pause();
+  console.log("CHECKPOINT_DONE");
+});
+`,
+    );
+
+    try {
+      const runResult = await librettoCli(
+        `run "${integrationFilePath}" main --session default --headless --debug`,
+      );
+      expect(runResult.exitCode).toBe(0);
+      expect(runResult.stdout).toContain("CHECKPOINT_0");
+      expect(runResult.stdout).toContain("Workflow paused.");
+      expect(runResult.stdout).not.toContain("CHECKPOINT_1");
+      expect(runResult.stdout).not.toContain("Integration completed.");
+
+      const firstResume = await librettoCli("resume --session default");
+      expect(firstResume.exitCode).toBe(0);
+      expect(firstResume.stdout).toContain("CHECKPOINT_1");
+      expect(firstResume.stdout).toContain("Workflow paused.");
+      expect(firstResume.stdout).not.toContain("CHECKPOINT_2");
+      expect(firstResume.stdout).not.toContain("Integration completed.");
+
+      const secondResume = await librettoCli("resume --session default");
+      expect(secondResume.exitCode).toBe(0);
+      expect(secondResume.stdout).toContain("CHECKPOINT_2");
+      expect(secondResume.stdout).toContain("Workflow paused.");
+      expect(secondResume.stdout).not.toContain("CHECKPOINT_DONE");
+      expect(secondResume.stdout).not.toContain("Integration completed.");
+
+      const thirdResume = await librettoCli("resume --session default");
+      expect(thirdResume.exitCode).toBe(0);
+      expect(thirdResume.stdout).toContain("CHECKPOINT_DONE");
+      expect(thirdResume.stdout).toContain("Integration completed.");
+      expect(thirdResume.stdout).not.toContain("Workflow paused.");
+    } finally {
+      await librettoCli("close --session default");
+    }
+  }, 60_000);
+
   test("fails resume when session is not paused", async ({
     librettoCli,
     seedSessionState,

--- a/packages/libretto-cli/src/cli-pause.test.ts
+++ b/packages/libretto-cli/src/cli-pause.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect } from "vitest";
+import { test } from "./test-fixtures";
+
+describe("CLI pause behavior", () => {
+  test("resume waits until workflow completes", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    seedSessionState,
+    writeWorkflowScript,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    await seedSessionState({ session: "default", mode: "interactive" });
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-pause-once.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async (ctx) => {
+  console.log("WORKFLOW_BEFORE_PAUSE");
+  await ctx.pause();
+  console.log("WORKFLOW_AFTER_PAUSE");
+});
+`,
+    );
+
+    try {
+      const runResult = await librettoCli(
+        `run "${integrationFilePath}" main --session default --headless --debug`,
+      );
+      expect(runResult.exitCode).toBe(0);
+      expect(runResult.stdout).toContain("WORKFLOW_BEFORE_PAUSE");
+      expect(runResult.stdout).toContain("Workflow paused.");
+      expect(runResult.stdout).not.toContain("WORKFLOW_AFTER_PAUSE");
+      expect(runResult.stdout).not.toContain("Integration completed.");
+
+      const resumeResult = await librettoCli("resume --session default");
+      expect(resumeResult.exitCode).toBe(0);
+      expect(resumeResult.stdout).toContain(
+        'Resume signal sent for session "default".',
+      );
+      expect(resumeResult.stdout).toContain("WORKFLOW_AFTER_PAUSE");
+      expect(resumeResult.stdout).toContain("Integration completed.");
+    } finally {
+      await librettoCli("close --session default");
+    }
+  }, 45_000);
+
+  test("resume returns when workflow pauses again", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    seedSessionState,
+    writeWorkflowScript,
+  }) => {
+    await seedSessionPermission("default", "interactive");
+    await seedSessionState({ session: "default", mode: "interactive" });
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-pause-twice.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async (ctx) => {
+  console.log("WORKFLOW_BEFORE_PAUSE_1");
+  await ctx.pause();
+  console.log("WORKFLOW_BETWEEN_PAUSES");
+  await ctx.pause();
+  console.log("WORKFLOW_AFTER_PAUSE_2");
+});
+`,
+    );
+
+    try {
+      const runResult = await librettoCli(
+        `run "${integrationFilePath}" main --session default --headless --debug`,
+      );
+      expect(runResult.exitCode).toBe(0);
+      expect(runResult.stdout).toContain("Workflow paused.");
+      expect(runResult.stdout).not.toContain("WORKFLOW_AFTER_PAUSE_2");
+
+      const firstResume = await librettoCli("resume --session default");
+      expect(firstResume.exitCode).toBe(0);
+      expect(firstResume.stdout).toContain("Workflow paused.");
+      expect(firstResume.stdout).not.toContain("Integration completed.");
+
+      const secondResume = await librettoCli("resume --session default");
+      expect(secondResume.exitCode).toBe(0);
+      expect(secondResume.stdout).toContain("Integration completed.");
+    } finally {
+      await librettoCli("close --session default");
+    }
+  }, 45_000);
+
+  test("fails resume when session is not paused", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    await seedSessionState({ session: "default", mode: "interactive" });
+    const result = await librettoCli("resume --session default");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Session "default" is not paused.');
+  });
+});

--- a/packages/libretto-cli/src/cli-pause.test.ts
+++ b/packages/libretto-cli/src/cli-pause.test.ts
@@ -6,11 +6,9 @@ describe("CLI pause behavior", () => {
     librettoCli,
     librettoRuntimePath,
     seedSessionPermission,
-    seedSessionState,
     writeWorkflowScript,
   }) => {
-    await seedSessionPermission("default", "interactive");
-    await seedSessionState({ session: "default", mode: "interactive" });
+    await seedSessionPermission("default", "full-access");
     const integrationFilePath = await writeWorkflowScript(
       "integration-pause-once.mjs",
       `
@@ -52,11 +50,9 @@ export const main = workflow({}, async (ctx) => {
     librettoCli,
     librettoRuntimePath,
     seedSessionPermission,
-    seedSessionState,
     writeWorkflowScript,
   }) => {
-    await seedSessionPermission("default", "interactive");
-    await seedSessionState({ session: "default", mode: "interactive" });
+    await seedSessionPermission("default", "full-access");
     const integrationFilePath = await writeWorkflowScript(
       "integration-pause-twice.mjs",
       `
@@ -99,11 +95,9 @@ export const main = workflow({}, async (ctx) => {
     librettoCli,
     librettoRuntimePath,
     seedSessionPermission,
-    seedSessionState,
     writeWorkflowScript,
   }) => {
-    await seedSessionPermission("default", "interactive");
-    await seedSessionState({ session: "default", mode: "interactive" });
+    await seedSessionPermission("default", "full-access");
     const integrationFilePath = await writeWorkflowScript(
       "integration-pause-multiple.mjs",
       `
@@ -161,9 +155,60 @@ export const main = workflow({}, async (ctx) => {
     librettoCli,
     seedSessionState,
   }) => {
-    await seedSessionState({ session: "default", mode: "interactive" });
+    await seedSessionState({ session: "default", mode: "full-access" });
     const result = await librettoCli("resume --session default");
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Session "default" is not paused.');
   });
+
+  test("open fails while paused workflow session is active, then resume continues", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    writeWorkflowScript,
+  }) => {
+    await seedSessionPermission("default", "full-access");
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-pause-stale-artifacts.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async (ctx) => {
+  console.log("WORKFLOW_PAUSE_POINT");
+  await ctx.pause();
+  console.log("WORKFLOW_AFTER_RESUME");
+});
+`,
+    );
+
+    try {
+      const runResult = await librettoCli(
+        `run "${integrationFilePath}" main --session default --headless --debug`,
+      );
+      expect(runResult.exitCode).toBe(0);
+      expect(runResult.stdout).toContain("WORKFLOW_PAUSE_POINT");
+      expect(runResult.stdout).toContain("Workflow paused.");
+
+      const openAttempt = await librettoCli(
+        "open https://example.com --session default",
+        { PATH: "/definitely-not-real" },
+      );
+      expect(openAttempt.exitCode).toBe(1);
+      expect(openAttempt.stderr).toContain(
+        'Session "default" is already open and connected to',
+      );
+      expect(openAttempt.stderr).toContain(
+        "Create a new session or close the current one with: libretto-cli close --session default",
+      );
+
+      const resumeResult = await librettoCli("resume --session default");
+      expect(resumeResult.exitCode).toBe(0);
+      expect(resumeResult.stdout).toContain("WORKFLOW_AFTER_RESUME");
+      expect(resumeResult.stdout).toContain("Integration completed.");
+    } finally {
+      await librettoCli("close --session default");
+    }
+  }, 60_000);
 });

--- a/packages/libretto-cli/src/cli-pause.test.ts
+++ b/packages/libretto-cli/src/cli-pause.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect } from "vitest";
 import { test } from "./test-fixtures";
 
@@ -211,4 +212,95 @@ export const main = workflow({}, async (ctx) => {
       await librettoCli("close --session default");
     }
   }, 60_000);
+
+  test("completed run preserves session logs and allows session reuse", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    writeWorkflowScript,
+    workspacePath,
+  }) => {
+    await seedSessionPermission("default", "full-access");
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-complete-once.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async () => {
+  console.log("WORKFLOW_DONE");
+});
+`,
+    );
+
+    const runResult = await librettoCli(
+      `run "${integrationFilePath}" main --session default --headless --debug`,
+    );
+    expect(runResult.exitCode).toBe(0);
+    expect(runResult.stdout).toContain("WORKFLOW_DONE");
+    expect(runResult.stdout).toContain("Integration completed.");
+
+    const sessionDir = workspacePath(".libretto", "sessions", "default");
+    const statePath = workspacePath(".libretto", "sessions", "default", "state.json");
+    expect(existsSync(sessionDir)).toBe(true);
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as { status?: string };
+    expect(state.status).toBe("completed");
+
+    const openAttempt = await librettoCli(
+      "open https://example.com --session default",
+      { PATH: "/definitely-not-real" },
+    );
+    expect(openAttempt.exitCode).toBe(1);
+    expect(openAttempt.stderr).toContain("Failed to launch browser child process:");
+    expect(openAttempt.stderr).not.toContain(
+      'Session "default" is already open and connected to',
+    );
+  }, 45_000);
+
+  test("failed run preserves session logs and allows session reuse", async ({
+    librettoCli,
+    librettoRuntimePath,
+    seedSessionPermission,
+    writeWorkflowScript,
+    workspacePath,
+  }) => {
+    await seedSessionPermission("default", "full-access");
+    const integrationFilePath = await writeWorkflowScript(
+      "integration-throw-once.mjs",
+      `
+import { workflow } from "${
+  librettoRuntimePath
+}";
+
+export const main = workflow({}, async () => {
+  throw new Error("INTENTIONAL_FAILURE");
+});
+`,
+    );
+
+    const runResult = await librettoCli(
+      `run "${integrationFilePath}" main --session default --headless --debug`,
+    );
+    expect(runResult.exitCode).toBe(1);
+    expect(runResult.stderr).toContain("INTENTIONAL_FAILURE");
+
+    const sessionDir = workspacePath(".libretto", "sessions", "default");
+    const statePath = workspacePath(".libretto", "sessions", "default", "state.json");
+    expect(existsSync(sessionDir)).toBe(true);
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as { status?: string };
+    expect(state.status).toBe("failed");
+
+    const openAttempt = await librettoCli(
+      "open https://example.com --session default",
+      { PATH: "/definitely-not-real" },
+    );
+    expect(openAttempt.exitCode).toBe(1);
+    expect(openAttempt.stderr).toContain("Failed to launch browser child process:");
+    expect(openAttempt.stderr).not.toContain(
+      'Session "default" is already open and connected to',
+    );
+  }, 45_000);
 });

--- a/packages/libretto-cli/src/cli-stateful.test.ts
+++ b/packages/libretto-cli/src/cli-stateful.test.ts
@@ -180,7 +180,7 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"readonly-session\" is read-only. Only a human can authorize interactive mode.",
+      "Session \"readonly-session\" is read-only. Only a human can authorize full-access mode.",
     );
   });
 
@@ -197,14 +197,14 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"legacy-session\" is read-only. Only a human can authorize interactive mode.",
+      "Session \"legacy-session\" is read-only. Only a human can authorize full-access mode.",
     );
     expect(result.stderr).toContain(
-      "libretto-cli session-mode interactive --session legacy-session",
+      "libretto-cli session-mode full-access --session legacy-session",
     );
   });
 
-  test("rejects exec when session mode is missing even if permissioned interactive", async ({
+  test("rejects exec when session mode is missing even if permissioned full-access", async ({
     seedSessionState,
     seedSessionPermission,
     librettoCli,
@@ -220,7 +220,7 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"permissioned-session\" is read-only. Only a human can authorize interactive mode.",
+      "Session \"permissioned-session\" is read-only. Only a human can authorize full-access mode.",
     );
   });
 
@@ -266,10 +266,10 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"flip-session\" is read-only. Only a human can authorize interactive mode.",
+      "Session \"flip-session\" is read-only. Only a human can authorize full-access mode.",
     );
     expect(result.stderr).toContain(
-      "libretto-cli session-mode interactive --session flip-session",
+      "libretto-cli session-mode full-access --session flip-session",
     );
   });
 

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -27,6 +27,7 @@ const CLI_COMMANDS = new Set([
   "snapshot",
   "network",
   "actions",
+  "resume",
   "close",
   "--help",
   "-h",
@@ -47,6 +48,7 @@ Commands:
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when both flags are provided
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
+  resume                  Resume a paused workflow in the active session
   close                   Close the browser
 
 Options:
@@ -70,6 +72,7 @@ Examples:
   libretto-cli ai configure <codex|claude|gemini> -- <command prefix...>
   libretto-cli snapshot
   libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
+  libretto-cli resume --session default
   libretto-cli close
 
   # Multiple sessions

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -41,10 +41,10 @@ Commands:
   open <url> [--headless] Launch browser and open URL (headed by default)
                           Automatically loads saved profile if available
   run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug]  Run an exported Libretto workflow from a file; pass --debug to enable pause-on-failure debugging (or --no-debug to disable)
-  session-mode <read-only|interactive> Set session execution mode
+  session-mode <read-only|full-access> Set session execution mode
   ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)
-  exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until interactive)
+  exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until full-access)
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when both flags are provided
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
@@ -58,7 +58,7 @@ Options:
 Examples:
   libretto-cli open https://linkedin.com
   # default sessions are read-only; enable actions only after explicit human approval
-  libretto-cli session-mode interactive --session default
+  libretto-cli session-mode full-access --session default
 
   # ... manually log in ...
   libretto-cli save linkedin.com

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -11,8 +11,8 @@ import {
 import { getLog } from "../core/context.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
+  assertSessionAvailableForStart,
   getSessionPermissionMode,
-  takeOverSessionOwner,
   readSessionStateOrThrow,
   readOnlySessionError,
 } from "../core/session.js";
@@ -388,7 +388,7 @@ async function runResume(session: string): Promise<void> {
 }
 
 async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promise<void> {
-  await takeOverSessionOwner(args.session, "run");
+  assertSessionAvailableForStart(args.session);
   const signalPaths = getPauseSignalPaths(args.session);
   clearSignalIfExists(signalPaths.pausedSignalPath);
   clearSignalIfExists(signalPaths.resumeSignalPath);

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -12,6 +12,7 @@ import { getLog } from "../core/context.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
   getSessionPermissionMode,
+  takeOverSessionOwner,
   readSessionStateOrThrow,
   readOnlySessionError,
 } from "../core/session.js";
@@ -248,22 +249,6 @@ function readJsonFileIfExists(path: string): unknown {
   }
 }
 
-function readPausedAt(path: string): string | null {
-  const raw = readJsonFileIfExists(path);
-  if (!raw || typeof raw !== "object") return null;
-  const pausedAt = (raw as { pausedAt?: unknown }).pausedAt;
-  return typeof pausedAt === "string" ? pausedAt : null;
-}
-
-function readPausedOutputBytes(path: string): number {
-  const raw = readJsonFileIfExists(path);
-  if (!raw || typeof raw !== "object") return 0;
-  const outputBytes = (raw as { outputBytes?: unknown }).outputBytes;
-  return typeof outputBytes === "number" && Number.isFinite(outputBytes)
-    ? Math.max(0, Math.floor(outputBytes))
-    : 0;
-}
-
 function readFailureMessage(path: string): string | null {
   const raw = readJsonFileIfExists(path);
   if (!raw || typeof raw !== "object") return null;
@@ -279,20 +264,14 @@ function streamOutputSince(path: string, offset: number): number {
   return output.length;
 }
 
-type WorkflowWaitMode = "any-pause" | "next-pause";
-
 type WaitForWorkflowOutcomeArgs = {
-  signalPaths: ReturnType<typeof getPauseSignalPaths>;
+  session: string;
   pid: number;
-  outputOffset: number;
-  mode: WorkflowWaitMode;
-  pausedAtBaseline?: string | null;
-  operation: "run" | "resume";
 };
 
 type WorkflowOutcome = {
-  status: "completed" | "paused";
-  outputOffset: number;
+  status: "completed" | "paused" | "failed" | "exited";
+  message?: string;
 };
 
 function clearSignalIfExists(path: string): void {
@@ -307,46 +286,34 @@ function clearSignalIfExists(path: string): void {
 async function waitForWorkflowOutcome(
   args: WaitForWorkflowOutcomeArgs,
 ): Promise<WorkflowOutcome> {
+  const signalPaths = getPauseSignalPaths(args.session);
   if (args.pid <= 0) {
-    throw new Error(`Could not determine workflow process id for ${args.operation}.`);
+    return { status: "exited" };
   }
-  let outputOffset = args.outputOffset;
+  let outputOffset = 0;
 
   while (true) {
-    outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+    outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
 
-    if (existsSync(args.signalPaths.failedSignalPath)) {
-      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
-      const message = readFailureMessage(args.signalPaths.failedSignalPath);
-      throw new Error(
-        message
-          ? `Workflow failed during ${args.operation}: ${message}`
-          : `Workflow failed during ${args.operation}.`,
-      );
+    if (existsSync(signalPaths.failedSignalPath)) {
+      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      const message = readFailureMessage(signalPaths.failedSignalPath);
+      return { status: "failed", message: message ?? undefined };
     }
 
-    if (existsSync(args.signalPaths.completedSignalPath)) {
-      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
-      return { status: "completed", outputOffset };
+    if (existsSync(signalPaths.completedSignalPath)) {
+      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      return { status: "completed" };
     }
 
-    if (existsSync(args.signalPaths.pausedSignalPath)) {
-      const pausedAt = readPausedAt(args.signalPaths.pausedSignalPath);
-      const isPauseOutcome = args.mode === "any-pause"
-        ? true
-        : !args.pausedAtBaseline ||
-            (pausedAt !== null && pausedAt !== args.pausedAtBaseline);
-      if (isPauseOutcome) {
-        outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
-        return { status: "paused", outputOffset };
-      }
+    if (existsSync(signalPaths.pausedSignalPath)) {
+      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      return { status: "paused" };
     }
 
     if (!isProcessRunning(args.pid)) {
-      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
-      throw new Error(
-        `Workflow process exited before reporting completion or pause during ${args.operation}.`,
-      );
+      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      return { status: "exited" };
     }
 
     await new Promise((resolveWait) => setTimeout(resolveWait, 250));
@@ -375,8 +342,10 @@ async function runResume(session: string): Promise<void> {
     );
   }
 
-  const pausedAtBeforeResume = readPausedAt(pausedSignalPath);
-  let outputOffset = readPausedOutputBytes(pausedSignalPath);
+  // Clear stale pause/output markers before signaling resume so we always wait
+  // for the next pause/completion and only stream post-resume logs.
+  clearSignalIfExists(pausedSignalPath);
+  clearSignalIfExists(outputSignalPath);
   clearSignalIfExists(completedSignalPath);
   clearSignalIfExists(failedSignalPath);
 
@@ -395,28 +364,31 @@ async function runResume(session: string): Promise<void> {
   console.log(`Resume signal sent for session "${session}".`);
 
   const outcome = await waitForWorkflowOutcome({
-    signalPaths: {
-      pausedSignalPath,
-      resumeSignalPath,
-      completedSignalPath,
-      failedSignalPath,
-      outputSignalPath,
-    },
+    session,
     pid: state.pid,
-    outputOffset,
-    mode: "next-pause",
-    pausedAtBaseline: pausedAtBeforeResume,
-    operation: "resume",
   });
 
   if (outcome.status === "completed") {
     console.log("Integration completed.");
     return;
   }
+  if (outcome.status === "failed") {
+    throw new Error(
+      outcome.message
+        ? `Workflow failed after resume: ${outcome.message}`
+        : "Workflow failed after resume.",
+    );
+  }
+  if (outcome.status === "exited") {
+    throw new Error(
+      `Workflow process for session "${session}" exited before reporting completion or pause.`,
+    );
+  }
   console.log("Workflow paused.");
 }
 
 async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promise<void> {
+  await takeOverSessionOwner(args.session, "run");
   const signalPaths = getPauseSignalPaths(args.session);
   clearSignalIfExists(signalPaths.pausedSignalPath);
   clearSignalIfExists(signalPaths.resumeSignalPath);
@@ -436,14 +408,20 @@ async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promis
   worker.disconnect();
   worker.unref();
   const outcome = await waitForWorkflowOutcome({
-    signalPaths,
+    session: args.session,
     pid: worker.pid ?? 0,
-    outputOffset: 0,
-    mode: "any-pause",
-    operation: "run",
   });
   if (outcome.status === "paused") {
     console.log("Workflow paused.");
+    return;
+  }
+  if (outcome.status === "failed") {
+    throw new Error(outcome.message ?? "Workflow failed during run.");
+  }
+  if (outcome.status === "exited") {
+    throw new Error(
+      "Workflow process exited before reporting completion or pause during run.",
+    );
   }
 }
 

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { fork } from "node:child_process";
 import * as moduleBuiltin from "node:module";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ import {
   disconnectBrowser,
 } from "../core/browser.js";
 import { getLog } from "../core/context.js";
+import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
   getSessionPermissionMode,
   readSessionStateOrThrow,
@@ -230,6 +231,144 @@ function parseJsonArg(label: string, raw: string): unknown {
   }
 }
 
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJsonFileIfExists(path: string): unknown {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readPausedAt(path: string): string | null {
+  const raw = readJsonFileIfExists(path);
+  if (!raw || typeof raw !== "object") return null;
+  const pausedAt = (raw as { pausedAt?: unknown }).pausedAt;
+  return typeof pausedAt === "string" ? pausedAt : null;
+}
+
+function readPausedOutputBytes(path: string): number {
+  const raw = readJsonFileIfExists(path);
+  if (!raw || typeof raw !== "object") return 0;
+  const outputBytes = (raw as { outputBytes?: unknown }).outputBytes;
+  return typeof outputBytes === "number" && Number.isFinite(outputBytes)
+    ? Math.max(0, Math.floor(outputBytes))
+    : 0;
+}
+
+function readFailureMessage(path: string): string | null {
+  const raw = readJsonFileIfExists(path);
+  if (!raw || typeof raw !== "object") return null;
+  const message = (raw as { message?: unknown }).message;
+  return typeof message === "string" ? message : null;
+}
+
+function streamOutputSince(path: string, offset: number): number {
+  if (!existsSync(path)) return offset;
+  const output = readFileSync(path);
+  if (output.length <= offset) return output.length;
+  process.stdout.write(output.subarray(offset));
+  return output.length;
+}
+
+function clearSignalIfExists(path: string): void {
+  if (!existsSync(path)) return;
+  try {
+    unlinkSync(path);
+  } catch {
+    // Ignore cleanup failures; next checks still validate actual state.
+  }
+}
+
+async function runResume(session: string): Promise<void> {
+  const state = readSessionStateOrThrow(session);
+  const {
+    pausedSignalPath,
+    resumeSignalPath,
+    completedSignalPath,
+    failedSignalPath,
+    outputSignalPath,
+  } = getPauseSignalPaths(session);
+
+  if (!existsSync(pausedSignalPath)) {
+    throw new Error(
+      `Session "${session}" is not paused. Run "libretto-cli run ... --session ${session}" and call ctx.pause() first.`,
+    );
+  }
+
+  if (!isProcessRunning(state.pid)) {
+    throw new Error(
+      `No active paused workflow found for session "${session}" (worker pid ${state.pid} is not running).`,
+    );
+  }
+
+  const pausedAtBeforeResume = readPausedAt(pausedSignalPath);
+  let outputOffset = readPausedOutputBytes(pausedSignalPath);
+  clearSignalIfExists(completedSignalPath);
+  clearSignalIfExists(failedSignalPath);
+
+  writeFileSync(
+    resumeSignalPath,
+    JSON.stringify(
+      {
+        resumedAt: new Date().toISOString(),
+        sourcePid: process.pid,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  console.log(`Resume signal sent for session "${session}".`);
+
+  while (true) {
+    outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+
+    if (existsSync(failedSignalPath)) {
+      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+      const message = readFailureMessage(failedSignalPath);
+      throw new Error(
+        message
+          ? `Workflow failed after resume: ${message}`
+          : "Workflow failed after resume.",
+      );
+    }
+
+    if (existsSync(completedSignalPath)) {
+      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+      console.log("Integration completed.");
+      return;
+    }
+
+    if (existsSync(pausedSignalPath)) {
+      const pausedAt = readPausedAt(pausedSignalPath);
+      if (!pausedAtBeforeResume || (pausedAt && pausedAt !== pausedAtBeforeResume)) {
+        outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+        console.log("Workflow paused.");
+        return;
+      }
+    }
+
+    if (!isProcessRunning(state.pid)) {
+      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+      throw new Error(
+        `Workflow process for session "${session}" exited before reporting completion or pause.`,
+      );
+    }
+
+    await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+  }
+}
+
 function isRunIntegrationWorkerMessage(
   value: unknown,
 ): value is RunIntegrationWorkerMessage {
@@ -309,9 +448,6 @@ async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promis
       }
       if (raw.type === "paused") {
         console.log("Workflow paused.");
-        if (worker.connected) {
-          worker.disconnect();
-        }
         worker.unref();
         resolveOnce();
         return;
@@ -437,6 +573,14 @@ export function registerExecutionCommands(yargs: Argv): Argv {
           headless: headlessMode ?? false,
           debug: debugMode,
         });
+      },
+    )
+    .command(
+      "resume",
+      "Resume a paused workflow for the current session",
+      (cmd) => cmd,
+      async (argv) => {
+        await runResume(String(argv.session));
       },
     );
 }

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -21,7 +21,6 @@ import {
   wrapPageForActionLogging,
 } from "../core/telemetry.js";
 import type {
-  RunIntegrationWorkerMessage,
   RunIntegrationWorkerRequest,
 } from "../workers/run-integration-worker-protocol.js";
 
@@ -280,12 +279,77 @@ function streamOutputSince(path: string, offset: number): number {
   return output.length;
 }
 
+type WorkflowWaitMode = "any-pause" | "next-pause";
+
+type WaitForWorkflowOutcomeArgs = {
+  signalPaths: ReturnType<typeof getPauseSignalPaths>;
+  pid: number;
+  outputOffset: number;
+  mode: WorkflowWaitMode;
+  pausedAtBaseline?: string | null;
+  operation: "run" | "resume";
+};
+
+type WorkflowOutcome = {
+  status: "completed" | "paused";
+  outputOffset: number;
+};
+
 function clearSignalIfExists(path: string): void {
   if (!existsSync(path)) return;
   try {
     unlinkSync(path);
   } catch {
     // Ignore cleanup failures; next checks still validate actual state.
+  }
+}
+
+async function waitForWorkflowOutcome(
+  args: WaitForWorkflowOutcomeArgs,
+): Promise<WorkflowOutcome> {
+  if (args.pid <= 0) {
+    throw new Error(`Could not determine workflow process id for ${args.operation}.`);
+  }
+  let outputOffset = args.outputOffset;
+
+  while (true) {
+    outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+
+    if (existsSync(args.signalPaths.failedSignalPath)) {
+      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+      const message = readFailureMessage(args.signalPaths.failedSignalPath);
+      throw new Error(
+        message
+          ? `Workflow failed during ${args.operation}: ${message}`
+          : `Workflow failed during ${args.operation}.`,
+      );
+    }
+
+    if (existsSync(args.signalPaths.completedSignalPath)) {
+      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+      return { status: "completed", outputOffset };
+    }
+
+    if (existsSync(args.signalPaths.pausedSignalPath)) {
+      const pausedAt = readPausedAt(args.signalPaths.pausedSignalPath);
+      const isPauseOutcome = args.mode === "any-pause"
+        ? true
+        : !args.pausedAtBaseline ||
+            (pausedAt !== null && pausedAt !== args.pausedAtBaseline);
+      if (isPauseOutcome) {
+        outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+        return { status: "paused", outputOffset };
+      }
+    }
+
+    if (!isProcessRunning(args.pid)) {
+      outputOffset = streamOutputSince(args.signalPaths.outputSignalPath, outputOffset);
+      throw new Error(
+        `Workflow process exited before reporting completion or pause during ${args.operation}.`,
+      );
+    }
+
+    await new Promise((resolveWait) => setTimeout(resolveWait, 250));
   }
 }
 
@@ -330,147 +394,57 @@ async function runResume(session: string): Promise<void> {
   );
   console.log(`Resume signal sent for session "${session}".`);
 
-  while (true) {
-    outputOffset = streamOutputSince(outputSignalPath, outputOffset);
+  const outcome = await waitForWorkflowOutcome({
+    signalPaths: {
+      pausedSignalPath,
+      resumeSignalPath,
+      completedSignalPath,
+      failedSignalPath,
+      outputSignalPath,
+    },
+    pid: state.pid,
+    outputOffset,
+    mode: "next-pause",
+    pausedAtBaseline: pausedAtBeforeResume,
+    operation: "resume",
+  });
 
-    if (existsSync(failedSignalPath)) {
-      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
-      const message = readFailureMessage(failedSignalPath);
-      throw new Error(
-        message
-          ? `Workflow failed after resume: ${message}`
-          : "Workflow failed after resume.",
-      );
-    }
-
-    if (existsSync(completedSignalPath)) {
-      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
-      console.log("Integration completed.");
-      return;
-    }
-
-    if (existsSync(pausedSignalPath)) {
-      const pausedAt = readPausedAt(pausedSignalPath);
-      if (!pausedAtBeforeResume || (pausedAt && pausedAt !== pausedAtBeforeResume)) {
-        outputOffset = streamOutputSince(outputSignalPath, outputOffset);
-        console.log("Workflow paused.");
-        return;
-      }
-    }
-
-    if (!isProcessRunning(state.pid)) {
-      outputOffset = streamOutputSince(outputSignalPath, outputOffset);
-      throw new Error(
-        `Workflow process for session "${session}" exited before reporting completion or pause.`,
-      );
-    }
-
-    await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+  if (outcome.status === "completed") {
+    console.log("Integration completed.");
+    return;
   }
-}
-
-function isRunIntegrationWorkerMessage(
-  value: unknown,
-): value is RunIntegrationWorkerMessage {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Record<string, unknown>;
-  if (candidate.type === "completed") return true;
-  if (
-    candidate.type === "failed" &&
-    typeof candidate.message === "string"
-  ) {
-    return true;
-  }
-  if (
-    candidate.type === "paused" &&
-    typeof candidate.details === "object" &&
-    candidate.details !== null
-  ) {
-    const details = candidate.details as Record<string, unknown>;
-    return (
-      typeof details.sessionName === "string" &&
-      typeof details.pausedAt === "string" &&
-      typeof details.url === "string"
-    );
-  }
-  return false;
+  console.log("Workflow paused.");
 }
 
 async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promise<void> {
+  const signalPaths = getPauseSignalPaths(args.session);
+  clearSignalIfExists(signalPaths.pausedSignalPath);
+  clearSignalIfExists(signalPaths.resumeSignalPath);
+  clearSignalIfExists(signalPaths.completedSignalPath);
+  clearSignalIfExists(signalPaths.failedSignalPath);
+  clearSignalIfExists(signalPaths.outputSignalPath);
+
   const workerEntryPath = fileURLToPath(
     new URL("../workers/run-integration-worker.js", import.meta.url),
   );
   const payload = JSON.stringify(args);
   const worker = fork(workerEntryPath, [payload], {
-    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    detached: true,
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
     env: process.env,
   });
-
-  const onStdout = (chunk: Buffer | string) => {
-    process.stdout.write(chunk.toString());
-  };
-  const onStderr = (chunk: Buffer | string) => {
-    process.stderr.write(chunk.toString());
-  };
-  worker.stdout?.on("data", onStdout);
-  worker.stderr?.on("data", onStderr);
-
-  const cleanup = () => {
-    worker.stdout?.off("data", onStdout);
-    worker.stderr?.off("data", onStderr);
-    worker.removeAllListeners("message");
-    worker.removeAllListeners("error");
-    worker.removeAllListeners("exit");
-  };
-
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-
-    const resolveOnce = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve();
-    };
-
-    const rejectOnce = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-
-    worker.on("message", (raw: unknown) => {
-      if (!isRunIntegrationWorkerMessage(raw)) return;
-      if (raw.type === "completed") {
-        resolveOnce();
-        return;
-      }
-      if (raw.type === "paused") {
-        console.log("Workflow paused.");
-        worker.unref();
-        resolveOnce();
-        return;
-      }
-      rejectOnce(new Error(raw.message));
-    });
-
-    worker.on("error", (error) => {
-      rejectOnce(error);
-    });
-
-    worker.on("exit", (code, signal) => {
-      if (settled) return;
-      if (code === 0) {
-        resolveOnce();
-        return;
-      }
-      const reason = signal
-        ? `signal ${signal}`
-        : `code ${code ?? 1}`;
-      rejectOnce(new Error(`Integration worker exited with ${reason}.`));
-    });
+  worker.disconnect();
+  worker.unref();
+  const outcome = await waitForWorkflowOutcome({
+    signalPaths,
+    pid: worker.pid ?? 0,
+    outputOffset: 0,
+    mode: "any-pause",
+    operation: "run",
   });
+  if (outcome.status === "paused") {
+    console.log("Workflow paused.");
+  }
 }
 
 export function registerExecutionCommands(yargs: Argv): Argv {

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -15,6 +15,7 @@ import {
   getSessionPermissionMode,
   readSessionStateOrThrow,
   readOnlySessionError,
+  setSessionStatus,
 } from "../core/session.js";
 import {
   readActionLog,
@@ -348,6 +349,7 @@ async function runResume(session: string): Promise<void> {
   clearSignalIfExists(outputSignalPath);
   clearSignalIfExists(completedSignalPath);
   clearSignalIfExists(failedSignalPath);
+  setSessionStatus(session, "active");
 
   writeFileSync(
     resumeSignalPath,
@@ -369,10 +371,12 @@ async function runResume(session: string): Promise<void> {
   });
 
   if (outcome.status === "completed") {
+    setSessionStatus(session, "completed");
     console.log("Integration completed.");
     return;
   }
   if (outcome.status === "failed") {
+    setSessionStatus(session, "failed");
     throw new Error(
       outcome.message
         ? `Workflow failed after resume: ${outcome.message}`
@@ -380,10 +384,12 @@ async function runResume(session: string): Promise<void> {
     );
   }
   if (outcome.status === "exited") {
+    setSessionStatus(session, "exited");
     throw new Error(
       `Workflow process for session "${session}" exited before reporting completion or pause.`,
     );
   }
+  setSessionStatus(session, "paused");
   console.log("Workflow paused.");
 }
 
@@ -412,17 +418,21 @@ async function runIntegrationFromFile(args: RunIntegrationWorkerRequest): Promis
     pid: worker.pid ?? 0,
   });
   if (outcome.status === "paused") {
+    setSessionStatus(args.session, "paused");
     console.log("Workflow paused.");
     return;
   }
   if (outcome.status === "failed") {
+    setSessionStatus(args.session, "failed");
     throw new Error(outcome.message ?? "Workflow failed during run.");
   }
   if (outcome.status === "exited") {
+    setSessionStatus(args.session, "exited");
     throw new Error(
       "Workflow process exited before reporting completion or pause during run.",
     );
   }
+  setSessionStatus(args.session, "completed");
 }
 
 export function registerExecutionCommands(yargs: Argv): Argv {

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -19,6 +19,7 @@ import {
   readSessionStateOrThrow,
   logFileForSession,
   readSessionState,
+  takeOverSessionOwner,
   writeSessionState,
 } from "./session.js";
 
@@ -89,30 +90,6 @@ async function tryConnectToPort(
     log.error("cdp-connect-error", { error: err, port, endpoint });
     return null;
   }
-}
-
-async function tryConnect(
-  session: string,
-  timeoutMs: number = 5000,
-): Promise<Browser | null> {
-  const log = getLog();
-  log.info("try-connect", { session, timeoutMs });
-  const state = readSessionState(session);
-  if (!state) {
-    log.info("try-connect-no-state", { session });
-    return null;
-  }
-  const browser = await tryConnectToPort(state.port, timeoutMs);
-  if (!browser) {
-    log.warn("try-connect-failed-clearing-state", {
-      session,
-      port: state.port,
-      pid: state.pid,
-    });
-    clearSessionState(session);
-    return null;
-  }
-  return browser;
 }
 
 export function disconnectBrowser(browser: Browser, session?: string): void {
@@ -213,26 +190,7 @@ export async function runOpen(
   const sessionMode = getSessionPermissionMode(session);
   const url = normalizeUrl(rawUrl);
   log.info("open-start", { url, headed, session, sessionMode });
-
-  const existing = await tryConnect(session);
-  if (existing) {
-    log.info("open-reuse-existing", { session });
-    try {
-      const page = existing.contexts()[0]?.pages()[0];
-      if (page) {
-        await page.goto(url);
-        const existingState = readSessionState(session);
-        if (existingState && existingState.mode !== sessionMode) {
-          writeSessionState({ ...existingState, mode: sessionMode });
-        }
-        log.info("open-navigated", { url, session });
-        console.log(`Navigated to: ${url}`);
-        return;
-      }
-    } finally {
-      disconnectBrowser(existing, session);
-    }
-  }
+  await takeOverSessionOwner(session, "open");
 
   const port = await pickFreePort();
   const runId = generateRunId();

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -13,13 +13,13 @@ import {
   setLogFile,
 } from "./context.js";
 import {
+  assertSessionAvailableForStart,
   clearSessionState,
   generateRunId,
   getSessionPermissionMode,
   readSessionStateOrThrow,
   logFileForSession,
   readSessionState,
-  takeOverSessionOwner,
   writeSessionState,
 } from "./session.js";
 
@@ -190,7 +190,7 @@ export async function runOpen(
   const sessionMode = getSessionPermissionMode(session);
   const url = normalizeUrl(rawUrl);
   log.info("open-start", { url, headed, session, sessionMode });
-  await takeOverSessionOwner(session, "open");
+  assertSessionAvailableForStart(session);
 
   const port = await pickFreePort();
   const runId = generateRunId();

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -641,6 +641,7 @@ await new Promise(() => {});
         runId,
         startedAt: new Date().toISOString(),
         mode: sessionMode,
+        status: "active",
       });
       log.info("open-success", {
         url,

--- a/packages/libretto-cli/src/core/pause-signals.ts
+++ b/packages/libretto-cli/src/core/pause-signals.ts
@@ -1,0 +1,35 @@
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { getSessionDir } from "./context.js";
+
+export type PauseSignalPaths = {
+  pausedSignalPath: string;
+  resumeSignalPath: string;
+  completedSignalPath: string;
+  failedSignalPath: string;
+  outputSignalPath: string;
+};
+
+export function getPauseSignalPaths(session: string): PauseSignalPaths {
+  const sessionDir = getSessionDir(session);
+  return {
+    pausedSignalPath: join(sessionDir, `${session}.paused`),
+    resumeSignalPath: join(sessionDir, `${session}.resume`),
+    completedSignalPath: join(sessionDir, `${session}.completed`),
+    failedSignalPath: join(sessionDir, `${session}.failed`),
+    outputSignalPath: join(sessionDir, `${session}.output`),
+  };
+}
+
+export async function removeSignalIfExists(path: string): Promise<void> {
+  if (!existsSync(path)) return;
+  try {
+    await unlink(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+}

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -172,66 +172,13 @@ export function clearSessionState(session: string): void {
   log.info("session-state-cleared", { session, stateFile });
 }
 
-function isPidRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isPidRunning(pid)) return true;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
-  }
-  return !isPidRunning(pid);
-}
-
-export async function takeOverSessionOwner(
-  session: string,
-  nextOwner: "open" | "run",
-): Promise<void> {
-  const log = getLog();
+export function assertSessionAvailableForStart(session: string): void {
   const existingState = readSessionState(session);
   if (!existingState) return;
-
-  const { pid, runId } = existingState;
-  if (pid === process.pid) {
-    log.warn("session-takeover-self-owner", { session, pid, nextOwner, runId });
-    return;
-  }
-  if (!isPidRunning(pid)) {
-    log.info("session-takeover-stale-owner", { session, pid, nextOwner, runId });
-    return;
-  }
-
-  log.warn("session-takeover-terminating-owner", {
-    session,
-    existingPid: pid,
-    existingRunId: runId,
-    nextOwner,
-  });
-  console.warn(
-    `Warning: session "${session}" is currently owned by pid ${pid}; terminating it before ${nextOwner}.`,
+  const endpoint = `http://127.0.0.1:${existingState.port}`;
+  throw new Error(
+    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto-cli close --session ${session}`,
   );
-
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch (error) {
-    throw new Error(
-      `Could not take over session "${session}" from pid ${pid}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  const exited = await waitForPidExit(pid, 2_000);
-  if (!exited) {
-    throw new Error(
-      `Could not take over session "${session}": existing owner pid ${pid} did not exit after SIGTERM.`,
-    );
-  }
 }
 
 function ensureLibrettoDir(): void {

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -171,6 +171,68 @@ export function clearSessionState(session: string): void {
   log.info("session-state-cleared", { session, stateFile });
 }
 
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidRunning(pid)) return true;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  return !isPidRunning(pid);
+}
+
+export async function takeOverSessionOwner(
+  session: string,
+  nextOwner: "open" | "run",
+): Promise<void> {
+  const log = getLog();
+  const existingState = readSessionState(session);
+  if (!existingState) return;
+
+  const { pid, runId } = existingState;
+  if (pid === process.pid) {
+    log.warn("session-takeover-self-owner", { session, pid, nextOwner, runId });
+    return;
+  }
+  if (!isPidRunning(pid)) {
+    log.info("session-takeover-stale-owner", { session, pid, nextOwner, runId });
+    return;
+  }
+
+  log.warn("session-takeover-terminating-owner", {
+    session,
+    existingPid: pid,
+    existingRunId: runId,
+    nextOwner,
+  });
+  console.warn(
+    `Warning: session "${session}" is currently owned by pid ${pid}; terminating it before ${nextOwner}.`,
+  );
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    throw new Error(
+      `Could not take over session "${session}" from pid ${pid}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const exited = await waitForPidExit(pid, 2_000);
+  if (!exited) {
+    throw new Error(
+      `Could not take over session "${session}": existing owner pid ${pid} did not exit after SIGTERM.`,
+    );
+  }
+}
+
 function ensureLibrettoDir(): void {
   mkdirSync(LIBRETTO_CONFIG_DIR, { recursive: true });
 }

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -18,9 +18,11 @@ import {
 import {
   SESSION_STATE_VERSION,
   SessionModeSchema,
+  SessionStatusSchema,
   parseSessionStateContent,
   serializeSessionState,
   type SessionMode,
+  type SessionStatus,
   type SessionState,
 } from "libretto/state";
 
@@ -30,7 +32,7 @@ export const SESSION_DEFAULT = "default";
 export const SESSION_DEV_SERVER = "dev-server";
 export const SESSION_BROWSER_AGENT = "browser-agent";
 export { SESSION_STATE_VERSION };
-export type { SessionMode, SessionState };
+export type { SessionMode, SessionStatus, SessionState };
 
 type SessionPermissions = {
   defaultMode: SessionMode;
@@ -172,9 +174,45 @@ export function clearSessionState(session: string): void {
   log.info("session-state-cleared", { session, stateFile });
 }
 
+function isSessionStatus(value: unknown): value is SessionStatus {
+  return SessionStatusSchema.safeParse(value).success;
+}
+
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function setSessionStatus(session: string, status: SessionStatus): void {
+  const state = readSessionState(session);
+  if (!state) return;
+  if (state.status === status) return;
+  writeSessionState({
+    ...state,
+    status,
+  });
+}
+
 export function assertSessionAvailableForStart(session: string): void {
   const existingState = readSessionState(session);
   if (!existingState) return;
+  if (isSessionStatus(existingState.status)) {
+    if (
+      existingState.status === "completed" ||
+      existingState.status === "failed" ||
+      existingState.status === "exited"
+    ) {
+      return;
+    }
+  }
+  if (!isPidRunning(existingState.pid)) {
+    setSessionStatus(session, "exited");
+    return;
+  }
   const endpoint = `http://127.0.0.1:${existingState.port}`;
   throw new Error(
     `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto-cli close --session ${session}`,

--- a/packages/libretto-cli/src/test-fixtures.ts
+++ b/packages/libretto-cli/src/test-fixtures.ts
@@ -221,6 +221,7 @@ export const test = base.extend<CliFixtures>({
         pid: state?.pid ?? 12345,
         startedAt: state?.startedAt ?? "2026-01-01T00:00:00.000Z",
         mode: state?.mode,
+        status: state?.status,
       };
       const dir = workspacePath(".libretto", "sessions", session);
       await mkdir(dir, { recursive: true });

--- a/packages/libretto-cli/src/workers/run-integration-runtime.ts
+++ b/packages/libretto-cli/src/workers/run-integration-runtime.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, statSync } from "node:fs";
+import { appendFileSync, existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
@@ -50,14 +50,6 @@ function mirrorStdoutToFile(filePath: string): () => void {
   };
 }
 
-function getOutputByteCount(path: string): number {
-  try {
-    return statSync(path).size;
-  } catch {
-    return 0;
-  }
-}
-
 async function waitForResumeSignal(args: {
   signalPaths: ReturnType<typeof getPauseSignalPaths>;
   session: string;
@@ -67,17 +59,9 @@ async function waitForResumeSignal(args: {
   const { pausedSignalPath, resumeSignalPath } = args.signalPaths;
   await mkdir(getSessionDir(args.session), { recursive: true });
   await removeSignalIfExists(resumeSignalPath);
-  const outputBytes = getOutputByteCount(args.signalPaths.outputSignalPath);
   await writeFile(
     pausedSignalPath,
-    JSON.stringify(
-      {
-        ...args.details,
-        outputBytes,
-      },
-      null,
-      2,
-    ),
+    JSON.stringify(args.details, null, 2),
     "utf8",
   );
   await args.onPaused?.(args.details);

--- a/packages/libretto-cli/src/workers/run-integration-runtime.ts
+++ b/packages/libretto-cli/src/workers/run-integration-runtime.ts
@@ -1,16 +1,17 @@
-import { existsSync } from "node:fs";
+import { appendFileSync, existsSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   launchBrowser,
-  isRunDebugPauseSignal,
   type LibrettoAuthProfile,
   type LibrettoWorkflowContext,
   type RunDebugPauseDetails,
 } from "libretto";
 import { getProfilePath, normalizeDomain } from "../core/browser.js";
-import { getLog } from "../core/context.js";
+import { getLog, getSessionDir } from "../core/context.js";
+import { getPauseSignalPaths, removeSignalIfExists } from "../core/pause-signals.js";
 import type { RunIntegrationWorkerRequest } from "./run-integration-worker-protocol.js";
 
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
@@ -22,9 +23,74 @@ type LoadedLibrettoWorkflow = {
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
 
-type RunIntegrationOutcome =
-  | { status: "completed" }
-  | { status: "paused"; details: RunDebugPauseDetails };
+type RunIntegrationOutcome = { status: "completed" };
+
+const RESUME_POLL_INTERVAL_MS = 250;
+
+function mirrorStdoutToFile(filePath: string): () => void {
+  const stdout = process.stdout as NodeJS.WriteStream & {
+    write: (...args: any[]) => boolean;
+  };
+  const originalWrite = stdout.write.bind(stdout);
+
+  stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    try {
+      const buffer = Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(String(chunk), "utf8");
+      appendFileSync(filePath, buffer);
+    } catch {
+      // Ignore log mirroring failures; primary stdout should still flow.
+    }
+    return originalWrite(chunk, ...args);
+  }) as typeof stdout.write;
+
+  return () => {
+    stdout.write = originalWrite as typeof stdout.write;
+  };
+}
+
+function getOutputByteCount(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+async function waitForResumeSignal(args: {
+  signalPaths: ReturnType<typeof getPauseSignalPaths>;
+  session: string;
+  details: RunDebugPauseDetails;
+  onPaused?: (details: RunDebugPauseDetails) => Promise<void> | void;
+}): Promise<void> {
+  const { pausedSignalPath, resumeSignalPath } = args.signalPaths;
+  await mkdir(getSessionDir(args.session), { recursive: true });
+  await removeSignalIfExists(resumeSignalPath);
+  const outputBytes = getOutputByteCount(args.signalPaths.outputSignalPath);
+  await writeFile(
+    pausedSignalPath,
+    JSON.stringify(
+      {
+        ...args.details,
+        outputBytes,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await args.onPaused?.(args.details);
+
+  while (!existsSync(resumeSignalPath)) {
+    await new Promise((resolveWait) =>
+      setTimeout(resolveWait, RESUME_POLL_INTERVAL_MS),
+    );
+  }
+
+  await removeSignalIfExists(resumeSignalPath);
+  await removeSignalIfExists(pausedSignalPath);
+}
 
 function isLoadedLibrettoWorkflow(value: unknown): value is LoadedLibrettoWorkflow {
   if (!value || typeof value !== "object") return false;
@@ -115,13 +181,19 @@ async function loadWorkflowExport(
 async function runIntegrationInternal(
   args: RunIntegrationWorkerRequest,
   options: {
-    hangOnPause: boolean;
     onPaused?: (details: RunDebugPauseDetails) => Promise<void> | void;
   },
 ): Promise<RunIntegrationOutcome> {
   const log = getLog();
   const absolutePath = getAbsoluteIntegrationPath(args.integrationPath);
   const workflow = await loadWorkflowExport(absolutePath, args.exportName);
+  const signalPaths = getPauseSignalPaths(args.session);
+  await removeSignalIfExists(signalPaths.pausedSignalPath);
+  await removeSignalIfExists(signalPaths.resumeSignalPath);
+  await removeSignalIfExists(signalPaths.completedSignalPath);
+  await removeSignalIfExists(signalPaths.failedSignalPath);
+  await removeSignalIfExists(signalPaths.outputSignalPath);
+  const restoreStdout = mirrorStdoutToFile(signalPaths.outputSignalPath);
 
   console.log(
     `Running integration "${args.exportName}" from ${absolutePath} (${args.headless ? "headless" : "headed"})...`,
@@ -159,29 +231,52 @@ async function runIntegrationInternal(
     exportName: args.exportName,
     headless: args.headless,
     debug: args.debug,
+    pause: async () => {
+      const details: RunDebugPauseDetails = {
+        sessionName: args.session,
+        pausedAt: new Date().toISOString(),
+        url: browserSession.page.url(),
+      };
+      console.log(`[pause] Paused at ${details.url}`);
+      console.log("[pause] Waiting for resume signal...");
+      await waitForResumeSignal({
+        signalPaths,
+        session: args.session,
+        details,
+        onPaused: options.onPaused,
+      });
+      console.log("[pause] Resume signal received. Continuing workflow...");
+    },
   };
 
-  let pauseDetails: RunDebugPauseDetails | null = null;
   try {
     try {
       await workflow.run(workflowContext, args.params ?? {});
-      console.log("Integration completed.");
-      return { status: "completed" };
     } catch (error) {
-      if (!isRunDebugPauseSignal(error)) {
-        throw error;
-      }
-      pauseDetails = error.details;
-      await options.onPaused?.(pauseDetails);
-      if (options.hangOnPause) {
-        await new Promise<void>(() => {});
-      }
-      return { status: "paused", details: pauseDetails };
+      await writeFile(
+        signalPaths.failedSignalPath,
+        JSON.stringify(
+          {
+            failedAt: new Date().toISOString(),
+            message: error instanceof Error ? error.message : String(error),
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+      throw error;
     }
+    await writeFile(
+      signalPaths.completedSignalPath,
+      JSON.stringify({ completedAt: new Date().toISOString() }, null, 2),
+      "utf8",
+    );
+    console.log("Integration completed.");
+    return { status: "completed" };
   } finally {
-    if (!(options.hangOnPause && pauseDetails)) {
-      await browserSession.close();
-    }
+    restoreStdout();
+    await browserSession.close();
   }
 }
 
@@ -190,7 +285,6 @@ export async function runIntegrationFromFileInWorker(
   onPaused: (details: RunDebugPauseDetails) => Promise<void> | void,
 ): Promise<RunIntegrationOutcome> {
   return await runIntegrationInternal(args, {
-    hangOnPause: true,
     onPaused,
   });
 }

--- a/packages/libretto-cli/src/workers/run-integration-worker.ts
+++ b/packages/libretto-cli/src/workers/run-integration-worker.ts
@@ -7,8 +7,11 @@ import { ensureLibrettoSetup, setLogFile } from "../core/context.js";
 import { logFileForSession } from "../core/session.js";
 
 function sendMessage(message: RunIntegrationWorkerMessage): void {
-  if (typeof process.send === "function") {
+  if (typeof process.send !== "function" || !process.connected) return;
+  try {
     process.send(message);
+  } catch {
+    // Parent may have disconnected after initial run returns on pause.
   }
 }
 
@@ -58,17 +61,12 @@ async function main(): Promise<void> {
     const request = parseWorkerRequest(process.argv);
     ensureLibrettoSetup();
     setLogFile(logFileForSession(request.session));
-    const outcome = await runIntegrationFromFileInWorker(
+    await runIntegrationFromFileInWorker(
       request,
       async (details) => {
         sendMessage({ type: "paused", details });
       },
     );
-    if (outcome.status !== "completed") {
-      throw new Error(
-        "Invariant violation: worker returned paused outcome instead of hanging.",
-      );
-    }
     sendMessage({ type: "completed" });
     process.exit(0);
   } catch (error) {

--- a/packages/libretto-cli/src/workers/run-integration-worker.ts
+++ b/packages/libretto-cli/src/workers/run-integration-worker.ts
@@ -1,9 +1,11 @@
+import { writeFile } from "node:fs/promises";
 import type {
   RunIntegrationWorkerMessage,
   RunIntegrationWorkerRequest,
 } from "./run-integration-worker-protocol.js";
 import { runIntegrationFromFileInWorker } from "./run-integration-runtime.js";
 import { ensureLibrettoSetup, setLogFile } from "../core/context.js";
+import { getPauseSignalPaths } from "../core/pause-signals.js";
 import { logFileForSession } from "../core/session.js";
 
 function sendMessage(message: RunIntegrationWorkerMessage): void {
@@ -57,8 +59,9 @@ function parseWorkerRequest(argv: string[]): RunIntegrationWorkerRequest {
 }
 
 async function main(): Promise<void> {
+  let request: RunIntegrationWorkerRequest | null = null;
   try {
-    const request = parseWorkerRequest(process.argv);
+    request = parseWorkerRequest(process.argv);
     ensureLibrettoSetup();
     setLogFile(logFileForSession(request.session));
     await runIntegrationFromFileInWorker(
@@ -71,6 +74,21 @@ async function main(): Promise<void> {
     process.exit(0);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (request) {
+      const { failedSignalPath } = getPauseSignalPaths(request.session);
+      await writeFile(
+        failedSignalPath,
+        JSON.stringify(
+          {
+            failedAt: new Date().toISOString(),
+            message,
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    }
     sendMessage({ type: "failed", message });
     process.exit(1);
   }

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -17,25 +17,25 @@ Sessions start in **read-only mode** by default. **Every time you launch a brows
 >
 > I've opened the browser in **read-only mode**. I can observe the page, take snapshots, and inspect network traffic, but I **cannot** click, type, fill forms, submit, or execute any actions that modify the page.
 >
-> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **full-access mode**.
+> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **interactive mode**.
 
 **Rules:**
-- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants full access.
-- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants full access.
+- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants interactive access.
+- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants interactive access.
 
-### Full-access mode (user-approved)
+### Interactive mode (user-approved)
 
-> **Session mode: FULL-ACCESS**
+> **Session mode: INTERACTIVE**
 >
-> I've opened the browser in **full-access mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
+> I've opened the browser in **interactive mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
 >
 > If you'd like me to switch to **read-only mode** (observe only, no page modifications), let me know.
 
 ### Switching modes
 
-- When the user requests full-access mode, run `npx libretto session-mode full-access --session <name>` and then proceed with `exec`/`run`.
+- When the user requests interactive mode, run `npx libretto session-mode interactive --session <name>` and then proceed with `exec`/`run`.
 - Never change session mode unless the user explicitly approves.
-- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting full access. Switch the mode and confirm.
+- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting interactive access. Switch the mode and confirm.
 
 ## Ask, Don't Guess
 
@@ -47,7 +47,8 @@ If it's not obvious which element to click or what value to enter, **ask the use
 npx libretto open <url> [--headed]     # Launch browser and navigate (headless by default)
 npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
-npx libretto session-mode <read-only|full-access> [--session <name>] # Set session mode explicitly
+npx libretto resume                    # Resume a paused workflow for the current session
+npx libretto session-mode <read-only|interactive> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" --context "<situational info>"
 npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto-cli/profiles/
 npx libretto network                   # Show last 20 captured network requests
@@ -62,6 +63,16 @@ Built-in sessions: `default`, `dev-server`, `browser-agent`.
 
 Add `--visualize` to any `exec` command to show a ghost cursor and element highlight before each action executes. Use it when the user wants to see what will be clicked/filled before it happens.
 
+## Workflow Pause/Resume (`ctx.pause()`)
+
+Workflows pause from inside the workflow function by calling `await ctx.pause()`.
+
+- There are no pause options to pass at call sites. Pause is session-scoped and resolved from the active session.
+- `npx libretto run ...` waits until the workflow either completes or hits the next `ctx.pause()`.
+- On pause, the workflow process stays alive and keeps browser/session state.
+- `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
+- For multi-pause workflows, call `resume` repeatedly until the workflow completes.
+
 ## Globals Available in `exec`
 
 `page`, `context`, `state`, `browser`, `networkLog({ last?, filter?, method? })`, `actionLog({ last?, filter?, action?, source? })`, `console`, `fetch`, `Buffer`, `URL`, `setTimeout`
@@ -74,8 +85,8 @@ The `state` object persists across `exec` calls within the same session — use 
 # Open a page (starts in read-only mode)
 npx libretto open https://example.com
 
-# When user grants full access:
-npx libretto session-mode full-access --session default
+# When user grants interactive access:
+npx libretto session-mode interactive --session default
 
 # Interact with elements
 npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
@@ -119,8 +130,8 @@ When browser automation jobs fail (selectors timing out, clicks not working), us
 1. Add `page.pause()` before the problematic code section
 2. Start the job with `npx browser-agent start` (debug mode is always enabled locally)
 3. Wait ~60 seconds for the browser to hit the breakpoint
-4. Ask user if they approve full-access mode for `browser-agent`
-5. If approved, run `npx libretto session-mode full-access --session browser-agent`
+4. Ask user if they approve interactive mode for `browser-agent`
+5. If approved, run `npx libretto session-mode interactive --session browser-agent`
 6. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
 7. Once the fix works, codify it in source files
 8. Restart the job to verify end-to-end
@@ -133,7 +144,7 @@ npx browser-agent start \
   --params '{"vendorName":"eClinicalWorks"}'
 
 # Inspect page state
-npx libretto session-mode full-access --session browser-agent
+npx libretto session-mode interactive --session browser-agent
 npx libretto exec --session browser-agent "return await page.url();"
 npx libretto snapshot --session browser-agent \
   --objective "Find dropdown menus and their current selections" \
@@ -200,7 +211,7 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 - **Never use `page.screenshot()` via `exec`.** Use `npx libretto snapshot` instead — it captures the viewport, sends the screenshot + HTML to a vision model, and returns actionable selectors. The `fullPage` option is especially dangerous — it scrolls the entire page to stitch a screenshot, which can crash JavaScript-heavy pages (especially EMR portals like eClinicalWorks).
 - **Never run `exec` commands in parallel.** Always wait for one `exec` to finish before starting the next. Do not use `run_in_background` for `exec` calls. Running simultaneous `exec` calls opens multiple CDP connections to the same page, which corrupts the page state and kills the browser.
-- If `open` is called when a session already has a browser running, it navigates the existing browser to the new URL instead of launching a new one.
+- `open` and `run` take control of the session. If a session already has an owner PID, Libretto terminates it first and prints a warning.
 - Use `return <value>` in `exec` to print results. Strings print raw; objects print as JSON.
 - For iframe content, access via `page.locator('iframe[name="..."]').contentFrame()`.
 - Multiple sessions allow parallel browser instances: `--session test1`, `--session test2`.

--- a/packages/libretto/src/debug/index.ts
+++ b/packages/libretto/src/debug/index.ts
@@ -2,6 +2,6 @@ export {
 	debugPause,
 	DebugPauseSignal,
 	isDebugPauseSignal,
-	type DebugPauseOptions,
+	type DebugPauseContext,
 	type DebugPauseDetails,
 } from "./pause.js";

--- a/packages/libretto/src/debug/pause.ts
+++ b/packages/libretto/src/debug/pause.ts
@@ -1,11 +1,7 @@
 import type { Page } from "playwright";
-import { isDebugMode } from "../config/config.js";
-
-export type DebugPauseOptions = {
-	/** Whether pause mode is enabled for this call. Defaults to env-based debug mode. */
-	enabled?: boolean;
-	/** Session name to include in pause metadata. Defaults to "libretto". */
-	sessionName?: string;
+export type DebugPauseContext = {
+	page: Page;
+	session: string;
 };
 
 export type DebugPauseDetails = {
@@ -13,10 +9,6 @@ export type DebugPauseDetails = {
 	pausedAt: string;
 	url: string;
 };
-
-function getSessionName(options?: DebugPauseOptions): string {
-	return options?.sessionName ?? "libretto";
-}
 
 export class DebugPauseSignal extends Error {
 	public readonly details: DebugPauseDetails;
@@ -48,18 +40,12 @@ export function isDebugPauseSignal(error: unknown): error is DebugPauseSignal {
 
 /**
  * Signals a workflow pause to the caller.
- * When enabled, this throws a typed signal that supervisors can intercept.
+ * This always throws a typed signal that supervisors can intercept.
  */
-export async function debugPause(
-	page: Page,
-	options?: DebugPauseOptions,
-): Promise<void> {
-	const enabled = options?.enabled ?? isDebugMode();
-	if (!enabled) return;
-
-	const url = page.url();
+export async function debugPause(context: DebugPauseContext): Promise<never> {
+	const url = context.page.url();
 	const details: DebugPauseDetails = {
-		sessionName: getSessionName(options),
+		sessionName: context.session,
 		pausedAt: new Date().toISOString(),
 		url,
 	};

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -67,7 +67,7 @@ export {
 	debugPause,
 	DebugPauseSignal,
 	isDebugPauseSignal,
-	type DebugPauseOptions,
+	type DebugPauseContext,
 	type DebugPauseDetails,
 } from "./debug/pause.js";
 
@@ -108,7 +108,7 @@ export {
 	debugPause as runDebugPause,
 	DebugPauseSignal as RunDebugPauseSignal,
 	isDebugPauseSignal as isRunDebugPauseSignal,
-	type DebugPauseOptions as RunDebugPauseOptions,
+	type DebugPauseContext as RunDebugPauseContext,
 	type DebugPauseDetails as RunDebugPauseDetails,
 	type LaunchBrowserArgs,
 	type BrowserSession,

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -25,11 +25,13 @@ export type { LLMClient, Message, MessageContentPart } from "./llm/types.js";
 export {
 	SESSION_STATE_VERSION,
 	SessionModeSchema,
+	SessionStatusSchema,
 	SessionStateFileSchema,
 	parseSessionStateData,
 	parseSessionStateContent,
 	serializeSessionState,
 	type SessionMode,
+	type SessionStatus,
 	type SessionState,
 	type SessionStateFile,
 } from "./state/index.js";

--- a/packages/libretto/src/run/api.ts
+++ b/packages/libretto/src/run/api.ts
@@ -6,6 +6,6 @@ export {
 	debugPause,
 	DebugPauseSignal,
 	isDebugPauseSignal,
-	type DebugPauseOptions,
+	type DebugPauseContext,
 	type DebugPauseDetails,
 } from "../debug/pause.js";

--- a/packages/libretto/src/run/browser.ts
+++ b/packages/libretto/src/run/browser.ts
@@ -81,6 +81,7 @@ export async function launchBrowser({
           ? parsedExistingState.data.runId
           : `runtime-${Date.now()}`,
         startedAt: new Date().toISOString(),
+        status: "active",
         ...(parsedExistingState.success && parsedExistingState.data.mode
           ? { mode: parsedExistingState.data.mode }
           : {}),

--- a/packages/libretto/src/state/index.ts
+++ b/packages/libretto/src/state/index.ts
@@ -1,11 +1,13 @@
 export {
 	SESSION_STATE_VERSION,
 	SessionModeSchema,
+	SessionStatusSchema,
 	SessionStateFileSchema,
 	parseSessionStateData,
 	parseSessionStateContent,
 	serializeSessionState,
 	type SessionMode,
+	type SessionStatus,
 	type SessionState,
 	type SessionStateFile,
 } from "./session-state.js";

--- a/packages/libretto/src/state/session-state.ts
+++ b/packages/libretto/src/state/session-state.ts
@@ -3,6 +3,13 @@ import { z } from "zod";
 export const SESSION_STATE_VERSION = 1;
 
 export const SessionModeSchema = z.enum(["read-only", "full-access"]);
+export const SessionStatusSchema = z.enum([
+	"active",
+	"paused",
+	"completed",
+	"failed",
+	"exited",
+]);
 export const SessionStateFileSchema = z.object({
 	version: z.literal(SESSION_STATE_VERSION),
 	port: z.number().int().min(0).max(65535),
@@ -11,9 +18,11 @@ export const SessionStateFileSchema = z.object({
 	runId: z.string().min(1),
 	startedAt: z.string().datetime({ offset: true }),
 	mode: SessionModeSchema.optional(),
+	status: SessionStatusSchema.optional(),
 });
 
 export type SessionMode = z.infer<typeof SessionModeSchema>;
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
 export type SessionStateFile = z.infer<typeof SessionStateFileSchema>;
 export type SessionState = Omit<SessionStateFile, "version">;
 

--- a/packages/libretto/src/step/runner.ts
+++ b/packages/libretto/src/step/runner.ts
@@ -161,11 +161,13 @@ export function createRunner(config: RunnerConfig = {}): Runner {
 
 						stepLogger.info("step:debug-bundle", { path: bundle.bundlePath });
 
-						// Pause for debugging
-						await debugPause(page, {
-							enabled: debug,
-							sessionName,
-						});
+						// Pause for debugging only when debug mode is enabled.
+						if (debug) {
+							await debugPause({
+								page,
+								session: sessionName,
+							});
+						}
 
 						throw firstError;
 					}

--- a/packages/libretto/src/workflow/workflow.ts
+++ b/packages/libretto/src/workflow/workflow.ts
@@ -21,6 +21,7 @@ export type LibrettoWorkflowContext = {
 	exportName: string;
 	headless: boolean;
 	debug: boolean;
+	pause: () => Promise<void>;
 };
 
 export type LibrettoWorkflowHandler<Input = unknown, Output = unknown> = (


### PR DESCRIPTION
## Summary
- refactor `run` and `resume` to share file-based workflow outcome waiting
- keep paused workflows alive in-place and make `resume` wait for completion or the next pause
- simplify pause semantics to `ctx.pause()` with session-scoped signaling
- make `open` and `run` fail fast when a session name is already active, with an explicit close/new-session message
- add stronger CLI coverage for multi-pause resume cycles, active-session blocking, and close-then-retry flow
- update skill docs and add root `AGENTS.md` with package structure and command guidance

## Validation
- `pnpm --filter libretto-cli type-check`
- `pnpm --filter libretto-cli test -- src/cli-basic.test.ts`
- `pnpm --filter libretto-cli test -- src/cli-pause.test.ts`
- `pnpm --filter libretto-cli test -- src/cli-stateful.test.ts`
- `pnpm i`
