### PR TITLE
Remove permissions model and default to full access

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -5,37 +5,16 @@ description: "Browser automation CLI for building integrations, with a network-f
 
 # Browser Integration with Libretto CLI
 
-Use the `npx libretto` CLI to automate web interactions, debug browser agent jobs, and prototype fixes with explicit full-access approval when needed.
+Use the `npx libretto` CLI to automate web interactions, debug browser agent jobs, and prototype fixes.
 
-## CRITICAL: Session Modes
+## CRITICAL: Session Access
 
-Sessions start in **read-only mode** by default. **Every time you launch a browser — whether via `open` or `run` — you MUST immediately announce the session mode.** This is non-negotiable. Do NOT skip the announcement. Do NOT abbreviate it.
-
-### Read-only mode (default)
-
-> **Session mode: READ-ONLY**
->
-> I've opened the browser in **read-only mode**. I can observe the page, take snapshots, and inspect network traffic, but I **cannot** click, type, fill forms, submit, or execute any actions that modify the page.
->
-> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **full-access mode**.
+Libretto sessions are **full-access by default**. You can use `exec` and `run` immediately after opening a session.
 
 **Rules:**
-- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants full-access.
-- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants full-access.
-
-### Full-access mode (user-approved)
-
-> **Session mode: FULL-ACCESS**
->
-> I've opened the browser in **full-access mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
->
-> If you'd like me to switch to **read-only mode** (observe only, no page modifications), let me know.
-
-### Switching modes
-
-- When the user requests full-access mode, run `npx libretto session-mode full-access --session <name>` and then proceed with `exec`/`run`.
-- Never change session mode unless the user explicitly approves.
-- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting full-access. Switch the mode and confirm.
+- Always announce which session you opened and what page you are on.
+- Use `snapshot`, `network`, and `actions` first when debugging unknown page state.
+- Before any potentially mutating action (submit/save/delete, or non-idempotent API calls), describe what you are about to do and wait for explicit user confirmation.
 
 ## Ask, Don't Guess
 
@@ -48,7 +27,6 @@ npx libretto open <url> [--headless]   # Launch browser and navigate (headed by 
 npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
 npx libretto resume                    # Resume a paused workflow for the current session
-npx libretto session-mode <read-only|full-access> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" [--context "<situational info>"]
 npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto/profiles/
 npx libretto network                   # Show last 20 captured network requests
@@ -113,11 +91,8 @@ If an action fails despite an element being visible, you should not keep retryin
 ## Workflow: Browse and Interact
 
 ```bash
-# Open a page (starts in read-only mode)
+# Open a page
 npx libretto open https://example.com
-
-# When user grants full-access:
-npx libretto session-mode full-access --session default
 
 # Interact with elements
 npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
@@ -161,11 +136,9 @@ When browser automation jobs fail (selectors timing out, clicks not working), us
 1. Add `page.pause()` before the problematic code section
 2. Start the job with `npx browser-agent start` (debug mode is always enabled locally)
 3. Wait ~60 seconds for the browser to hit the breakpoint
-4. Ask user if they approve full-access mode for `browser-agent`
-5. If approved, run `npx libretto session-mode full-access --session browser-agent`
-6. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
-7. Once the fix works, codify it in source files
-8. Restart the job to verify end-to-end
+4. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
+5. Once the fix works, codify it in source files
+6. Restart the job to verify end-to-end
 
 ```bash
 # Start job in background
@@ -175,7 +148,6 @@ npx browser-agent start \
   --params '{"vendorName":"eClinicalWorks"}'
 
 # Inspect page state
-npx libretto session-mode full-access --session browser-agent
 npx libretto exec --session browser-agent "return await page.url();"
 npx libretto snapshot --session browser-agent \
   --objective "Find dropdown menus and their current selections" \

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidelines for `packages/`
+
+- Any behavior change in `packages/libretto` or `packages/libretto-cli` must be accompanied by updates to the skill documentation when relevant.
+- Skill documentation source of truth is `packages/libretto/skill/SKILL.md`.
+- For these skill-documentation updates, use the `technical-writing` skill.

--- a/packages/libretto-cli/src/cli.ts
+++ b/packages/libretto-cli/src/cli.ts
@@ -20,7 +20,6 @@ import {
 const CLI_COMMANDS = new Set([
   "open",
   "run",
-  "session-mode",
   "ai",
   "save",
   "exec",
@@ -41,10 +40,9 @@ Commands:
   open <url> [--headless] Launch browser and open URL (headed by default)
                           Automatically loads saved profile if available
   run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug]  Run an exported Libretto workflow from a file; pass --debug to enable pause-on-failure debugging (or --no-debug to disable)
-  session-mode <read-only|full-access> Set session execution mode
   ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)
-  exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight; blocked until full-access)
+  exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight)
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when objective is provided (context optional)
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
@@ -57,8 +55,6 @@ Options:
 
 Examples:
   libretto-cli open https://linkedin.com
-  # default sessions are read-only; enable actions only after explicit human approval
-  libretto-cli session-mode full-access --session default
 
   # ... manually log in ...
   libretto-cli save linkedin.com

--- a/packages/libretto-cli/src/commands/browser.ts
+++ b/packages/libretto-cli/src/commands/browser.ts
@@ -1,24 +1,5 @@
 import type { Argv } from "yargs";
 import { runClose, runOpen, runSave } from "../core/browser.js";
-import {
-  readOnlySessionError,
-  readSessionState,
-  setSessionPermissionMode,
-  writeSessionState,
-  type SessionMode,
-} from "../core/session.js";
-
-function runSessionMode(session: string, mode: SessionMode): void {
-  setSessionPermissionMode(session, mode);
-  const state = readSessionState(session);
-  if (state) {
-    writeSessionState({
-      ...state,
-      mode,
-    });
-  }
-  console.log(`Session "${session}" is now ${mode}.`);
-}
 
 export function registerBrowserCommands(yargs: Argv): Argv {
   return yargs
@@ -34,25 +15,12 @@ export function registerBrowserCommands(yargs: Argv): Argv {
           .option("headless", {
             type: "boolean",
             default: false,
-          })
-          .option("allow-actions", {
-            type: "boolean",
-            default: false,
-            hidden: true,
           }),
       async (argv) => {
         const hasHeadedFlag = Boolean(argv.headed);
         const hasHeadlessFlag = Boolean(argv.headless);
         if (hasHeadedFlag && hasHeadlessFlag) {
           throw new Error("Cannot pass both --headed and --headless.");
-        }
-        const allowActions = Boolean(
-          argv["allow-actions"] ?? (argv as { allowActions?: boolean }).allowActions,
-        );
-        if (allowActions) {
-          throw new Error(
-            `--allow-actions is not supported for open. ${readOnlySessionError(String(argv.session))}`,
-          );
         }
         const headed = hasHeadedFlag || !hasHeadlessFlag;
         const url = argv.url as string | undefined;
@@ -62,20 +30,6 @@ export function registerBrowserCommands(yargs: Argv): Argv {
           );
         }
         await runOpen(url, headed, String(argv.session));
-      },
-    )
-    .command(
-      "session-mode [mode]",
-      "Set session execution mode",
-      (cmd) => cmd.positional("mode", { type: "string" }),
-      async (argv) => {
-        const mode = argv.mode;
-        if (mode !== "read-only" && mode !== "full-access") {
-          throw new Error(
-            "Usage: libretto-cli session-mode <read-only|full-access> [--session <name>]",
-          );
-        }
-        runSessionMode(String(argv.session), mode);
       },
     )
     .command(

--- a/packages/libretto-cli/src/commands/execution.ts
+++ b/packages/libretto-cli/src/commands/execution.ts
@@ -12,9 +12,7 @@ import { getLog } from "../core/context.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
   assertSessionAvailableForStart,
-  getSessionPermissionMode,
   readSessionStateOrThrow,
-  readOnlySessionError,
   setSessionStatus,
 } from "../core/session.js";
 import {
@@ -111,11 +109,7 @@ async function runExec(
   visualize = false,
 ): Promise<void> {
   const log = getLog();
-  const sessionState = readSessionStateOrThrow(session);
-  const mode = sessionState.mode ?? "read-only";
-  if (mode !== "full-access") {
-    throw new Error(readOnlySessionError(session));
-  }
+  readSessionStateOrThrow(session);
 
   log.info("exec-start", {
     session,
@@ -478,11 +472,6 @@ export function registerExecutionCommands(yargs: Argv): Argv {
           .option("params-file", { type: "string" })
           .option("headed", { type: "boolean", default: false })
           .option("headless", { type: "boolean", default: false })
-          .option("allow-actions", {
-            type: "boolean",
-            default: false,
-            hidden: true,
-          })
           .option("debug", { type: "boolean" }),
       async (argv) => {
         const usage =
@@ -494,17 +483,6 @@ export function registerExecutionCommands(yargs: Argv): Argv {
         }
 
         const session = String(argv.session);
-        const allowActions = Boolean(
-          argv["allow-actions"] ?? (argv as { allowActions?: boolean }).allowActions,
-        );
-        if (allowActions) {
-          throw new Error(
-            `--allow-actions is not supported for run. ${readOnlySessionError(session)}`,
-          );
-        }
-        if (getSessionPermissionMode(session) !== "full-access") {
-          throw new Error(readOnlySessionError(session));
-        }
 
         const rawInlineParams = argv.params as string | undefined;
         const paramsFile = argv["params-file"] as string | undefined;

--- a/packages/libretto-cli/src/core/ai-config.ts
+++ b/packages/libretto-cli/src/core/ai-config.ts
@@ -18,21 +18,12 @@ export const AiConfigSchema = z
   .strict();
 export type AiConfig = z.infer<typeof AiConfigSchema>;
 
-const SessionModeSchema = z.enum(["read-only", "full-access"]);
-const SessionPermissionsSchema = z
-  .object({
-    defaultMode: SessionModeSchema.default("read-only"),
-    sessions: z.record(SessionModeSchema).default({}),
-  })
-  .strict();
-
 export const LibrettoConfigSchema = z
   .object({
     version: z.literal(CURRENT_CONFIG_VERSION),
     ai: AiConfigSchema.optional(),
-    permissions: SessionPermissionsSchema.optional(),
   })
-  .strict();
+  .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
 
 export const AI_CONFIG_PRESETS: Record<AiPreset, string[]> = {
@@ -116,7 +107,6 @@ export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolea
   writeLibrettoConfig(
     {
       version: librettoConfig.version,
-      permissions: librettoConfig.permissions,
     },
     configPath,
   );

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -16,7 +16,6 @@ import {
   assertSessionAvailableForStart,
   clearSessionState,
   generateRunId,
-  getSessionPermissionMode,
   readSessionStateOrThrow,
   logFileForSession,
   readSessionState,
@@ -187,9 +186,8 @@ export async function runOpen(
   session: string,
 ): Promise<void> {
   let log = getLog();
-  const sessionMode = getSessionPermissionMode(session);
   const url = normalizeUrl(rawUrl);
-  log.info("open-start", { url, headed, session, sessionMode });
+  log.info("open-start", { url, headed, session });
   assertSessionAvailableForStart(session);
 
   const port = await pickFreePort();
@@ -209,7 +207,6 @@ export async function runOpen(
   log.info("open-launching", {
     url,
     mode: browserMode,
-    sessionMode,
     session,
     port,
     runId,
@@ -640,13 +637,11 @@ await new Promise(() => {});
         session,
         runId,
         startedAt: new Date().toISOString(),
-        mode: sessionMode,
         status: "active",
       });
       log.info("open-success", {
         url,
         mode: browserMode,
-        sessionMode,
         session,
         port,
         runId,

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -11,17 +11,13 @@ import {
   getSessionDir,
   getSessionLogsPath,
   getSessionStatePath,
-  LIBRETTO_CONFIG_DIR,
-  LIBRETTO_CONFIG_PATH,
   LIBRETTO_SESSIONS_DIR,
 } from "./context.js";
 import {
   SESSION_STATE_VERSION,
-  SessionModeSchema,
   SessionStatusSchema,
   parseSessionStateContent,
   serializeSessionState,
-  type SessionMode,
   type SessionStatus,
   type SessionState,
 } from "libretto/state";
@@ -32,12 +28,7 @@ export const SESSION_DEFAULT = "default";
 export const SESSION_DEV_SERVER = "dev-server";
 export const SESSION_BROWSER_AGENT = "browser-agent";
 export { SESSION_STATE_VERSION };
-export type { SessionMode, SessionStatus, SessionState };
-
-type SessionPermissions = {
-  defaultMode: SessionMode;
-  sessions: Record<string, SessionMode>;
-};
+export type { SessionStatus, SessionState };
 
 export function generateRunId(): string {
   return new Date()
@@ -216,141 +207,5 @@ export function assertSessionAvailableForStart(session: string): void {
   const endpoint = `http://127.0.0.1:${existingState.port}`;
   throw new Error(
     `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto-cli close --session ${session}`,
-  );
-}
-
-function ensureLibrettoDir(): void {
-  mkdirSync(LIBRETTO_CONFIG_DIR, { recursive: true });
-}
-
-function isSessionMode(value: unknown): value is SessionMode {
-  return SessionModeSchema.safeParse(value).success;
-}
-
-export function readSessionPermissions(): SessionPermissions {
-  if (!existsSync(LIBRETTO_CONFIG_PATH)) {
-    return { defaultMode: "read-only", sessions: {} };
-  }
-
-  try {
-    const rawConfig = JSON.parse(
-      readFileSync(LIBRETTO_CONFIG_PATH, "utf-8"),
-    ) as Record<string, unknown>;
-
-    if (rawConfig.version !== 1) {
-      throw new Error("unsupported version");
-    }
-
-    const rawPermissions = rawConfig.permissions;
-    if (rawPermissions === undefined) {
-      return { defaultMode: "read-only", sessions: {} };
-    }
-    if (
-      typeof rawPermissions !== "object" ||
-      rawPermissions === null ||
-      Array.isArray(rawPermissions)
-    ) {
-      throw new Error("permissions must be an object");
-    }
-
-    const typedPermissions = rawPermissions as Record<string, unknown>;
-
-    let defaultMode: SessionMode = "read-only";
-    if (typedPermissions.defaultMode !== undefined) {
-      if (!isSessionMode(typedPermissions.defaultMode)) {
-        throw new Error("invalid defaultMode");
-      }
-      defaultMode = typedPermissions.defaultMode;
-    }
-
-    const normalized: Record<string, SessionMode> = {};
-    if (typedPermissions.sessions !== undefined) {
-      if (
-        typeof typedPermissions.sessions !== "object" ||
-        typedPermissions.sessions === null ||
-        Array.isArray(typedPermissions.sessions)
-      ) {
-        throw new Error("sessions must be an object");
-      }
-
-      const sessions = typedPermissions.sessions as Record<string, unknown>;
-      for (const [session, mode] of Object.entries(sessions)) {
-        if (!isSessionMode(mode)) {
-          throw new Error(`invalid mode for session "${session}"`);
-        }
-        normalized[session] = mode;
-      }
-    }
-
-    return { defaultMode, sessions: normalized };
-  } catch {
-    throw new Error(
-      `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
-    );
-  }
-}
-
-export function writeSessionPermissions(permissions: SessionPermissions): void {
-  ensureLibrettoDir();
-  let rawConfig: Record<string, unknown> = { version: 1 };
-
-  if (existsSync(LIBRETTO_CONFIG_PATH)) {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(LIBRETTO_CONFIG_PATH, "utf-8"),
-      ) as Record<string, unknown>;
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        throw new Error("config must be an object");
-      }
-      rawConfig = parsed;
-    } catch {
-      throw new Error(
-        `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
-      );
-    }
-  }
-
-  if (rawConfig.version !== undefined && rawConfig.version !== 1) {
-    throw new Error(
-      `Session permissions are invalid at ${LIBRETTO_CONFIG_PATH}.`,
-    );
-  }
-
-  rawConfig.version = 1;
-  rawConfig.permissions = permissions;
-  writeFileSync(
-    LIBRETTO_CONFIG_PATH,
-    JSON.stringify(rawConfig, null, 2),
-    "utf-8",
-  );
-}
-
-export function getSessionPermissionMode(session: string): SessionMode {
-  const permissions = readSessionPermissions();
-  return permissions.sessions[session] ?? permissions.defaultMode;
-}
-
-export function setSessionPermissionMode(
-  session: string,
-  mode: SessionMode,
-): void {
-  const permissions = readSessionPermissions();
-  if (mode === permissions.defaultMode) {
-    delete permissions.sessions[session];
-  } else {
-    permissions.sessions[session] = mode;
-  }
-  writeSessionPermissions(permissions);
-}
-
-export function readOnlySessionError(session: string): string {
-  return (
-    `Session "${session}" is read-only. ` +
-    "Only a human can authorize full-access mode. " +
-    `If you want me to enable it, explicitly tell me to run: libretto-cli session-mode full-access --session ${session}`
   );
 }

--- a/packages/libretto-cli/test/basic.spec.ts
+++ b/packages/libretto-cli/test/basic.spec.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
@@ -10,9 +10,6 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(
       "Usage: libretto-cli <command> [--session <name>]",
-    );
-    expect(result.stdout).toContain(
-      "session-mode <read-only|full-access> Set session execution mode",
     );
     expect(result.stdout).toContain(
       "Capture PNG + HTML; analyze when objective is provided (context optional)",
@@ -86,26 +83,15 @@ describe("basic CLI subprocess behavior", () => {
     );
   });
 
-  test("fails run by default in read-only session", async ({ librettoCli }) => {
-    const result = await librettoCli("run ./integration.ts main");
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      'Session "default" is read-only. Only a human can authorize full-access mode.',
-    );
-  });
-
-  test("allows run guard when session is permissioned full-access", async ({
+  test("fails run when integration file does not exist", async ({
     librettoCli,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const result = await librettoCli("run ./integration.ts main");
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).not.toContain("is read-only");
     expect(result.stderr).toContain("Integration file does not exist:");
   });
 
   test("fails run with invalid JSON in --params", async ({ librettoCli }) => {
-    await librettoCli("session-mode full-access --session default");
     const result = await librettoCli(
       "run ./integration.ts main --params \"{not-json}\"",
     );
@@ -117,7 +103,6 @@ describe("basic CLI subprocess behavior", () => {
     librettoCli,
     workspaceDir,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const paramsPath = join(workspaceDir, "invalid-params.json");
     await writeFile(paramsPath, "{not-json}", "utf8");
 
@@ -132,7 +117,6 @@ describe("basic CLI subprocess behavior", () => {
     librettoCli,
     workspaceDir,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const paramsPath = join(workspaceDir, "params.json");
     await writeFile(paramsPath, "{}", "utf8");
 
@@ -149,7 +133,6 @@ describe("basic CLI subprocess behavior", () => {
     librettoCli,
     workspaceDir,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const missingPath = join(workspaceDir, "missing-params.json");
 
     const result = await librettoCli(
@@ -165,7 +148,6 @@ describe("basic CLI subprocess behavior", () => {
     librettoCli,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     await writeWorkflow(
       "integration.ts",
       `
@@ -185,7 +167,6 @@ export async function main() {
     workspaceDir,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     await writeWorkflow(
       "integration.ts",
       `
@@ -215,7 +196,6 @@ export const main = {
     librettoCli,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     await writeWorkflow(
       "integration.ts",
       `
@@ -248,7 +228,6 @@ export const main = workflow(
     workspaceDir,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     await writeWorkflow(
       "integration.ts",
       `
@@ -273,7 +252,6 @@ export const main = workflow({}, async () => "ok");
     workspaceDir,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     await writeWorkflow(
       "integration.ts",
       `
@@ -308,7 +286,6 @@ export const main = workflow(
     librettoCli,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const integrationFilePath = await writeWorkflow(
       "integration-pause.mjs",
       `
@@ -335,7 +312,6 @@ export const main = workflow({}, async (ctx) => {
     librettoCli,
     writeWorkflow,
   }) => {
-    await librettoCli("session-mode full-access --session default");
     const integrationFilePath = await writeWorkflow(
       "integration-complete.mjs",
       `
@@ -353,79 +329,6 @@ export const main = workflow({}, async () => {
     expect(result.stdout).toContain("Integration completed.");
     expect(result.stdout).not.toContain("Workflow paused.");
   }, 45_000);
-
-  test("fails open when deprecated --allow-actions flag is passed", async ({
-    librettoCli,
-  }) => {
-    const result = await librettoCli(
-      "open https://example.com --allow-actions",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "--allow-actions is not supported for open.",
-    );
-  });
-
-  test("fails run when deprecated --allow-actions flag is passed", async ({
-    librettoCli,
-  }) => {
-    const result = await librettoCli(
-      "run ./integration.ts main --allow-actions",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "--allow-actions is not supported for run.",
-    );
-  });
-
-  test("session-mode full-access writes session permission", async ({
-    librettoCli,
-    workspaceDir,
-  }) => {
-    const result = await librettoCli(
-      "session-mode full-access --session consented",
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Session "consented" is now full-access.');
-
-    const raw = JSON.parse(
-      await readFile(join(workspaceDir, ".libretto", "config.json"), "utf8"),
-    ) as {
-      permissions?: {
-        sessions?: Record<string, string>;
-      };
-    };
-    expect(raw.permissions?.sessions?.consented).toBe("full-access");
-  });
-
-  test("session-mode read-only removes full-access permission", async ({
-    librettoCli,
-    workspaceDir,
-  }) => {
-    await librettoCli("session-mode full-access --session toggled");
-    const result = await librettoCli(
-      "session-mode read-only --session toggled",
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Session "toggled" is now read-only.');
-
-    const raw = JSON.parse(
-      await readFile(join(workspaceDir, ".libretto", "config.json"), "utf8"),
-    ) as {
-      permissions?: {
-        sessions?: Record<string, string>;
-      };
-    };
-    expect(raw.permissions?.sessions?.toggled).toBeUndefined();
-  });
-
-  test("fails session-mode with invalid mode", async ({ librettoCli }) => {
-    const result = await librettoCli("session-mode maybe --session default");
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "Usage: libretto-cli session-mode <read-only|full-access> [--session <name>]",
-    );
-  });
 
   test("fails save with missing target usage error", async ({
     librettoCli,

--- a/packages/libretto-cli/test/stateful.spec.ts
+++ b/packages/libretto-cli/test/stateful.spec.ts
@@ -12,7 +12,6 @@ async function writeSessionState(
     port?: number;
     pid?: number;
     startedAt?: string;
-    mode?: "read-only" | "full-access";
   },
 ): Promise<string> {
   const dir = join(workspaceDir, ".libretto", "sessions", state.session);
@@ -26,7 +25,6 @@ async function writeSessionState(
     pid: state.pid ?? 12345,
     startedAt: state.startedAt ?? "2026-01-01T00:00:00.000Z",
   };
-  if (state.mode) payload.mode = state.mode;
   await writeFile(path, JSON.stringify(payload, null, 2), "utf8");
   return path;
 }
@@ -369,124 +367,28 @@ describe("state-driven CLI subprocess behavior", () => {
     ).toBe(true);
   });
 
-  test("blocks exec in read-only open sessions", async ({
+  test("exec ignores legacy mode fields and attempts to connect", async ({
     workspaceDir,
     librettoCli,
   }) => {
-    await writeSessionState(workspaceDir, {
-      session: "readonly-session",
-      mode: "read-only",
-    });
-
-    const result = await librettoCli(
-      "exec \"return await page.title()\" --session readonly-session",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "Session \"readonly-session\" is read-only. Only a human can authorize full-access mode.",
-    );
-  });
-
-  test("rejects exec when session mode is not specified", async ({
-    workspaceDir,
-    librettoCli,
-  }) => {
-    await writeSessionState(workspaceDir, {
-      session: "legacy-session",
-    });
-
-    const result = await librettoCli(
-      "exec \"return await page.title()\" --session legacy-session",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "Session \"legacy-session\" is read-only. Only a human can authorize full-access mode.",
-    );
-    expect(result.stderr).toContain(
-      "libretto-cli session-mode full-access --session legacy-session",
-    );
-  });
-
-  test("rejects exec when session mode is missing even if permissioned full-access", async ({
-    workspaceDir,
-    librettoCli,
-  }) => {
-    await writeSessionState(workspaceDir, {
-      session: "permissioned-session",
+    const statePath = await writeSessionState(workspaceDir, {
+      session: "legacy-mode-session",
       port: 65534,
     });
-    await mkdir(join(workspaceDir, ".libretto"), { recursive: true });
-    await writeFile(
-      join(workspaceDir, ".libretto", "config.json"),
-      JSON.stringify(
-        {
-          version: 1,
-          permissions: {
-            sessions: {
-              "permissioned-session": "full-access",
-            },
-          },
-        },
-        null,
-        2,
-      ),
-      "utf8",
-    );
+    const rawState = JSON.parse(await readFile(statePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    rawState.mode = "read-only";
+    await writeFile(statePath, JSON.stringify(rawState, null, 2), "utf8");
 
     const result = await librettoCli(
-      "exec \"return await page.title()\" --session permissioned-session",
+      "exec \"return await page.title()\" --session legacy-mode-session",
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain(
-      "Session \"permissioned-session\" is read-only. Only a human can authorize full-access mode.",
+      "No browser running for session \"legacy-mode-session\".",
     );
-  });
-
-  test("does not apply read-only guard when session allows actions", async ({
-    workspaceDir,
-    librettoCli,
-  }) => {
-    await writeSessionState(workspaceDir, {
-      session: "interactive-session",
-      port: 65534,
-      mode: "full-access",
-    });
-
-    const result = await librettoCli(
-      "exec \"return await page.title()\" --session interactive-session",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).not.toContain("is read-only");
-    expect(result.stderr).toContain(
-      "No browser running for session \"interactive-session\".",
-    );
-  });
-
-  test("rejects exec after session is switched back to read-only", async ({
-    workspaceDir,
-    librettoCli,
-  }) => {
-    await writeSessionState(workspaceDir, {
-      session: "flip-session",
-      mode: "full-access",
-    });
-
-    const setReadOnly = await librettoCli(
-      "session-mode read-only --session flip-session",
-    );
-    expect(setReadOnly.exitCode).toBe(0);
-    expect(setReadOnly.stdout).toContain(
-      "Session \"flip-session\" is now read-only.",
-    );
-
-    const result = await librettoCli(
-      "exec \"return await page.title()\" --session flip-session",
-    );
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain(
-      "Session \"flip-session\" is read-only. Only a human can authorize full-access mode.",
-    );
-    expect(result.stderr).toContain("libretto-cli session-mode full-access --session flip-session");
   });
 
   test("rejects session state files with unsupported version", async ({

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -5,37 +5,16 @@ description: "Browser automation CLI for building integrations, with a network-f
 
 # Browser Integration with Libretto CLI
 
-Use the `npx libretto` CLI to automate web interactions, debug browser agent jobs, and prototype fixes with explicit full-access approval when needed.
+Use the `npx libretto` CLI to automate web interactions, debug browser agent jobs, and prototype fixes.
 
-## CRITICAL: Session Modes
+## CRITICAL: Session Access
 
-Sessions start in **read-only mode** by default. **Every time you launch a browser — whether via `open` or `run` — you MUST immediately announce the session mode.** This is non-negotiable. Do NOT skip the announcement. Do NOT abbreviate it.
-
-### Read-only mode (default)
-
-> **Session mode: READ-ONLY**
->
-> I've opened the browser in **read-only mode**. I can observe the page, take snapshots, and inspect network traffic, but I **cannot** click, type, fill forms, submit, or execute any actions that modify the page.
->
-> If you'd like me to interact with elements (clicking buttons, filling forms, submitting data, scrolling, or making network requests), let me know and I'll switch to **full-access mode**.
+Libretto sessions are **full-access by default**. You can use `exec` and `run` immediately after opening a session.
 
 **Rules:**
-- Use ONLY read-only-safe commands (`snapshot`, `network`, `actions`) until the user explicitly grants full-access.
-- Do NOT proceed with any `exec` or `run` commands until the user explicitly grants full-access.
-
-### Full-access mode (user-approved)
-
-> **Session mode: FULL-ACCESS**
->
-> I've opened the browser in **full-access mode**. I have full control to click, type, fill forms, navigate, scroll, make network requests, and execute Playwright commands on the page.
->
-> If you'd like me to switch to **read-only mode** (observe only, no page modifications), let me know.
-
-### Switching modes
-
-- When the user requests full-access mode, run `npx libretto session-mode full-access --session <name>` and then proceed with `exec`/`run`.
-- Never change session mode unless the user explicitly approves.
-- If the user says something like "go ahead", "interact", "click around", or "do whatever you need" — that counts as granting full-access. Switch the mode and confirm.
+- Always announce which session you opened and what page you are on.
+- Use `snapshot`, `network`, and `actions` first when debugging unknown page state.
+- Before any potentially mutating action (submit/save/delete, or non-idempotent API calls), describe what you are about to do and wait for explicit user confirmation.
 
 ## Ask, Don't Guess
 
@@ -48,7 +27,6 @@ npx libretto open <url> [--headless]   # Launch browser and navigate (headed by 
 npx libretto exec <code> [--visualize] # Execute Playwright TypeScript code (--visualize enables ghost cursor + highlight)
 npx libretto run <integrationFile> <integrationExport> # Execute integration actions
 npx libretto resume                    # Resume a paused workflow for the current session
-npx libretto session-mode <read-only|full-access> [--session <name>] # Set session mode explicitly
 npx libretto snapshot --objective "<what to find>" [--context "<situational info>"]
 npx libretto save <url|domain>         # Save session (cookies, localStorage) to .libretto/profiles/
 npx libretto network                   # Show last 20 captured network requests
@@ -113,11 +91,8 @@ If an action fails despite an element being visible, you should not keep retryin
 ## Workflow: Browse and Interact
 
 ```bash
-# Open a page (starts in read-only mode)
+# Open a page
 npx libretto open https://example.com
-
-# When user grants full-access:
-npx libretto session-mode full-access --session default
 
 # Interact with elements
 npx libretto exec "await page.locator('button:has-text(\"Sign in\")').click()"
@@ -161,11 +136,9 @@ When browser automation jobs fail (selectors timing out, clicks not working), us
 1. Add `page.pause()` before the problematic code section
 2. Start the job with `npx browser-agent start` (debug mode is always enabled locally)
 3. Wait ~60 seconds for the browser to hit the breakpoint
-4. Ask user if they approve full-access mode for `browser-agent`
-5. If approved, run `npx libretto session-mode full-access --session browser-agent`
-6. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
-7. Once the fix works, codify it in source files
-8. Restart the job to verify end-to-end
+4. Use `npx libretto exec` (with `--session browser-agent`) to inspect and prototype fixes
+5. Once the fix works, codify it in source files
+6. Restart the job to verify end-to-end
 
 ```bash
 # Start job in background
@@ -175,7 +148,6 @@ npx browser-agent start \
   --params '{"vendorName":"eClinicalWorks"}'
 
 # Inspect page state
-npx libretto session-mode full-access --session browser-agent
 npx libretto exec --session browser-agent "return await page.url();"
 npx libretto snapshot --session browser-agent \
   --objective "Find dropdown menus and their current selections" \

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -24,13 +24,11 @@ export {
 export type { LLMClient, Message, MessageContentPart } from "./llm/types.js";
 export {
 	SESSION_STATE_VERSION,
-	SessionModeSchema,
 	SessionStatusSchema,
 	SessionStateFileSchema,
 	parseSessionStateData,
 	parseSessionStateContent,
 	serializeSessionState,
-	type SessionMode,
 	type SessionStatus,
 	type SessionState,
 	type SessionStateFile,

--- a/packages/libretto/src/run/browser.ts
+++ b/packages/libretto/src/run/browser.ts
@@ -82,9 +82,6 @@ export async function launchBrowser({
           : `runtime-${Date.now()}`,
         startedAt: new Date().toISOString(),
         status: "active",
-        ...(parsedExistingState.success && parsedExistingState.data.mode
-          ? { mode: parsedExistingState.data.mode }
-          : {}),
       },
       null,
       2,

--- a/packages/libretto/src/state/index.ts
+++ b/packages/libretto/src/state/index.ts
@@ -1,12 +1,10 @@
 export {
 	SESSION_STATE_VERSION,
-	SessionModeSchema,
 	SessionStatusSchema,
 	SessionStateFileSchema,
 	parseSessionStateData,
 	parseSessionStateContent,
 	serializeSessionState,
-	type SessionMode,
 	type SessionStatus,
 	type SessionState,
 	type SessionStateFile,

--- a/packages/libretto/src/state/session-state.ts
+++ b/packages/libretto/src/state/session-state.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export const SESSION_STATE_VERSION = 1;
 
-export const SessionModeSchema = z.enum(["read-only", "full-access"]);
 export const SessionStatusSchema = z.enum([
 	"active",
 	"paused",
@@ -17,11 +16,9 @@ export const SessionStateFileSchema = z.object({
 	session: z.string().min(1),
 	runId: z.string().min(1),
 	startedAt: z.string().datetime({ offset: true }),
-	mode: SessionModeSchema.optional(),
 	status: SessionStatusSchema.optional(),
 });
 
-export type SessionMode = z.infer<typeof SessionModeSchema>;
 export type SessionStatus = z.infer<typeof SessionStatusSchema>;
 export type SessionStateFile = z.infer<typeof SessionStateFileSchema>;
 export type SessionState = Omit<SessionStateFile, "version">;


### PR DESCRIPTION
## Summary
- remove session permission handling and mode state from `libretto` runtime exports/state schema
- remove CLI permission gates (`session-mode`, read-only/full-access checks, and deprecated `--allow-actions` guards)
- update CLI tests for always-allowed behavior
- update `packages/libretto/skill/SKILL.md` (and synced generated copy) to reflect full-access sessions
- add `packages/AGENTS.md` guidance to update skill docs (using technical-writing skill) when CLI/runtime behavior changes

## Validation
- `pnpm --filter libretto type-check`
- `pnpm --filter libretto-cli test -- test/basic.spec.ts test/stateful.spec.ts`
