### PR TITLE
Remove runId from session state and open output

### DIFF
--- a/packages/libretto-cli/src/commands/snapshot.ts
+++ b/packages/libretto-cli/src/commands/snapshot.ts
@@ -2,7 +2,6 @@ import { mkdirSync } from "node:fs";
 import type { Argv } from "yargs";
 import { connect, disconnectBrowser } from "../core/browser.js";
 import { getLog, getSessionSnapshotRunDir } from "../core/context.js";
-import { generateRunId } from "../core/session.js";
 import {
   canAnalyzeSnapshots,
   runInterpret,
@@ -11,12 +10,14 @@ import {
 
 const DEFAULT_SNAPSHOT_CONTEXT = "No additional user context provided.";
 
+function generateSnapshotRunId(): string {
+  return `snapshot-${Date.now()}`;
+}
+
 async function captureScreenshot(session: string): Promise<ScreenshotPair> {
   const log = getLog();
   log.info("screenshot-start", { session });
-  const snapshotRunId = `snapshot-${generateRunId()}-${Math.random()
-    .toString(36)
-    .slice(2, 8)}`;
+  const snapshotRunId = generateSnapshotRunId();
   const snapshotRunDir = getSessionSnapshotRunDir(session, snapshotRunId);
   mkdirSync(snapshotRunDir, { recursive: true });
   const { browser, page } = await connect(session);

--- a/packages/libretto-cli/src/core/browser.ts
+++ b/packages/libretto-cli/src/core/browser.ts
@@ -15,7 +15,6 @@ import {
 import {
   assertSessionAvailableForStart,
   clearSessionState,
-  generateRunId,
   getSessionPermissionMode,
   readSessionStateOrThrow,
   logFileForSession,
@@ -193,7 +192,6 @@ export async function runOpen(
   assertSessionAvailableForStart(session);
 
   const port = await pickFreePort();
-  const runId = generateRunId();
   const runLogPath = logFileForSession(session);
   const networkLogPath = getSessionNetworkLogPath(session);
   const actionsLogPath = getSessionActionsLogPath(session);
@@ -212,7 +210,6 @@ export async function runOpen(
     sessionMode,
     session,
     port,
-    runId,
     domain,
     useProfile,
     profilePath: useProfile ? profilePath : undefined,
@@ -221,9 +218,7 @@ export async function runOpen(
   if (useProfile) {
     console.log(`Loading saved profile for ${domain}`);
   }
-  console.log(
-    `Launching ${browserMode} browser (session: ${session}, run: ${runId})...`,
-  );
+  console.log(`Launching ${browserMode} browser (session: ${session})...`);
 
   const escapedProfilePath = profilePath
     .replace(/\\/g, "\\\\")
@@ -638,7 +633,6 @@ await new Promise(() => {});
         port,
         pid: child.pid!,
         session,
-        runId,
         startedAt: new Date().toISOString(),
         mode: sessionMode,
         status: "active",
@@ -649,7 +643,6 @@ await new Promise(() => {});
         sessionMode,
         session,
         port,
-        runId,
         pid: child.pid,
       });
       console.log(`Browser open (${browserMode}): ${url}`);

--- a/packages/libretto-cli/src/core/session.ts
+++ b/packages/libretto-cli/src/core/session.ts
@@ -39,14 +39,6 @@ type SessionPermissions = {
   sessions: Record<string, SessionMode>;
 };
 
-export function generateRunId(): string {
-  return new Date()
-    .toISOString()
-    .replace(/[-:T]/g, "")
-    .replace(/\..+/, "")
-    .replace(/^(\d{8})(\d{6})$/, "$1-$2");
-}
-
 export function logFileForSession(session: string): string {
   validateSessionName(session);
   const dir = getSessionDir(session);
@@ -159,7 +151,6 @@ export function writeSessionState(state: SessionState): void {
     stateFile,
     port: state.port,
     pid: state.pid,
-    runId: state.runId,
   });
 }
 

--- a/packages/libretto-cli/test/stateful.spec.ts
+++ b/packages/libretto-cli/test/stateful.spec.ts
@@ -8,7 +8,6 @@ async function writeSessionState(
   workspaceDir: string,
   state: {
     session: string;
-    runId?: string;
     port?: number;
     pid?: number;
     startedAt?: string;
@@ -21,7 +20,6 @@ async function writeSessionState(
   const payload: Record<string, unknown> = {
     version: 1,
     session: state.session,
-    runId: state.runId ?? "run-seeded",
     port: state.port ?? 9222,
     pid: state.pid ?? 12345,
     startedAt: state.startedAt ?? "2026-01-01T00:00:00.000Z",
@@ -279,7 +277,6 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await writeSessionState(workspaceDir, {
       session: "net-session",
-      runId: "run-net",
     });
     const logPath = await writeJsonl(workspaceDir, "net-session", "network.jsonl", [
       {
@@ -327,7 +324,6 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     await writeSessionState(workspaceDir, {
       session: "actions-session",
-      runId: "run-actions",
     });
     const logPath = await writeJsonl(workspaceDir, "actions-session", "actions.jsonl", [
       {
@@ -502,7 +498,6 @@ describe("state-driven CLI subprocess behavior", () => {
         {
           version: 2,
           session,
-          runId: "run-invalid-version",
           port: 65534,
           pid: 12345,
           startedAt: "2026-01-01T00:00:00.000Z",

--- a/packages/libretto/src/run/browser.ts
+++ b/packages/libretto/src/run/browser.ts
@@ -77,9 +77,6 @@ export async function launchBrowser({
         session: sessionName,
         port: debugPort,
         pid: process.pid,
-        runId: parsedExistingState.success
-          ? parsedExistingState.data.runId
-          : `runtime-${Date.now()}`,
         startedAt: new Date().toISOString(),
         status: "active",
         ...(parsedExistingState.success && parsedExistingState.data.mode

--- a/packages/libretto/src/state/session-state.ts
+++ b/packages/libretto/src/state/session-state.ts
@@ -15,7 +15,6 @@ export const SessionStateFileSchema = z.object({
 	port: z.number().int().min(0).max(65535),
 	pid: z.number().int(),
 	session: z.string().min(1),
-	runId: z.string().min(1),
 	startedAt: z.string().datetime({ offset: true }),
 	mode: SessionModeSchema.optional(),
 	status: SessionStatusSchema.optional(),


### PR DESCRIPTION
## Summary
- remove `runId` from the shared session-state schema and runtime session-state writes
- remove `runId` generation/logging from CLI session state handling and `open` output
- keep snapshot run ids independent of session `runId` by using a timestamp-based snapshot id
- update seeded CLI stateful tests to stop requiring `runId` in `state.json`

## Validation
- `pnpm --filter libretto-cli test -- test/stateful.spec.ts`
- `pnpm --filter libretto-cli test -- test/basic.spec.ts`
