### PR TITLE
Refactor session telemetry to share open/run path

### DIFF
--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -25,6 +25,7 @@ const CLI_COMMANDS = new Set([
   "snapshot",
   "network",
   "actions",
+  "pages",
   "resume",
   "close",
   "--help",
@@ -45,6 +46,7 @@ Commands:
   snapshot [--objective <text> --context <text>]  Capture PNG + HTML; analyze when objective is provided (context optional)
   network [--last N] [--filter regex] [--method M] [--clear]  View captured network requests
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
+  pages                   List open pages in the active session
   resume                  Resume a paused workflow in the active session
   close                   Close the browser
 

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -3,6 +3,7 @@ import type { LoggerApi } from "../../shared/logger/index.js";
 import {
   runClose as runCloseWithLogger,
   runOpen,
+  runPages,
   runSave,
 } from "../core/browser.js";
 import { withSessionLogger } from "../core/context.js";
@@ -50,6 +51,9 @@ export function registerBrowserCommands(yargs: Argv, logger: LoggerApi): Argv {
         await runSave(urlOrDomain, String(argv.session), logger);
       },
     )
+    .command("pages", "List open pages in the session", (cmd) => cmd, async (argv) => {
+      await runPages(String(argv.session), logger);
+    })
     .command("close", "Close the browser", (cmd) => cmd, async (argv) => {
       await runCloseWithLogger(String(argv.session), logger);
     });

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -108,6 +108,7 @@ async function runExec(
   session: string,
   logger: LoggerApi,
   visualize = false,
+  pageId?: string,
 ): Promise<void> {
   readSessionStateOrThrow(session);
 
@@ -116,8 +117,12 @@ async function runExec(
     codeLength: code.length,
     codePreview: code.slice(0, 200),
     visualize,
+    pageId,
   });
-  const { browser, context, page } = await connect(session, logger);
+  const { browser, context, page } = await connect(session, logger, 10000, {
+    pageId,
+    requireSinglePage: true,
+  });
 
   const STALL_THRESHOLD_MS = 60_000;
   let lastActivityTs = Date.now();
@@ -450,7 +455,10 @@ export function registerExecutionCommands(yargs: Argv, logger: LoggerApi): Argv 
     .command(
       "exec [code..]",
       "Execute Playwright TypeScript code",
-      (cmd) => cmd.option("visualize", { type: "boolean", default: false }),
+      (cmd) =>
+        cmd
+          .option("visualize", { type: "boolean", default: false })
+          .option("page", { type: "string" }),
       async (argv) => {
         const codeParts = Array.isArray(argv.code)
           ? (argv.code as string[])
@@ -463,7 +471,13 @@ export function registerExecutionCommands(yargs: Argv, logger: LoggerApi): Argv 
             "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
           );
         }
-        await runExec(code, String(argv.session), logger, Boolean(argv.visualize));
+        await runExec(
+          code,
+          String(argv.session),
+          logger,
+          Boolean(argv.visualize),
+          argv.page ? String(argv.page) : undefined,
+        );
       },
     )
     .command(

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -119,10 +119,15 @@ async function runExec(
     visualize,
     pageId,
   });
-  const { browser, context, page } = await connect(session, logger, 10000, {
-    pageId,
-    requireSinglePage: true,
-  });
+  const { browser, context, page, pageId: resolvedPageId } = await connect(
+    session,
+    logger,
+    10000,
+    {
+      pageId,
+      requireSinglePage: true,
+    },
+  );
 
   const STALL_THRESHOLD_MS = 60_000;
   let lastActivityTs = Date.now();
@@ -154,7 +159,7 @@ async function runExec(
   };
   process.on("SIGINT", sigintHandler);
 
-  wrapPageForActionLogging(page, session, onActivity);
+  wrapPageForActionLogging(page, session, resolvedPageId, onActivity);
 
   if (visualize) {
     await installInstrumentation(page, { visualize: true, logger });
@@ -164,7 +169,7 @@ async function runExec(
     const execState: Record<string, unknown> = {};
 
     const networkLog = (
-      opts: { last?: number; filter?: string; method?: string } = {},
+      opts: { last?: number; filter?: string; method?: string; pageId?: string } = {},
     ) => {
       return readNetworkLog(session, opts);
     };
@@ -175,6 +180,7 @@ async function runExec(
         filter?: string;
         action?: string;
         source?: string;
+        pageId?: string;
       } = {},
     ) => {
       return readActionLog(session, opts);

--- a/packages/libretto/src/cli/commands/logs.ts
+++ b/packages/libretto/src/cli/commands/logs.ts
@@ -1,4 +1,6 @@
 import type { Argv } from "yargs";
+import { listOpenPages } from "../core/browser.js";
+import { withSessionLogger } from "../core/context.js";
 import {
   clearActionLog,
   clearNetworkLog,
@@ -7,6 +9,20 @@ import {
   readActionLog,
   readNetworkLog,
 } from "../core/telemetry.js";
+
+async function resolvePageId(session: string, pageId?: string): Promise<string | undefined> {
+  if (!pageId) return undefined;
+  const pages = await withSessionLogger(session, async (logger) =>
+    listOpenPages(session, logger),
+  );
+  const foundPage = pages.find((page) => page.id === pageId);
+  if (!foundPage) {
+    throw new Error(
+      `Page "${pageId}" was not found in session "${session}". Run "libretto-cli pages --session ${session}" to list ids.`,
+    );
+  }
+  return pageId;
+}
 
 export function registerLogCommands(yargs: Argv): Argv {
   return yargs
@@ -18,18 +34,25 @@ export function registerLogCommands(yargs: Argv): Argv {
           .option("last", { type: "number" })
           .option("filter", { type: "string" })
           .option("method", { type: "string" })
+          .option("page", { type: "string" })
           .option("clear", { type: "boolean", default: false }),
       async (argv) => {
+        const session = String(argv.session);
         if (argv.clear) {
-          clearNetworkLog(String(argv.session));
+          clearNetworkLog(session);
           console.log("Network log cleared.");
           return;
         }
+        const pageId = await resolvePageId(
+          session,
+          argv.page ? String(argv.page) : undefined,
+        );
 
-        const entries = readNetworkLog(String(argv.session), {
+        const entries = readNetworkLog(session, {
           last: typeof argv.last === "number" ? argv.last : undefined,
           filter: argv.filter as string | undefined,
           method: argv.method as string | undefined,
+          pageId,
         });
 
         if (entries.length === 0) {
@@ -52,19 +75,26 @@ export function registerLogCommands(yargs: Argv): Argv {
           .option("filter", { type: "string" })
           .option("action", { type: "string" })
           .option("source", { type: "string" })
+          .option("page", { type: "string" })
           .option("clear", { type: "boolean", default: false }),
       async (argv) => {
+        const session = String(argv.session);
         if (argv.clear) {
-          clearActionLog(String(argv.session));
+          clearActionLog(session);
           console.log("Action log cleared.");
           return;
         }
+        const pageId = await resolvePageId(
+          session,
+          argv.page ? String(argv.page) : undefined,
+        );
 
-        const entries = readActionLog(String(argv.session), {
+        const entries = readActionLog(session, {
           last: typeof argv.last === "number" ? argv.last : undefined,
           filter: argv.filter as string | undefined,
           action: argv.action as string | undefined,
           source: argv.source as string | undefined,
+          pageId,
         });
 
         if (entries.length === 0) {

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -10,16 +10,23 @@ import {
 } from "../core/snapshot-analyzer.js";
 
 const DEFAULT_SNAPSHOT_CONTEXT = "No additional user context provided.";
+function generateSnapshotRunId(): string {
+  return `snapshot-${Date.now()}`;
+}
 
 async function captureScreenshot(
   session: string,
   logger: LoggerApi,
+  pageId?: string,
 ): Promise<ScreenshotPair> {
-  logger.info("screenshot-start", { session });
-  const snapshotRunId = `snapshot-${Date.now()}`;
+  logger.info("screenshot-start", { session, pageId });
+  const snapshotRunId = generateSnapshotRunId();
   const snapshotRunDir = getSessionSnapshotRunDir(session, snapshotRunId);
   mkdirSync(snapshotRunDir, { recursive: true });
-  const { browser, page } = await connect(session, logger);
+  const { browser, page } = await connect(session, logger, 10000, {
+    pageId,
+    requireSinglePage: true,
+  });
 
   try {
     const title = await page.title();
@@ -65,10 +72,11 @@ async function captureScreenshot(
 async function runSnapshot(
   session: string,
   logger: LoggerApi,
+  pageId?: string,
   objective?: string,
   context?: string,
 ): Promise<void> {
-  const { pngPath, htmlPath } = await captureScreenshot(session, logger);
+  const { pngPath, htmlPath } = await captureScreenshot(session, logger, pageId);
 
   console.log("Screenshot saved:");
   console.log(`  PNG:  ${pngPath}`);
@@ -108,12 +116,14 @@ export function registerSnapshotCommands(yargs: Argv, logger: LoggerApi): Argv {
     "Capture PNG + HTML; analyze when --objective is provided (--context optional)",
     (cmd) =>
       cmd
+        .option("page", { type: "string" })
         .option("objective", { type: "string" })
         .option("context", { type: "string" }),
     async (argv) => {
       await runSnapshot(
         String(argv.session),
         logger,
+        argv.page ? String(argv.page) : undefined,
         argv.objective as string | undefined,
         argv.context as string | undefined,
       );

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -1,4 +1,4 @@
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type CDPSession, type Page } from "playwright";
 import { openSync, existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -107,10 +107,51 @@ export function disconnectBrowser(
   }
 }
 
+function resolveOperationalPages(browser: Browser): Page[] {
+  return browser
+    .contexts()
+    .flatMap((context) => context.pages())
+    .filter(isOperationalPage);
+}
+
+type PageReference = {
+  id: string;
+  page: Page;
+};
+
+async function resolvePageId(page: Page): Promise<string> {
+  const cdpSession: CDPSession = await page.context().newCDPSession(page);
+  try {
+    const targetInfo = await cdpSession.send("Target.getTargetInfo");
+    const targetId = (targetInfo as { targetInfo?: { targetId?: unknown } })?.targetInfo
+      ?.targetId;
+    if (typeof targetId !== "string" || targetId.length === 0) {
+      throw new Error(`Could not resolve target id for page at URL "${page.url()}".`);
+    }
+    return targetId;
+  } finally {
+    await cdpSession.detach();
+  }
+}
+
+async function resolvePageReferences(pages: Page[]): Promise<PageReference[]> {
+  const refs = await Promise.all(
+    pages.map(async (page) => {
+      const id = await resolvePageId(page);
+      return { id, page };
+    }),
+  );
+  return refs;
+}
+
 export async function connect(
   session: string,
   logger: LoggerApi,
   timeoutMs: number = 10000,
+  options?: {
+    pageId?: string;
+    requireSinglePage?: boolean;
+  },
 ): Promise<{
   browser: Browser;
   context: BrowserContext;
@@ -139,7 +180,7 @@ export async function connect(
   }
 
   const allPages = contexts.flatMap((c) => c.pages());
-  const pages = allPages.filter(isOperationalPage);
+  const pages = resolveOperationalPages(browser);
 
   logger.info("connect-pages", {
     session,
@@ -156,7 +197,21 @@ export async function connect(
     throw new Error("No pages found.");
   }
 
-  const page = pages[pages.length - 1]!;
+  if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
+    throw new Error(
+      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto-cli pages --session ${session}" to list ids).`,
+    );
+  }
+
+  const pageRefs = await resolvePageReferences(pages);
+  const page = options?.pageId
+    ? (pageRefs.find((ref) => ref.id === options.pageId)?.page ?? null)
+    : pages[pages.length - 1]!;
+  if (!page) {
+    throw new Error(
+      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto-cli pages --session ${session}" to list ids.`,
+    );
+  }
   const context = page.context();
 
   page.on("close", () => {
@@ -193,10 +248,10 @@ export async function runPages(session: string, logger: LoggerApi): Promise<void
       console.log("No pages found.");
       return;
     }
+    const pageRefs = await resolvePageReferences(pages);
 
     console.log("Open pages:");
-    pages.forEach((page, index) => {
-      const pageId = `page-${index + 1}`;
+    pageRefs.forEach(({ page, id: pageId }) => {
       const activeSuffix = page === activePage ? " active=true" : "";
       console.log(`  id=${pageId} url=${page.url()}${activeSuffix}`);
     });

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -89,6 +89,11 @@ async function tryConnectToPort(
   }
 }
 
+function isOperationalPage(page: Page): boolean {
+  const url = page.url();
+  return !url.startsWith("devtools://") && !url.startsWith("chrome-error://");
+}
+
 export function disconnectBrowser(
   browser: Browser,
   logger: LoggerApi,
@@ -134,10 +139,7 @@ export async function connect(
   }
 
   const allPages = contexts.flatMap((c) => c.pages());
-  const pages = allPages.filter((p) => {
-    const url = p.url();
-    return !url.startsWith("devtools://") && !url.startsWith("chrome-error://");
-  });
+  const pages = allPages.filter(isOperationalPage);
 
   logger.info("connect-pages", {
     session,
@@ -179,6 +181,28 @@ export async function connect(
 
   logger.info("connect-success", { session, pageUrl: page.url() });
   return { browser, context, page };
+}
+
+export async function runPages(session: string, logger: LoggerApi): Promise<void> {
+  logger.info("pages-start", { session });
+  const { browser, page: activePage } = await connect(session, logger);
+
+  try {
+    const pages = browser.contexts().flatMap((ctx) => ctx.pages()).filter(isOperationalPage);
+    if (pages.length === 0) {
+      console.log("No pages found.");
+      return;
+    }
+
+    console.log("Open pages:");
+    pages.forEach((page, index) => {
+      const pageId = `page-${index + 1}`;
+      const activeSuffix = page === activePage ? " active=true" : "";
+      console.log(`  id=${pageId} url=${page.url()}${activeSuffix}`);
+    });
+  } finally {
+    disconnectBrowser(browser, logger, session);
+  }
 }
 
 export async function runOpen(

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -19,6 +19,7 @@ import {
   readSessionState,
   writeSessionState,
 } from "./session.js";
+import { installSessionTelemetry } from "./session-telemetry.js";
 
 async function pickFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -334,77 +335,21 @@ export async function runOpen(
   const launcherCode = `
 import { chromium } from 'playwright';
 import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 const LOG_FILE = '${escapedLogPath}';
 const NETWORK_LOG = '${escapedNetworkLogPath}';
 const ACTIONS_LOG = '${escapedActionsLogPath}';
-mkdirSync(NETWORK_LOG.replace(/\\/[^\\/]+$/, ''), { recursive: true });
+mkdirSync(dirname(NETWORK_LOG), { recursive: true });
 
-const STATIC_EXT_RE = /\\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\\?|$)/i;
-const pageIdCache = new WeakMap();
-async function resolvePageId(p) {
-	if (!p) return undefined;
-	let cdpSession = null;
-	try {
-		cdpSession = await context.newCDPSession(p);
-		const targetInfo = await cdpSession.send('Target.getTargetInfo');
-		const targetId = targetInfo && targetInfo.targetInfo ? targetInfo.targetInfo.targetId : undefined;
-		return typeof targetId === 'string' && targetId.length > 0 ? targetId : undefined;
-	} catch {
-		return undefined;
-	} finally {
-		try { if (cdpSession) await cdpSession.detach(); } catch {}
-	}
-}
-async function getPageId(p) {
-	if (!p) return undefined;
-	const cached = pageIdCache.get(p);
-	if (cached) return cached;
-	const resolved = await resolvePageId(p);
-	if (resolved) pageIdCache.set(p, resolved);
-	return resolved;
-}
-async function logNetworkResponse(response) {
-	try {
-		const req = response.request();
-		const url = req.url();
-		if (STATIC_EXT_RE.test(url) || url.startsWith('chrome-extension://')) return;
-		let pageId = undefined;
-		try {
-			const frame = response.frame();
-			const responsePage = frame ? frame.page() : null;
-			pageId = await getPageId(responsePage);
-		} catch {}
-		let responseBody = null;
-		try {
-			const buf = await response.body();
-			responseBody = buf.toString('utf-8');
-		} catch {}
-		const entry = JSON.stringify({
-			ts: new Date().toISOString(),
-			pageId,
-			method: req.method(),
-			url,
-			status: response.status(),
-			contentType: response.headers()['content-type'] || null,
-			postData: req.method() === 'POST' || req.method() === 'PUT' || req.method() === 'PATCH'
-				? (req.postData() || '').substring(0, 2000)
-				: undefined,
-			responseBody,
-		});
-		appendFileSync(NETWORK_LOG, entry + '\\n');
-	} catch {}
-}
+${installSessionTelemetry.toString()}
 
 function logAction(entry) {
-	try {
-		const record = { ts: new Date().toISOString(), ...entry };
-		appendFileSync(ACTIONS_LOG, JSON.stringify(record) + '\\n');
-	} catch {}
+	appendFileSync(ACTIONS_LOG, JSON.stringify(entry) + '\\n');
 }
-async function logActionForPage(p, entry) {
-	const pageId = await getPageId(p);
-	logAction({ ...entry, pageId });
+
+function logNetwork(entry) {
+	appendFileSync(NETWORK_LOG, JSON.stringify(entry) + '\\n');
 }
 
 function childLog(level, event, data = {}) {
@@ -421,190 +366,6 @@ function childLog(level, event, data = {}) {
 	} catch {}
 }
 
-async function setupActionTracking(p) {
-	let pageId = await getPageId(p);
-	async function logTrackedAction(entry) {
-		if (!pageId) pageId = await getPageId(p);
-		logAction({ ...entry, pageId });
-	}
-	await p.exposeFunction('__btActionLog', async (jsonStr) => {
-		try { await logTrackedAction({ ...JSON.parse(jsonStr), source: 'user' }); } catch {}
-	});
-
-	await p.addInitScript(() => {
-		if (window.__btDomListenersInstalled) return;
-		window.__btDomListenersInstalled = true;
-
-		function identify(el) {
-			if (!el || !el.tagName) return '';
-			var tid = el.getAttribute('data-testid');
-			if (tid) return '[data-testid="' + tid + '"]';
-			var role = el.getAttribute('role') || '';
-			var id = el.id;
-			if (role && id) return role + '#' + id;
-			var name = el.getAttribute('aria-label') || (el.textContent || '').trim().slice(0, 30) || '';
-			if (role && name) return role + ' "' + name + '"';
-			var tag = el.tagName.toLowerCase();
-			var cls = el.className && typeof el.className === 'string' ? '.' + el.className.trim().split(/\\s+/).slice(0, 2).join('.') : '';
-			return tag + cls;
-		}
-
-		var clickTimer = null;
-		var pendingClick = null;
-
-		document.addEventListener('click', function(e) {
-			if (window.__btApiActionInProgress) return;
-			var target = e.target;
-			var sel = identify(target);
-			if (target.type === 'checkbox') {
-				if (typeof window.__btActionLog === 'function') {
-					window.__btActionLog(JSON.stringify({ action: target.checked ? 'check' : 'uncheck', selector: sel, success: true }));
-				}
-				return;
-			}
-			pendingClick = { selector: sel };
-			if (clickTimer) clearTimeout(clickTimer);
-			clickTimer = setTimeout(function() {
-				if (pendingClick && typeof window.__btActionLog === 'function') {
-					window.__btActionLog(JSON.stringify({ action: 'click', selector: pendingClick.selector, success: true }));
-				}
-				pendingClick = null;
-				clickTimer = null;
-			}, 200);
-		}, true);
-
-		document.addEventListener('dblclick', function(e) {
-			if (window.__btApiActionInProgress) return;
-			if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; pendingClick = null; }
-			var sel = identify(e.target);
-			if (typeof window.__btActionLog === 'function') {
-				window.__btActionLog(JSON.stringify({ action: 'dblclick', selector: sel, success: true }));
-			}
-		}, true);
-
-		var inputTimers = new WeakMap();
-		document.addEventListener('input', function(e) {
-			if (window.__btApiActionInProgress) return;
-			var target = e.target;
-			var sel = identify(target);
-			if (target.tagName === 'SELECT') {
-				if (typeof window.__btActionLog === 'function') {
-					window.__btActionLog(JSON.stringify({ action: 'selectOption', selector: sel, value: target.value, success: true }));
-				}
-				return;
-			}
-			var existing = inputTimers.get(target);
-			if (existing) clearTimeout(existing);
-			inputTimers.set(target, setTimeout(function() {
-				inputTimers.delete(target);
-				if (typeof window.__btActionLog === 'function') {
-					window.__btActionLog(JSON.stringify({ action: 'fill', selector: sel, value: (target.value || '').slice(0, 100), success: true }));
-				}
-			}, 500));
-		}, true);
-
-		var SPECIAL_KEYS = ['Enter','Escape','Tab','Backspace','Delete','ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Home','End','PageUp','PageDown','F1','F2','F3','F4','F5','F6','F7','F8','F9','F10','F11','F12'];
-		document.addEventListener('keydown', function(e) {
-			if (window.__btApiActionInProgress) return;
-			var isShortcut = e.ctrlKey || e.metaKey || e.altKey;
-			if (!isShortcut && SPECIAL_KEYS.indexOf(e.key) === -1) return;
-			var sel = identify(e.target);
-			var keyDesc = (e.ctrlKey ? 'Ctrl+' : '') + (e.metaKey ? 'Meta+' : '') + (e.altKey ? 'Alt+' : '') + (e.shiftKey ? 'Shift+' : '') + e.key;
-			if (typeof window.__btActionLog === 'function') {
-				window.__btActionLog(JSON.stringify({ action: 'press', selector: sel, value: keyDesc, success: true }));
-			}
-		}, true);
-
-		var scrollTimer = null;
-		document.addEventListener('scroll', function() {
-			if (window.__btApiActionInProgress) return;
-			if (scrollTimer) clearTimeout(scrollTimer);
-			scrollTimer = setTimeout(function() {
-				scrollTimer = null;
-				if (typeof window.__btActionLog === 'function') {
-					window.__btActionLog(JSON.stringify({ action: 'scroll', selector: 'document', value: 'y=' + window.scrollY, success: true }));
-				}
-			}, 300);
-		}, true);
-	});
-
-	var PAGE_ACTIONS = ['click', 'dblclick', 'fill', 'type', 'press', 'check', 'uncheck', 'selectOption', 'hover', 'focus'];
-	var NAV_ACTIONS = ['goto', 'reload', 'goBack', 'goForward'];
-
-	for (var m of PAGE_ACTIONS) {
-		(function(method) {
-			var orig = p[method].bind(p);
-			p[method] = async function() {
-				var args = Array.from(arguments);
-				var start = Date.now();
-				try { await p.evaluate(function() { window.__btApiActionInProgress = true; }); } catch {}
-				try {
-					var result = await orig.apply(null, args);
-					await logTrackedAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, value: args[1] !== undefined ? String(args[1]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
-					return result;
-				} catch (err) {
-					await logTrackedAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
-					throw err;
-				} finally {
-					try { await p.evaluate(function() { window.__btApiActionInProgress = false; }); } catch {}
-				}
-			};
-		})(m);
-	}
-
-	for (var m of NAV_ACTIONS) {
-		(function(method) {
-			var orig = p[method].bind(p);
-			p[method] = async function() {
-				var args = Array.from(arguments);
-				var start = Date.now();
-				try {
-					var result = await orig.apply(null, args);
-					await logTrackedAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : p.url(), duration: Date.now() - start, success: true });
-					return result;
-				} catch (err) {
-					await logTrackedAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
-					throw err;
-				}
-			};
-		})(m);
-	}
-
-	var LOCATOR_FACTORIES = ['locator', 'getByRole', 'getByText', 'getByLabel', 'getByPlaceholder', 'getByAltText', 'getByTitle', 'getByTestId'];
-	for (var f of LOCATOR_FACTORIES) {
-		(function(factory) {
-			var orig = p[factory].bind(p);
-			p[factory] = function() {
-				var args = Array.from(arguments);
-				var locator = orig.apply(null, args);
-				var hint = factory + '(' + args.map(function(a) { return typeof a === 'string' ? a : JSON.stringify(a); }).join(', ') + ')';
-					for (var am of PAGE_ACTIONS) {
-						(function(actMethod) {
-							if (typeof locator[actMethod] !== 'function') return;
-							var origAct = locator[actMethod].bind(locator);
-							locator[actMethod] = async function() {
-								var actArgs = Array.from(arguments);
-								var start = Date.now();
-								try { await p.evaluate(function() { window.__btApiActionInProgress = true; }); } catch {}
-								try {
-									var result = await origAct.apply(null, actArgs);
-									await logTrackedAction({ action: actMethod, source: 'agent', selector: hint, value: actArgs[0] !== undefined ? String(actArgs[0]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
-									return result;
-								} catch (err) {
-									await logTrackedAction({ action: actMethod, source: 'agent', selector: hint, duration: Date.now() - start, success: false, error: err.message });
-									throw err;
-								} finally {
-									try { await p.evaluate(function() { window.__btApiActionInProgress = false; }); } catch {}
-								}
-							};
-						})(am);
-					}
-				return locator;
-			};
-		})(f);
-	}
-}
-
 const browser = await chromium.launch({
 	headless: ${!headed},
 	args: ['--disable-blink-features=AutomationControlled', '--remote-debugging-port=${port}', '--remote-debugging-address=127.0.0.1', '--no-focus-on-check'],
@@ -619,48 +380,17 @@ const context = await browser.newContext({
 	viewport: { width: 1366, height: 768 },
 	userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
 });
-context.on('response', logNetworkResponse);
 
 const page = await context.newPage();
 page.setDefaultTimeout(30000);
 page.setDefaultNavigationTimeout(45000);
 
-await setupActionTracking(page);
-
-page.on('crash', () => childLog('error', 'page-crash', { url: page.url() }));
-page.on('close', () => childLog('warn', 'page-close', { url: page.url(), trace: new Error('page-close-trace').stack }));
-page.on('pageerror', (err) => childLog('error', 'page-error', { message: err.message, stack: err.stack }));
-page.on('console', (msg) => {
-	if (msg.type() === 'error' || msg.type() === 'warning') {
-		childLog(msg.type() === 'error' ? 'error' : 'warn', 'console-' + msg.type(), { text: msg.text(), url: page.url() });
-	}
-});
-page.on('framenavigated', async (frame) => {
-	if (frame === page.mainFrame()) {
-		childLog('info', 'page-navigated', { url: frame.url() });
-		await logActionForPage(page, { action: 'navigate', source: 'agent', url: frame.url(), success: true });
-	}
-});
-page.on('requestfailed', (req) => {
-	const failure = req.failure();
-	childLog('warn', 'request-failed', { url: req.url(), method: req.method(), errorText: failure?.errorText });
-});
-page.on('popup', async (popup) => await logActionForPage(page, { action: 'popup', source: 'agent', url: popup.url(), success: true }));
-page.on('dialog', async (dialog) => await logActionForPage(page, { action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
-
-context.on('page', async (newPage) => {
-	const newPageId = await getPageId(newPage);
-	childLog('info', 'new-page-created', { url: newPage.url(), pageId: newPageId });
-	newPage.on('crash', () => childLog('error', 'page-crash', { url: newPage.url() }));
-	newPage.on('close', () => childLog('info', 'page-close', { url: newPage.url(), trace: new Error('page-close-trace').stack }));
-	newPage.on('popup', async (popup) => await logActionForPage(newPage, { action: 'popup', source: 'agent', url: popup.url(), success: true }));
-	newPage.on('dialog', async (dialog) => await logActionForPage(newPage, { action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
-	newPage.on('framenavigated', async (frame) => {
-		if (frame === newPage.mainFrame()) await logActionForPage(newPage, { action: 'navigate', source: 'agent', url: frame.url(), success: true });
-	});
-	try { await setupActionTracking(newPage); } catch (err) {
-		childLog('warn', 'action-tracking-setup-failed', { url: newPage.url(), error: err.message });
-	}
+await installSessionTelemetry({
+	context,
+	initialPage: page,
+	includeUserDomActions: true,
+	logAction,
+	logNetwork,
 });
 
 

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -119,6 +119,12 @@ type PageReference = {
   page: Page;
 };
 
+export type OpenPageSummary = {
+  id: string;
+  url: string;
+  active: boolean;
+};
+
 async function resolvePageId(page: Page): Promise<string> {
   const cdpSession: CDPSession = await page.context().newCDPSession(page);
   try {
@@ -144,6 +150,24 @@ async function resolvePageReferences(pages: Page[]): Promise<PageReference[]> {
   return refs;
 }
 
+export async function listOpenPages(
+  session: string,
+  logger: LoggerApi,
+): Promise<OpenPageSummary[]> {
+  const { browser, page: activePage } = await connect(session, logger);
+  try {
+    const pages = browser.contexts().flatMap((ctx) => ctx.pages()).filter(isOperationalPage);
+    const pageRefs = await resolvePageReferences(pages);
+    return pageRefs.map(({ id, page }) => ({
+      id,
+      url: page.url(),
+      active: page === activePage,
+    }));
+  } finally {
+    disconnectBrowser(browser, logger, session);
+  }
+}
+
 export async function connect(
   session: string,
   logger: LoggerApi,
@@ -156,6 +180,7 @@ export async function connect(
   browser: Browser;
   context: BrowserContext;
   page: Page;
+  pageId: string;
 }> {
   logger.info("connect", { session, timeoutMs });
   const state = readSessionStateOrThrow(session);
@@ -204,14 +229,15 @@ export async function connect(
   }
 
   const pageRefs = await resolvePageReferences(pages);
-  const page = options?.pageId
-    ? (pageRefs.find((ref) => ref.id === options.pageId)?.page ?? null)
-    : pages[pages.length - 1]!;
-  if (!page) {
+  const pageRef = options?.pageId
+    ? (pageRefs.find((ref) => ref.id === options.pageId) ?? null)
+    : pageRefs[pageRefs.length - 1]!;
+  if (!pageRef) {
     throw new Error(
       `Page "${options?.pageId}" was not found in session "${session}". Run "libretto-cli pages --session ${session}" to list ids.`,
     );
   }
+  const page = pageRef.page;
   const context = page.context();
 
   page.on("close", () => {
@@ -235,29 +261,23 @@ export async function connect(
   });
 
   logger.info("connect-success", { session, pageUrl: page.url() });
-  return { browser, context, page };
+  return { browser, context, page, pageId: pageRef.id };
 }
 
 export async function runPages(session: string, logger: LoggerApi): Promise<void> {
   logger.info("pages-start", { session });
-  const { browser, page: activePage } = await connect(session, logger);
+  const pageSummaries = await listOpenPages(session, logger);
 
-  try {
-    const pages = browser.contexts().flatMap((ctx) => ctx.pages()).filter(isOperationalPage);
-    if (pages.length === 0) {
-      console.log("No pages found.");
-      return;
-    }
-    const pageRefs = await resolvePageReferences(pages);
-
-    console.log("Open pages:");
-    pageRefs.forEach(({ page, id: pageId }) => {
-      const activeSuffix = page === activePage ? " active=true" : "";
-      console.log(`  id=${pageId} url=${page.url()}${activeSuffix}`);
-    });
-  } finally {
-    disconnectBrowser(browser, logger, session);
+  if (pageSummaries.length === 0) {
+    console.log("No pages found.");
+    return;
   }
+
+  console.log("Open pages:");
+  pageSummaries.forEach((pageSummary) => {
+    const activeSuffix = pageSummary.active ? " active=true" : "";
+    console.log(`  id=${pageSummary.id} url=${pageSummary.url}${activeSuffix}`);
+  });
 }
 
 export async function runOpen(
@@ -321,11 +341,40 @@ const ACTIONS_LOG = '${escapedActionsLogPath}';
 mkdirSync(NETWORK_LOG.replace(/\\/[^\\/]+$/, ''), { recursive: true });
 
 const STATIC_EXT_RE = /\\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\\?|$)/i;
+const pageIdCache = new WeakMap();
+async function resolvePageId(p) {
+	if (!p) return undefined;
+	let cdpSession = null;
+	try {
+		cdpSession = await context.newCDPSession(p);
+		const targetInfo = await cdpSession.send('Target.getTargetInfo');
+		const targetId = targetInfo && targetInfo.targetInfo ? targetInfo.targetInfo.targetId : undefined;
+		return typeof targetId === 'string' && targetId.length > 0 ? targetId : undefined;
+	} catch {
+		return undefined;
+	} finally {
+		try { if (cdpSession) await cdpSession.detach(); } catch {}
+	}
+}
+async function getPageId(p) {
+	if (!p) return undefined;
+	const cached = pageIdCache.get(p);
+	if (cached) return cached;
+	const resolved = await resolvePageId(p);
+	if (resolved) pageIdCache.set(p, resolved);
+	return resolved;
+}
 async function logNetworkResponse(response) {
 	try {
 		const req = response.request();
 		const url = req.url();
 		if (STATIC_EXT_RE.test(url) || url.startsWith('chrome-extension://')) return;
+		let pageId = undefined;
+		try {
+			const frame = response.frame();
+			const responsePage = frame ? frame.page() : null;
+			pageId = await getPageId(responsePage);
+		} catch {}
 		let responseBody = null;
 		try {
 			const buf = await response.body();
@@ -333,6 +382,7 @@ async function logNetworkResponse(response) {
 		} catch {}
 		const entry = JSON.stringify({
 			ts: new Date().toISOString(),
+			pageId,
 			method: req.method(),
 			url,
 			status: response.status(),
@@ -352,6 +402,10 @@ function logAction(entry) {
 		appendFileSync(ACTIONS_LOG, JSON.stringify(record) + '\\n');
 	} catch {}
 }
+async function logActionForPage(p, entry) {
+	const pageId = await getPageId(p);
+	logAction({ ...entry, pageId });
+}
 
 function childLog(level, event, data = {}) {
 	try {
@@ -368,8 +422,13 @@ function childLog(level, event, data = {}) {
 }
 
 async function setupActionTracking(p) {
-	await p.exposeFunction('__btActionLog', (jsonStr) => {
-		try { logAction({ ...JSON.parse(jsonStr), source: 'user' }); } catch {}
+	let pageId = await getPageId(p);
+	async function logTrackedAction(entry) {
+		if (!pageId) pageId = await getPageId(p);
+		logAction({ ...entry, pageId });
+	}
+	await p.exposeFunction('__btActionLog', async (jsonStr) => {
+		try { await logTrackedAction({ ...JSON.parse(jsonStr), source: 'user' }); } catch {}
 	});
 
 	await p.addInitScript(() => {
@@ -481,10 +540,10 @@ async function setupActionTracking(p) {
 				try { await p.evaluate(function() { window.__btApiActionInProgress = true; }); } catch {}
 				try {
 					var result = await orig.apply(null, args);
-					logAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, value: args[1] !== undefined ? String(args[1]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
+					await logTrackedAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, value: args[1] !== undefined ? String(args[1]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
 					return result;
 				} catch (err) {
-					logAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
+					await logTrackedAction({ action: method, source: 'agent', selector: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
 					throw err;
 				} finally {
 					try { await p.evaluate(function() { window.__btApiActionInProgress = false; }); } catch {}
@@ -501,10 +560,10 @@ async function setupActionTracking(p) {
 				var start = Date.now();
 				try {
 					var result = await orig.apply(null, args);
-					logAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : p.url(), duration: Date.now() - start, success: true });
+					await logTrackedAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : p.url(), duration: Date.now() - start, success: true });
 					return result;
 				} catch (err) {
-					logAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
+					await logTrackedAction({ action: method, source: 'agent', url: typeof args[0] === 'string' ? args[0] : undefined, duration: Date.now() - start, success: false, error: err.message });
 					throw err;
 				}
 			};
@@ -519,27 +578,27 @@ async function setupActionTracking(p) {
 				var args = Array.from(arguments);
 				var locator = orig.apply(null, args);
 				var hint = factory + '(' + args.map(function(a) { return typeof a === 'string' ? a : JSON.stringify(a); }).join(', ') + ')';
-				for (var am of PAGE_ACTIONS) {
-					(function(actMethod) {
-						if (typeof locator[actMethod] !== 'function') return;
-						var origAct = locator[actMethod].bind(locator);
-						locator[actMethod] = async function() {
-							var actArgs = Array.from(arguments);
-							var start = Date.now();
-							try { await p.evaluate(function() { window.__btApiActionInProgress = true; }); } catch {}
-							try {
-								var result = await origAct.apply(null, actArgs);
-								logAction({ action: actMethod, source: 'agent', selector: hint, value: actArgs[0] !== undefined ? String(actArgs[0]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
-								return result;
-							} catch (err) {
-								logAction({ action: actMethod, source: 'agent', selector: hint, duration: Date.now() - start, success: false, error: err.message });
-								throw err;
-							} finally {
-								try { await p.evaluate(function() { window.__btApiActionInProgress = false; }); } catch {}
-							}
-						};
-					})(am);
-				}
+					for (var am of PAGE_ACTIONS) {
+						(function(actMethod) {
+							if (typeof locator[actMethod] !== 'function') return;
+							var origAct = locator[actMethod].bind(locator);
+							locator[actMethod] = async function() {
+								var actArgs = Array.from(arguments);
+								var start = Date.now();
+								try { await p.evaluate(function() { window.__btApiActionInProgress = true; }); } catch {}
+								try {
+									var result = await origAct.apply(null, actArgs);
+									await logTrackedAction({ action: actMethod, source: 'agent', selector: hint, value: actArgs[0] !== undefined ? String(actArgs[0]).slice(0, 100) : undefined, duration: Date.now() - start, success: true });
+									return result;
+								} catch (err) {
+									await logTrackedAction({ action: actMethod, source: 'agent', selector: hint, duration: Date.now() - start, success: false, error: err.message });
+									throw err;
+								} finally {
+									try { await p.evaluate(function() { window.__btApiActionInProgress = false; }); } catch {}
+								}
+							};
+						})(am);
+					}
 				return locator;
 			};
 		})(f);
@@ -560,6 +619,7 @@ const context = await browser.newContext({
 	viewport: { width: 1366, height: 768 },
 	userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
 });
+context.on('response', logNetworkResponse);
 
 const page = await context.newPage();
 page.setDefaultTimeout(30000);
@@ -575,29 +635,28 @@ page.on('console', (msg) => {
 		childLog(msg.type() === 'error' ? 'error' : 'warn', 'console-' + msg.type(), { text: msg.text(), url: page.url() });
 	}
 });
-page.on('framenavigated', (frame) => {
+page.on('framenavigated', async (frame) => {
 	if (frame === page.mainFrame()) {
 		childLog('info', 'page-navigated', { url: frame.url() });
-		logAction({ action: 'navigate', source: 'agent', url: frame.url(), success: true });
+		await logActionForPage(page, { action: 'navigate', source: 'agent', url: frame.url(), success: true });
 	}
 });
 page.on('requestfailed', (req) => {
 	const failure = req.failure();
 	childLog('warn', 'request-failed', { url: req.url(), method: req.method(), errorText: failure?.errorText });
 });
-page.on('response', logNetworkResponse);
-page.on('popup', (popup) => logAction({ action: 'popup', source: 'agent', url: popup.url(), success: true }));
-page.on('dialog', (dialog) => logAction({ action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
+page.on('popup', async (popup) => await logActionForPage(page, { action: 'popup', source: 'agent', url: popup.url(), success: true }));
+page.on('dialog', async (dialog) => await logActionForPage(page, { action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
 
 context.on('page', async (newPage) => {
-	childLog('info', 'new-page-created', { url: newPage.url() });
+	const newPageId = await getPageId(newPage);
+	childLog('info', 'new-page-created', { url: newPage.url(), pageId: newPageId });
 	newPage.on('crash', () => childLog('error', 'page-crash', { url: newPage.url() }));
 	newPage.on('close', () => childLog('info', 'page-close', { url: newPage.url(), trace: new Error('page-close-trace').stack }));
-	newPage.on('response', logNetworkResponse);
-	newPage.on('popup', (popup) => logAction({ action: 'popup', source: 'agent', url: popup.url(), success: true }));
-	newPage.on('dialog', (dialog) => logAction({ action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
-	newPage.on('framenavigated', (frame) => {
-		if (frame === newPage.mainFrame()) logAction({ action: 'navigate', source: 'agent', url: frame.url(), success: true });
+	newPage.on('popup', async (popup) => await logActionForPage(newPage, { action: 'popup', source: 'agent', url: popup.url(), success: true }));
+	newPage.on('dialog', async (dialog) => await logActionForPage(newPage, { action: 'dialog', source: 'agent', value: dialog.type() + ': ' + dialog.message().slice(0, 500), success: true }));
+	newPage.on('framenavigated', async (frame) => {
+		if (frame === newPage.mainFrame()) await logActionForPage(newPage, { action: 'navigate', source: 'agent', url: frame.url(), success: true });
 	});
 	try { await setupActionTracking(newPage); } catch (err) {
 		childLog('warn', 'action-tracking-setup-failed', { url: newPage.url(), error: err.message });

--- a/packages/libretto/src/cli/core/session-telemetry.ts
+++ b/packages/libretto/src/cli/core/session-telemetry.ts
@@ -1,0 +1,553 @@
+import type { BrowserContext, Page } from "playwright";
+
+type TelemetryEntry = Record<string, unknown>;
+
+type InstallSessionTelemetryOptions = {
+  context: BrowserContext;
+  initialPage: Page;
+  logAction: (entry: TelemetryEntry) => void;
+  logNetwork: (entry: TelemetryEntry) => void;
+  includeUserDomActions?: boolean;
+};
+
+export async function installSessionTelemetry(
+  options: InstallSessionTelemetryOptions,
+): Promise<void> {
+  const STATIC_EXT_RE = /\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\?|$)/i;
+  const { context, initialPage, logAction, logNetwork } = options;
+  const includeUserDomActions = options.includeUserDomActions ?? false;
+  const pageIdCache = new WeakMap<Page, string>();
+  const wrappedPages = new WeakSet<Page>();
+  const exposedPages = new WeakSet<Page>();
+
+  const resolvePageId = async (page: Page): Promise<string> => {
+    if (pageIdCache.has(page)) return pageIdCache.get(page)!;
+    const cdpSession = await context.newCDPSession(page);
+    try {
+      const targetInfo = await cdpSession.send("Target.getTargetInfo");
+      const targetId = (targetInfo as { targetInfo?: { targetId?: unknown } })?.targetInfo
+        ?.targetId;
+      if (typeof targetId !== "string" || targetId.length === 0) {
+        throw new Error(`Could not resolve target id for page at URL "${page.url()}".`);
+      }
+      pageIdCache.set(page, targetId);
+      return targetId;
+    } finally {
+      await cdpSession.detach();
+    }
+  };
+
+  const emitAction = (entry: TelemetryEntry): void => {
+    logAction({
+      ts: new Date().toISOString(),
+      ...entry,
+    });
+  };
+
+  const emitNetwork = (entry: TelemetryEntry): void => {
+    logNetwork({
+      ts: new Date().toISOString(),
+      ...entry,
+    });
+  };
+
+  const markApiActionInProgress = async (page: Page, inProgress: boolean): Promise<void> => {
+    await page.evaluate((flag) => {
+      (window as any).__btApiActionInProgress = flag;
+    }, inProgress);
+  };
+
+  const wrapLocator = (locator: any, page: Page, pageId: string): any => {
+    if (locator.__librettoActionLogged) return locator;
+    locator.__librettoActionLogged = true;
+
+    const locatorActionMethods = [
+      "click",
+      "dblclick",
+      "fill",
+      "type",
+      "press",
+      "check",
+      "uncheck",
+      "selectOption",
+      "hover",
+      "focus",
+      "scrollIntoViewIfNeeded",
+      "waitFor",
+      "innerHTML",
+      "innerText",
+      "textContent",
+      "inputValue",
+      "isChecked",
+      "isDisabled",
+      "isEditable",
+      "isEnabled",
+      "isHidden",
+      "isVisible",
+      "count",
+      "boundingBox",
+      "screenshot",
+      "evaluate",
+      "evaluateAll",
+      "evaluateHandle",
+      "getAttribute",
+      "dispatchEvent",
+      "setInputFiles",
+      "selectText",
+      "dragTo",
+      "highlight",
+      "tap",
+    ] as const;
+    const locatorReturningMethods = [
+      "first",
+      "last",
+      "locator",
+      "getByRole",
+      "getByText",
+      "getByLabel",
+      "getByPlaceholder",
+      "getByAltText",
+      "getByTitle",
+      "getByTestId",
+      "filter",
+      "and",
+      "or",
+    ] as const;
+
+    for (const actMethod of locatorActionMethods) {
+      if (typeof locator[actMethod] !== "function") continue;
+      const originalAction = locator[actMethod].bind(locator);
+      locator[actMethod] = async (...actionArgs: any[]) => {
+        const start = Date.now();
+        await markApiActionInProgress(page, true);
+        try {
+          const result = await originalAction(...actionArgs);
+          emitAction({
+            pageId,
+            action: actMethod,
+            source: "agent",
+            selector: "locator",
+            value:
+              actionArgs[0] !== undefined
+                ? String(actionArgs[0]).slice(0, 100)
+                : undefined,
+            duration: Date.now() - start,
+            success: true,
+          });
+          return result;
+        } catch (error: any) {
+          emitAction({
+            pageId,
+            action: actMethod,
+            source: "agent",
+            selector: "locator",
+            duration: Date.now() - start,
+            success: false,
+            error: error?.message ?? String(error),
+          });
+          throw error;
+        } finally {
+          await markApiActionInProgress(page, false);
+        }
+      };
+    }
+
+    for (const method of locatorReturningMethods) {
+      if (typeof locator[method] !== "function") continue;
+      const originalMethod = locator[method].bind(locator);
+      locator[method] = (...args: any[]) => {
+        const child = originalMethod(...args);
+        return wrapLocator(child, page, pageId);
+      };
+    }
+
+    if (typeof locator.nth === "function") {
+      const originalNth = locator.nth.bind(locator);
+      locator.nth = (index: number) => {
+        const child = originalNth(index);
+        return wrapLocator(child, page, pageId);
+      };
+    }
+
+    if (typeof locator.all === "function") {
+      const originalAll = locator.all.bind(locator);
+      locator.all = async () => {
+        const items: any[] = await originalAll();
+        return items.map((item: any) => wrapLocator(item, page, pageId));
+      };
+    }
+
+    return locator;
+  };
+
+  const installUserDomTracking = async (page: Page, pageId: string): Promise<void> => {
+    if (exposedPages.has(page)) return;
+    exposedPages.add(page);
+
+    await page.exposeFunction("__btActionLog", (jsonStr: string) => {
+      const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+      emitAction({
+        pageId,
+        source: "user",
+        ...parsed,
+      });
+    });
+
+    await page.addInitScript(() => {
+      if ((window as any).__btDomListenersInstalled) return;
+      (window as any).__btDomListenersInstalled = true;
+
+      const identify = (el: any): string => {
+        if (!el || !el.tagName) return "";
+        const testId = el.getAttribute("data-testid");
+        if (testId) return `[data-testid="${testId}"]`;
+        const role = el.getAttribute("role") || "";
+        const id = el.id;
+        if (role && id) return `${role}#${id}`;
+        const label =
+          el.getAttribute("aria-label") ||
+          (el.textContent || "").trim().slice(0, 30) ||
+          "";
+        if (role && label) return `${role} "${label}"`;
+        const tag = el.tagName.toLowerCase();
+        const cls =
+          el.className && typeof el.className === "string"
+            ? "." + el.className.trim().split(/\s+/).slice(0, 2).join(".")
+            : "";
+        return `${tag}${cls}`;
+      };
+
+      let clickTimer: ReturnType<typeof setTimeout> | null = null;
+      let pendingClick: { selector: string } | null = null;
+
+      document.addEventListener(
+        "click",
+        (event) => {
+          if ((window as any).__btApiActionInProgress) return;
+          const target = event.target as any;
+          const selector = identify(target);
+          if (target?.type === "checkbox") {
+            (window as any).__btActionLog(
+              JSON.stringify({
+                action: target.checked ? "check" : "uncheck",
+                selector,
+                success: true,
+              }),
+            );
+            return;
+          }
+          pendingClick = { selector };
+          if (clickTimer) clearTimeout(clickTimer);
+          clickTimer = setTimeout(() => {
+            if (pendingClick) {
+              (window as any).__btActionLog(
+                JSON.stringify({
+                  action: "click",
+                  selector: pendingClick.selector,
+                  success: true,
+                }),
+              );
+            }
+            pendingClick = null;
+            clickTimer = null;
+          }, 200);
+        },
+        true,
+      );
+
+      document.addEventListener(
+        "dblclick",
+        (event) => {
+          if ((window as any).__btApiActionInProgress) return;
+          if (clickTimer) {
+            clearTimeout(clickTimer);
+            clickTimer = null;
+            pendingClick = null;
+          }
+          const selector = identify(event.target);
+          (window as any).__btActionLog(
+            JSON.stringify({ action: "dblclick", selector, success: true }),
+          );
+        },
+        true,
+      );
+
+      const inputTimers = new WeakMap<any, ReturnType<typeof setTimeout>>();
+      document.addEventListener(
+        "input",
+        (event) => {
+          if ((window as any).__btApiActionInProgress) return;
+          const target = event.target as any;
+          const selector = identify(target);
+          if (target.tagName === "SELECT") {
+            (window as any).__btActionLog(
+              JSON.stringify({
+                action: "selectOption",
+                selector,
+                value: target.value,
+                success: true,
+              }),
+            );
+            return;
+          }
+          const existing = inputTimers.get(target);
+          if (existing) clearTimeout(existing);
+          inputTimers.set(
+            target,
+            setTimeout(() => {
+              inputTimers.delete(target);
+              (window as any).__btActionLog(
+                JSON.stringify({
+                  action: "fill",
+                  selector,
+                  value: (target.value || "").slice(0, 100),
+                  success: true,
+                }),
+              );
+            }, 500),
+          );
+        },
+        true,
+      );
+
+      const specialKeys = new Set([
+        "Enter",
+        "Escape",
+        "Tab",
+        "Backspace",
+        "Delete",
+        "ArrowUp",
+        "ArrowDown",
+        "ArrowLeft",
+        "ArrowRight",
+        "Home",
+        "End",
+        "PageUp",
+        "PageDown",
+        "F1",
+        "F2",
+        "F3",
+        "F4",
+        "F5",
+        "F6",
+        "F7",
+        "F8",
+        "F9",
+        "F10",
+        "F11",
+        "F12",
+      ]);
+      document.addEventListener(
+        "keydown",
+        (event) => {
+          if ((window as any).__btApiActionInProgress) return;
+          const isShortcut = event.ctrlKey || event.metaKey || event.altKey;
+          if (!isShortcut && !specialKeys.has(event.key)) return;
+          const selector = identify(event.target);
+          const keyDesc =
+            (event.ctrlKey ? "Ctrl+" : "") +
+            (event.metaKey ? "Meta+" : "") +
+            (event.altKey ? "Alt+" : "") +
+            (event.shiftKey ? "Shift+" : "") +
+            event.key;
+          (window as any).__btActionLog(
+            JSON.stringify({
+              action: "press",
+              selector,
+              value: keyDesc,
+              success: true,
+            }),
+          );
+        },
+        true,
+      );
+
+      let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+      document.addEventListener(
+        "scroll",
+        () => {
+          if ((window as any).__btApiActionInProgress) return;
+          if (scrollTimer) clearTimeout(scrollTimer);
+          scrollTimer = setTimeout(() => {
+            scrollTimer = null;
+            (window as any).__btActionLog(
+              JSON.stringify({
+                action: "scroll",
+                selector: "document",
+                value: `y=${window.scrollY}`,
+                success: true,
+              }),
+            );
+          }, 300);
+        },
+        true,
+      );
+    });
+  };
+
+  const wrapPageActions = (page: Page, pageId: string): void => {
+    if (wrappedPages.has(page)) return;
+    wrappedPages.add(page);
+
+    const pageActions = [
+      "click",
+      "dblclick",
+      "fill",
+      "type",
+      "press",
+      "check",
+      "uncheck",
+      "selectOption",
+      "hover",
+      "focus",
+    ] as const;
+    const navActions = ["goto", "reload", "goBack", "goForward"] as const;
+    const locatorFactories = [
+      "locator",
+      "getByRole",
+      "getByText",
+      "getByLabel",
+      "getByPlaceholder",
+      "getByAltText",
+      "getByTitle",
+      "getByTestId",
+    ] as const;
+
+    for (const method of pageActions) {
+      const originalMethod = (page as any)[method].bind(page);
+      (page as any)[method] = async (...args: any[]) => {
+        const start = Date.now();
+        await markApiActionInProgress(page, true);
+        try {
+          const result = await originalMethod(...args);
+          emitAction({
+            pageId,
+            action: method,
+            source: "agent",
+            selector: typeof args[0] === "string" ? args[0] : undefined,
+            value: args[1] !== undefined ? String(args[1]).slice(0, 100) : undefined,
+            duration: Date.now() - start,
+            success: true,
+          });
+          return result;
+        } catch (error: any) {
+          emitAction({
+            pageId,
+            action: method,
+            source: "agent",
+            selector: typeof args[0] === "string" ? args[0] : undefined,
+            duration: Date.now() - start,
+            success: false,
+            error: error?.message ?? String(error),
+          });
+          throw error;
+        } finally {
+          await markApiActionInProgress(page, false);
+        }
+      };
+    }
+
+    for (const method of navActions) {
+      const originalMethod = (page as any)[method].bind(page);
+      (page as any)[method] = async (...args: any[]) => {
+        const start = Date.now();
+        try {
+          const result = await originalMethod(...args);
+          emitAction({
+            pageId,
+            action: method,
+            source: "agent",
+            url: typeof args[0] === "string" ? args[0] : page.url(),
+            duration: Date.now() - start,
+            success: true,
+          });
+          return result;
+        } catch (error: any) {
+          emitAction({
+            pageId,
+            action: method,
+            source: "agent",
+            url: typeof args[0] === "string" ? args[0] : undefined,
+            duration: Date.now() - start,
+            success: false,
+            error: error?.message ?? String(error),
+          });
+          throw error;
+        }
+      };
+    }
+
+    for (const factory of locatorFactories) {
+      const originalFactory = (page as any)[factory].bind(page);
+      (page as any)[factory] = (...factoryArgs: any[]) => {
+        const locator = originalFactory(...factoryArgs);
+        return wrapLocator(locator, page, pageId);
+      };
+    }
+  };
+
+  const installForPage = async (page: Page): Promise<void> => {
+    const pageId = await resolvePageId(page);
+    wrapPageActions(page, pageId);
+
+    if (includeUserDomActions) {
+      await installUserDomTracking(page, pageId);
+    }
+
+    page.on("response", async (response) => {
+      const request = response.request();
+      const url = request.url();
+      if (STATIC_EXT_RE.test(url) || url.startsWith("chrome-extension://")) return;
+      emitNetwork({
+        pageId,
+        method: request.method(),
+        url,
+        status: response.status(),
+        contentType: response.headers()["content-type"] ?? null,
+        postData:
+          request.method() === "POST" ||
+          request.method() === "PUT" ||
+          request.method() === "PATCH"
+            ? (request.postData() ?? "").substring(0, 2000)
+            : undefined,
+        responseBody: null,
+        size: null,
+        durationMs: null,
+      });
+    });
+
+    page.on("framenavigated", (frame) => {
+      if (frame !== page.mainFrame()) return;
+      emitAction({
+        pageId,
+        action: "navigate",
+        source: "agent",
+        url: frame.url(),
+        success: true,
+      });
+    });
+    page.on("popup", (popup) => {
+      emitAction({
+        pageId,
+        action: "popup",
+        source: "agent",
+        url: popup.url(),
+        success: true,
+      });
+    });
+    page.on("dialog", (dialog) => {
+      emitAction({
+        pageId,
+        action: "dialog",
+        source: "agent",
+        value: `${dialog.type()}: ${dialog.message().slice(0, 500)}`,
+        success: true,
+      });
+    });
+  };
+
+  await installForPage(initialPage);
+  context.on("page", (newPage) => {
+    void installForPage(newPage);
+  });
+}

--- a/packages/libretto/src/cli/core/telemetry.ts
+++ b/packages/libretto/src/cli/core/telemetry.ts
@@ -8,6 +8,7 @@ import { assertSessionStateExistsOrThrow } from "./session.js";
 
 export type NetworkLogEntry = {
   ts: string;
+  pageId?: string;
   method: string;
   url: string;
   status: number;
@@ -20,7 +21,7 @@ export type NetworkLogEntry = {
 
 export function readNetworkLog(
   session: string,
-  opts: { last?: number; filter?: string; method?: string } = {},
+  opts: { last?: number; filter?: string; method?: string; pageId?: string } = {},
 ): NetworkLogEntry[] {
   assertSessionStateExistsOrThrow(session);
   const logPath = getSessionNetworkLogPath(session);
@@ -41,6 +42,9 @@ export function readNetworkLog(
   if (opts.filter) {
     const re = new RegExp(opts.filter, "i");
     entries = entries.filter((e) => re.test(e.url));
+  }
+  if (opts.pageId) {
+    entries = entries.filter((e) => e.pageId === opts.pageId);
   }
 
   const last = opts.last ?? 20;
@@ -78,6 +82,7 @@ export function clearNetworkLog(session: string): void {
 
 export type ActionLogEntry = {
   ts: string;
+  pageId?: string;
   action: string;
   source: "user" | "agent";
   selector?: string;
@@ -105,6 +110,7 @@ export function readActionLog(
     filter?: string;
     action?: string;
     source?: string;
+    pageId?: string;
   } = {},
 ): ActionLogEntry[] {
   assertSessionStateExistsOrThrow(session);
@@ -136,6 +142,9 @@ export function readActionLog(
         re.test(e.value || "") ||
         re.test(e.url || ""),
     );
+  }
+  if (opts.pageId) {
+    entries = entries.filter((e) => e.pageId === opts.pageId);
   }
 
   const last = opts.last ?? 20;
@@ -228,6 +237,7 @@ function wrapLocator(
   hint: string,
   session: string,
   page: Page,
+  pageId?: string,
   onActivity?: () => void,
 ): any {
   if (locator.__librettoActionLogged) return locator;
@@ -246,6 +256,7 @@ function wrapLocator(
       try {
         const result = await origAct(...actArgs);
         parentLogAction(session, {
+          pageId,
           action: actMethod,
           source: "agent",
           selector: hint,
@@ -260,6 +271,7 @@ function wrapLocator(
         return result;
       } catch (err: any) {
         parentLogAction(session, {
+          pageId,
           action: actMethod,
           source: "agent",
           selector: hint,
@@ -288,7 +300,7 @@ function wrapLocator(
         args.length > 0
           ? `${hint}.${formatHint(method, args)}`
           : `${hint}.${method}()`;
-      return wrapLocator(child, childHint, session, page, onActivity);
+      return wrapLocator(child, childHint, session, page, pageId, onActivity);
     };
   }
 
@@ -297,7 +309,7 @@ function wrapLocator(
     locator.nth = (index: number) => {
       const child = origNth(index);
       const childHint = `${hint}.nth(${index})`;
-      return wrapLocator(child, childHint, session, page, onActivity);
+      return wrapLocator(child, childHint, session, page, pageId, onActivity);
     };
   }
 
@@ -307,7 +319,7 @@ function wrapLocator(
       const items: any[] = await origAll();
       return items.map((item: any, i: number) => {
         const childHint = `${hint}.all()[${i}]`;
-        return wrapLocator(item, childHint, session, page, onActivity);
+        return wrapLocator(item, childHint, session, page, pageId, onActivity);
       });
     };
   }
@@ -318,6 +330,7 @@ function wrapLocator(
 export function wrapPageForActionLogging(
   page: Page,
   session: string,
+  pageId?: string,
   onActivity?: () => void,
 ): void {
   const PAGE_ACTIONS = [
@@ -346,6 +359,7 @@ export function wrapPageForActionLogging(
       try {
         const result = await orig(...args);
         parentLogAction(session, {
+          pageId,
           action: method,
           source: "agent",
           selector: typeof args[0] === "string" ? args[0] : undefined,
@@ -358,6 +372,7 @@ export function wrapPageForActionLogging(
         return result;
       } catch (err: any) {
         parentLogAction(session, {
+          pageId,
           action: method,
           source: "agent",
           selector: typeof args[0] === "string" ? args[0] : undefined,
@@ -384,6 +399,7 @@ export function wrapPageForActionLogging(
       try {
         const result = await orig(...args);
         parentLogAction(session, {
+          pageId,
           action: method,
           source: "agent",
           url: typeof args[0] === "string" ? args[0] : page.url(),
@@ -394,6 +410,7 @@ export function wrapPageForActionLogging(
         return result;
       } catch (err: any) {
         parentLogAction(session, {
+          pageId,
           action: method,
           source: "agent",
           url: typeof args[0] === "string" ? args[0] : undefined,
@@ -423,7 +440,7 @@ export function wrapPageForActionLogging(
     (page as any)[factory] = (...factoryArgs: any[]) => {
       const locator = orig(...factoryArgs);
       const hint = formatHint(factory, factoryArgs);
-      return wrapLocator(locator, hint, session, page, onActivity);
+      return wrapLocator(locator, hint, session, page, pageId, onActivity);
     };
   }
 }

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import type { BrowserContext, Page } from "playwright";
 import {
   launchBrowser,
   type LibrettoAuthProfile,
@@ -11,8 +12,12 @@ import {
 } from "../../index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { getProfilePath, normalizeDomain } from "../core/browser.js";
-import { getSessionDir } from "../core/context.js";
+import {
+  getSessionDir,
+  getSessionNetworkLogPath,
+} from "../core/context.js";
 import { getPauseSignalPaths, removeSignalIfExists } from "../core/pause-signals.js";
+import { wrapPageForActionLogging } from "../core/telemetry.js";
 import type { RunIntegrationWorkerRequest } from "./run-integration-worker-protocol.js";
 
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
@@ -27,6 +32,7 @@ type LoadedLibrettoWorkflow = {
 type RunIntegrationOutcome = { status: "completed" };
 
 const RESUME_POLL_INTERVAL_MS = 250;
+const STATIC_EXT_RE = /\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\?|$)/i;
 
 function mirrorStdoutToFile(filePath: string): () => void {
   const stdout = process.stdout as NodeJS.WriteStream & {
@@ -126,6 +132,70 @@ function getAbsoluteIntegrationPath(integrationPath: string): string {
   return absolutePath;
 }
 
+async function resolvePageId(page: Page): Promise<string | undefined> {
+  const cdpSession = await page.context().newCDPSession(page);
+  try {
+    const targetInfo = await cdpSession.send("Target.getTargetInfo");
+    const targetId = (targetInfo as { targetInfo?: { targetId?: unknown } })?.targetInfo
+      ?.targetId;
+    return typeof targetId === "string" && targetId.length > 0 ? targetId : undefined;
+  } finally {
+    await cdpSession.detach();
+  }
+}
+
+async function installWorkflowTelemetry(
+  session: string,
+  context: BrowserContext,
+  page: Page,
+): Promise<void> {
+  const networkLogPath = getSessionNetworkLogPath(session);
+  const pageIdCache = new WeakMap<Page, string | undefined>();
+
+  const getPageId = async (targetPage: Page): Promise<string | undefined> => {
+    if (pageIdCache.has(targetPage)) {
+      return pageIdCache.get(targetPage);
+    }
+    const resolved = await resolvePageId(targetPage);
+    pageIdCache.set(targetPage, resolved);
+    return resolved;
+  };
+
+  const wrapPage = async (targetPage: Page): Promise<void> => {
+    const pageId = await getPageId(targetPage);
+    wrapPageForActionLogging(targetPage, session, pageId);
+    targetPage.on("response", async (response) => {
+      const request = response.request();
+      const url = request.url();
+      if (STATIC_EXT_RE.test(url) || url.startsWith("chrome-extension://")) return;
+
+      const entry = {
+        ts: new Date().toISOString(),
+        pageId,
+        method: request.method(),
+        url,
+        status: response.status(),
+        contentType: response.headers()["content-type"] ?? null,
+        postData:
+          request.method() === "POST" ||
+          request.method() === "PUT" ||
+          request.method() === "PATCH"
+            ? (request.postData() ?? "").substring(0, 2000)
+            : undefined,
+        responseBody: null,
+        size: null,
+        durationMs: null,
+      };
+      appendFileSync(networkLogPath, JSON.stringify(entry) + "\n");
+    });
+  };
+
+  await wrapPage(page);
+  context.on("page", (newPage) => {
+    void wrapPage(newPage);
+  });
+}
+
 async function loadWorkflowExport(
   absolutePath: string,
   exportName: string,
@@ -206,6 +276,11 @@ async function runIntegrationInternal(
     headless: args.headless,
     storageStatePath,
   });
+  await installWorkflowTelemetry(
+    args.session,
+    browserSession.context,
+    browserSession.page,
+  );
 
   const workflowContext: LibrettoWorkflowContext = {
     logger: integrationLogger,

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -3,7 +3,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import type { BrowserContext, Page } from "playwright";
 import {
   launchBrowser,
   type LibrettoAuthProfile,
@@ -13,11 +12,12 @@ import {
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { getProfilePath, normalizeDomain } from "../core/browser.js";
 import {
+  getSessionActionsLogPath,
   getSessionDir,
   getSessionNetworkLogPath,
 } from "../core/context.js";
 import { getPauseSignalPaths, removeSignalIfExists } from "../core/pause-signals.js";
-import { wrapPageForActionLogging } from "../core/telemetry.js";
+import { installSessionTelemetry } from "../core/session-telemetry.js";
 import type { RunIntegrationWorkerRequest } from "./run-integration-worker-protocol.js";
 
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
@@ -32,7 +32,6 @@ type LoadedLibrettoWorkflow = {
 type RunIntegrationOutcome = { status: "completed" };
 
 const RESUME_POLL_INTERVAL_MS = 250;
-const STATIC_EXT_RE = /\.(css|js|png|jpg|jpeg|gif|woff|woff2|ttf|ico|svg)(\?|$)/i;
 
 function mirrorStdoutToFile(filePath: string): () => void {
   const stdout = process.stdout as NodeJS.WriteStream & {
@@ -132,70 +131,6 @@ function getAbsoluteIntegrationPath(integrationPath: string): string {
   return absolutePath;
 }
 
-async function resolvePageId(page: Page): Promise<string | undefined> {
-  const cdpSession = await page.context().newCDPSession(page);
-  try {
-    const targetInfo = await cdpSession.send("Target.getTargetInfo");
-    const targetId = (targetInfo as { targetInfo?: { targetId?: unknown } })?.targetInfo
-      ?.targetId;
-    return typeof targetId === "string" && targetId.length > 0 ? targetId : undefined;
-  } finally {
-    await cdpSession.detach();
-  }
-}
-
-async function installWorkflowTelemetry(
-  session: string,
-  context: BrowserContext,
-  page: Page,
-): Promise<void> {
-  const networkLogPath = getSessionNetworkLogPath(session);
-  const pageIdCache = new WeakMap<Page, string | undefined>();
-
-  const getPageId = async (targetPage: Page): Promise<string | undefined> => {
-    if (pageIdCache.has(targetPage)) {
-      return pageIdCache.get(targetPage);
-    }
-    const resolved = await resolvePageId(targetPage);
-    pageIdCache.set(targetPage, resolved);
-    return resolved;
-  };
-
-  const wrapPage = async (targetPage: Page): Promise<void> => {
-    const pageId = await getPageId(targetPage);
-    wrapPageForActionLogging(targetPage, session, pageId);
-    targetPage.on("response", async (response) => {
-      const request = response.request();
-      const url = request.url();
-      if (STATIC_EXT_RE.test(url) || url.startsWith("chrome-extension://")) return;
-
-      const entry = {
-        ts: new Date().toISOString(),
-        pageId,
-        method: request.method(),
-        url,
-        status: response.status(),
-        contentType: response.headers()["content-type"] ?? null,
-        postData:
-          request.method() === "POST" ||
-          request.method() === "PUT" ||
-          request.method() === "PATCH"
-            ? (request.postData() ?? "").substring(0, 2000)
-            : undefined,
-        responseBody: null,
-        size: null,
-        durationMs: null,
-      };
-      appendFileSync(networkLogPath, JSON.stringify(entry) + "\n");
-    });
-  };
-
-  await wrapPage(page);
-  context.on("page", (newPage) => {
-    void wrapPage(newPage);
-  });
-}
-
 async function loadWorkflowExport(
   absolutePath: string,
   exportName: string,
@@ -276,11 +211,19 @@ async function runIntegrationInternal(
     headless: args.headless,
     storageStatePath,
   });
-  await installWorkflowTelemetry(
-    args.session,
-    browserSession.context,
-    browserSession.page,
-  );
+  const actionsLogPath = getSessionActionsLogPath(args.session);
+  const networkLogPath = getSessionNetworkLogPath(args.session);
+  await installSessionTelemetry({
+    context: browserSession.context,
+    initialPage: browserSession.page,
+    includeUserDomActions: true,
+    logAction: (entry) => {
+      appendFileSync(actionsLogPath, JSON.stringify(entry) + "\n");
+    },
+    logNetwork: (entry) => {
+      appendFileSync(networkLogPath, JSON.stringify(entry) + "\n");
+    },
+  });
 
   const workflowContext: LibrettoWorkflowContext = {
     logger: integrationLogger,

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -30,9 +30,6 @@ describe("multi-page CLI behavior", () => {
     try {
       const singlePageResult = await librettoCli(`pages --session ${session}`);
       expect(singlePageResult.exitCode).toBe(0);
-      const singlePage = parsePagesOutput(singlePageResult.stdout);
-      expect(singlePage.length).toBeGreaterThan(0);
-      expect(singlePage.length).toBe(1);
       await evaluate(singlePageResult.stdout).toMatch(
         "Lists exactly one open page and that page URL includes example.com.",
       );
@@ -44,17 +41,6 @@ describe("multi-page CLI behavior", () => {
 
       const multiplePagesResult = await librettoCli(`pages --session ${session}`);
       expect(multiplePagesResult.exitCode).toBe(0);
-      const multiplePages = parsePagesOutput(multiplePagesResult.stdout);
-      expect(multiplePages.length).toBeGreaterThan(0);
-      expect(multiplePages.length).toBeGreaterThanOrEqual(2);
-      expect(
-        multiplePages.some((entry) => entry.url.includes("example.com")),
-      ).toBe(true);
-      expect(
-        multiplePages.some((entry) =>
-          entry.url.includes("multi-page-secondary"),
-        ),
-      ).toBe(true);
       await evaluate(multiplePagesResult.stdout).toMatch(
         "Lists both example.com and multi-page-secondary pages with page ids.",
       );
@@ -110,13 +96,11 @@ describe("multi-page CLI behavior", () => {
       const pagesResult = await librettoCli(`pages --session ${session}`);
       expect(pagesResult.exitCode).toBe(0);
       const pages = parsePagesOutput(pagesResult.stdout);
-      expect(pages.length).toBeGreaterThan(0);
       const examplePage = pages.find((pageEntry) =>
         pageEntry.url.includes("example.com"),
       );
 
       expect(examplePage).toBeDefined();
-      expect(examplePage?.id).toMatch(/^[a-zA-Z0-9._-]+$/);
 
       const result = await librettoCli(
         `exec "return await page.url()" --page ${examplePage?.id} --session ${session}`,
@@ -175,7 +159,6 @@ describe("multi-page CLI behavior", () => {
       const pagesResult = await librettoCli(`pages --session ${session}`);
       expect(pagesResult.exitCode).toBe(0);
       const pages = parsePagesOutput(pagesResult.stdout);
-      expect(pages.length).toBeGreaterThan(0);
       const exampleComPage = pages.find((entry) =>
         entry.url.includes("tab=one"),
       );

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -19,6 +19,7 @@ function parsePagesOutput(output: string): PageListEntry[] {
 describe("multi-page CLI behavior", () => {
   test("pages lists open pages with id and url", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-pages-command";
     const opened = await librettoCli(
@@ -32,7 +33,9 @@ describe("multi-page CLI behavior", () => {
       const singlePage = parsePagesOutput(singlePageResult.stdout);
       expect(singlePage.length).toBeGreaterThan(0);
       expect(singlePage.length).toBe(1);
-      expect(singlePage[0]?.url).toContain("example.com");
+      await evaluate(singlePageResult.stdout).toMatch(
+        "Lists exactly one open page and that page URL includes example.com.",
+      );
 
       const secondPageResult = await librettoCli(
         `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
@@ -52,6 +55,9 @@ describe("multi-page CLI behavior", () => {
           entry.url.includes("multi-page-secondary"),
         ),
       ).toBe(true);
+      await evaluate(multiplePagesResult.stdout).toMatch(
+        "Lists both example.com and multi-page-secondary pages with page ids.",
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -59,6 +65,7 @@ describe("multi-page CLI behavior", () => {
 
   test("exec requires --page when multiple pages are open", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-exec-requires-page";
     const opened = await librettoCli(
@@ -76,8 +83,9 @@ describe("multi-page CLI behavior", () => {
         `exec "return await page.url()" --session ${session}`,
       );
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("Multiple pages are open");
-      expect(result.stderr).toContain("--page");
+      await evaluate(result.stderr).toMatch(
+        "Explains multiple pages are open and requires passing --page.",
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -85,6 +93,7 @@ describe("multi-page CLI behavior", () => {
 
   test("exec --page targets the requested page id", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-exec-targeting";
     const opened = await librettoCli(
@@ -113,7 +122,9 @@ describe("multi-page CLI behavior", () => {
         `exec "return await page.url()" --page ${examplePage?.id} --session ${session}`,
       );
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("example.com");
+      await evaluate(result.stdout).toMatch(
+        "Returns the URL for the targeted page and includes example.com.",
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -121,6 +132,7 @@ describe("multi-page CLI behavior", () => {
 
   test("snapshot requires --page when multiple pages are open", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-snapshot-requires-page";
     const opened = await librettoCli(
@@ -136,8 +148,9 @@ describe("multi-page CLI behavior", () => {
 
       const snapshot = await librettoCli(`snapshot --session ${session}`);
       expect(snapshot.exitCode).toBe(1);
-      expect(snapshot.stderr).toContain("Multiple pages are open");
-      expect(snapshot.stderr).toContain("--page");
+      await evaluate(snapshot.stderr).toMatch(
+        "Explains multiple pages are open and requires passing --page.",
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -145,6 +158,7 @@ describe("multi-page CLI behavior", () => {
 
   test("actions and network commands filter correctly by page id", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-log-page-id";
     const opened = await librettoCli(
@@ -185,33 +199,33 @@ describe("multi-page CLI behavior", () => {
         `actions --session ${session} --page ${exampleComPage?.id} --action reload --last 20`,
       );
       expect(actionsCom.exitCode).toBe(0);
-      expect(actionsCom.stdout).toContain("action(s) shown.");
-      expect(actionsCom.stdout).toContain("tab=one");
-      expect(actionsCom.stdout).not.toContain("tab=two");
+      await evaluate(actionsCom.stdout).toMatch(
+        "Shows action results for the tab=one page, includes action(s) shown, and does not include tab=two.",
+      );
 
       const actionsOrg = await librettoCli(
         `actions --session ${session} --page ${exampleOrgPage?.id} --action reload --last 20`,
       );
       expect(actionsOrg.exitCode).toBe(0);
-      expect(actionsOrg.stdout).toContain("action(s) shown.");
-      expect(actionsOrg.stdout).toContain("tab=two");
-      expect(actionsOrg.stdout).not.toContain("tab=one");
+      await evaluate(actionsOrg.stdout).toMatch(
+        "Shows action results for the tab=two page, includes action(s) shown, and does not include tab=one.",
+      );
 
       const networkCom = await librettoCli(
         `network --session ${session} --page ${exampleComPage?.id} --last 20`,
       );
       expect(networkCom.exitCode).toBe(0);
-      expect(networkCom.stdout).toContain("request(s) shown.");
-      expect(networkCom.stdout).toContain("tab=one");
-      expect(networkCom.stdout).not.toContain("tab=two");
+      await evaluate(networkCom.stdout).toMatch(
+        "Shows network results for the tab=one page, includes request(s) shown, and does not include tab=two.",
+      );
 
       const networkOrg = await librettoCli(
         `network --session ${session} --page ${exampleOrgPage?.id} --last 20`,
       );
       expect(networkOrg.exitCode).toBe(0);
-      expect(networkOrg.stdout).toContain("request(s) shown.");
-      expect(networkOrg.stdout).toContain("tab=two");
-      expect(networkOrg.stdout).not.toContain("tab=one");
+      await evaluate(networkOrg.stdout).toMatch(
+        "Shows network results for the tab=two page, includes request(s) shown, and does not include tab=one.",
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -221,6 +235,7 @@ describe("multi-page CLI behavior", () => {
 
   test("commands fail with a clear error for unknown page ids", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-invalid-page-id";
     const missingPageId = "MISSING_PAGE_ID_FOR_TEST";
@@ -234,25 +249,33 @@ describe("multi-page CLI behavior", () => {
         `exec "return page.url()" --session ${session} --page ${missingPageId}`,
       );
       expect(execResult.exitCode).toBe(1);
-      expect(execResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+      await evaluate(execResult.stderr).toMatch(
+        `Says page id ${missingPageId} was not found for this session.`,
+      );
 
       const snapshotResult = await librettoCli(
         `snapshot --session ${session} --page ${missingPageId}`,
       );
       expect(snapshotResult.exitCode).toBe(1);
-      expect(snapshotResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+      await evaluate(snapshotResult.stderr).toMatch(
+        `Says page id ${missingPageId} was not found for this session.`,
+      );
 
       const actionsResult = await librettoCli(
         `actions --session ${session} --page ${missingPageId}`,
       );
       expect(actionsResult.exitCode).toBe(1);
-      expect(actionsResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+      await evaluate(actionsResult.stderr).toMatch(
+        `Says page id ${missingPageId} was not found for this session.`,
+      );
 
       const networkResult = await librettoCli(
         `network --session ${session} --page ${missingPageId}`,
       );
       expect(networkResult.exitCode).toBe(1);
-      expect(networkResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+      await evaluate(networkResult.stderr).toMatch(
+        `Says page id ${missingPageId} was not found for this session.`,
+      );
     } finally {
       await librettoCli(`close --session ${session}`);
     }
@@ -260,6 +283,7 @@ describe("multi-page CLI behavior", () => {
 
   test("closed page ids are rejected by page-targeted commands", async ({
     librettoCli,
+    evaluate,
   }) => {
     const session = "multi-page-closed-page-id";
     const opened = await librettoCli(
@@ -288,14 +312,16 @@ describe("multi-page CLI behavior", () => {
 
       const pagesAfterClose = await librettoCli(`pages --session ${session}`);
       expect(pagesAfterClose.exitCode).toBe(0);
-      expect(pagesAfterClose.stdout).not.toContain(closeTwoPage?.id ?? "");
+      await evaluate(pagesAfterClose.stdout).toMatch(
+        `Does not list the closed page id ${closeTwoPage?.id ?? ""}.`,
+      );
 
       const stalePageExec = await librettoCli(
         `exec "return page.url();" --session ${session} --page ${closeTwoPage?.id}`,
       );
       expect(stalePageExec.exitCode).toBe(1);
-      expect(stalePageExec.stderr).toContain(
-        `Page "${closeTwoPage?.id}" was not found`,
+      await evaluate(stalePageExec.stderr).toMatch(
+        `Says page id ${closeTwoPage?.id ?? ""} was not found for this session.`,
       );
     } finally {
       await librettoCli(`close --session ${session}`);
@@ -304,6 +330,7 @@ describe("multi-page CLI behavior", () => {
 
   test("run --debug supports page-scoped logs for multiple pages", async ({
     librettoCli,
+    evaluate,
     writeWorkflow,
   }) => {
     const session = "multi-page-run-debug-page-logs";
@@ -327,7 +354,9 @@ export const main = workflow({}, async (ctx) => {
       `run "${integrationFilePath}" main --session ${session} --headless --debug`,
     );
     expect(runResult.exitCode).toBe(0);
-    expect(runResult.stdout).toContain("Workflow paused.");
+    await evaluate(runResult.stdout).toMatch(
+      "Includes text indicating the workflow paused.",
+    );
 
     try {
       const pagesResult = await librettoCli(`pages --session ${session}`);
@@ -340,15 +369,17 @@ export const main = workflow({}, async (ctx) => {
         `actions --session ${session} --page ${runTwoPage?.id} --action reload --last 20`,
       );
       expect(actionsResult.exitCode).toBe(0);
-      expect(actionsResult.stdout).toContain("action(s) shown.");
-      expect(actionsResult.stdout).toContain("run=two");
+      await evaluate(actionsResult.stdout).toMatch(
+        "Shows action results for the run=two page and includes action(s) shown.",
+      );
 
       const networkResult = await librettoCli(
         `network --session ${session} --page ${runTwoPage?.id} --last 20`,
       );
       expect(networkResult.exitCode).toBe(0);
-      expect(networkResult.stdout).toContain("request(s) shown.");
-      expect(networkResult.stdout).toContain("run=two");
+      await evaluate(networkResult.stdout).toMatch(
+        "Shows network results for the run=two page and includes request(s) shown.",
+      );
     } finally {
       await librettoCli(`resume --session ${session}`);
       await librettoCli(`close --session ${session}`);

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -1,0 +1,219 @@
+import { describe, expect } from "vitest";
+import { test } from "./fixtures";
+
+type PageListEntry = {
+  id: string;
+  url: string;
+};
+
+function parsePagesOutput(output: string): PageListEntry[] {
+  const entries: PageListEntry[] = [];
+  const lineRegex = /id=([a-zA-Z0-9._-]+)\s+url=(\S+)/g;
+  let match: RegExpExecArray | null = null;
+  while ((match = lineRegex.exec(output)) !== null) {
+    entries.push({ id: match[1]!, url: match[2]! });
+  }
+  return entries;
+}
+
+describe("multi-page CLI behavior", () => {
+  test("pages lists open pages with id and url", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-pages-command";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const singlePageResult = await librettoCli(`pages --session ${session}`);
+      expect(singlePageResult.exitCode).toBe(0);
+      const singlePage = parsePagesOutput(singlePageResult.stdout);
+      expect(singlePage.length).toBeGreaterThan(0);
+      expect(singlePage.length).toBe(1);
+      expect(singlePage[0]?.url).toContain("example.com");
+
+      const secondPageResult = await librettoCli(
+        `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageResult.exitCode).toBe(0);
+
+      const multiplePagesResult = await librettoCli(`pages --session ${session}`);
+      expect(multiplePagesResult.exitCode).toBe(0);
+      const multiplePages = parsePagesOutput(multiplePagesResult.stdout);
+      expect(multiplePages.length).toBeGreaterThan(0);
+      expect(multiplePages.length).toBeGreaterThanOrEqual(2);
+      expect(
+        multiplePages.some((entry) => entry.url.includes("example.com")),
+      ).toBe(true);
+      expect(
+        multiplePages.some((entry) =>
+          entry.url.includes("multi-page-secondary"),
+        ),
+      ).toBe(true);
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 45_000);
+
+  test("exec requires --page when multiple pages are open", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-exec-requires-page";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const secondPageResult = await librettoCli(
+        `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageResult.exitCode).toBe(0);
+
+      const result = await librettoCli(
+        `exec "return await page.url()" --session ${session}`,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Multiple pages are open");
+      expect(result.stderr).toContain("--page");
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 45_000);
+
+  test("exec --page targets the requested page id", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-exec-targeting";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const secondPageResult = await librettoCli(
+        `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageResult.exitCode).toBe(0);
+
+      const pagesResult = await librettoCli(`pages --session ${session}`);
+      expect(pagesResult.exitCode).toBe(0);
+      const pages = parsePagesOutput(pagesResult.stdout);
+      expect(pages.length).toBeGreaterThan(0);
+      const examplePage = pages.find((pageEntry) =>
+        pageEntry.url.includes("example.com"),
+      );
+
+      expect(examplePage).toBeDefined();
+      expect(examplePage?.id).toMatch(/^[a-zA-Z0-9._-]+$/);
+
+      const result = await librettoCli(
+        `exec "return await page.url()" --page ${examplePage?.id} --session ${session}`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("example.com");
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 45_000);
+
+  test("snapshot requires --page when multiple pages are open", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-snapshot-requires-page";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const secondPageResult = await librettoCli(
+        `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageResult.exitCode).toBe(0);
+
+      const snapshot = await librettoCli(`snapshot --session ${session}`);
+      expect(snapshot.exitCode).toBe(1);
+      expect(snapshot.stderr).toContain("Multiple pages are open");
+      expect(snapshot.stderr).toContain("--page");
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 45_000);
+
+  test("actions and network commands filter correctly by page id", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-log-page-id";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const secondPageOpened = await librettoCli(
+        `exec "const p = await context.newPage(); await p.goto('https://example.org'); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageOpened.exitCode).toBe(0);
+
+      const pagesResult = await librettoCli(`pages --session ${session}`);
+      expect(pagesResult.exitCode).toBe(0);
+      const pages = parsePagesOutput(pagesResult.stdout);
+      expect(pages.length).toBeGreaterThan(0);
+      const exampleComPage = pages.find((entry) =>
+        entry.url.includes("example.com"),
+      );
+      const exampleOrgPage = pages.find((entry) =>
+        entry.url.includes("example.org"),
+      );
+      expect(exampleComPage).toBeDefined();
+      expect(exampleOrgPage).toBeDefined();
+
+      const reloadCom = await librettoCli(
+        `exec "await page.reload(); return await page.url();" --page ${exampleComPage?.id} --session ${session}`,
+      );
+      expect(reloadCom.exitCode).toBe(0);
+
+      const reloadOrg = await librettoCli(
+        `exec "await page.reload(); return await page.url();" --page ${exampleOrgPage?.id} --session ${session}`,
+      );
+      expect(reloadOrg.exitCode).toBe(0);
+
+      const actionsCom = await librettoCli(
+        `actions --session ${session} --page ${exampleComPage?.id} --last 20`,
+      );
+      expect(actionsCom.exitCode).toBe(0);
+      expect(actionsCom.stdout).toContain("action(s) shown.");
+      expect(actionsCom.stdout).toContain("example.com");
+      expect(actionsCom.stdout).not.toContain("example.org");
+
+      const actionsOrg = await librettoCli(
+        `actions --session ${session} --page ${exampleOrgPage?.id} --last 20`,
+      );
+      expect(actionsOrg.exitCode).toBe(0);
+      expect(actionsOrg.stdout).toContain("action(s) shown.");
+      expect(actionsOrg.stdout).toContain("example.org");
+      expect(actionsOrg.stdout).not.toContain("example.com");
+
+      const networkCom = await librettoCli(
+        `network --session ${session} --page ${exampleComPage?.id} --last 20`,
+      );
+      expect(networkCom.exitCode).toBe(0);
+      expect(networkCom.stdout).toContain("request(s) shown.");
+      expect(networkCom.stdout).toContain("example.com");
+      expect(networkCom.stdout).not.toContain("example.org");
+
+      const networkOrg = await librettoCli(
+        `network --session ${session} --page ${exampleOrgPage?.id} --last 20`,
+      );
+      expect(networkOrg.exitCode).toBe(0);
+      expect(networkOrg.stdout).toContain("request(s) shown.");
+      expect(networkOrg.stdout).toContain("example.org");
+      expect(networkOrg.stdout).not.toContain("example.com");
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 60_000);
+});

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -216,4 +216,142 @@ describe("multi-page CLI behavior", () => {
       await librettoCli(`close --session ${session}`);
     }
   }, 60_000);
+
+  test.todo("network --page includes requests from context.newPage pages");
+
+  test("commands fail with a clear error for unknown page ids", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-invalid-page-id";
+    const missingPageId = "MISSING_PAGE_ID_FOR_TEST";
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const execResult = await librettoCli(
+        `exec "return page.url()" --session ${session} --page ${missingPageId}`,
+      );
+      expect(execResult.exitCode).toBe(1);
+      expect(execResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+
+      const snapshotResult = await librettoCli(
+        `snapshot --session ${session} --page ${missingPageId}`,
+      );
+      expect(snapshotResult.exitCode).toBe(1);
+      expect(snapshotResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+
+      const actionsResult = await librettoCli(
+        `actions --session ${session} --page ${missingPageId}`,
+      );
+      expect(actionsResult.exitCode).toBe(1);
+      expect(actionsResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+
+      const networkResult = await librettoCli(
+        `network --session ${session} --page ${missingPageId}`,
+      );
+      expect(networkResult.exitCode).toBe(1);
+      expect(networkResult.stderr).toContain(`Page "${missingPageId}" was not found`);
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 45_000);
+
+  test("closed page ids are rejected by page-targeted commands", async ({
+    librettoCli,
+  }) => {
+    const session = "multi-page-closed-page-id";
+    const opened = await librettoCli(
+      `open https://example.com/?close=one --headless --session ${session}`,
+    );
+    expect(opened.exitCode).toBe(0);
+
+    try {
+      const secondPageOpened = await librettoCli(
+        `exec "await page.evaluate(() => window.open('https://example.com/?close=two', '_blank')); await page.waitForTimeout(1500); return context.pages().length;" --session ${session}`,
+      );
+      expect(secondPageOpened.exitCode).toBe(0);
+
+      const pagesBeforeClose = await librettoCli(`pages --session ${session}`);
+      expect(pagesBeforeClose.exitCode).toBe(0);
+      const entriesBeforeClose = parsePagesOutput(pagesBeforeClose.stdout);
+      const closeTwoPage = entriesBeforeClose.find((entry) =>
+        entry.url.includes("close=two"),
+      );
+      expect(closeTwoPage).toBeDefined();
+
+      const closePageResult = await librettoCli(
+        `exec "await page.close(); return 'closed';" --session ${session} --page ${closeTwoPage?.id}`,
+      );
+      expect(closePageResult.exitCode).toBe(0);
+
+      const pagesAfterClose = await librettoCli(`pages --session ${session}`);
+      expect(pagesAfterClose.exitCode).toBe(0);
+      expect(pagesAfterClose.stdout).not.toContain(closeTwoPage?.id ?? "");
+
+      const stalePageExec = await librettoCli(
+        `exec "return page.url();" --session ${session} --page ${closeTwoPage?.id}`,
+      );
+      expect(stalePageExec.exitCode).toBe(1);
+      expect(stalePageExec.stderr).toContain(
+        `Page "${closeTwoPage?.id}" was not found`,
+      );
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 60_000);
+
+  test("run --debug supports page-scoped logs for multiple pages", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const session = "multi-page-run-debug-page-logs";
+    const integrationFilePath = await writeWorkflow(
+      "integration-multi-page-debug.mjs",
+      `
+export const main = workflow({}, async (ctx) => {
+  await ctx.page.goto("https://example.com/?run=one");
+  await ctx.page.evaluate(() => window.open("https://example.com/?run=two", "_blank"));
+  await ctx.page.waitForTimeout(1500);
+  const secondPage = ctx.context.pages().find((p) => p.url().includes("run=two"));
+  if (!secondPage) throw new Error("Second page was not opened");
+  await secondPage.reload();
+  await ctx.pause();
+});
+`,
+      ["workflow"],
+    );
+
+    const runResult = await librettoCli(
+      `run "${integrationFilePath}" main --session ${session} --headless --debug`,
+    );
+    expect(runResult.exitCode).toBe(0);
+    expect(runResult.stdout).toContain("Workflow paused.");
+
+    try {
+      const pagesResult = await librettoCli(`pages --session ${session}`);
+      expect(pagesResult.exitCode).toBe(0);
+      const pages = parsePagesOutput(pagesResult.stdout);
+      const runTwoPage = pages.find((entry) => entry.url.includes("run=two"));
+      expect(runTwoPage).toBeDefined();
+
+      const actionsResult = await librettoCli(
+        `actions --session ${session} --page ${runTwoPage?.id} --action reload --last 20`,
+      );
+      expect(actionsResult.exitCode).toBe(0);
+      expect(actionsResult.stdout).toContain("action(s) shown.");
+      expect(actionsResult.stdout).toContain("run=two");
+
+      const networkResult = await librettoCli(
+        `network --session ${session} --page ${runTwoPage?.id} --last 20`,
+      );
+      expect(networkResult.exitCode).toBe(0);
+      expect(networkResult.stdout).toContain("request(s) shown.");
+      expect(networkResult.stdout).toContain("run=two");
+    } finally {
+      await librettoCli(`resume --session ${session}`);
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 90_000);
 });

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -148,13 +148,13 @@ describe("multi-page CLI behavior", () => {
   }) => {
     const session = "multi-page-log-page-id";
     const opened = await librettoCli(
-      `open https://example.com --headless --session ${session}`,
+      `open https://example.com/?tab=one --headless --session ${session}`,
     );
     expect(opened.exitCode).toBe(0);
 
     try {
       const secondPageOpened = await librettoCli(
-        `exec "const p = await context.newPage(); await p.goto('https://example.org'); return context.pages().length;" --session ${session}`,
+        `exec "await page.evaluate(() => window.open('https://example.com/?tab=two', '_blank')); await page.waitForTimeout(1500); return context.pages().length;" --session ${session}`,
       );
       expect(secondPageOpened.exitCode).toBe(0);
 
@@ -163,10 +163,10 @@ describe("multi-page CLI behavior", () => {
       const pages = parsePagesOutput(pagesResult.stdout);
       expect(pages.length).toBeGreaterThan(0);
       const exampleComPage = pages.find((entry) =>
-        entry.url.includes("example.com"),
+        entry.url.includes("tab=one"),
       );
       const exampleOrgPage = pages.find((entry) =>
-        entry.url.includes("example.org"),
+        entry.url.includes("tab=two"),
       );
       expect(exampleComPage).toBeDefined();
       expect(exampleOrgPage).toBeDefined();
@@ -182,36 +182,36 @@ describe("multi-page CLI behavior", () => {
       expect(reloadOrg.exitCode).toBe(0);
 
       const actionsCom = await librettoCli(
-        `actions --session ${session} --page ${exampleComPage?.id} --last 20`,
+        `actions --session ${session} --page ${exampleComPage?.id} --action reload --last 20`,
       );
       expect(actionsCom.exitCode).toBe(0);
       expect(actionsCom.stdout).toContain("action(s) shown.");
-      expect(actionsCom.stdout).toContain("example.com");
-      expect(actionsCom.stdout).not.toContain("example.org");
+      expect(actionsCom.stdout).toContain("tab=one");
+      expect(actionsCom.stdout).not.toContain("tab=two");
 
       const actionsOrg = await librettoCli(
-        `actions --session ${session} --page ${exampleOrgPage?.id} --last 20`,
+        `actions --session ${session} --page ${exampleOrgPage?.id} --action reload --last 20`,
       );
       expect(actionsOrg.exitCode).toBe(0);
       expect(actionsOrg.stdout).toContain("action(s) shown.");
-      expect(actionsOrg.stdout).toContain("example.org");
-      expect(actionsOrg.stdout).not.toContain("example.com");
+      expect(actionsOrg.stdout).toContain("tab=two");
+      expect(actionsOrg.stdout).not.toContain("tab=one");
 
       const networkCom = await librettoCli(
         `network --session ${session} --page ${exampleComPage?.id} --last 20`,
       );
       expect(networkCom.exitCode).toBe(0);
       expect(networkCom.stdout).toContain("request(s) shown.");
-      expect(networkCom.stdout).toContain("example.com");
-      expect(networkCom.stdout).not.toContain("example.org");
+      expect(networkCom.stdout).toContain("tab=one");
+      expect(networkCom.stdout).not.toContain("tab=two");
 
       const networkOrg = await librettoCli(
         `network --session ${session} --page ${exampleOrgPage?.id} --last 20`,
       );
       expect(networkOrg.exitCode).toBe(0);
       expect(networkOrg.stdout).toContain("request(s) shown.");
-      expect(networkOrg.stdout).toContain("example.org");
-      expect(networkOrg.stdout).not.toContain("example.com");
+      expect(networkOrg.stdout).toContain("tab=two");
+      expect(networkOrg.stdout).not.toContain("tab=one");
     } finally {
       await librettoCli(`close --session ${session}`);
     }


### PR DESCRIPTION
## Summary
- add a shared `installSessionTelemetry` module for session-scoped action/network instrumentation
- switch `run` worker telemetry setup to use the shared installer
- switch `open` launcher telemetry setup to use the shared installer
- remove `open`-only telemetry listener behavior so `open` and `run` emit through the same telemetry path
- align `run` with `open` by enabling DOM user action telemetry in both

## Validation
- `pnpm --filter libretto-cli test -- test/multi-page.spec.ts`
