### PR TITLE
fix: type LibrettoWorkflowContext.logger as MinimalLogger instead of unknown

### DIFF
--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -1,4 +1,5 @@
 import type { Browser, BrowserContext, Page } from "playwright";
+import type { MinimalLogger } from "../logger/logger.js";
 
 export const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
@@ -12,7 +13,7 @@ export type LibrettoWorkflowMetadata = {
 };
 
 export type LibrettoWorkflowContext = {
-	logger: unknown;
+	logger: MinimalLogger;
 	page: Page;
 	context: BrowserContext;
 	browser: Browser;


### PR DESCRIPTION
## Problem

`LibrettoWorkflowContext.logger` was typed as `unknown`, which forced workflow authors to cast it before use:

\`\`\`typescript
const logger = ctx.logger as LoggerApi; // unsafe cast required
logger.info("Starting...");
\`\`\`

This was discovered while integrating libretto into a consumer codebase.

## Fix

Type `logger` as `MinimalLogger` — the lightweight interface libretto already exports for exactly this purpose:

\`\`\`typescript
// Before
logger: unknown;

// After
logger: MinimalLogger;
\`\`\`

`MinimalLogger` has `info`, `warn`, and `error` methods and is satisfied by any standard logger. Workflow authors can now use the logger directly with full type safety, without needing to know about or import `LoggerApi`.

## Notes

- `files` fix (skill + scripts missing from published package) was already merged to main before this branch — confirmed the postinstall now works correctly.
- Type-check passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)