### PR TITLE
feat(cli): add close --all with optional force

### DIFF
--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -48,7 +48,7 @@ Commands:
   actions [--last N] [--filter regex] [--action TYPE] [--source SOURCE] [--clear]  View captured actions
   pages                   List open pages in the active session
   resume                  Resume a paused workflow in the active session
-  close                   Close the browser
+  close [--all] [--force]  Close the browser for the session, or all tracked sessions with --all
 
 Options:
   --session <name>        Use a named session (default: "default")
@@ -71,6 +71,8 @@ Examples:
   libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
   libretto-cli resume --session default
   libretto-cli close
+  libretto-cli close --all
+  libretto-cli close --all --force
 
   # Multiple sessions
   libretto-cli open https://site1.com --session test1

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import {
   runClose as runCloseWithLogger,
+  runCloseAll as runCloseAllWithLogger,
   runOpen,
   runPages,
   runSave,
@@ -54,9 +55,34 @@ export function registerBrowserCommands(yargs: Argv, logger: LoggerApi): Argv {
     .command("pages", "List open pages in the session", (cmd) => cmd, async (argv) => {
       await runPages(String(argv.session), logger);
     })
-    .command("close", "Close the browser", (cmd) => cmd, async (argv) => {
-      await runCloseWithLogger(String(argv.session), logger);
-    });
+    .command(
+      "close",
+      "Close the browser",
+      (cmd) =>
+        cmd
+          .option("all", {
+            type: "boolean",
+            default: false,
+            describe: "Close all tracked sessions in this workspace",
+          })
+          .option("force", {
+            type: "boolean",
+            default: false,
+            describe: "Force kill sessions that ignore SIGTERM (requires --all)",
+          }),
+      async (argv) => {
+        const closeAll = Boolean(argv.all);
+        const force = Boolean(argv.force);
+        if (force && !closeAll) {
+          throw new Error("Usage: libretto-cli close --all [--force]");
+        }
+        if (closeAll) {
+          await runCloseAllWithLogger(logger, { force });
+          return;
+        }
+        await runCloseWithLogger(String(argv.session), logger);
+      },
+    );
 }
 
 export async function runClose(session: string): Promise<void> {

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -657,22 +657,6 @@ function sendSignalToProcessGroupOrPid(
   session: string,
 ): void {
   try {
-    process.kill(-pid, signal);
-    logger.info("close-signal-process-group", { session, pid, signal });
-    return;
-  } catch (groupErr) {
-    const groupCode = (groupErr as NodeJS.ErrnoException).code;
-    if (groupCode !== "ESRCH") {
-      logger.warn("close-signal-process-group-failed", {
-        session,
-        pid,
-        signal,
-        error: groupErr,
-      });
-    }
-  }
-
-  try {
     process.kill(pid, signal);
     logger.info("close-signal-pid", { session, pid, signal });
   } catch (pidErr) {
@@ -716,6 +700,20 @@ function resolveClosableSessions(logger: LoggerApi): {
   return { closable, clearedUnreadableStates };
 }
 
+function clearStoppedSessionStates(
+  sessions: ReadonlyArray<ClosableSession>,
+  logger: LoggerApi,
+): number {
+  let cleared = 0;
+  for (const session of sessions) {
+    if (!isPidRunning(session.pid)) {
+      clearSessionState(session.session, logger);
+      cleared += 1;
+    }
+  }
+  return cleared;
+}
+
 export async function runCloseAll(
   logger: LoggerApi,
   options?: { force?: boolean },
@@ -746,12 +744,7 @@ export async function runCloseAll(
 
   let survivors = closable.filter((target) => isPidRunning(target.pid));
   if (survivors.length > 0 && !force) {
-    const closed = closable.length - survivors.length;
-    for (const target of closable) {
-      if (!isPidRunning(target.pid)) {
-        clearSessionState(target.session, logger);
-      }
-    }
+    const closed = clearStoppedSessionStates(closable, logger);
 
     throw new Error(
       [
@@ -775,15 +768,17 @@ export async function runCloseAll(
     await waitForCloseSignalWindow(FORCE_CLOSE_WAIT_MS);
     survivors = survivors.filter((target) => isPidRunning(target.pid));
     if (survivors.length > 0) {
+      const closed = clearStoppedSessionStates(closable, logger);
       throw new Error(
-        `Failed to force-close ${survivors.length} session(s): ${formatSessionList(survivors)}.`,
+        [
+          `Failed to force-close ${survivors.length} session(s): ${formatSessionList(survivors)}.`,
+          `Closed ${closed} session(s).`,
+        ].join("\n"),
       );
     }
   }
 
-  for (const target of closable) {
-    clearSessionState(target.session, logger);
-  }
+  clearStoppedSessionStates(closable, logger);
 
   if (clearedUnreadableStates > 0) {
     console.log(

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -14,12 +14,16 @@ import {
 import {
   assertSessionAvailableForStart,
   clearSessionState,
+  listSessionsWithStateFile,
   readSessionStateOrThrow,
   logFileForSession,
   readSessionState,
   writeSessionState,
 } from "./session.js";
 import { installSessionTelemetry } from "./session-telemetry.js";
+
+const CLOSE_WAIT_MS = 1_500;
+const FORCE_CLOSE_WAIT_MS = 300;
 
 async function pickFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -618,17 +622,178 @@ export async function runClose(session: string, logger: LoggerApi): Promise<void
 
   logger.info("close-killing", { session, pid: state.pid, port: state.port });
 
-  try {
-    process.kill(state.pid, "SIGTERM");
-  } catch (err) {
-    logger.warn("close-kill-failed", { error: err, session, pid: state.pid });
-  }
+  sendSignalToProcessGroupOrPid(state.pid, "SIGTERM", logger, session);
 
-  await new Promise((r) => setTimeout(r, 1500));
+  await waitForCloseSignalWindow(CLOSE_WAIT_MS);
 
   clearSessionState(session, logger);
   logger.info("close-success", { session });
   console.log(`Browser closed (session: ${session}).`);
+}
+
+type ClosableSession = {
+  session: string;
+  pid: number;
+  port: number;
+};
+
+function waitForCloseSignalWindow(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sendSignalToProcessGroupOrPid(
+  pid: number,
+  signal: NodeJS.Signals,
+  logger: LoggerApi,
+  session: string,
+): void {
+  try {
+    process.kill(-pid, signal);
+    logger.info("close-signal-process-group", { session, pid, signal });
+    return;
+  } catch (groupErr) {
+    const groupCode = (groupErr as NodeJS.ErrnoException).code;
+    if (groupCode !== "ESRCH") {
+      logger.warn("close-signal-process-group-failed", {
+        session,
+        pid,
+        signal,
+        error: groupErr,
+      });
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+    logger.info("close-signal-pid", { session, pid, signal });
+  } catch (pidErr) {
+    const pidCode = (pidErr as NodeJS.ErrnoException).code;
+    if (pidCode !== "ESRCH") {
+      logger.warn("close-signal-pid-failed", {
+        session,
+        pid,
+        signal,
+        error: pidErr,
+      });
+    }
+  }
+}
+
+function formatSessionList(targets: ReadonlyArray<{ session: string }>): string {
+  return targets.map((target) => `"${target.session}"`).join(", ");
+}
+
+function resolveClosableSessions(logger: LoggerApi): {
+  closable: ClosableSession[];
+  clearedUnreadableStates: number;
+} {
+  const sessions = listSessionsWithStateFile();
+  const closable: ClosableSession[] = [];
+  let clearedUnreadableStates = 0;
+  for (const session of sessions) {
+    const state = readSessionState(session, logger);
+    if (!state) {
+      clearSessionState(session, logger);
+      clearedUnreadableStates += 1;
+      continue;
+    }
+    closable.push({
+      session,
+      pid: state.pid,
+      port: state.port,
+    });
+  }
+
+  return { closable, clearedUnreadableStates };
+}
+
+export async function runCloseAll(
+  logger: LoggerApi,
+  options?: { force?: boolean },
+): Promise<void> {
+  const force = Boolean(options?.force);
+  logger.info("close-all-start", { force });
+  const { closable, clearedUnreadableStates } = resolveClosableSessions(logger);
+  if (closable.length === 0) {
+    if (clearedUnreadableStates > 0) {
+      console.log(
+        `Cleared ${clearedUnreadableStates} unreadable session state file(s).`,
+      );
+    }
+    console.log("No browser sessions found.");
+    return;
+  }
+
+  for (const target of closable) {
+    logger.info("close-all-sigterm", {
+      session: target.session,
+      pid: target.pid,
+      port: target.port,
+    });
+    sendSignalToProcessGroupOrPid(target.pid, "SIGTERM", logger, target.session);
+  }
+
+  await waitForCloseSignalWindow(CLOSE_WAIT_MS);
+
+  let survivors = closable.filter((target) => isPidRunning(target.pid));
+  if (survivors.length > 0 && !force) {
+    const closed = closable.length - survivors.length;
+    for (const target of closable) {
+      if (!isPidRunning(target.pid)) {
+        clearSessionState(target.session, logger);
+      }
+    }
+
+    throw new Error(
+      [
+        `Failed to close ${survivors.length} session(s) gracefully: ${formatSessionList(survivors)}.`,
+        `Closed ${closed} session(s).`,
+        "Retry with: libretto-cli close --all --force",
+      ].join("\n"),
+    );
+  }
+
+  let forceKilled = 0;
+  if (survivors.length > 0) {
+    for (const survivor of survivors) {
+      logger.warn("close-all-sigkill", {
+        session: survivor.session,
+        pid: survivor.pid,
+      });
+      sendSignalToProcessGroupOrPid(survivor.pid, "SIGKILL", logger, survivor.session);
+      forceKilled += 1;
+    }
+    await waitForCloseSignalWindow(FORCE_CLOSE_WAIT_MS);
+    survivors = survivors.filter((target) => isPidRunning(target.pid));
+    if (survivors.length > 0) {
+      throw new Error(
+        `Failed to force-close ${survivors.length} session(s): ${formatSessionList(survivors)}.`,
+      );
+    }
+  }
+
+  for (const target of closable) {
+    clearSessionState(target.session, logger);
+  }
+
+  if (clearedUnreadableStates > 0) {
+    console.log(
+      `Cleared ${clearedUnreadableStates} unreadable session state file(s).`,
+    );
+  }
+  console.log(`Closed ${closable.length} session(s).`);
+  if (forceKilled > 0) {
+    console.log(`Force-killed ${forceKilled} session(s).`);
+  }
 }
 
 export function resolvePath(filePath: string): string {

--- a/packages/libretto/src/cli/core/session.ts
+++ b/packages/libretto/src/cli/core/session.ts
@@ -86,11 +86,22 @@ export function readSessionState(
   }
 }
 
-function listActiveSessions(): string[] {
+export function listSessionsWithStateFile(): string[] {
   if (!existsSync(LIBRETTO_SESSIONS_DIR)) return [];
-  return readdirSync(LIBRETTO_SESSIONS_DIR).filter((session) =>
-    existsSync(getSessionStatePath(session)),
-  );
+  return readdirSync(LIBRETTO_SESSIONS_DIR)
+    .filter((session) => {
+      try {
+        validateSessionName(session);
+      } catch {
+        return false;
+      }
+      return existsSync(getSessionStatePath(session));
+    })
+    .sort();
+}
+
+function listActiveSessions(): string[] {
+  return listSessionsWithStateFile();
 }
 
 function throwSessionNotFoundError(session: string): never {

--- a/packages/libretto/test/AGENTS.md
+++ b/packages/libretto/test/AGENTS.md
@@ -1,0 +1,6 @@
+# Test Guidelines
+
+- Do not test implementation details, such as internal `.libretto` file structure or specific output formatting details.
+- Use user-level abstractions like `librettoCli` and `evaluate`; use `expect` only for exact string expectations.
+- Do not use `try`/`finally`; test sessions are automatically cleaned up at the end of each test.
+- Do not test exit codes.

--- a/packages/libretto/test/fixtures.ts
+++ b/packages/libretto/test/fixtures.ts
@@ -356,6 +356,21 @@ async function evaluateTextMatch(opts: {
   return { ...fresh, cached: false };
 }
 
+async function closeAllSessionsInWorkspace(workspaceDir: string): Promise<void> {
+  if (!existsSync(cliEntry)) return;
+  const closeAll = await execProcess(
+    process.execPath,
+    [cliEntry, "close", "--all"],
+    workspaceDir,
+  );
+  if (closeAll.exitCode === 0) return;
+  await execProcess(
+    process.execPath,
+    [cliEntry, "close", "--all", "--force"],
+    workspaceDir,
+  );
+}
+
 export const test = base.extend<CliFixtures>({
   workspaceDir: async ({ task }, use) => {
     const workspaceDir = workspaceDirForTask(task);
@@ -364,6 +379,11 @@ export const test = base.extend<CliFixtures>({
     try {
       await use(workspaceDir);
     } finally {
+      try {
+        await closeAllSessionsInWorkspace(workspaceDir);
+      } catch {
+        // Best-effort cleanup. Workspace removal still runs below.
+      }
       await rm(workspaceDir, { recursive: true, force: true });
     }
   },

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -27,7 +27,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const singlePageResult = await librettoCli(`pages --session ${session}`);
       expect(singlePageResult.exitCode).toBe(0);
       await evaluate(singlePageResult.stdout).toMatch(
@@ -44,9 +43,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(multiplePagesResult.stdout).toMatch(
         "Lists both example.com and multi-page-secondary pages with page ids.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("exec requires --page when multiple pages are open", async ({
@@ -59,7 +55,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const secondPageResult = await librettoCli(
         `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
       );
@@ -72,9 +67,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(result.stderr).toMatch(
         "Explains multiple pages are open and requires passing --page.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("exec --page targets the requested page id", async ({
@@ -87,7 +79,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const secondPageResult = await librettoCli(
         `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
       );
@@ -109,9 +100,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(result.stdout).toMatch(
         "Returns the URL for the targeted page and includes example.com.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("snapshot requires --page when multiple pages are open", async ({
@@ -124,7 +112,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const secondPageResult = await librettoCli(
         `exec "const p = await context.newPage(); await p.goto('data:text/html,multi-page-secondary'); return context.pages().length;" --session ${session}`,
       );
@@ -135,9 +122,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(snapshot.stderr).toMatch(
         "Explains multiple pages are open and requires passing --page.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("actions and network commands filter correctly by page id", async ({
@@ -150,7 +134,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const secondPageOpened = await librettoCli(
         `exec "await page.evaluate(() => window.open('https://example.com/?tab=two', '_blank')); await page.waitForTimeout(1500); return context.pages().length;" --session ${session}`,
       );
@@ -209,9 +192,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(networkOrg.stdout).toMatch(
         "Shows network results for the tab=two page, includes request(s) shown, and does not include tab=one.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 60_000);
 
   test.todo("network --page includes requests from context.newPage pages");
@@ -227,7 +207,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const execResult = await librettoCli(
         `exec "return page.url()" --session ${session} --page ${missingPageId}`,
       );
@@ -259,9 +238,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(networkResult.stderr).toMatch(
         `Says page id ${missingPageId} was not found for this session.`,
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("closed page ids are rejected by page-targeted commands", async ({
@@ -274,7 +250,6 @@ describe("multi-page CLI behavior", () => {
     );
     expect(opened.exitCode).toBe(0);
 
-    try {
       const secondPageOpened = await librettoCli(
         `exec "await page.evaluate(() => window.open('https://example.com/?close=two', '_blank')); await page.waitForTimeout(1500); return context.pages().length;" --session ${session}`,
       );
@@ -306,9 +281,6 @@ describe("multi-page CLI behavior", () => {
       await evaluate(stalePageExec.stderr).toMatch(
         `Says page id ${closeTwoPage?.id ?? ""} was not found for this session.`,
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 60_000);
 
   test("run --debug supports page-scoped logs for multiple pages", async ({
@@ -341,7 +313,6 @@ export const main = workflow({}, async (ctx) => {
       "Includes text indicating the workflow paused.",
     );
 
-    try {
       const pagesResult = await librettoCli(`pages --session ${session}`);
       expect(pagesResult.exitCode).toBe(0);
       const pages = parsePagesOutput(pagesResult.stdout);
@@ -363,9 +334,5 @@ export const main = workflow({}, async (ctx) => {
       await evaluate(networkResult.stdout).toMatch(
         "Shows network results for the run=two page and includes request(s) shown.",
       );
-    } finally {
-      await librettoCli(`resume --session ${session}`);
-      await librettoCli(`close --session ${session}`);
-    }
   }, 90_000);
 });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -51,20 +51,6 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
-function killProcessTree(pid: number): void {
-  try {
-    process.kill(-pid, "SIGKILL");
-    return;
-  } catch {
-    // Fall through to direct pid kill.
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Ignore best-effort cleanup failures.
-  }
-}
-
 async function waitForProcessToStop(
   pid: number,
   timeoutMs: number = 3_000,
@@ -208,16 +194,12 @@ describe("state-driven CLI subprocess behavior", () => {
       );
       expect(opened.exitCode).toBe(0);
 
-      try {
         const snapshot = await librettoCli(
           `snapshot --objective "Find heading" --context "Preset ${preset} snapshot smoke test" --session ${session}`,
         );
         expect(snapshot.exitCode).toBe(0);
         expect(snapshot.stdout).toContain("Interpretation:");
         expect(snapshot.stdout).toContain(`Answer: snapshot-ok-${preset}`);
-      } finally {
-        await librettoCli(`close --session ${session}`);
-      }
     }, 45_000);
   }
 
@@ -236,17 +218,12 @@ describe("state-driven CLI subprocess behavior", () => {
       `open https://example.com --headless --session ${session}`,
     );
     expect(opened.exitCode).toBe(0);
-
-    try {
       const snapshot = await librettoCli(
         `snapshot --objective "Find heading" --session ${session}`,
       );
       expect(snapshot.exitCode).toBe(0);
       expect(snapshot.stdout).toContain("Interpretation:");
       expect(snapshot.stdout).toContain("Answer: snapshot-ok-objective-only");
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("fails snapshot when --context is provided without --objective", async ({
@@ -257,8 +234,6 @@ describe("state-driven CLI subprocess behavior", () => {
       `open https://example.com --headless --session ${session}`,
     );
     expect(opened.exitCode).toBe(0);
-
-    try {
       const snapshot = await librettoCli(
         `snapshot --context "extra context only" --session ${session}`,
       );
@@ -266,9 +241,6 @@ describe("state-driven CLI subprocess behavior", () => {
       expect(snapshot.stderr).toContain(
         "Couldn't run analysis: --objective is required when providing --context.",
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("fails open when session already has an active browser", async ({
@@ -279,8 +251,6 @@ describe("state-driven CLI subprocess behavior", () => {
       `open https://example.com --headless --session ${session}`,
     );
     expect(firstOpen.exitCode).toBe(0);
-
-    try {
       const secondOpen = await librettoCli(
         `open https://example.com --headless --session ${session}`,
       );
@@ -291,9 +261,6 @@ describe("state-driven CLI subprocess behavior", () => {
       expect(secondOpen.stderr).toContain(
         `libretto-cli close --session ${session}`,
       );
-    } finally {
-      await librettoCli(`close --session ${session}`);
-    }
   }, 45_000);
 
   test("prints no-op message when closing a session with no browser", async ({
@@ -370,8 +337,6 @@ describe("state-driven CLI subprocess behavior", () => {
       pid: pid!,
       port: 65533,
     });
-
-    try {
       const graceful = await librettoCli("close --all");
       expect(graceful.exitCode).toBe(1);
       expect(graceful.stderr).toContain(
@@ -387,11 +352,6 @@ describe("state-driven CLI subprocess behavior", () => {
       expect(forced.stdout).toContain("Force-killed 1 session(s).");
       expect(existsSync(statePath)).toBe(false);
       expect(await waitForProcessToStop(pid!, 5_000)).toBe(true);
-    } finally {
-      if (pid && isProcessRunning(pid)) {
-        killProcessTree(pid);
-      }
-    }
   }, 20_000);
 
   test("reads and clears network logs from seeded run data", async ({

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { join } from "node:path";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
@@ -39,6 +40,43 @@ async function writeJsonl(
   const body = entries.map((entry) => JSON.stringify(entry)).join("\n");
   await writeFile(filePath, body ? `${body}\n` : "", "utf8");
   return filePath;
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killProcessTree(pid: number): void {
+  try {
+    process.kill(-pid, "SIGKILL");
+    return;
+  } catch {
+    // Fall through to direct pid kill.
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Ignore best-effort cleanup failures.
+  }
+}
+
+async function waitForProcessToStop(
+  pid: number,
+  timeoutMs: number = 3_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !isProcessRunning(pid);
 }
 
 const SNAPSHOT_PRESETS = ["codex", "claude", "gemini"] as const;
@@ -268,6 +306,93 @@ describe("state-driven CLI subprocess behavior", () => {
       `No browser running for session "${session}".`,
     );
   });
+
+  test("prints no-op message when closing all sessions and none exist", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("close --all");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No browser sessions found.");
+  });
+
+  test("rejects close --force without --all", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("close --force");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Usage: libretto-cli close --all [--force]");
+  });
+
+  test("close --all clears stale session state files", async ({
+    librettoCli,
+    workspaceDir,
+  }) => {
+    const firstStatePath = await writeSessionState(workspaceDir, {
+      session: "stale-one",
+      pid: 424_241,
+      port: 65531,
+    });
+    const secondStatePath = await writeSessionState(workspaceDir, {
+      session: "stale-two",
+      pid: 424_242,
+      port: 65532,
+    });
+
+    const result = await librettoCli("close --all");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Closed 2 session(s).");
+    expect(existsSync(firstStatePath)).toBe(false);
+    expect(existsSync(secondStatePath)).toBe(false);
+  });
+
+  test("close --all requires --force when a session ignores SIGTERM", async ({
+    librettoCli,
+    workspaceDir,
+  }) => {
+    const session = "stubborn-sigterm";
+    const stubbornChild = spawn(
+      process.execPath,
+      [
+        "-e",
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+    stubbornChild.unref();
+    const pid = stubbornChild.pid;
+    expect(pid).toBeDefined();
+
+    const statePath = await writeSessionState(workspaceDir, {
+      session,
+      pid: pid!,
+      port: 65533,
+    });
+
+    try {
+      const graceful = await librettoCli("close --all");
+      expect(graceful.exitCode).toBe(1);
+      expect(graceful.stderr).toContain(
+        `Failed to close 1 session(s) gracefully: "${session}".`,
+      );
+      expect(graceful.stderr).toContain("Retry with: libretto-cli close --all --force");
+      expect(existsSync(statePath)).toBe(true);
+      expect(isProcessRunning(pid!)).toBe(true);
+
+      const forced = await librettoCli("close --all --force");
+      expect(forced.exitCode).toBe(0);
+      expect(forced.stdout).toContain("Closed 1 session(s).");
+      expect(forced.stdout).toContain("Force-killed 1 session(s).");
+      expect(existsSync(statePath)).toBe(false);
+      expect(await waitForProcessToStop(pid!, 5_000)).toBe(true);
+    } finally {
+      if (pid && isProcessRunning(pid)) {
+        killProcessTree(pid);
+      }
+    }
+  }, 20_000);
 
   test("reads and clears network logs from seeded run data", async ({
     librettoCli,


### PR DESCRIPTION
## Summary
- add `libretto-cli close --all` to close all tracked sessions in the current workspace
- add `--force` behavior that escalates from `SIGTERM` to `SIGKILL` for stubborn session processes
- improve close-all cleanup to always clear state for sessions confirmed stopped, including partial force-close failure paths
- update CLI help text for `close --all --force`
- add stateful tests for no-op behavior, flag validation, stale state cleanup, and forced teardown path

## Validation
- `pnpm --filter libretto type-check`
- `pnpm --filter libretto test -- test/stateful.spec.ts`
