### PR TITLE
Remove run debug flag and auto-recycle failed run sessions

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -51,6 +51,14 @@ Workflows pause from inside the workflow function by calling `await ctx.pause()`
 - `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
 - For multi-pause workflows, call `resume` repeatedly until the workflow completes.
 
+## Workflow Failures and Reruns
+
+- `npx libretto run` always uses the same failure-inspection behavior; no separate debug flag is needed.
+- On workflow failure, Libretto prints the workflow error and keeps the browser open for inspection.
+- After a failed run, use `npx libretto exec --session <name> "<code>"` to inspect or prototype fixes.
+- Re-running `npx libretto run ... --session <name>` re-runs the workflow for that session.
+- If the same session still has a failed workflow worker, Libretto releases that failed worker process before rerunning.
+
 ## Globals Available in `exec`
 
 `page`, `context`, `state`, `browser`, `networkLog({ last?, filter?, method? })`, `actionLog({ last?, filter?, action?, source? })`, `console`, `fetch`, `Buffer`, `URL`, `setTimeout`
@@ -214,7 +222,8 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 - **Never use `page.screenshot()` via `exec`.** Use `npx libretto snapshot` instead — it captures the viewport, sends the screenshot + HTML to a vision model, and returns actionable selectors. The `fullPage` option is especially dangerous — it scrolls the entire page to stitch a screenshot, which can crash JavaScript-heavy pages (especially EMR portals like eClinicalWorks).
 - **Never run `exec` commands in parallel.** Always wait for one `exec` to finish before starting the next. Do not use `run_in_background` for `exec` calls. Running simultaneous `exec` calls opens multiple CDP connections to the same page, which corrupts the page state and kills the browser.
-- `open` and `run` require an available session. If the session is already active, Libretto fails fast and asks you to close the existing session or use a different `--session`.
+- `open` requires an available session. If the session is already active, Libretto fails fast and asks you to close the existing session or use a different `--session`.
+- `run` also requires an available session, except for the specific case of a prior failed `run` in the same session; in that case Libretto releases the failed worker and allows rerun.
 - Use `return <value>` in `exec` to print results. Strings print raw; objects print as JSON.
 - For iframe content, access via `page.locator('iframe[name="..."]').contentFrame()`.
 - Multiple sessions allow parallel browser instances: `--session test1`, `--session test2`.

--- a/packages/libretto/skill/SKILL.md
+++ b/packages/libretto/skill/SKILL.md
@@ -51,6 +51,14 @@ Workflows pause from inside the workflow function by calling `await ctx.pause()`
 - `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
 - For multi-pause workflows, call `resume` repeatedly until the workflow completes.
 
+## Workflow Failures and Reruns
+
+- `npx libretto run` always uses the same failure-inspection behavior; no separate debug flag is needed.
+- On workflow failure, Libretto prints the workflow error and keeps the browser open for inspection.
+- After a failed run, use `npx libretto exec --session <name> "<code>"` to inspect or prototype fixes.
+- Re-running `npx libretto run ... --session <name>` re-runs the workflow for that session.
+- If the same session still has a failed workflow worker, Libretto releases that failed worker process before rerunning.
+
 ## Globals Available in `exec`
 
 `page`, `context`, `state`, `browser`, `networkLog({ last?, filter?, method? })`, `actionLog({ last?, filter?, action?, source? })`, `console`, `fetch`, `Buffer`, `URL`, `setTimeout`
@@ -214,7 +222,8 @@ When the snapshot doesn't give you enough detail — why an element is hidden, w
 
 - **Never use `page.screenshot()` via `exec`.** Use `npx libretto snapshot` instead — it captures the viewport, sends the screenshot + HTML to a vision model, and returns actionable selectors. The `fullPage` option is especially dangerous — it scrolls the entire page to stitch a screenshot, which can crash JavaScript-heavy pages (especially EMR portals like eClinicalWorks).
 - **Never run `exec` commands in parallel.** Always wait for one `exec` to finish before starting the next. Do not use `run_in_background` for `exec` calls. Running simultaneous `exec` calls opens multiple CDP connections to the same page, which corrupts the page state and kills the browser.
-- `open` and `run` require an available session. If the session is already active, Libretto fails fast and asks you to close the existing session or use a different `--session`.
+- `open` requires an available session. If the session is already active, Libretto fails fast and asks you to close the existing session or use a different `--session`.
+- `run` also requires an available session, except for the specific case of a prior failed `run` in the same session; in that case Libretto releases the failed worker and allows rerun.
 - Use `return <value>` in `exec` to print results. Strings print raw; objects print as JSON.
 - For iframe content, access via `page.locator('iframe[name="..."]').contentFrame()`.
 - Multiple sessions allow parallel browser instances: `--session test1`, `--session test2`.

--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -39,7 +39,7 @@ function printUsage(): void {
 Commands:
   open <url> [--headless] Launch browser and open URL (headed by default)
                           Automatically loads saved profile if available
-  run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug]  Run an exported Libretto workflow from a file; pass --debug to enable pause-on-failure debugging (or --no-debug to disable)
+  run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless]  Run an exported Libretto workflow from a file
   ai configure [preset] [-- <command prefix...>]  Configure AI runtime for analysis commands
   save <url|domain>       Save current browser session (cookies, localStorage, etc.)
   exec <code> [--visualize]  Execute Playwright typescript code (--visualize enables ghost cursor + highlight)

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -12,6 +12,8 @@ import {
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
   assertSessionAvailableForStart,
+  clearSessionState,
+  readSessionState,
   readSessionStateOrThrow,
   setSessionStatus,
 } from "../core/session.js";
@@ -246,6 +248,61 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
+async function stopExistingFailedRunSession(
+  session: string,
+  logger: LoggerApi,
+): Promise<void> {
+  const existingState = readSessionState(session, logger);
+  if (!existingState || existingState.status !== "failed") {
+    return;
+  }
+  if (!isProcessRunning(existingState.pid)) {
+    setSessionStatus(session, "exited", logger);
+    return;
+  }
+
+  logger.info("run-stop-existing-failed-session", {
+    session,
+    pid: existingState.pid,
+    port: existingState.port,
+  });
+  console.log(
+    `Killed existing browser process for session "${session}" (pid ${existingState.pid}).`,
+  );
+  try {
+    process.kill(existingState.pid, "SIGTERM");
+  } catch (err) {
+    logger.warn("run-stop-existing-failed-session-sigterm-error", {
+      session,
+      pid: existingState.pid,
+      error: err,
+    });
+  }
+
+  const stopDeadline = Date.now() + 3_000;
+  while (isProcessRunning(existingState.pid) && Date.now() < stopDeadline) {
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  if (isProcessRunning(existingState.pid)) {
+    try {
+      process.kill(existingState.pid, "SIGKILL");
+    } catch (err) {
+      logger.warn("run-stop-existing-failed-session-sigkill-error", {
+        session,
+        pid: existingState.pid,
+        error: err,
+      });
+    }
+  }
+
+  if (isProcessRunning(existingState.pid)) {
+    throw new Error(
+      `Could not stop existing failed run session "${session}" (pid ${existingState.pid}). Run "libretto-cli close --session ${session}" and try again.`,
+    );
+  }
+  clearSessionState(session, logger);
+}
+
 function readJsonFileIfExists(path: string): unknown {
   if (!existsSync(path)) return null;
   try {
@@ -415,6 +472,7 @@ async function runIntegrationFromFile(
   args: RunIntegrationWorkerRequest,
   logger: LoggerApi,
 ): Promise<void> {
+  await stopExistingFailedRunSession(args.session, logger);
   assertSessionAvailableForStart(args.session, logger);
   const signalPaths = getPauseSignalPaths(args.session);
   clearSignalIfExists(signalPaths.pausedSignalPath);
@@ -445,7 +503,10 @@ async function runIntegrationFromFile(
   }
   if (outcome.status === "failed") {
     setSessionStatus(args.session, "failed", logger);
-    throw new Error(outcome.message ?? "Workflow failed during run.");
+    const baseMessage = outcome.message ?? "Workflow failed during run.";
+    throw new Error(
+      `${baseMessage}\nBrowser is still open. You can use \`exec\` to inspect it. Call \`run\` to re-run the workflow.`,
+    );
   }
   if (outcome.status === "exited") {
     setSessionStatus(args.session, "exited", logger);
@@ -494,13 +555,18 @@ export function registerExecutionCommands(yargs: Argv, logger: LoggerApi): Argv 
           .option("params", { type: "string" })
           .option("params-file", { type: "string" })
           .option("headed", { type: "boolean", default: false })
-          .option("headless", { type: "boolean", default: false })
-          .option("debug", { type: "boolean" }),
+          .option("headless", { type: "boolean", default: false }),
       async (argv) => {
         const usage =
-          "Usage: libretto-cli run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug]";
+          "Usage: libretto-cli run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless]";
         const integrationPath = argv.integrationFile as string | undefined;
         const exportName = argv.integrationExport as string | undefined;
+        const legacyDebug = (argv as Record<string, unknown>).debug;
+        if (legacyDebug !== undefined) {
+          throw new Error(
+            "The --debug flag has been removed. Run the command without --debug.",
+          );
+        }
         if (!integrationPath || !exportName) {
           throw new Error(usage);
         }
@@ -542,19 +608,12 @@ export function registerExecutionCommands(yargs: Argv, logger: LoggerApi): Argv 
             ? true
             : undefined;
 
-        const debugFlag = argv.debug as boolean | undefined;
-        const debugMode =
-          debugFlag !== undefined
-            ? debugFlag
-            : process.env.LIBRETTO_DEBUG === "true";
-
         await runIntegrationFromFile({
           integrationPath,
           exportName,
           session,
           params,
           headless: headlessMode ?? false,
-          debug: debugMode,
         }, logger);
       },
     )

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { fork } from "node:child_process";
+import { spawn } from "node:child_process";
 import * as moduleBuiltin from "node:module";
 import { fileURLToPath } from "node:url";
 import type { Argv } from "yargs";
@@ -464,12 +464,11 @@ async function runIntegrationFromFile(
     new URL("../workers/run-integration-worker.js", import.meta.url),
   );
   const payload = JSON.stringify(args);
-  const worker = fork(workerEntryPath, [payload], {
+  const worker = spawn(process.execPath, [workerEntryPath, payload], {
     detached: true,
-    stdio: ["ignore", "ignore", "ignore", "ipc"],
+    stdio: "ignore",
     env: process.env,
   });
-  worker.disconnect();
   worker.unref();
   const outcome = await waitForWorkflowOutcome({
     session: args.session,

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -256,51 +256,30 @@ async function stopExistingFailedRunSession(
   if (!existingState || existingState.status !== "failed") {
     return;
   }
-  if (!isProcessRunning(existingState.pid)) {
-    setSessionStatus(session, "exited", logger);
-    return;
-  }
-
-  logger.info("run-stop-existing-failed-session", {
+  logger.info("run-release-existing-failed-session", {
     session,
     pid: existingState.pid,
     port: existingState.port,
   });
-  console.log(
-    `Killed existing browser process for session "${session}" (pid ${existingState.pid}).`,
-  );
-  try {
-    process.kill(existingState.pid, "SIGTERM");
-  } catch (err) {
-    logger.warn("run-stop-existing-failed-session-sigterm-error", {
-      session,
-      pid: existingState.pid,
-      error: err,
-    });
-  }
+  clearSessionState(session, logger);
 
   const stopDeadline = Date.now() + 3_000;
   while (isProcessRunning(existingState.pid) && Date.now() < stopDeadline) {
     await new Promise((resolveWait) => setTimeout(resolveWait, 100));
   }
   if (isProcessRunning(existingState.pid)) {
-    try {
-      process.kill(existingState.pid, "SIGKILL");
-    } catch (err) {
-      logger.warn("run-stop-existing-failed-session-sigkill-error", {
-        session,
-        pid: existingState.pid,
-        error: err,
-      });
-    }
-  }
-
-  if (isProcessRunning(existingState.pid)) {
-    throw new Error(
-      `Could not stop existing failed run session "${session}" (pid ${existingState.pid}). Run "libretto-cli close --session ${session}" and try again.`,
+    logger.warn("run-release-existing-failed-session-timeout", {
+      session,
+      pid: existingState.pid,
+    });
+    console.warn(
+      `Existing failed workflow process for session "${session}" (pid ${existingState.pid}) is still shutting down; continuing.`,
     );
+    return;
   }
-  clearSessionState(session, logger);
+  console.log(
+    `Closed existing failed workflow process for session "${session}" (pid ${existingState.pid}).`,
+  );
 }
 
 function readJsonFileIfExists(path: string): unknown {
@@ -503,9 +482,8 @@ async function runIntegrationFromFile(
   }
   if (outcome.status === "failed") {
     setSessionStatus(args.session, "failed", logger);
-    const baseMessage = outcome.message ?? "Workflow failed during run.";
     throw new Error(
-      `${baseMessage}\nBrowser is still open. You can use \`exec\` to inspect it. Call \`run\` to re-run the workflow.`,
+      `${outcome.message ?? "Workflow failed during run."}\nBrowser is still open. You can use \`exec\` to inspect it. Call \`run\` to re-run the workflow.`,
     );
   }
   if (outcome.status === "exited") {

--- a/packages/libretto/src/cli/core/session.ts
+++ b/packages/libretto/src/cli/core/session.ts
@@ -15,7 +15,6 @@ import {
 } from "./context.js";
 import {
   SESSION_STATE_VERSION,
-  SessionStatusSchema,
   parseSessionStateContent,
   serializeSessionState,
   type SessionStatus,
@@ -159,10 +158,6 @@ export function clearSessionState(session: string, logger?: LoggerApi): void {
   logger?.info("session-state-cleared", { session, stateFile });
 }
 
-function isSessionStatus(value: unknown): value is SessionStatus {
-  return SessionStatusSchema.safeParse(value).success;
-}
-
 function isPidRunning(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -192,15 +187,6 @@ export function assertSessionAvailableForStart(
 ): void {
   const existingState = readSessionState(session, logger);
   if (!existingState) return;
-  if (isSessionStatus(existingState.status)) {
-    if (
-      existingState.status === "completed" ||
-      existingState.status === "failed" ||
-      existingState.status === "exited"
-    ) {
-      return;
-    }
-  }
   if (!isPidRunning(existingState.pid)) {
     setSessionStatus(session, "exited", logger);
     return;

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
@@ -10,11 +10,13 @@ import {
   type RunDebugPauseDetails,
 } from "../../index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
+import { parseSessionStateContent } from "../../shared/state/index.js";
 import { getProfilePath, normalizeDomain } from "../core/browser.js";
 import {
   getSessionActionsLogPath,
   getSessionDir,
   getSessionNetworkLogPath,
+  getSessionStatePath,
 } from "../core/context.js";
 import { getPauseSignalPaths, removeSignalIfExists } from "../core/pause-signals.js";
 import { installSessionTelemetry } from "../core/session-telemetry.js";
@@ -29,9 +31,12 @@ type LoadedLibrettoWorkflow = {
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
 
-type RunIntegrationOutcome = { status: "completed" };
+type RunIntegrationOutcome =
+  | { status: "completed" }
+  | { status: "failed-held" };
 
 const RESUME_POLL_INTERVAL_MS = 250;
+const FAILURE_HOLD_POLL_INTERVAL_MS = 250;
 
 function mirrorStdoutToFile(filePath: string): () => void {
   const stdout = process.stdout as NodeJS.WriteStream & {
@@ -80,6 +85,41 @@ async function waitForResumeSignal(args: {
 
   await removeSignalIfExists(resumeSignalPath);
   await removeSignalIfExists(pausedSignalPath);
+}
+
+function readSessionStatePid(session: string): number | null {
+  const statePath = getSessionStatePath(session);
+  if (!existsSync(statePath)) return null;
+
+  try {
+    return parseSessionStateContent(readFileSync(statePath, "utf8"), statePath).pid;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForFailureSessionRelease(args: {
+  session: string;
+  expectedPid: number;
+  logger: LoggerApi;
+}): Promise<void> {
+  const { session, expectedPid, logger } = args;
+  logger.info("run-failure-session-hold", { session, expectedPid });
+
+  while (true) {
+    const currentPid = readSessionStatePid(session);
+    if (currentPid !== expectedPid) {
+      logger.info("run-failure-session-released", {
+        session,
+        expectedPid,
+        currentPid,
+      });
+      return;
+    }
+    await new Promise((resolveWait) =>
+      setTimeout(resolveWait, FAILURE_HOLD_POLL_INTERVAL_MS),
+    );
+  }
 }
 
 function isLoadedLibrettoWorkflow(value: unknown): value is LoadedLibrettoWorkflow {
@@ -234,7 +274,6 @@ async function runIntegrationInternal(
     integrationPath: absolutePath,
     exportName: args.exportName,
     headless: args.headless,
-    debug: args.debug,
     pause: async () => {
       const details: RunDebugPauseDetails = {
         sessionName: args.session,
@@ -257,19 +296,25 @@ async function runIntegrationInternal(
     try {
       await workflow.run(workflowContext, args.params ?? {});
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       await writeFile(
         signalPaths.failedSignalPath,
         JSON.stringify(
           {
             failedAt: new Date().toISOString(),
-            message: error instanceof Error ? error.message : String(error),
+            message: errorMessage,
           },
           null,
           2,
         ),
         "utf8",
       );
-      throw error;
+      await waitForFailureSessionRelease({
+        session: args.session,
+        expectedPid: process.pid,
+        logger,
+      });
+      return { status: "failed-held" };
     }
     await writeFile(
       signalPaths.completedSignalPath,

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -65,7 +65,6 @@ async function waitForResumeSignal(args: {
   signalPaths: ReturnType<typeof getPauseSignalPaths>;
   session: string;
   details: RunDebugPauseDetails;
-  onPaused?: (details: RunDebugPauseDetails) => Promise<void> | void;
 }): Promise<void> {
   const { pausedSignalPath, resumeSignalPath } = args.signalPaths;
   await mkdir(getSessionDir(args.session), { recursive: true });
@@ -75,7 +74,6 @@ async function waitForResumeSignal(args: {
     JSON.stringify(args.details, null, 2),
     "utf8",
   );
-  await args.onPaused?.(args.details);
 
   while (!existsSync(resumeSignalPath)) {
     await new Promise((resolveWait) =>
@@ -212,7 +210,6 @@ async function runIntegrationInternal(
   args: RunIntegrationWorkerRequest,
   options: {
     logger: LoggerApi;
-    onPaused?: (details: RunDebugPauseDetails) => Promise<void> | void;
   },
 ): Promise<RunIntegrationOutcome> {
   const { logger } = options;
@@ -286,7 +283,6 @@ async function runIntegrationInternal(
         signalPaths,
         session: args.session,
         details,
-        onPaused: options.onPaused,
       });
       console.log("[pause] Resume signal received. Continuing workflow...");
     },
@@ -332,10 +328,8 @@ async function runIntegrationInternal(
 export async function runIntegrationFromFileInWorker(
   args: RunIntegrationWorkerRequest,
   logger: LoggerApi,
-  onPaused: (details: RunDebugPauseDetails) => Promise<void> | void,
 ): Promise<RunIntegrationOutcome> {
   return await runIntegrationInternal(args, {
     logger,
-    onPaused,
   });
 }

--- a/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
@@ -6,7 +6,6 @@ export type RunIntegrationWorkerRequest = {
   session: string;
   params: unknown;
   headless: boolean;
-  debug: boolean;
 };
 
 export type RunIntegrationWorkerMessage =

--- a/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
@@ -1,12 +1,17 @@
+import { z } from "zod";
 import type { RunDebugPauseDetails } from "../../index.js";
 
-export type RunIntegrationWorkerRequest = {
-  integrationPath: string;
-  exportName: string;
-  session: string;
-  params: unknown;
-  headless: boolean;
-};
+export const RunIntegrationWorkerRequestSchema = z.object({
+  integrationPath: z.string().min(1),
+  exportName: z.string().min(1),
+  session: z.string().min(1),
+  params: z.unknown(),
+  headless: z.boolean(),
+});
+
+export type RunIntegrationWorkerRequest = z.infer<
+  typeof RunIntegrationWorkerRequestSchema
+>;
 
 export type RunIntegrationWorkerMessage =
   | { type: "completed" }

--- a/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { RunDebugPauseDetails } from "../../index.js";
 
 export const RunIntegrationWorkerRequestSchema = z.object({
   integrationPath: z.string().min(1),
@@ -12,8 +11,3 @@ export const RunIntegrationWorkerRequestSchema = z.object({
 export type RunIntegrationWorkerRequest = z.infer<
   typeof RunIntegrationWorkerRequestSchema
 >;
-
-export type RunIntegrationWorkerMessage =
-  | { type: "completed" }
-  | { type: "paused"; details: RunDebugPauseDetails }
-  | { type: "failed"; message: string };

--- a/packages/libretto/src/cli/workers/run-integration-worker.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker.ts
@@ -44,7 +44,6 @@ function parseWorkerRequest(argv: string[]): RunIntegrationWorkerRequest {
     typeof candidate.exportName !== "string" ||
     typeof candidate.session !== "string" ||
     typeof candidate.headless !== "boolean" ||
-    typeof candidate.debug !== "boolean" ||
     !("params" in candidate)
   ) {
     throw new Error("Worker payload is missing required fields.");
@@ -55,7 +54,6 @@ function parseWorkerRequest(argv: string[]): RunIntegrationWorkerRequest {
     exportName: candidate.exportName,
     session: candidate.session,
     headless: candidate.headless,
-    debug: candidate.debug,
     params: candidate.params,
   };
 }
@@ -67,16 +65,20 @@ async function main(): Promise<void> {
     request = parseWorkerRequest(process.argv);
     const workerRequest = request;
     ensureLibrettoSetup();
+    let outcomeStatus: "completed" | "failed-held" = "completed";
     await withSessionLogger(workerRequest.session, async (logger) => {
-      await runIntegrationFromFileInWorker(
+      const outcome = await runIntegrationFromFileInWorker(
         workerRequest,
         logger,
         async (details) => {
           sendMessage({ type: "paused", details });
         },
       );
+      outcomeStatus = outcome.status;
     });
-    sendMessage({ type: "completed" });
+    if (outcomeStatus === "completed") {
+      sendMessage({ type: "completed" });
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (request) {

--- a/packages/libretto/src/cli/workers/run-integration-worker.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker.ts
@@ -2,7 +2,6 @@ import { writeFile } from "node:fs/promises";
 import { ZodError } from "zod";
 import {
   RunIntegrationWorkerRequestSchema,
-  type RunIntegrationWorkerMessage,
   type RunIntegrationWorkerRequest,
 } from "./run-integration-worker-protocol.js";
 import { runIntegrationFromFileInWorker } from "./run-integration-runtime.js";
@@ -11,15 +10,6 @@ import {
   withSessionLogger,
 } from "../core/context.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
-
-function sendMessage(message: RunIntegrationWorkerMessage): void {
-  if (typeof process.send !== "function" || !process.connected) return;
-  try {
-    process.send(message);
-  } catch {
-    // Parent may have disconnected after initial run returns on pause.
-  }
-}
 
 function parseWorkerRequest(argv: string[]): RunIntegrationWorkerRequest {
   const rawPayload = argv[2];
@@ -56,20 +46,9 @@ async function main(): Promise<void> {
     request = parseWorkerRequest(process.argv);
     const workerRequest = request;
     ensureLibrettoSetup();
-    let outcomeStatus: "completed" | "failed-held" = "completed";
     await withSessionLogger(workerRequest.session, async (logger) => {
-      const outcome = await runIntegrationFromFileInWorker(
-        workerRequest,
-        logger,
-        async (details) => {
-          sendMessage({ type: "paused", details });
-        },
-      );
-      outcomeStatus = outcome.status;
+      await runIntegrationFromFileInWorker(workerRequest, logger);
     });
-    if (outcomeStatus === "completed") {
-      sendMessage({ type: "completed" });
-    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (request) {
@@ -87,7 +66,6 @@ async function main(): Promise<void> {
         "utf8",
       );
     }
-    sendMessage({ type: "failed", message });
     exitCode = 1;
   }
   process.exit(exitCode);

--- a/packages/libretto/src/cli/workers/run-integration-worker.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker.ts
@@ -1,7 +1,9 @@
 import { writeFile } from "node:fs/promises";
-import type {
-  RunIntegrationWorkerMessage,
-  RunIntegrationWorkerRequest,
+import { ZodError } from "zod";
+import {
+  RunIntegrationWorkerRequestSchema,
+  type RunIntegrationWorkerMessage,
+  type RunIntegrationWorkerRequest,
 } from "./run-integration-worker-protocol.js";
 import { runIntegrationFromFileInWorker } from "./run-integration-runtime.js";
 import {
@@ -34,28 +36,17 @@ function parseWorkerRequest(argv: string[]): RunIntegrationWorkerRequest {
     );
   }
 
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("Worker payload must be an object.");
+  try {
+    return RunIntegrationWorkerRequestSchema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const details = error.issues
+        .map((issue) => `${issue.path.join(".") || "root"}: ${issue.message}`)
+        .join("; ");
+      throw new Error(`Worker payload is invalid: ${details}`);
+    }
+    throw error;
   }
-
-  const candidate = parsed as Record<string, unknown>;
-  if (
-    typeof candidate.integrationPath !== "string" ||
-    typeof candidate.exportName !== "string" ||
-    typeof candidate.session !== "string" ||
-    typeof candidate.headless !== "boolean" ||
-    !("params" in candidate)
-  ) {
-    throw new Error("Worker payload is missing required fields.");
-  }
-
-  return {
-    integrationPath: candidate.integrationPath,
-    exportName: candidate.exportName,
-    session: candidate.session,
-    headless: candidate.headless,
-    params: candidate.params,
-  };
 }
 
 async function main(): Promise<void> {

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -21,7 +21,6 @@ export type LibrettoWorkflowContext = {
 	integrationPath: string;
 	exportName: string;
 	headless: boolean;
-	debug: boolean;
 	pause: () => Promise<void>;
 };
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -251,7 +251,7 @@ export const main = workflow({}, async (ctx) => {
     );
 
     const result = await librettoCli(
-      `run "${integrationFilePath}" main --session default --headless --debug`,
+      `run "${integrationFilePath}" main --session default --headless`,
     );
     await evaluate(result.stdout).toMatch(
       "Includes WORKFLOW_BEFORE_PAUSE and Workflow paused, and does not include WORKFLOW_AFTER_PAUSE or Integration completed.",
@@ -279,6 +279,44 @@ export const main = workflow({}, async () => {
       "Includes WORKFLOW_COMPLETES and Integration completed, and does not include Workflow paused.",
     );
   }, 45_000);
+
+  test("run prints failure guidance and keeps browser open for exec inspection", async ({
+    librettoCli,
+    evaluate,
+    writeWorkflow,
+  }) => {
+    const session = "debug-selector-error-guidance";
+    const integrationFilePath = await writeWorkflow(
+      "integration-selector-error-debug.mjs",
+      `
+export const main = workflow({}, async (ctx) => {
+  await ctx.page.goto("https://example.com");
+  await ctx.page.locator("[").click();
+});
+`,
+    );
+
+    try {
+      const runResult = await librettoCli(
+        `run "${integrationFilePath}" main --session ${session} --headless`,
+      );
+      await evaluate(runResult.stderr).toMatch(
+        "Includes the workflow error and also gives guidance that the browser is still open, to use exec for inspection, and to run run again to re-run the workflow.",
+      );
+
+      const rerunResult = await librettoCli(
+        `run "${integrationFilePath}" main --session ${session} --headless`,
+      );
+      await evaluate(rerunResult.stdout).toMatch(
+        `Mentions that an existing browser process for session ${session} was killed before rerunning.`,
+      );
+      await evaluate(rerunResult.stderr).toMatch(
+        "Includes the workflow error and guidance text, and does not say the session is already open and connected.",
+      );
+    } finally {
+      await librettoCli(`close --session ${session}`);
+    }
+  }, 60_000);
 
   test("fails save with missing target usage error", async ({
     librettoCli,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -307,11 +307,8 @@ export const main = workflow({}, async (ctx) => {
       const rerunResult = await librettoCli(
         `run "${integrationFilePath}" main --session ${session} --headless`,
       );
-      await evaluate(rerunResult.stdout).toMatch(
-        `Mentions that an existing browser process for session ${session} was killed before rerunning.`,
-      );
       await evaluate(rerunResult.stderr).toMatch(
-        "Includes the workflow error and guidance text, and does not say the session is already open and connected.",
+        "Includes the workflow error and the same casual guidance that browser stays open for exec and run can rerun, and does not say the session is already open and connected.",
       );
     } finally {
       await librettoCli(`close --session ${session}`);

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -311,7 +311,7 @@ describe("multi-page CLI behavior", () => {
     }
   }, 60_000);
 
-  test("run --debug supports page-scoped logs for multiple pages", async ({
+  test("run supports page-scoped logs for multiple pages", async ({
     librettoCli,
     evaluate,
     writeWorkflow,
@@ -334,7 +334,7 @@ export const main = workflow({}, async (ctx) => {
     );
 
     const runResult = await librettoCli(
-      `run "${integrationFilePath}" main --session ${session} --headless --debug`,
+      `run "${integrationFilePath}" main --session ${session} --headless`,
     );
     expect(runResult.exitCode).toBe(0);
     await evaluate(runResult.stdout).toMatch(


### PR DESCRIPTION
## Summary
- remove the `--debug` option from `libretto-cli run` and remove `ctx.debug` from workflow context
- make run failure guidance unconditional: always tell users the browser is still open and they can use `exec`
- keep failed run workers alive for inspection, and on a subsequent `run` in the same failed session, automatically stop the old worker/browser process before starting a new run
- reject legacy `--debug` usage with a clear error message
- update CLI usage text and tests to reflect the new run behavior

## Validation
- `pnpm --filter libretto type-check`
- `pnpm --filter libretto test -- test/basic.spec.ts -t "run prints failure guidance and keeps browser open for exec inspection"`
- `pnpm --filter libretto test -- test/basic.spec.ts -t "returns paused status when workflow hits ctx.pause"`
- `pnpm --filter libretto test -- test/multi-page.spec.ts -t "run supports page-scoped logs for multiple pages"`
