### PR TITLE
feat: improve consumer DX with AI SDK adapter, init command, and docs

### DIFF
--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -1,231 +1,125 @@
 # Libretto
 
-A TypeScript library for browser automation with AI-powered recovery and data extraction. Built on Playwright.
-
-## Features
-
-- **AI-powered recovery** — Vision-based agent that automatically detects and dismisses popups or obstacles using an LLM
-- **Structured data extraction** — Extract typed data from web pages using AI vision + Zod schemas
-- **Error detection** — Classify form/submission errors against known patterns
-- **In-browser network requests** — Execute authenticated fetch calls inside the page context with optional Zod validation
-- **File downloads** — Trigger and intercept file downloads via click, with optional save-to-disk
-- **Dry-run mode** — Skip mutations in development without side effects
-- **Pluggable LLM** — Bring your own LLM provider (Claude, GPT, etc.) via a simple interface
-- **Pluggable logging** — All runtime functions accept an optional logger; defaults to console output
+AI-powered browser automation library and CLI built on Playwright.
 
 ## Installation
 
 ```bash
 pnpm add libretto playwright zod
+npx libretto init
 ```
 
-`playwright` and `zod` are peer dependencies.
+> **pnpm users:** add `onlyBuiltDependencies` to your `package.json` to allow
+> Playwright's postinstall script to run:
+>
+> ```jsonc
+> // package.json
+> {
+>   "pnpm": {
+>     "onlyBuiltDependencies": ["playwright"]
+>   }
+> }
+> ```
 
 ## Quick Start
 
-```typescript
-import { chromium } from "playwright";
-import { extractFromPage, attemptWithRecovery } from "libretto";
+### 1. Configure your LLM
 
-const browser = await chromium.launch();
-const page = await browser.newPage();
-
-await page.goto("https://example.com/login");
-await page.fill("#email", "user@example.com");
-await page.fill("#password", "secret");
-
-// Automatically retry with AI popup recovery on failure
-await attemptWithRecovery(page, () => page.click('button[type="submit"]'));
-
-await browser.close();
-```
-
-## Runtime Functions
-
-### Recovery
-
-#### `attemptWithRecovery(page, fn, logger?, llmClient?)`
-
-Executes a function and, if it fails, uses AI vision to detect and dismiss popups before retrying once.
+The easiest way is to use the built-in Vercel AI SDK adapter with any compatible provider:
 
 ```typescript
-import { attemptWithRecovery } from "libretto";
+import { createLLMClientFromModel } from "libretto/llm";
+import { openai } from "@ai-sdk/openai";
 
-await attemptWithRecovery(page, async () => {
-  await page.click('button[type="submit"]');
-}, undefined, llmClient);
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
 ```
 
-#### `executeRecoveryAgent(page, instruction, logger?, llmClient?)`
-
-Runs a multi-step vision-based recovery agent that takes screenshots and executes browser actions (click, type, scroll, etc.) to resolve obstacles.
+Or use any other provider:
 
 ```typescript
-import { executeRecoveryAgent } from "libretto";
+import { createLLMClientFromModel } from "libretto";
+import { anthropic } from "@ai-sdk/anthropic";
 
-await executeRecoveryAgent(
-  page,
-  "Close the cookie consent banner",
-  undefined,
-  llmClient,
-);
+const llmClient = createLLMClientFromModel(anthropic("claude-sonnet-4-20250514"));
 ```
 
-#### `detectSubmissionError(page, error, logContext, llmClient, knownErrors?, logger?)`
-
-Uses a screenshot + LLM vision to detect if an error occurred during a form submission. Matches against provided known error patterns.
-
-```typescript
-import { detectSubmissionError } from "libretto";
-
-try {
-  await page.click("#submit");
-} catch (error) {
-  const result = await detectSubmissionError(page, error, "checkout", llmClient, [
-    { id: "duplicate", errorPatterns: ["already exists"], userMessage: "Duplicate entry" },
-  ]);
-  console.log(result.errorId, result.message);
-}
-```
-
-### Data Extraction
-
-#### `extractFromPage(options)`
-
-Extract structured data from a page using AI vision + a Zod schema.
-
-```typescript
-import { extractFromPage } from "libretto";
-import { z } from "zod";
-
-const result = await extractFromPage({
-  page,
-  llmClient,
-  instruction: "Extract the product name and price",
-  schema: z.object({
-    name: z.string(),
-    price: z.number(),
-  }),
-  selector: ".product-card", // optional — scopes to a specific element
-});
-// result is typed as { name: string; price: number }
-```
-
-### Network
-
-#### `pageRequest(page, config, options?)`
-
-Executes a fetch call inside the browser context via `page.evaluate()`, inheriting the page's cookies and auth state. Supports optional Zod validation.
-
-```typescript
-import { pageRequest } from "libretto";
-import { z } from "zod";
-
-const data = await pageRequest(
-  page,
-  {
-    url: "https://example.com/api/profile",
-    method: "GET",
-    responseType: "json",
-  },
-  {
-    schema: z.object({ name: z.string(), email: z.string() }),
-  },
-);
-```
-
-### Downloads
-
-#### `downloadViaClick(page, selector, options?)`
-
-Triggers a file download by clicking a DOM element and intercepts the result.
-
-```typescript
-import { downloadViaClick } from "libretto";
-
-const { buffer, filename } = await downloadViaClick(page, "#download-btn");
-```
-
-#### `downloadAndSave(page, selector, options?)`
-
-Same as `downloadViaClick` but also writes the file to disk.
-
-```typescript
-import { downloadAndSave } from "libretto";
-
-const { savedTo } = await downloadAndSave(page, "#export-csv", {
-  savePath: "./exports/report.csv",
-});
-```
-
-## LLM Client Interface
-
-Provide your own implementation backed by any LLM provider:
+You can also implement the `LLMClient` interface directly for full control:
 
 ```typescript
 import type { LLMClient } from "libretto";
 
-const myLLMClient: LLMClient = {
+const llmClient: LLMClient = {
   async generateObject({ prompt, schema, temperature }) {
     // Call your LLM, return parsed + validated result
   },
   async generateObjectFromMessages({ messages, schema, temperature }) {
-    // Call your LLM with message history, return parsed + validated result
+    // Call your LLM with message history (may include images)
   },
 };
 ```
 
-## Logging
-
-All runtime functions accept an optional `logger` parameter. When omitted, output goes to `console.log` with `[INFO]`, `[WARN]`, `[ERROR]` prefixes.
-
-For structured logging, use the built-in `Logger` class:
+### 2. Write a workflow
 
 ```typescript
-import { Logger, createFileLogSink, prettyConsoleSink } from "libretto";
+import { workflow } from "libretto";
+import { z } from "zod";
 
-const logger = new Logger()
-  .withSink(createFileLogSink({ filePath: "./app.log" }))
-  .withSink(prettyConsoleSink);
+export default workflow({
+  name: "extract-product",
+  schema: z.object({ url: z.string() }),
+  handler: async (ctx) => {
+    const page = ctx.page;
+    await page.goto(ctx.params.url);
 
-const scoped = logger.withScope("auth");
-scoped.info("login attempt", { user: "alice" });
-scoped.error("login failed", { reason: "bad password" });
+    const data = await ctx.extract({
+      instruction: "Extract the product name and price",
+      schema: z.object({ name: z.string(), price: z.number() }),
+    });
+
+    return data;
+  },
+});
 ```
+
+### 3. Run it
+
+```bash
+npx libretto run ./workflows/extract-product.ts extractProduct \
+  --params '{"url": "https://example.com/product"}'
+```
+
+## CLI Commands
+
+```
+npx libretto init                  # Copy skills, install Playwright Chromium
+npx libretto open <url>            # Launch browser and open URL
+npx libretto run <file> <export>   # Run a workflow
+npx libretto ai configure <preset> # Configure AI runtime (codex, claude, gemini)
+npx libretto snapshot              # Capture page screenshot + HTML
+npx libretto exec <code>           # Execute Playwright code
+```
+
+Run `npx libretto help` for the full list.
 
 ## Module Exports
 
-Libretto provides granular imports:
+| Import                     | Contents                                                      |
+| -------------------------- | ------------------------------------------------------------- |
+| `libretto`                 | Everything                                                    |
+| `libretto/llm`             | `LLMClient` type, `createLLMClient`, `createLLMClientFromModel` |
+| `libretto/recovery`        | `attemptWithRecovery`, `executeRecoveryAgent`, `detectSubmissionError` |
+| `libretto/extract`         | `extractFromPage`                                             |
+| `libretto/network`         | `pageRequest`                                                 |
+| `libretto/download`        | `downloadViaClick`, `downloadAndSave`                         |
+| `libretto/logger`          | `Logger`, `defaultLogger`, sinks                              |
+| `libretto/debug`           | `debugPause`                                                  |
+| `libretto/config`          | `isDryRun`, `isDebugMode`, `shouldPauseBeforeMutation`        |
+| `libretto/instrumentation` | `instrumentPage`, `installInstrumentation`                    |
+| `libretto/visualization`   | Ghost cursor and highlight helpers                            |
+| `libretto/run`             | `launchBrowser`                                               |
+| `libretto/state`           | Session state serialization and parsing                       |
 
-| Import                   | Contents                                                  |
-| ------------------------ | --------------------------------------------------------- |
-| `libretto`               | Everything                                                |
-| `libretto/logger`        | `Logger`, `defaultLogger`, sinks                          |
-| `libretto/recovery`      | `attemptWithRecovery`, `executeRecoveryAgent`, `detectSubmissionError` |
-| `libretto/extract`       | `extractFromPage`                                         |
-| `libretto/network`       | `pageRequest`                                             |
-| `libretto/download`      | `downloadViaClick`, `downloadAndSave`                     |
-| `libretto/debug`         | `debugPause`                                              |
-| `libretto/config`        | `isDryRun`, `isDebugMode`, `shouldPauseBeforeMutation`    |
-| `libretto/instrumentation` | `instrumentPage`, `installInstrumentation`              |
-| `libretto/visualization` | Ghost cursor and highlight helpers                        |
-| `libretto/run`           | `launchBrowser`                                           |
-| `libretto/state`         | Session state serialization and parsing                   |
-| `libretto/llm`           | `LLMClient` type                                          |
+## Links
 
-## Configuration
-
-Runtime flags via environment variables:
-
-| Env Variable          | Effect                                              |
-| --------------------- | --------------------------------------------------- |
-| `LIBRETTO_DEBUG`      | Enable debug mode                                   |
-| `LIBRETTO_DRY_RUN`   | Enable dry-run mode (defaults to `true` in development) |
-
-## Development
-
-```bash
-pnpm install
-pnpm build         # compile to dist/
-pnpm type-check    # typecheck without emitting
-```
+- [GitHub](https://github.com/saffron-health/libretto)
+- [Issues](https://github.com/saffron-health/libretto/issues)

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -5,6 +5,7 @@ import { registerAICommands } from "./commands/ai.js";
 import { registerBrowserCommands } from "./commands/browser.js";
 import { registerExecutionCommands } from "./commands/execution.js";
 import { registerLogCommands } from "./commands/logs.js";
+import { registerInitCommand } from "./commands/init.js";
 import { registerSnapshotCommands } from "./commands/snapshot.js";
 import {
   closeLogger,
@@ -28,6 +29,7 @@ const CLI_COMMANDS = new Set([
   "pages",
   "resume",
   "close",
+  "init",
   "--help",
   "-h",
   "help",
@@ -37,6 +39,7 @@ function printUsage(): void {
   console.log(`Usage: libretto-cli <command> [--session <name>]
 
 Commands:
+  init [--skip-browsers] Initialize libretto (copy skills, install browsers)
   open <url> [--headless] Launch browser and open URL (headed by default)
                           Automatically loads saved profile if available
   run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--headed|--headless] [--debug]  Run an exported Libretto workflow from a file; pass --debug to enable pause-on-failure debugging (or --no-debug to disable)
@@ -181,6 +184,7 @@ function createParser(logger: Logger): Argv {
   parser = registerLogCommands(parser);
   parser = registerAICommands(parser);
   parser = registerSnapshotCommands(parser, logger);
+  parser = registerInitCommand(parser);
   parser = parser.command("help", "Show usage", () => {}, () => {
     printUsage();
   });

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -1,0 +1,112 @@
+import type { Argv } from "yargs";
+import { existsSync, mkdirSync, cpSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { REPO_ROOT } from "../core/context.js";
+
+function getSkillSourceDir(): string {
+	// Resolve relative to this file's location in the package
+	const thisDir = dirname(fileURLToPath(import.meta.url));
+	// From dist/cli/commands/ -> package root
+	const pkgRoot = join(thisDir, "..", "..", "..");
+	const skillDir = join(pkgRoot, "skill");
+	if (existsSync(skillDir)) return skillDir;
+	const skillsDir = join(pkgRoot, "skills");
+	if (existsSync(skillsDir)) return skillsDir;
+	throw new Error(
+		"Could not find skill/ or skills/ directory in the libretto package.",
+	);
+}
+
+function copySkills(): void {
+	const src = getSkillSourceDir();
+	const files = readdirSync(src);
+	if (files.length === 0) {
+		console.log("  No skill files found to copy.");
+		return;
+	}
+
+	const targets = [
+		join(REPO_ROOT, ".agents", "skills", "libretto"),
+		join(REPO_ROOT, ".claude", "skills", "libretto"),
+	];
+
+	for (const target of targets) {
+		mkdirSync(target, { recursive: true });
+		cpSync(src, target, { recursive: true });
+		console.log(`  \u2713 Copied skill files to ${target}`);
+	}
+}
+
+function installBrowsers(): void {
+	console.log("\nInstalling Playwright Chromium...");
+	const result = spawnSync("npx", ["playwright", "install", "chromium"], {
+		stdio: "inherit",
+		shell: true,
+	});
+	if (result.status === 0) {
+		console.log("  \u2713 Playwright Chromium installed");
+	} else {
+		console.error(
+			"  \u2717 Failed to install Playwright Chromium. Run manually: npx playwright install chromium",
+		);
+	}
+}
+
+function checkSnapshotLLM(): void {
+	const hasAnyCreds =
+		process.env.GOOGLE_CLOUD_PROJECT ||
+		process.env.GCLOUD_PROJECT ||
+		process.env.ANTHROPIC_API_KEY ||
+		process.env.OPENAI_API_KEY;
+
+	console.log("\nSnapshot LLM configuration:");
+	if (hasAnyCreds) {
+		console.log("  \u2713 LLM credentials detected");
+	} else {
+		console.log("  \u2717 No LLM credentials found.");
+		console.log("    Set one of the following environment variables:");
+		console.log("      GOOGLE_CLOUD_PROJECT  (for Vertex AI / Gemini)");
+		console.log("      ANTHROPIC_API_KEY     (for Claude)");
+		console.log("      OPENAI_API_KEY        (for GPT)");
+		console.log(
+			"    Then configure via: npx libretto ai configure <preset>",
+		);
+	}
+}
+
+export function registerInitCommand(yargs: Argv): Argv {
+	return yargs.command(
+		"init",
+		"Initialize libretto in the current project",
+		(cmd) =>
+			cmd.option("skip-browsers", {
+				type: "boolean",
+				default: false,
+				describe: "Skip Playwright Chromium installation",
+			}),
+		(argv) => {
+			console.log("Initializing libretto...\n");
+
+			console.log("Copying skill files...");
+			try {
+				copySkills();
+			} catch (err) {
+				console.error(
+					`  \u2717 ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+
+			if (!argv["skip-browsers"]) {
+				installBrowsers();
+			} else {
+				console.log("\nSkipping browser installation (--skip-browsers)");
+			}
+
+			checkSnapshotLLM();
+
+			console.log("\n\u2713 libretto init complete");
+		},
+	);
+}

--- a/packages/libretto/src/cli/core/context.ts
+++ b/packages/libretto/src/cli/core/context.ts
@@ -70,6 +70,13 @@ export function ensureLibrettoSetup(): void {
   if (!existsSync(LIBRETTO_GITIGNORE_PATH)) {
     writeFileSync(LIBRETTO_GITIGNORE_PATH, LIBRETTO_GITIGNORE_CONTENT, "utf-8");
   }
+
+  // Nudge users to run init if skills haven't been installed yet
+  const agentsSkillsDir = join(REPO_ROOT, ".agents", "skills", "libretto");
+  const claudeSkillsDir = join(REPO_ROOT, ".claude", "skills", "libretto");
+  if (!existsSync(agentsSkillsDir) && !existsSync(claudeSkillsDir)) {
+    console.log("[libretto] Skills not installed. Run 'npx libretto init' to complete setup.");
+  }
 }
 
 export function createLoggerForSession(session: string): Logger {

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -8,6 +8,7 @@ export {
 
 // LLM client interface
 export type { LLMClient, Message, MessageContentPart } from "./shared/llm/types.js";
+export { createLLMClientFromModel } from "./shared/llm/ai-sdk-adapter.js";
 export {
 	SESSION_STATE_VERSION,
 	SessionStatusSchema,

--- a/packages/libretto/src/shared/llm/ai-sdk-adapter.ts
+++ b/packages/libretto/src/shared/llm/ai-sdk-adapter.ts
@@ -43,8 +43,17 @@ export function createLLMClientFromModel(model: LanguageModel): LLMClient {
 				if (typeof msg.content === "string") {
 					return { role: msg.role, content: msg.content };
 				}
+				if (msg.role === "assistant") {
+					// AssistantContent only supports text parts (no images)
+					return {
+						role: "assistant" as const,
+						content: msg.content
+							.filter((part): part is typeof part & { type: "text" } => part.type === "text")
+							.map((part) => ({ type: "text" as const, text: part.text })),
+					};
+				}
 				return {
-					role: msg.role as "user",
+					role: "user" as const,
 					content: msg.content.map((part) =>
 						part.type === "text"
 							? { type: "text" as const, text: part.text }

--- a/packages/libretto/src/shared/llm/ai-sdk-adapter.ts
+++ b/packages/libretto/src/shared/llm/ai-sdk-adapter.ts
@@ -1,0 +1,65 @@
+import { generateObject, type LanguageModel } from "ai";
+import type { ZodType, infer as ZodInfer } from "zod";
+import type { LLMClient, Message } from "./types.js";
+
+/**
+ * Creates a libretto LLMClient from a Vercel AI SDK LanguageModel.
+ *
+ * This eliminates the need for consumers to write their own adapter
+ * when using @ai-sdk/openai, @ai-sdk/anthropic, @ai-sdk/google-vertex,
+ * or any other Vercel AI SDK-compatible provider.
+ *
+ * @example
+ * ```typescript
+ * import { createLLMClientFromModel } from "libretto/llm";
+ * import { openai } from "@ai-sdk/openai";
+ *
+ * const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+ * ```
+ */
+export function createLLMClientFromModel(model: LanguageModel): LLMClient {
+	return {
+		async generateObject<T extends ZodType>(opts: {
+			prompt: string;
+			schema: T;
+			temperature?: number;
+		}): Promise<ZodInfer<T>> {
+			const { object } = await generateObject({
+				model,
+				schema: opts.schema,
+				prompt: opts.prompt,
+				temperature: opts.temperature ?? 0,
+			});
+			return object;
+		},
+
+		async generateObjectFromMessages<T extends ZodType>(opts: {
+			messages: Message[];
+			schema: T;
+			temperature?: number;
+		}): Promise<ZodInfer<T>> {
+			// Convert libretto Message format to AI SDK message format
+			const messages = opts.messages.map((msg) => {
+				if (typeof msg.content === "string") {
+					return { role: msg.role, content: msg.content };
+				}
+				return {
+					role: msg.role as "user",
+					content: msg.content.map((part) =>
+						part.type === "text"
+							? { type: "text" as const, text: part.text }
+							: { type: "image" as const, image: part.image },
+					),
+				};
+			});
+
+			const { object } = await generateObject({
+				model,
+				schema: opts.schema,
+				messages,
+				temperature: opts.temperature ?? 0,
+			});
+			return object;
+		},
+	};
+}

--- a/packages/libretto/src/shared/llm/index.ts
+++ b/packages/libretto/src/shared/llm/index.ts
@@ -1,2 +1,3 @@
 export type { LLMClient, Message, MessageContentPart } from "./types.js";
 export { createLLMClient } from "./client.js";
+export { createLLMClientFromModel } from "./ai-sdk-adapter.js";

--- a/packages/libretto/src/shared/llm/types.ts
+++ b/packages/libretto/src/shared/llm/types.ts
@@ -15,14 +15,46 @@ export type Message = {
  * Users provide their own implementation backed by any LLM provider
  * (OpenAI, Anthropic, etc.). Libretto uses this interface for AI extraction,
  * recovery agents, and error detection.
+ *
+ * **Error handling:** implementations should throw on failure rather than
+ * returning sentinel values (e.g. `null` or `undefined`). Libretto relies
+ * on exceptions to trigger retry/recovery logic.
+ *
+ * A ready-made adapter for the Vercel AI SDK is available via
+ * {@link createLLMClientFromModel} in `libretto/llm`.
  */
 export interface LLMClient {
+	/**
+	 * Generate a structured object from a single text prompt.
+	 *
+	 * The underlying model **must** support structured / JSON output so that
+	 * the response can be parsed and validated against the provided Zod schema.
+	 *
+	 * @param opts.prompt - The text prompt sent to the model.
+	 * @param opts.schema - A Zod schema describing the expected response shape.
+	 * @param opts.temperature - Sampling temperature (default chosen by implementation, typically 0).
+	 * @returns The parsed object matching the schema.
+	 * @throws On LLM or parsing failure.
+	 */
 	generateObject<T extends z.ZodType>(opts: {
 		prompt: string;
 		schema: T;
 		temperature?: number;
 	}): Promise<z.infer<T>>;
 
+	/**
+	 * Generate a structured object from a conversation-style message array.
+	 *
+	 * Messages may contain **image content** (base64 data URIs via
+	 * {@link MessageContentPart}), so the backing model must support
+	 * vision / multimodal input when images are present.
+	 *
+	 * @param opts.messages - Ordered list of user/assistant messages, potentially multimodal.
+	 * @param opts.schema - A Zod schema describing the expected response shape.
+	 * @param opts.temperature - Sampling temperature (default chosen by implementation, typically 0).
+	 * @returns The parsed object matching the schema.
+	 * @throws On LLM or parsing failure.
+	 */
 	generateObjectFromMessages<T extends z.ZodType>(opts: {
 		messages: Message[];
 		schema: T;


### PR DESCRIPTION
## Summary

- **R1: AI SDK Adapter** — New `createLLMClientFromModel()` function that wraps any Vercel AI SDK `LanguageModel` into libretto's `LLMClient` interface. Consumers no longer need to write manual adapters when using `@ai-sdk/openai`, `@ai-sdk/anthropic`, etc.
- **R2: Init Command** — New `npx libretto init` command that copies skill files to `.agents/` and `.claude/` directories, installs Playwright Chromium, and checks for LLM credentials. Also adds a console nudge when skills are missing during normal CLI usage.
- **R4: README** — Rewrote the npm README with a concise quick-start guide, installation notes for pnpm users (`onlyBuiltDependencies`), and a clean module exports table.
- **R6: JSDoc** — Added comprehensive JSDoc to `LLMClient` interface and both methods, documenting parameters, error handling expectations, and linking to the adapter.

## Context

These changes come from a real integration test of libretto into the monorepo's browser-agent. The integration surfaced several friction points; these four fixes address the highest-priority items.

**Known remaining issue:** libretto depends on `ai@^6.x` but the monorepo uses `ai@5.x`, making `createLLMClientFromModel` unusable there until the version mismatch is resolved (either by widening the peer dep or by upgrading the consumer).

## Test plan

- [ ] Verify `npx libretto init` copies skills and installs Chromium
- [ ] Verify `createLLMClientFromModel` works with `@ai-sdk/openai` and `@ai-sdk/anthropic`
- [ ] Verify README renders correctly on npm
- [ ] Verify existing CLI commands still work (no regressions from init registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)