### PR TITLE
Improve README structure and init AI runtime guidance

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -45,12 +45,12 @@ Built-in sessions: `default`, `dev-server`, `browser-agent`.
 
 Add `--visualize` to any `exec` command to show a ghost cursor and element highlight before each action executes. Use it when the user wants to see what will be clicked/filled before it happens.
 
-## Workflow Pause/Resume (`ctx.pause()`)
+## Workflow Pause/Resume (`pause()`)
 
-Workflows pause from inside the workflow function by calling `await ctx.pause()`.
+Workflows pause by calling `await pause()` (imported from `"libretto"`). In production (`NODE_ENV=production`) it is a no-op.
 
 - There are no pause options to pass at call sites. Pause is session-scoped and resolved from the active session.
-- `npx libretto run ...` waits until the workflow either completes or hits the next `ctx.pause()`.
+- `npx libretto run ...` waits until the workflow either completes or hits the next `pause()`.
 - On pause, the workflow process stays alive and keeps browser/session state.
 - `npx libretto resume --session <name>` sends resume signal and then waits until completion or the next pause.
 - For multi-pause workflows, call `resume` repeatedly until the workflow completes.
@@ -326,7 +326,7 @@ The browser stays open indefinitely until explicitly closed with `npx libretto c
 
 If the site requires login, ask the user how auth should work in the generated workflow:
 
-1. Save a local profile (recommended for local runs): open in `--headed`, have the user log in manually, run `npx libretto save <domain>`, and generate workflow metadata with `authProfile: { type: "local", domain: "<hostname>" }`.
+1. Save a local profile (recommended for local runs): open in `--headed`, have the user log in manually, run `npx libretto save <domain>`, and pass `--auth-profile <domain>` when running the workflow (e.g. `npx libretto run ./file.ts main --auth-profile example.com`).
 2. Use user-managed credential logic in Playwright code (no local profile dependency).
 
 If local profile is chosen, include this warning in your generated workflow guidance: local profiles are machine-local (other users/environments will not have them), and sessions can expire so re-login/re-save may be required.

--- a/.agents/skills/libretto/code-generation-rules.md
+++ b/.agents/skills/libretto/code-generation-rules.md
@@ -7,7 +7,7 @@ These rules apply when generating production TypeScript files from interactive b
 Generated files must export a `workflow()` instance so they can be run via `npx libretto run <file> <exportName>`. Import `workflow` and its types from `"libretto"`:
 
 ```typescript
-import { workflow, type LibrettoWorkflowContext } from "libretto";
+import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
 
 type Input = {
   // Define the expected input shape — passed via --params JSON
@@ -21,15 +21,11 @@ type Output = {
 };
 
 export const myWorkflow = workflow<Input, Output>(
-  {
-    // If the site requires a saved login session:
-    authProfile: { type: "local", domain: "example.com" },
-    // Omit authProfile if no login is needed
-  },
-  async (ctx: LibrettoWorkflowContext, input: Input): Promise<Output> => {
+  {},
+  async (ctx, input): Promise<Output> => {
     const { page } = ctx;
 
-    // workflow logic here — use ctx.page, ctx.context, ctx.browser
+    // workflow logic here — use ctx.page, ctx.logger, ctx.services
     await page.goto("https://example.com");
     // ...
 
@@ -41,10 +37,47 @@ export const myWorkflow = workflow<Input, Output>(
 **Key points:**
 
 - The named export (e.g., `myWorkflow`) is what you pass as the second arg to `npx libretto run ./file.ts myWorkflow`
-- `ctx` provides `page`, `context`, `browser`, `session`, `logger`, `headless`, `integrationPath`, `exportName`
+- `ctx` provides `page`, `logger`, and `services` (generic, default `{}`)
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
-- If `authProfile` is set with a domain, libretto loads the saved browser profile for that domain (created via `npx libretto save <domain>`)
+- If the site requires a saved login session, pass `--auth-profile <domain>` to the CLI (created via `npx libretto save <domain>`)
+- Use `await pause()` (imported from `"libretto"`) to pause the workflow for debugging. It is a no-op in production.
 - The browser is launched and closed automatically by the CLI — do not launch or close it in the handler
+
+## Passing Application Dependencies via Services
+
+Use the third generic on `workflow<Input, Output, Services>` to inject
+dependencies that exist in your application but not in libretto's runtime
+(DB transactions, API clients, caches, etc.):
+
+```typescript
+import { type Transaction } from "./db";
+
+type MyServices = { tx?: Transaction };
+
+export const myWorkflow = workflow<Input, Output, MyServices>(
+  {},
+  async (ctx, input) => {
+    if (ctx.services.tx) {
+      await ctx.services.tx.insert(/* ... */);
+    } else {
+      ctx.logger.info("No DB transaction — skipping write");
+    }
+    // ... browser automation ...
+  },
+);
+```
+
+In production, the caller passes services when invoking `.run()`:
+
+```typescript
+await myWorkflow.run(
+  { page, logger, services: { tx } },
+  input,
+);
+```
+
+When running standalone via `npx libretto run`, services defaults to `{}`,
+so mark fields optional for anything unavailable in that context.
 
 ## Playwright Locators for DOM Interaction
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,64 @@
-# libretto monorepo
+# Libretto
 
-## workspace packages
+Libretto gives your coding agent superpowers for building, debugging, and maintaining browser RPA integrations.
 
-- `packages/libretto` - the core library package
-- `packages/libretto-cli` - the CLI package
+It is designed for engineering teams that automate workflows in web apps and want to move from brittle browser-only scripts to faster, more reliable network-first integrations.
 
-## development
+## Installation
+
+Install Libretto in your project:
 
 ```bash
-pnpm install
+pnpm add libretto playwright zod
+npx libretto init
+```
+
+## Usage
+
+Libretto is usually used through prompts with the Libretto skill.
+
+### One-shot script generation
+
+```text
+Use the Libretto skill. Go on LinkedIn and scrape the first 10 posts for content, who posted it, the number of reactions, the first 25 comments, and the first 25 reposts.
+```
+
+### Interactive script building
+
+```text
+Use the Libretto skill. Let's interactively build a script to scrape scheduling info from the eClinicalWorks EHR.
+```
+
+### Convert browser automation to network requests
+
+```text
+We have a browser script at ./integration.ts that automates going to Hacker News and getting the first 10 posts. Convert it to direct network scripts instead. Use the Libretto skill.
+```
+
+### Fix broken integrations
+
+```text
+We have a browser script at ./integration.ts that is supposed to go to Availity and perform an eligibility check for a patient. But I'm getting a broken selector error when I run it. Fix it. Use the Libretto skill.
+```
+
+You can also run workflows directly from the CLI:
+
+```bash
+npx libretto help
+npx libretto run ./integration.ts main
+```
+
+## Authors
+
+Maintained by the team at [Saffron Health](https://saffron.health).
+
+## Development
+
+For local development in this monorepo:
+
+```bash
+pnpm i
 pnpm build
 pnpm type-check
-pnpm --filter libretto-cli dev
+pnpm test
 ```
-
-## cli safety mode
-
-`libretto-cli open` starts sessions in read-only mode by default. `exec` and `run` are blocked until the session is explicitly made interactive.
-
-```bash
-# default: read-only session (exec blocked)
-libretto-cli open https://example.com
-
-# user explicitly approves this session for actions
-libretto-cli session-mode interactive --session default
-
-# now action commands can run in that session
-libretto-cli exec "return await page.url()" --session default
-libretto-cli run ./integration.ts main --session default
-
-# lock it back down afterward
-libretto-cli session-mode read-only --session default
-```
-
-## AI configuration
-
-Analysis commands use a shared AI runtime config file at `.libretto/config.json`.
-There are two ways to configure it:
-
-### Option 1: External coding agent (recommended)
-
-Configure an external coding agent — no API keys needed in libretto, the agent handles its own authentication:
-
-```bash
-# Use one of: codex, claude, gemini
-libretto-cli ai configure codex
-libretto-cli ai configure claude
-libretto-cli ai configure gemini
-
-# Optionally provide a custom command prefix
-libretto-cli ai configure codex -- my-custom-codex --flag
-
-# Show current configuration
-libretto-cli ai configure
-
-# Clear configuration
-libretto-cli ai configure --clear
-```
-
-### Option 2: Built-in LLM client via environment variables
-
-If no external agent is configured, the CLI falls back to its built-in LLM client. This requires at least one of the following environment variables to be set:
-
-- `GOOGLE_CLOUD_PROJECT` or `GCLOUD_PROJECT` — for Google/Gemini models
-- `ANTHROPIC_API_KEY` — for Anthropic models
-- `OPENAI_API_KEY` — for OpenAI models
-
-If neither an external agent nor any of these environment variables are configured, analysis commands (including `snapshot`) will fail with an error.

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -4,10 +4,19 @@ import { join, dirname, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REPO_ROOT } from "../core/context.js";
-import { formatCommandPrefix, readAiConfig } from "../core/ai-config.js";
+import {
+	AI_CONFIG_PRESETS,
+	AiPresetSchema,
+	formatCommandPrefix,
+	readAiConfig,
+} from "../core/ai-config.js";
 
-const AI_RUNTIME_COMMANDS = ["codex", "claude", "gemini"] as const;
-type AIRuntimeCommand = (typeof AI_RUNTIME_COMMANDS)[number];
+const AI_RUNTIME_PRESETS = AiPresetSchema.options;
+type AIRuntimePreset = (typeof AI_RUNTIME_PRESETS)[number];
+
+function getPresetCommand(preset: AIRuntimePreset): string {
+	return AI_CONFIG_PRESETS[preset][0] ?? "";
+}
 
 function isCommandDefined(command: string | undefined): boolean {
 	if (!command) return false;
@@ -41,15 +50,15 @@ function isCommandDefined(command: string | undefined): boolean {
 	return pathEntries.some((dir) => existsSync(join(dir, command)));
 }
 
-function detectAvailableAiRuntimeCommands(): AIRuntimeCommand[] {
-	return AI_RUNTIME_COMMANDS.filter((command): command is AIRuntimeCommand =>
-		isCommandDefined(command),
+function detectAvailableAiRuntimeCommands(): AIRuntimePreset[] {
+	return AI_RUNTIME_PRESETS.filter((preset): preset is AIRuntimePreset =>
+		isCommandDefined(getPresetCommand(preset)),
 	);
 }
 
 function printAiConfigureCommands(prefix: string = "    "): void {
-	for (const command of AI_RUNTIME_COMMANDS) {
-		console.log(`${prefix}npx libretto ai configure ${command}`);
+	for (const preset of AI_RUNTIME_PRESETS) {
+		console.log(`${prefix}npx libretto ai configure ${preset}`);
 	}
 }
 

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -62,6 +62,12 @@ function printAiConfigureCommands(prefix: string = "    "): void {
 	}
 }
 
+function printDifferentAnalyzerHint(prefix: string = "    "): void {
+	console.log(
+		`${prefix}Use npx libretto ai configure <gemini|claude|codex> to configure a different AI analyzer.`,
+	);
+}
+
 function getSkillSourceDir(): string {
 	// Resolve relative to this file's location in the package
 	const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -124,10 +130,17 @@ function checkAiRuntimeConfiguration(): void {
 	const availableCommands = detectAvailableAiRuntimeCommands();
 
 	console.log("\nAI runtime configuration:");
+	console.log(
+		"  Libretto can use your coding agent as a subagent to analyze snapshots and other page signals.",
+	);
+	console.log(
+		"  This is optional, but it significantly improves page understanding and debugging performance.",
+	);
 	if (configReadError) {
 		console.log(`  \u2717 Could not read AI config: ${configReadError}`);
 		console.log("    Reconfigure with:");
 		printAiConfigureCommands("      ");
+		printDifferentAnalyzerHint("    ");
 		return;
 	}
 
@@ -144,6 +157,7 @@ function checkAiRuntimeConfiguration(): void {
 			}
 			console.log("    Reconfigure with:");
 			printAiConfigureCommands("      ");
+			printDifferentAnalyzerHint("    ");
 			return;
 		}
 
@@ -151,6 +165,7 @@ function checkAiRuntimeConfiguration(): void {
 			`  \u2713 Configured (${config.preset}): ${formatCommandPrefix(config.commandPrefix)}`,
 		);
 		console.log("    Analysis commands are ready to use.");
+		printDifferentAnalyzerHint("    ");
 		return;
 	}
 
@@ -164,6 +179,7 @@ function checkAiRuntimeConfiguration(): void {
 	}
 	console.log("    Configure one with:");
 	printAiConfigureCommands("      ");
+	printDifferentAnalyzerHint("    ");
 	console.log("    Optionally provide a custom command prefix with '-- ...'.");
 }
 

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -154,6 +154,10 @@ function checkAiRuntimeConfiguration(): void {
 				console.log(
 					`    Detected available commands: ${availableCommands.join(", ")}`,
 				);
+			} else {
+				console.log(
+					"    No codex, claude, or gemini analyzer command was detected on PATH.",
+				);
 			}
 			console.log("    Reconfigure with:");
 			printAiConfigureCommands("      ");
@@ -175,7 +179,7 @@ function checkAiRuntimeConfiguration(): void {
 			`    Detected available commands: ${availableCommands.join(", ")}`,
 		);
 	} else {
-		console.log("    codex, claude, and gemini are not currently available to configure.");
+		console.log("    No codex, claude, or gemini analyzer command was detected on PATH.");
 	}
 	console.log("    Configure one with:");
 	printAiConfigureCommands("      ");

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import type { Argv } from "yargs";
-import { existsSync, mkdirSync, cpSync, readdirSync } from "node:fs";
-import { join, dirname, delimiter } from "node:path";
+import { accessSync, constants, existsSync, mkdirSync, cpSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, delimiter, extname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REPO_ROOT } from "../core/context.js";
@@ -18,11 +18,33 @@ function getPresetCommand(preset: AIRuntimePreset): string {
 	return AI_CONFIG_PRESETS[preset][0] ?? "";
 }
 
+function isRunnableFile(filePath: string): boolean {
+	try {
+		const stats = statSync(filePath);
+		if (!stats.isFile()) return false;
+
+		if (process.platform === "win32") {
+			const pathExt = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
+			const extensions = pathExt
+				.split(";")
+				.map((ext) => ext.trim().toUpperCase())
+				.filter(Boolean);
+			const fileExt = extname(filePath).toUpperCase();
+			return extensions.includes(fileExt);
+		}
+
+		accessSync(filePath, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function isCommandDefined(command: string | undefined): boolean {
 	if (!command) return false;
 
 	if (command.includes("/") || command.includes("\\")) {
-		return existsSync(command);
+		return isRunnableFile(command);
 	}
 
 	const pathEnv = process.env.PATH ?? "";
@@ -43,11 +65,11 @@ function isCommandDefined(command: string | undefined): boolean {
 			);
 
 		return pathEntries.some((dir) =>
-			candidates.some((candidate) => existsSync(join(dir, candidate))),
+			candidates.some((candidate) => isRunnableFile(join(dir, candidate))),
 		);
 	}
 
-	return pathEntries.some((dir) => existsSync(join(dir, command)));
+	return pathEntries.some((dir) => isRunnableFile(join(dir, command)));
 }
 
 function detectAvailableAiRuntimeCommands(): AIRuntimePreset[] {

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import type { Argv } from "yargs";
 import { existsSync, mkdirSync, cpSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REPO_ROOT } from "../core/context.js";
@@ -16,14 +16,41 @@ function isCommandDefined(command: string | undefined): boolean {
 		return existsSync(command);
 	}
 
-	const result = spawnSync("which", [command], { stdio: "ignore" });
-	return result.status === 0;
+	const pathEnv = process.env.PATH ?? "";
+	if (!pathEnv) return false;
+
+	const pathEntries = pathEnv.split(delimiter).filter(Boolean);
+	if (process.platform === "win32") {
+		const pathExt = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
+		const extensions = pathExt
+			.split(";")
+			.map((ext) => ext.trim())
+			.filter(Boolean);
+		const hasExtension = /\.[^./\\]+$/.test(command);
+		const candidates = hasExtension
+			? [command]
+			: extensions.map((ext) =>
+				ext.startsWith(".") ? `${command}${ext}` : `${command}.${ext}`,
+			);
+
+		return pathEntries.some((dir) =>
+			candidates.some((candidate) => existsSync(join(dir, candidate))),
+		);
+	}
+
+	return pathEntries.some((dir) => existsSync(join(dir, command)));
 }
 
 function detectAvailableAiRuntimeCommands(): AIRuntimeCommand[] {
 	return AI_RUNTIME_COMMANDS.filter((command): command is AIRuntimeCommand =>
 		isCommandDefined(command),
 	);
+}
+
+function printAiConfigureCommands(prefix: string = "    "): void {
+	for (const command of AI_RUNTIME_COMMANDS) {
+		console.log(`${prefix}npx libretto ai configure ${command}`);
+	}
 }
 
 function getSkillSourceDir(): string {
@@ -76,10 +103,25 @@ function installBrowsers(): void {
 }
 
 function checkAiRuntimeConfiguration(): void {
-	const config = readAiConfig();
+	let config: ReturnType<typeof readAiConfig> = null;
+	let configReadError: string | null = null;
+
+	try {
+		config = readAiConfig();
+	} catch (error) {
+		configReadError = error instanceof Error ? error.message : String(error);
+	}
+
 	const availableCommands = detectAvailableAiRuntimeCommands();
 
 	console.log("\nAI runtime configuration:");
+	if (configReadError) {
+		console.log(`  \u2717 Could not read AI config: ${configReadError}`);
+		console.log("    Reconfigure with:");
+		printAiConfigureCommands("      ");
+		return;
+	}
+
 	if (config) {
 		const configuredCommand = config.commandPrefix[0];
 		if (!isCommandDefined(configuredCommand)) {
@@ -92,9 +134,7 @@ function checkAiRuntimeConfiguration(): void {
 				);
 			}
 			console.log("    Reconfigure with:");
-			console.log("      npx libretto ai configure codex");
-			console.log("      npx libretto ai configure claude");
-			console.log("      npx libretto ai configure gemini");
+			printAiConfigureCommands("      ");
 			return;
 		}
 
@@ -114,9 +154,7 @@ function checkAiRuntimeConfiguration(): void {
 		console.log("    codex, claude, and gemini are not currently available to configure.");
 	}
 	console.log("    Configure one with:");
-	console.log("      npx libretto ai configure codex");
-	console.log("      npx libretto ai configure claude");
-	console.log("      npx libretto ai configure gemini");
+	printAiConfigureCommands("      ");
 	console.log("    Optionally provide a custom command prefix with '-- ...'.");
 }
 

--- a/packages/libretto/src/cli/commands/init.ts
+++ b/packages/libretto/src/cli/commands/init.ts
@@ -4,6 +4,27 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REPO_ROOT } from "../core/context.js";
+import { formatCommandPrefix, readAiConfig } from "../core/ai-config.js";
+
+const AI_RUNTIME_COMMANDS = ["codex", "claude", "gemini"] as const;
+type AIRuntimeCommand = (typeof AI_RUNTIME_COMMANDS)[number];
+
+function isCommandDefined(command: string | undefined): boolean {
+	if (!command) return false;
+
+	if (command.includes("/") || command.includes("\\")) {
+		return existsSync(command);
+	}
+
+	const result = spawnSync("which", [command], { stdio: "ignore" });
+	return result.status === 0;
+}
+
+function detectAvailableAiRuntimeCommands(): AIRuntimeCommand[] {
+	return AI_RUNTIME_COMMANDS.filter((command): command is AIRuntimeCommand =>
+		isCommandDefined(command),
+	);
+}
 
 function getSkillSourceDir(): string {
 	// Resolve relative to this file's location in the package
@@ -54,26 +75,49 @@ function installBrowsers(): void {
 	}
 }
 
-function checkSnapshotLLM(): void {
-	const hasAnyCreds =
-		process.env.GOOGLE_CLOUD_PROJECT ||
-		process.env.GCLOUD_PROJECT ||
-		process.env.ANTHROPIC_API_KEY ||
-		process.env.OPENAI_API_KEY;
+function checkAiRuntimeConfiguration(): void {
+	const config = readAiConfig();
+	const availableCommands = detectAvailableAiRuntimeCommands();
 
-	console.log("\nSnapshot LLM configuration:");
-	if (hasAnyCreds) {
-		console.log("  \u2713 LLM credentials detected");
-	} else {
-		console.log("  \u2717 No LLM credentials found.");
-		console.log("    Set one of the following environment variables:");
-		console.log("      GOOGLE_CLOUD_PROJECT  (for Vertex AI / Gemini)");
-		console.log("      ANTHROPIC_API_KEY     (for Claude)");
-		console.log("      OPENAI_API_KEY        (for GPT)");
+	console.log("\nAI runtime configuration:");
+	if (config) {
+		const configuredCommand = config.commandPrefix[0];
+		if (!isCommandDefined(configuredCommand)) {
+			console.log(
+				`  \u2717 Configured command not found: ${configuredCommand ?? "(empty)"}`,
+			);
+			if (availableCommands.length > 0) {
+				console.log(
+					`    Detected available commands: ${availableCommands.join(", ")}`,
+				);
+			}
+			console.log("    Reconfigure with:");
+			console.log("      npx libretto ai configure codex");
+			console.log("      npx libretto ai configure claude");
+			console.log("      npx libretto ai configure gemini");
+			return;
+		}
+
 		console.log(
-			"    Then configure via: npx libretto ai configure <preset>",
+			`  \u2713 Configured (${config.preset}): ${formatCommandPrefix(config.commandPrefix)}`,
 		);
+		console.log("    Analysis commands are ready to use.");
+		return;
 	}
+
+	console.log("  \u2717 No AI config set.");
+	if (availableCommands.length > 0) {
+		console.log(
+			`    Detected available commands: ${availableCommands.join(", ")}`,
+		);
+	} else {
+		console.log("    codex, claude, and gemini are not currently available to configure.");
+	}
+	console.log("    Configure one with:");
+	console.log("      npx libretto ai configure codex");
+	console.log("      npx libretto ai configure claude");
+	console.log("      npx libretto ai configure gemini");
+	console.log("    Optionally provide a custom command prefix with '-- ...'.");
 }
 
 export function registerInitCommand(yargs: Argv): Argv {
@@ -104,7 +148,7 @@ export function registerInitCommand(yargs: Argv): Argv {
 				console.log("\nSkipping browser installation (--skip-browsers)");
 			}
 
-			checkSnapshotLLM();
+			checkAiRuntimeConfiguration();
 
 			console.log("\n\u2713 libretto init complete");
 		},


### PR DESCRIPTION
## Summary
- rewrite the root README for browser-RPA developer audiences with clearer install and usage examples
- add a dedicated Development section at the bottom of the README
- update `libretto init` AI messaging to focus on `ai configure` rather than env vars
- detect whether `codex`, `claude`, or `gemini` commands are available and surface when they are not available to configure
- clarify in `init` that coding-agent analyzer integration is optional, explain why it helps, and add explicit guidance for switching analyzers

## Validation
- pnpm --filter libretto type-check
