### PR TITLE
Fix inconsistent MinimalLogger data parameter types

### DIFF
--- a/packages/libretto/src/shared/logger/logger.ts
+++ b/packages/libretto/src/shared/logger/logger.ts
@@ -12,7 +12,7 @@ export type LogOptions = {
  * implement withScope, withContext, flush, etc.
  */
 export type MinimalLogger = {
-	info: (event: string, data?: Record<string, any>) => void;
+	info: (event: string, data?: any) => void;
 	warn: (event: string, data?: any) => void;
 	error: (event: string, data?: any) => any;
 };
@@ -47,7 +47,7 @@ export type LoggerApi = {
 	) => void;
 	info: (
 		event: string,
-		data?: Record<string, any>,
+		data?: Error | ({ error: Error } & Record<string, any>) | unknown,
 		options?: LogOptions,
 	) => void;
 
@@ -273,8 +273,41 @@ export class Logger implements LoggerApi {
 		});
 	}
 
-	info(event: string, data?: Record<string, any>, options?: LogOptions) {
-		this.entry({ level: "info", event, data, options });
+	info(
+		event: string,
+		dataOrError?: Error | ({ error: Error } & Record<string, any>) | unknown,
+		options?: LogOptions,
+	) {
+		const data =
+			dataOrError instanceof Error
+				? {
+						error: {
+							type: dataOrError.constructor.name,
+							message: dataOrError.message,
+							stack: dataOrError.stack || null,
+						},
+					}
+				: isObject(dataOrError) && dataOrError.error instanceof Error
+					? {
+							...dataOrError,
+							error: {
+								type: dataOrError.error.constructor.name,
+								message: dataOrError.error.message,
+								stack: dataOrError.error.stack || null,
+							},
+						}
+					: isObject(dataOrError)
+						? dataOrError
+						: dataOrError !== undefined
+							? { error: dataOrError }
+							: undefined;
+
+		this.entry({
+			level: "info",
+			event,
+			data: data as Record<string, any>,
+			options,
+		});
 	}
 
 	withScope(scope: string, context: Record<string, any> = {}): LoggerApi {


### PR DESCRIPTION
## Summary
- The `info` method on `MinimalLogger`, `LoggerApi`, and the `Logger` class restricted its `data` parameter to `Record<string, any>`, while `warn` and `error` accepted `any`/`unknown`. This inconsistency could cause type errors when callers pass non-record data (e.g., `Error` objects) to `info`.
- Updated all three `info` signatures to accept the same data types as `warn` and `error`.
- Updated the `Logger.info` implementation to normalize `Error` values the same way `warn` and `error` already do.

## Test plan
- [x] `pnpm type-check` passes cleanly
- [x] `pnpm build` succeeds with no errors
- [x] Verified all existing `.info()` call sites pass object literals — widening the type does not break any existing callers
- [x] Existing test failures are pre-existing (missing OpenAI API key secret), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)