### PR TITLE
chore: bump libretto version to 0.3.0

### DIFF
--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump `libretto` package version from `0.2.4` to `0.3.0`

## Testing
- `pnpm --filter libretto publish` (successful publish of `libretto@0.3.0`)
