### PR TITLE
Add eval framework and manual Evals workflow

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,6 +3,9 @@ name: Evals
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,40 @@
+name: Evals
+
+on:
+  workflow_dispatch:
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Validate eval credentials
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "ANTHROPIC_API_KEY secret is required to run evals." >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: pnpm eval

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"cli": "pnpm --filter libretto exec node bin/libretto.mjs",
 		"dev": "pnpm --filter libretto build && pnpm --filter libretto exec node dist/cli/index.js",
 		"test": "pnpm --filter libretto test",
+		"eval": "pnpm --filter libretto eval",
 		"test:watch": "pnpm --filter libretto test:watch"
 	},
 	"devDependencies": {

--- a/packages/libretto/evals/fixtures.ts
+++ b/packages/libretto/evals/fixtures.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { test as base } from "vitest";
+import { ClaudeEvalHarness, ensureClaudeAuthConfigured } from "./harness.js";
+
+type EvalFixtures = {
+  harness: ClaudeEvalHarness;
+};
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const packageRoot = resolve(here, "..");
+const repoRoot = resolve(packageRoot, "../..");
+const skillPath = resolve(packageRoot, "skill/SKILL.md");
+
+let cachedSkillMarkdown: string | null = null;
+
+async function getSkillMarkdown(): Promise<string> {
+  if (cachedSkillMarkdown !== null) return cachedSkillMarkdown;
+  cachedSkillMarkdown = await readFile(skillPath, "utf8");
+  return cachedSkillMarkdown;
+}
+
+export const test = base.extend<EvalFixtures>({
+  harness: async ({}, use) => {
+    ensureClaudeAuthConfigured();
+    const harness = new ClaudeEvalHarness({
+      cwd: repoRoot,
+      model: process.env.LIBRETTO_EVAL_MODEL?.trim() || undefined,
+      librettoSkillMarkdown: await getSkillMarkdown(),
+    });
+    try {
+      await use(harness);
+    } finally {
+      await harness.close();
+    }
+  },
+});
+
+export { expect } from "vitest";

--- a/packages/libretto/evals/harness.ts
+++ b/packages/libretto/evals/harness.ts
@@ -263,10 +263,6 @@ export class EvalResponse {
     this.model = opts.model;
   }
 
-  text(): string {
-    return this.transcript;
-  }
-
   async evaluate(assertion: string): Promise<EvaluationVerdict> {
     const verdict = await evaluateTranscript({
       assertion,

--- a/packages/libretto/evals/harness.ts
+++ b/packages/libretto/evals/harness.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  query,
+  type Options,
+  type PermissionMode,
+  type SDKAssistantMessage,
+  type SDKMessage,
+  type SDKResultMessage,
+  type SettingSource,
+} from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const EvaluationVerdictSchema = z.object({
+  success: z.boolean(),
+  reason: z.string().trim().min(1),
+});
+
+const EVAL_GCP_PROJECT = "saffron-health";
+const ANTHROPIC_API_KEY_SECRET_NAME = "anthropic-api-key";
+
+let didAttemptSecretLoad = false;
+
+const MAX_TRANSCRIPT_CHARS = 20_000;
+
+type EvaluationVerdict = z.infer<typeof EvaluationVerdictSchema>;
+
+function clip(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n[truncated to first ${maxChars} chars]`;
+}
+
+function asJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getSecret(secretName: string): string {
+  const result = spawnSync(
+    "gcloud",
+    [
+      "secrets",
+      "versions",
+      "access",
+      "latest",
+      `--project=${EVAL_GCP_PROJECT}`,
+      `--secret=${secretName}`,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status === 0 && result.stdout.trim().length > 0) {
+    return result.stdout.trim();
+  }
+  return "";
+}
+
+function ensureClaudeAuthEnvFromSecretIfNeeded(): void {
+  if (didAttemptSecretLoad) return;
+  didAttemptSecretLoad = true;
+
+  if (typeof process.env.ANTHROPIC_API_KEY === "string" && process.env.ANTHROPIC_API_KEY.trim().length > 0) {
+    return;
+  }
+
+  const value = getSecret(ANTHROPIC_API_KEY_SECRET_NAME);
+  if (value) {
+    process.env.ANTHROPIC_API_KEY = value;
+  }
+}
+
+function hasAnthropicApiKey(): boolean {
+  const value = process.env.ANTHROPIC_API_KEY;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function extractSessionId(messages: SDKMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const candidate = messages[i];
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      "session_id" in candidate &&
+      typeof candidate.session_id === "string" &&
+      candidate.session_id.length > 0
+    ) {
+      return candidate.session_id;
+    }
+  }
+  return null;
+}
+
+function extractResultMessage(messages: SDKMessage[]): SDKResultMessage | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const candidate = messages[i];
+    if (candidate.type === "result") {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function extractAssistantText(message: SDKAssistantMessage): string {
+  const content = message.message.content;
+  if (!Array.isArray(content)) return "";
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const typedBlock = block as Record<string, unknown>;
+    if (typedBlock.type === "text" && typeof typedBlock.text === "string") {
+      parts.push(typedBlock.text);
+      continue;
+    }
+    if (typedBlock.type === "tool_use") {
+      const name =
+        typeof typedBlock.name === "string" && typedBlock.name.length > 0
+          ? typedBlock.name
+          : "unknown_tool";
+      parts.push(`[tool_use:${name}] ${asJson(typedBlock.input)}`);
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+function formatMessagesForEvaluation(messages: SDKMessage[]): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    switch (message.type) {
+      case "assistant": {
+        const assistantText = extractAssistantText(message);
+        if (assistantText) {
+          lines.push(`assistant:\n${assistantText}`);
+        }
+        break;
+      }
+      case "tool_use_summary": {
+        lines.push(`tool_use_summary:\n${message.summary}`);
+        break;
+      }
+      case "result": {
+        if (message.subtype === "success") {
+          lines.push(`result:\n${message.result}`);
+        } else {
+          lines.push(`result_error:\n${message.errors.join("\n")}`);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return lines.join("\n\n").trim();
+}
+
+async function evaluateTranscript(opts: {
+  assertion: string;
+  transcript: string;
+  cwd: string;
+  model?: string;
+}): Promise<EvaluationVerdict> {
+  const prompt = [
+    "Evaluate whether TRANSCRIPT satisfies ASSERTION.",
+    "Return only JSON with keys: success (boolean), reason (string).",
+    "Be strict and set success=false if evidence is missing.",
+    "",
+    `ASSERTION:\n${opts.assertion}`,
+    "",
+    `TRANSCRIPT:\n${clip(opts.transcript, MAX_TRANSCRIPT_CHARS)}`,
+  ].join("\n");
+
+  const messages: SDKMessage[] = [];
+  for await (const message of query({
+    prompt,
+    options: {
+      cwd: opts.cwd,
+      model: opts.model,
+      tools: [],
+      maxTurns: 1,
+      persistSession: false,
+      permissionMode: "dontAsk",
+    },
+  })) {
+    messages.push(message);
+  }
+
+  const result = extractResultMessage(messages);
+  if (!result) {
+    throw new Error("Evaluation failed: no result message from SDK.");
+  }
+  if (result.subtype !== "success") {
+    const details = result.errors.filter((err) => err.trim().length > 0).join("\n");
+    throw new Error(
+      [
+        `Evaluation failed with subtype "${result.subtype}".`,
+        details || "No error details were provided by the SDK.",
+      ].join("\n"),
+    );
+  }
+
+  try {
+    const raw = result.result.trim();
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    const candidate = start >= 0 && end >= start ? raw.slice(start, end + 1) : raw;
+    const parsed = JSON.parse(candidate);
+    const fallback = EvaluationVerdictSchema.safeParse(parsed);
+    if (fallback.success) {
+      return fallback.data;
+    }
+  } catch {
+    // Fall through to explicit error.
+  }
+
+  throw new Error(`Evaluation returned invalid schema output: ${result.result}`);
+}
+
+export function ensureClaudeAuthConfigured(): void {
+  ensureClaudeAuthEnvFromSecretIfNeeded();
+  if (hasAnthropicApiKey()) return;
+  throw new Error(
+    [
+      "Claude eval configuration missing.",
+      `Expected to load ANTHROPIC_API_KEY from gcloud secret "${ANTHROPIC_API_KEY_SECRET_NAME}" in project "${EVAL_GCP_PROJECT}", or have ANTHROPIC_API_KEY already set.`,
+      "Ensure gcloud is installed/authenticated and the secret exists with at least one enabled version.",
+    ].join("\n"),
+  );
+}
+
+export type ClaudeEvalHarnessOptions = {
+  cwd: string;
+  librettoSkillMarkdown: string;
+  model?: string;
+  maxTurns?: number;
+  permissionMode?: PermissionMode;
+  settingSources?: SettingSource[];
+};
+
+export class EvalResponse {
+  readonly prompt: string;
+  readonly messages: SDKMessage[];
+  readonly sessionId: string | null;
+  readonly transcript: string;
+  readonly result: SDKResultMessage | null;
+  private readonly cwd: string;
+  private readonly model?: string;
+
+  constructor(opts: {
+    prompt: string;
+    messages: SDKMessage[];
+    sessionId: string | null;
+    cwd: string;
+    model?: string;
+  }) {
+    this.prompt = opts.prompt;
+    this.messages = opts.messages;
+    this.sessionId = opts.sessionId;
+    this.transcript = formatMessagesForEvaluation(opts.messages);
+    this.result = extractResultMessage(opts.messages);
+    this.cwd = opts.cwd;
+    this.model = opts.model;
+  }
+
+  text(): string {
+    return this.transcript;
+  }
+
+  async evaluate(assertion: string): Promise<EvaluationVerdict> {
+    const verdict = await evaluateTranscript({
+      assertion,
+      transcript: this.transcript,
+      cwd: this.cwd,
+      model: this.model,
+    });
+    if (!verdict.success) {
+      throw new Error(verdict.reason);
+    }
+    return verdict;
+  }
+}
+
+export class ClaudeEvalHarness {
+  private readonly cwd: string;
+  private readonly model?: string;
+  private readonly maxTurns: number;
+  private readonly permissionMode: PermissionMode;
+  private readonly settingSources: SettingSource[];
+  private readonly systemPromptAppend: string;
+  private sessionId: string;
+  private hasStarted = false;
+  private isClosed = false;
+
+  constructor(options: ClaudeEvalHarnessOptions) {
+    this.cwd = options.cwd;
+    this.model = options.model;
+    this.maxTurns = options.maxTurns ?? 20;
+    this.permissionMode = options.permissionMode ?? "bypassPermissions";
+    this.settingSources = options.settingSources ?? ["project"];
+    this.systemPromptAppend = [
+      "Use the following Libretto skill documentation as in-session guidance.",
+      "<libretto_skill>",
+      options.librettoSkillMarkdown,
+      "</libretto_skill>",
+    ].join("\n");
+    this.sessionId = randomUUID();
+  }
+
+  async send(prompt: string): Promise<EvalResponse> {
+    if (this.isClosed) {
+      throw new Error("Cannot send prompts after harness is closed.");
+    }
+
+    const options: Options = {
+      cwd: this.cwd,
+      model: this.model,
+      maxTurns: this.maxTurns,
+      tools: { type: "preset", preset: "claude_code" },
+      settingSources: this.settingSources,
+      permissionMode: this.permissionMode,
+      systemPrompt: {
+        type: "preset",
+        preset: "claude_code",
+        append: this.systemPromptAppend,
+      },
+    };
+
+    if (this.permissionMode === "bypassPermissions") {
+      options.allowDangerouslySkipPermissions = true;
+    }
+
+    if (this.hasStarted) {
+      options.resume = this.sessionId;
+    } else {
+      options.sessionId = this.sessionId;
+    }
+
+    const messages: SDKMessage[] = [];
+    for await (const message of query({ prompt, options })) {
+      messages.push(message);
+    }
+
+    const seenSessionId = extractSessionId(messages);
+    if (seenSessionId) {
+      this.sessionId = seenSessionId;
+      this.hasStarted = true;
+    }
+
+    return new EvalResponse({
+      prompt,
+      messages,
+      sessionId: seenSessionId ?? this.sessionId,
+      cwd: this.cwd,
+      model: this.model,
+    });
+  }
+
+  async close(): Promise<void> {
+    this.isClosed = true;
+  }
+}

--- a/packages/libretto/evals/smoke.spec.ts
+++ b/packages/libretto/evals/smoke.spec.ts
@@ -15,7 +15,7 @@ describe("eval harness smoke", () => {
       );
 
       expect(response.messages.length).toBeGreaterThan(0);
-      expect(response.text()).toContain("LIBRETTO_EVAL_SMOKE_OK");
+      expect(response.transcript).toContain("LIBRETTO_EVAL_SMOKE_OK");
 
       await response.evaluate(
         "The response explains that libretto is for browser automation, identifies snapshot as a command to inspect page contents, and includes LIBRETTO_EVAL_SMOKE_OK.",

--- a/packages/libretto/evals/smoke.spec.ts
+++ b/packages/libretto/evals/smoke.spec.ts
@@ -1,0 +1,26 @@
+import { describe } from "vitest";
+import { expect, test } from "./fixtures.js";
+
+describe("eval harness smoke", () => {
+  test(
+    "runs a single-turn eval with libretto skill context",
+    async ({ harness }) => {
+      const response = await harness.send(
+        [
+          "In exactly 3 bullet points:",
+          "1) Explain what libretto is for.",
+          "2) Name one command from the libretto skill that helps inspect what is on a page.",
+          "3) End the final bullet with the exact token LIBRETTO_EVAL_SMOKE_OK.",
+        ].join("\n"),
+      );
+
+      expect(response.messages.length).toBeGreaterThan(0);
+      expect(response.text()).toContain("LIBRETTO_EVAL_SMOKE_OK");
+
+      await response.evaluate(
+        "The response explains that libretto is for browser automation, identifies snapshot as a command to inspect page contents, and includes LIBRETTO_EVAL_SMOKE_OK.",
+      );
+    },
+    180_000,
+  );
+});

--- a/packages/libretto/evals/smoke.spec.ts
+++ b/packages/libretto/evals/smoke.spec.ts
@@ -21,6 +21,5 @@ describe("eval harness smoke", () => {
         "The response explains that libretto is for browser automation, identifies snapshot as a command to inspect page contents, and includes LIBRETTO_EVAL_SMOKE_OK.",
       );
     },
-    180_000,
   );
 });

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -96,6 +96,7 @@
     "type-check": "tsc --noEmit",
     "dev": "tsx src/cli/index.ts",
     "test": "pnpm run build && vitest run",
+    "eval": "pnpm run build && vitest run --config vitest.evals.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {
@@ -105,11 +106,18 @@
     "zod": ">=3.0.0"
   },
   "peerDependenciesMeta": {
-    "@ai-sdk/anthropic": { "optional": true },
-    "@ai-sdk/google-vertex": { "optional": true },
-    "@ai-sdk/openai": { "optional": true }
+    "@ai-sdk/anthropic": {
+      "optional": true
+    },
+    "@ai-sdk/google-vertex": {
+      "optional": true
+    },
+    "@ai-sdk/openai": {
+      "optional": true
+    }
   },
   "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.73",
     "@ai-sdk/anthropic": "^3.0.53",
     "@ai-sdk/google-vertex": "^4.0.72",
     "@ai-sdk/openai": "^3.0.39",

--- a/packages/libretto/tsconfig.json
+++ b/packages/libretto/tsconfig.json
@@ -13,6 +13,6 @@
 		"outDir": "./dist",
 		"rootDir": "."
 	},
-	"include": ["src/**/*.ts", "test/**/*.ts"],
+	"include": ["src/**/*.ts", "test/**/*.ts", "evals/**/*.ts"],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/libretto/vitest.evals.config.ts
+++ b/packages/libretto/vitest.evals.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "libretto-evals",
+    environment: "node",
+    include: ["evals/**/*.spec.ts"],
+    testTimeout: 180_000,
+    pool: "forks",
+    isolate: true,
+    fileParallelism: true,
+    maxWorkers: "100%",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.39
         version: 3.0.39(zod@3.25.76)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.73
+        version: 0.2.73(zod@3.25.76)
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
@@ -103,6 +106,12 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@anthropic-ai/claude-agent-sdk@0.2.73':
+    resolution: {integrity: sha512-JrHeMl93Q5ai9GMPAffQkSisbbDvD1skU2x6sf6WRzEZw0sK6aTG+XSiZHY2F5aSrfd4G2qUogLHEm6Y8obyOQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -257,6 +266,95 @@ packages:
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -1135,6 +1233,20 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
+  '@anthropic-ai/claude-agent-sdk@0.2.73(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -1211,6 +1323,68 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@isaacs/cliui@8.0.2':


### PR DESCRIPTION
## Summary
- add a dedicated eval harness under `packages/libretto/evals` built on `@anthropic-ai/claude-agent-sdk`
- split evals into a separate Vitest config and command (`pnpm eval`) so `pnpm test` excludes evals
- make eval auth configuration fail-fast (no silent skip) and load `ANTHROPIC_API_KEY` from GCP secret manager
- add a manually triggered GitHub workflow (`Evals`) that runs `pnpm eval`

## Validation
- `pnpm --filter libretto type-check`
- `pnpm --filter libretto eval`
