### PR TITLE
Add condensed DOM snapshots for analyzer workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .vscode/settings.json
 .env
 temp/
+**/tmp/

--- a/packages/libretto/specs/condensed-dom-snapshot.md
+++ b/packages/libretto/specs/condensed-dom-snapshot.md
@@ -1,0 +1,195 @@
+# Condensed DOM Snapshot
+
+## Problem overview
+
+The snapshot analyzer currently captures full `page.content()` HTML and also writes an abbreviated/trimmed HTML artifact for the snapshot run. On complex pages (LinkedIn, EMR portals), the full HTML is 500K–1MB — far exceeding useful context window budgets. The condensed HTML logic needs to be updated so the abbreviated artifact follows the rules in this spec rather than the older tiered trimming behavior.
+
+Other DOM consumers (`extract.ts`, `errors.ts`) have the same problem at smaller scale: they truncate at 30K–50K with a simple slice, losing everything after the cut.
+
+A principled HTML reduction pass that strips high-volume, low-value content before the LLM sees it would let more of the structurally important DOM fit within context limits.
+
+## Solution overview
+
+Add a `condenseDom()` function that transforms serialized HTML strings (the output of `page.content()`) into a reduced form. It operates as a **string transform on already-serialized HTML** — not a browser-side DOM walk, not a parsed DOM tree. This keeps it usable by all three current DOM consumers without changing their capture paths.
+
+For the snapshot CLI specifically, keep the existing artifact pattern: write the full HTML snapshot and the condensed HTML snapshot into the same snapshot run directory as the PNG (for example `page.png`, `page.html`, `page.condensed.html`). The analyzer should be pointed at both files by path so it can start from the condensed DOM and fall back to the full DOM if needed. For `extract.ts` and `errors.ts`, condensation can happen in memory before any length-based truncation; those flows do not need to persist a second HTML artifact.
+
+The function applies a fixed set of reduction rules in order. Each rule targets a category of content that is either redundant with the screenshot, structurally meaningless to a page consumer, or too large relative to its informational value.
+
+The output is **valid HTML** (parseable, with correct nesting preserved). Removed content is either deleted entirely or replaced with an HTML comment placeholder (`<!-- [N chars removed: description] -->`), never with ad-hoc syntax that would break HTML parsing. This matters because the analyzer prompt tells the model to return selectors that exist in the HTML snapshot.
+
+## Goals
+
+- Reduce LinkedIn-class pages from ~950K to under 250K characters while preserving all information needed for selector generation and page-state analysis.
+- Provide a single function usable by `snapshot-analyzer.ts`, `extract.ts`, and `errors.ts` without changing their capture mechanism (`page.content()`).
+- All reduction rules are general (based on observable properties of the HTML), not site-specific.
+- Output remains valid, parseable HTML.
+
+## Non-goals
+
+- No browser-side DOM manipulation or `page.evaluate()` capture paths. The function operates on the serialized HTML string that `page.content()` already returns.
+- No parsed DOM tree walking (e.g., jsdom, cheerio). Rules operate via regex/string transforms on serialized HTML. Rule 10 (empty elements) is deferred to a future phase because it requires tree awareness.
+- No objective-aware trimming. The same rules apply regardless of what the user is asking about.
+- No changes to the LLM prompt or the `InterpretResult` schema.
+- No structural deduplication of repeated siblings (future work).
+
+## Important files
+
+- `packages/libretto/src/cli/core/dom-trimmer.ts` — current implementation (to be renamed/refactored to `condenseDom()`).
+- `packages/libretto/src/cli/core/snapshot-analyzer.ts` — primary consumer. Reads snapshot artifacts by path, tells the analyzer to start from the condensed DOM and fall back to the full DOM.
+- `packages/libretto/src/runtime/extract/extract.ts` — extraction consumer. Captures `page.content()` and truncates at 50K. Lines 54–58.
+- `packages/libretto/src/runtime/recovery/errors.ts` — error detection consumer. Captures `page.content()` and truncates at 50K. Lines 72–77. Explicitly checks DOM for error messages that may not be visible in the screenshot (line 102).
+- `packages/libretto/src/cli/commands/snapshot.ts` — CLI entry point that captures HTML and calls `runInterpret()`.
+
+## Preserve list
+
+The condensed output must retain all of the following, regardless of which rules are applied:
+
+### Interactive elements
+All elements that can receive user interaction: `<a>`, `<button>`, `<input>`, `<select>`, `<textarea>`, `<form>`, `<details>`, `<dialog>`, `<label>`, and any element with `tabindex`, `contenteditable`, `role="button"`, `role="link"`, `role="tab"`, `role="menuitem"`, `role="checkbox"`, `role="radio"`, `role="switch"`, `role="slider"`, or `role="combobox"`.
+
+### Selector-relevant attributes
+- Identity: `id`, `name`, `for`.
+- Testing: `data-testid`, `data-test`, `data-qa`, `data-cy`.
+- Accessibility: `aria-label`, `aria-labelledby`, `aria-expanded`, `aria-selected`, `aria-checked`, `aria-disabled`, `aria-hidden`, `aria-haspopup`, `aria-controls`, `aria-owns`, `aria-live`, `aria-describedby`.
+- Semantic: `role`, `title`, `alt`, `type`, `value`, `placeholder`, `href`, `action`, `method`, `src` (on `<img>`, `<iframe>`, `<video>`, `<audio>`, `<source>`).
+
+### State and visibility signals
+- `disabled`, `hidden`, `inert`, `readonly`, `required`.
+- Inline style properties that affect interactability: `display`, `visibility`, `opacity`, `pointer-events`, `position`, `z-index`, `overflow` (and sub-properties like `overflow-x`).
+
+### All text content
+All text nodes, including text inside `aria-hidden="true"` elements, screen-reader-only spans, hidden validation messages, and live regions. The `errors.ts` consumer explicitly needs DOM text that is not visible in the screenshot (line 102), and `aria-label` values on other elements often reference this hidden text. "All text nodes" means: if a text node exists in the serialized HTML, it survives condensing.
+
+### Structural nesting
+The ancestor chain of every preserved element remains intact. No rule may delete a container element that has preserved descendants. Rules may strip _attributes_ from container elements but never remove the element itself if doing so would change the nesting context of a preserved descendant.
+
+## Reduction rules
+
+Rules are applied in the order listed below, always. There is no conditional "apply if over target size" logic — all rules run unconditionally, because they target content that is low-value regardless of page size. The `truncateText()` head/tail fallback remains as a final safety net after all rules have been applied.
+
+### Rule 1: Noscript blocks
+**Remove** `<noscript>` elements and their contents entirely. The page runs in a browser with JavaScript enabled; noscript content is never rendered or interactive.
+
+### Rule 2: HTML comments
+**Remove** all HTML comments (`<!-- ... -->`), except IE conditional comments (`<!--[if ...`). Build artifacts and framework markers.
+
+### Rule 3: Script contents
+**Hollow out** `<script>` tags: keep the opening and closing tags with all attributes (`src`, `type`, `id`, `defer`, `async`), replace the inline content with `<!-- [script, N chars] -->`. For `<script type="application/json">` or `application/ld+json`, use `<!-- [JSON data, N chars] -->`.
+
+**Why keep the tag:** The `src` attribute tells the model what scripts are loaded. The placeholder tells the model a script existed and how large it was.
+
+### Rule 4: Style contents
+**Hollow out** `<style>` tags: keep the tag with attributes, replace content with `<!-- [CSS, N chars] -->`.
+
+### Rule 5: Embedded binary data
+**Replace** base64 data URIs in `src` and `href` attributes with `[base64 <mime-type>]`. The model cannot decode base64; the screenshot shows the image.
+
+### Rule 6: Large opaque attribute values
+**Truncate** any attribute value longer than 200 characters that is not on the preserve list. The preserve list for this rule is the full selector-relevant attribute set from above: `id`, `name`, `for`, `data-testid`, `data-test`, `data-qa`, `data-cy`, `aria-label`, `aria-labelledby`, `aria-describedby`, `aria-expanded`, `aria-selected`, `aria-checked`, `aria-disabled`, `aria-hidden`, `aria-haspopup`, `aria-controls`, `aria-owns`, `aria-live`, `role`, `title`, `alt`, `type`, `value`, `placeholder`, `href`, `action`, `method`, and the allowed `src` attributes. Replace all other long values with `[N chars]`.
+
+This is general — it catches `data-*` tracking blobs, serialized state, encoded configs, and any other long machine-readable values, without needing to enumerate specific attribute names.
+
+### Rule 7: SVG elements
+**Collapse** each `<svg>` element into a single tag, preserving its `id`, `class`, `role`, `aria-label`, `aria-hidden`, `title`, and `data-testid` attributes. Replace all children with a single `<!-- [icon] -->` comment — except: if the SVG contains a `<title>` or `<desc>` child, extract that text and include it as `aria-label` on the collapsed `<svg>` (if no `aria-label` already exists). This ensures icon-only buttons whose label comes from an SVG `<title>` don't lose their only textual identifier.
+
+**Rationale:** On normal websites, SVG contents are overwhelmingly geometry (`<path>`, `<circle>`, `<rect>`, `<polygon>`, `<g>`, etc.), not rich HTML content. The bulky part is usually path data and other vector internals, which do not help with selector generation. The only SVG content we care about preserving is labeling and selector-relevant outer attributes.
+
+**Output example:**
+```html
+<svg role="img" aria-label="Like"><!-- [icon] --></svg>
+```
+
+### Rule 8: Inline style properties
+**Strip** visual-only CSS properties from `style=""` attributes. Keep only: `display`, `visibility`, `opacity`, `pointer-events`, `position`, `z-index`, `overflow`, `overflow-x`, `overflow-y`. Remove the entire `style` attribute if no properties survive.
+
+### Rule 9: Non-semantic class names
+**Strip** individual class names from `class=""` attributes that are obfuscated or hash-like. Keep class names that appear semantically meaningful.
+
+Detection heuristic (classify as **obfuscated** if any match):
+- Matches `_?[0-9a-f]{6,}` (hex hash, possibly underscore-prefixed).
+- Matches `[a-z]+_[0-9a-f]{4,}` (CSS module pattern: word + hash suffix).
+- Matches `[a-z]{1,2}[0-9]+` (short random: `a1`, `b42`).
+- Has 6+ characters and digit-to-letter ratio ≥ 0.5 with at least 2 digits.
+
+If all classes on an element are stripped, remove the entire `class` attribute. If some remain, keep only the surviving ones.
+
+**Cost of false positives:** On pages that expose _only_ hash-like classes (no `id`, `data-testid`, `aria-label`, or `role`), stripping classes can make selector generation harder. This is an accepted tradeoff — such pages already have poor selector surface, and the model can fall back to structural/positional selectors or text-based matching. The class names change between builds anyway, so selectors based on them would be fragile.
+
+### Rule 10: Cross-reference ID attributes
+**Keep** `aria-labelledby`, `aria-describedby`, `aria-controls`, and `aria-owns`.
+
+`aria-labelledby` is usually short and low-cost, and it preserves the explicit relationship between a control and the element that provides its accessible name. That relationship is useful for icon-only buttons, custom controls, and controls named by off-element or hidden text. The token savings from removing it are too small to justify the loss of information.
+
+`aria-describedby`, `aria-controls`, and `aria-owns` also convey structural relationships (which panel does this tab control? what element describes this input's validation error?) that are not always obvious from DOM nesting. `aria-describedby` in particular is used by the error detection flow to link controls to their validation messages.
+
+### Rule 11: Framework-internal and SVG visual attributes
+**Remove** attributes that match these categories:
+
+- **XML namespace declarations:** `xmlns`, `xmlns:*`, `xml:space`, `xml:lang`.
+- **SVG visual attributes** (only meaningful after Rule 7 if SVGs survived): `fill`, `stroke`, `stroke-width`, `stroke-linecap`, `stroke-linejoin`, `stroke-miterlimit`, `stroke-dasharray`, `stroke-dashoffset`, `stroke-opacity`, `fill-opacity`, `clip-rule`, `fill-rule`, `focusable` (on SVGs).
+
+Framework-internal attributes (like LinkedIn's `componentkey`) are handled by Rule 6 if their values are long, or by being non-semantic single-word non-standard attributes. Rather than maintaining a blocklist, we accept that short framework attributes (a few chars each) are low-cost to leave in. The 200-char threshold in Rule 6 catches the expensive ones.
+
+### Rule 12: Whitespace
+**Collapse** runs of spaces/tabs to a single space. Collapse multiple blank lines to a single newline. **Preserve** whitespace inside `<pre>` elements.
+
+This rule preserves text content semantically, not byte-for-byte. Text nodes survive, but non-meaningful whitespace is normalized outside `<pre>`.
+
+## Output contract
+
+```typescript
+type CondenseDomResult = {
+  /** The condensed HTML string. Valid, parseable HTML. */
+  html: string;
+  /** Character count of the input. */
+  originalLength: number;
+  /** Character count of the output. */
+  condensedLength: number;
+  /** Characters removed, keyed by rule name. */
+  reductions: Record<string, number>;
+};
+
+function condenseDom(html: string): CondenseDomResult;
+```
+
+The function takes a serialized HTML string (as returned by `page.content()`) and returns a condensed HTML string. There are no tiers, no configuration, no target size parameter. All rules always run. The existing `truncateText()` in `snapshot-analyzer.ts` remains as a separate downstream safety net.
+
+## Implementation
+
+### Phase 1: Rename and consolidate
+
+Rename `dom-trimmer.ts` to `condense-dom.ts`. Rename `trimDOM()` to `condenseDom()`. Remove the `tier` parameter — all rules always apply. Update the return type to `CondenseDomResult` (drop `tiersApplied`). Update imports in `snapshot-analyzer.ts` and `snapshot.ts`.
+
+Preserve the snapshot artifact workflow: after `page.content()` is captured in `snapshot.ts`, write both the raw HTML and the condensed HTML into the snapshot run directory next to the PNG. The condensed artifact should replace the current "trimmed" artifact conceptually, but still exist as a separate file on disk so the analyzer can read it first and the user can inspect it manually.
+
+- [ ] Rename file and function.
+- [ ] Remove tier gating logic.
+- [ ] Keep writing snapshot artifacts to the snapshot run directory: `page.png`, `page.html`, and `page.condensed.html` (or equivalent naming).
+- [ ] Replace non-HTML placeholders (`/* [script, N chars] */`, `[icon]`) with HTML comment placeholders (`<!-- [script, N chars] -->`, `<!-- [icon] -->`).
+- [ ] Update SVG collapse to extract `<title>`/`<desc>` text before collapsing.
+- [ ] Keep `aria-labelledby` in the condensed output; do not strip cross-reference ARIA attributes.
+- [ ] Update Rule 6 so long-value truncation exempts the full selector-relevant preserve list rather than a smaller ad hoc subset.
+- [ ] Remove `componentkey` and similar from the hardcoded framework attribute list; rely on Rule 6 for long values and accept short ones as low-cost noise.
+- [ ] Update `snapshot.ts` and `snapshot-analyzer.ts` so the analyzer is given both artifact paths and starts from the condensed HTML file, using the full HTML file only as a fallback for missing detail.
+- [ ] Success criteria: `pnpm -C packages/libretto exec tsc --noEmit` passes. Manually run `snapshot --objective "..."` on an active session and confirm the output includes condensation stats and analysis results.
+
+### Phase 2: Wire into extract and errors consumers
+
+- [ ] In `extract.ts` (line 38 and 54), call `condenseDom()` on `domContent` before the length-based truncation. This replaces the blunt 30K/50K slice with structured reduction.
+- [ ] In `errors.ts` (line 73), call `condenseDom()` on `htmlContent` before the 50K slice.
+- [ ] Success criteria: run a workflow that triggers extraction and verify the LLM receives condensed HTML. For errors, trigger a known error condition and verify the error detection still finds the error message in the condensed DOM.
+
+### Phase 3: Tune and measure
+
+- [ ] Collect condensation stats (original size, condensed size, per-rule reductions) across 10+ real snapshots from different sites (LinkedIn, EMR portals, etc.).
+- [ ] Identify any rules that are too aggressive (model fails to find selectors it previously found) or not aggressive enough (pages still exceed 500K after condensation).
+- [ ] Specifically verify that icon-only controls named via SVG `<title>`/`<desc>` or `aria-labelledby` still remain understandable in the condensed DOM.
+- [ ] Adjust thresholds (Rule 6 length threshold, Rule 9 heuristic) based on measured results.
+
+## Future work
+
+- **Structural deduplication:** Detect repeated sibling elements (e.g., 200 identical list items) and collapse to a representative sample. Requires tree-level analysis.
+- **Depth pruning:** Truncate deeply nested subtrees. Emergency measure for extreme DOMs.
+- **Objective-aware trimming:** Adjust aggressiveness based on the user's objective.
+- **Browser-side capture:** Run condensation logic in `page.evaluate()` for access to computed styles and bounding rects, enabling smarter decisions (e.g., off-screen + non-interactive = collapse).

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -3,6 +3,7 @@ import type { Argv } from "yargs";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { connect, disconnectBrowser } from "../core/browser.js";
 import { getSessionSnapshotRunDir } from "../core/context.js";
+import { condenseDom } from "../core/condense-dom.js";
 import {
   canAnalyzeSnapshots,
   runInterpret,
@@ -33,6 +34,7 @@ async function captureScreenshot(
     const pageUrl = page.url();
     const pngPath = `${snapshotRunDir}/page.png`;
     const htmlPath = `${snapshotRunDir}/page.html`;
+    const condensedHtmlPath = `${snapshotRunDir}/page.condensed.html`;
 
     await page.screenshot({ path: pngPath });
 
@@ -40,15 +42,25 @@ async function captureScreenshot(
     const fs = await import("node:fs/promises");
     await fs.writeFile(htmlPath, htmlContent);
 
+    // Write condensed DOM
+    const condenseResult = condenseDom(htmlContent);
+    await fs.writeFile(condensedHtmlPath, condenseResult.html);
+
     logger.info("screenshot-success", {
       session,
       pageUrl,
       title,
       pngPath,
       htmlPath,
+      condensedHtmlPath,
       snapshotRunId,
+      domCondenseStats: {
+        originalLength: condenseResult.originalLength,
+        condensedLength: condenseResult.condensedLength,
+        reductions: condenseResult.reductions,
+      },
     });
-    return { pngPath, htmlPath, baseName: snapshotRunId };
+    return { pngPath, htmlPath, condensedHtmlPath, baseName: snapshotRunId };
   } catch (err) {
     let pageAlive = false;
     let browserConnected = false;
@@ -76,11 +88,12 @@ async function runSnapshot(
   objective?: string,
   context?: string,
 ): Promise<void> {
-  const { pngPath, htmlPath } = await captureScreenshot(session, logger, pageId);
+  const { pngPath, htmlPath, condensedHtmlPath } = await captureScreenshot(session, logger, pageId);
 
-  console.log("Screenshot saved:");
-  console.log(`  PNG:  ${pngPath}`);
-  console.log(`  HTML: ${htmlPath}`);
+  console.log("Snapshot saved:");
+  console.log(`  PNG:              ${pngPath}`);
+  console.log(`  HTML:             ${htmlPath}`);
+  console.log(`  Condensed HTML:   ${condensedHtmlPath}`);
 
   const normalizedObjective = objective?.trim();
   const normalizedContext = context?.trim();
@@ -107,6 +120,7 @@ async function runSnapshot(
     context: normalizedContext ?? DEFAULT_SNAPSHOT_CONTEXT,
     pngPath,
     htmlPath,
+    condensedHtmlPath,
   }, logger);
 }
 

--- a/packages/libretto/src/cli/core/ai-config.ts
+++ b/packages/libretto/src/cli/core/ai-config.ts
@@ -13,6 +13,21 @@ export const AiConfigSchema = z
   .object({
     preset: AiPresetSchema,
     commandPrefix: z.array(z.string()).min(1),
+    /** Model override for the sub-agent session (e.g. "claude-sonnet-4-6", "o4-mini"). */
+    model: z.string().optional(),
+    /**
+     * Reasoning / thinking configuration.
+     * - Claude: passed as --thinking-budget <number>
+     * - Codex:  passed as --reasoning-effort <"low"|"medium"|"high">
+     */
+    reasoning: z.union([z.string(), z.number()]).optional(),
+    /**
+     * Restrict which tools the sub-agent session can use.
+     * - Claude: passed as --tools "Read,Grep,Glob"
+     * - Codex:  enforced via --sandbox (read-only already in default preset)
+     * - Gemini: not supported (ignored)
+     */
+    allowedTools: z.array(z.string()).optional(),
     updatedAt: z.string(),
   })
   .strict();
@@ -26,10 +41,21 @@ export const LibrettoConfigSchema = z
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
 
-export const AI_CONFIG_PRESETS: Record<AiPreset, string[]> = {
-  codex: ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only"],
-  claude: [join(homedir(), ".claude", "local", "claude"), "-p"],
-  gemini: ["gemini", "--output-format", "json"],
+export const AI_CONFIG_PRESETS: Record<AiPreset, Omit<AiConfig, "updatedAt">> = {
+  codex: {
+    preset: "codex",
+    commandPrefix: ["codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only"],
+  },
+  claude: {
+    preset: "claude",
+    commandPrefix: [join(homedir(), ".claude", "local", "claude"), "-p"],
+    allowedTools: ["Read", "Grep", "Glob"],
+  },
+  gemini: {
+    preset: "gemini",
+    commandPrefix: ["gemini", "--sandbox", "--yolo", "--output-format", "json"],
+    allowedTools: ["read_file", "list_directory", "search_file_content", "glob"],
+  },
 };
 
 function invalidConfigError(configPath: string): Error {
@@ -82,11 +108,13 @@ export function writeAiConfig(
   preset: AiPreset,
   commandPrefix: string[],
   configPath: string = LIBRETTO_CONFIG_PATH,
+  extra?: { model?: string; reasoning?: string | number; allowedTools?: string[] },
 ): AiConfig {
   const librettoConfig = readLibrettoConfig(configPath);
   const ai = AiConfigSchema.parse({
     preset,
     commandPrefix,
+    ...extra,
     updatedAt: new Date().toISOString(),
   });
   writeLibrettoConfig(
@@ -116,6 +144,9 @@ export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolea
 function printAiConfig(config: AiConfig, configPath: string): void {
   console.log(`AI preset: ${config.preset}`);
   console.log(`Command prefix: ${formatCommandPrefix(config.commandPrefix)}`);
+  if (config.model) console.log(`Model: ${config.model}`);
+  if (config.reasoning !== undefined) console.log(`Reasoning: ${config.reasoning}`);
+  if (config.allowedTools?.length) console.log(`Allowed tools: ${config.allowedTools.join(", ")}`);
   console.log(`Config file: ${configPath}`);
   console.log(`Updated at: ${config.updatedAt}`);
 }
@@ -179,12 +210,17 @@ export function runAiConfigure(
   }
 
   const preset = parsedPreset.data;
+  const presetDefaults = AI_CONFIG_PRESETS[preset];
   const commandPrefix =
     customPrefix.length > 0
       ? customPrefix
-      : AI_CONFIG_PRESETS[preset];
+      : presetDefaults.commandPrefix;
 
-  const config = writeAiConfig(preset, commandPrefix, configPath);
+  const config = writeAiConfig(preset, commandPrefix, configPath, {
+    model: presetDefaults.model,
+    reasoning: presetDefaults.reasoning,
+    allowedTools: presetDefaults.allowedTools,
+  });
   console.log("AI config saved.");
   printAiConfig(config, configPath);
 }

--- a/packages/libretto/src/cli/core/condense-dom.ts
+++ b/packages/libretto/src/cli/core/condense-dom.ts
@@ -1,0 +1,324 @@
+/**
+ * DOM condensation — reduces serialized HTML for LLM consumption.
+ *
+ * All rules run unconditionally (no tiers). The function operates on
+ * already-serialized HTML strings (the output of `page.content()`),
+ * not a browser-side DOM walk or parsed DOM tree.
+ *
+ * Rules applied in order:
+ *   1.  Noscript blocks — remove entirely
+ *   2.  HTML comments — remove (except IE conditionals)
+ *   3.  Script contents — hollow out, keep tags + attributes
+ *   4.  Style contents — hollow out, keep tags + attributes
+ *   5.  Embedded binary data — replace base64 data URIs
+ *   6.  Large opaque attribute values — truncate non-preserved attrs > 200 chars
+ *   7.  SVG elements — collapse to single tag, extract title/desc
+ *   8.  Inline style properties — keep only layout-relevant props
+ *   9.  Non-semantic class names — strip obfuscated/hash-like classes
+ *  10.  (Cross-reference IDs — preserved, no action needed)
+ *  11.  Framework-internal and SVG visual attributes — remove
+ *  12.  Whitespace — collapse (preserve <pre> content)
+ */
+
+export type CondenseDomResult = {
+  /** The condensed HTML string. Valid, parseable HTML. */
+  html: string;
+  /** Character count of the input. */
+  originalLength: number;
+  /** Character count of the output. */
+  condensedLength: number;
+  /** Characters removed, keyed by rule name. */
+  reductions: Record<string, number>;
+};
+
+/** Attributes exempt from Rule 6 truncation (the full selector-relevant preserve list). */
+const PRESERVED_ATTRS = new Set([
+  "id",
+  "name",
+  "for",
+  "data-testid",
+  "data-test",
+  "data-qa",
+  "data-cy",
+  "aria-label",
+  "aria-labelledby",
+  "aria-describedby",
+  "aria-expanded",
+  "aria-selected",
+  "aria-checked",
+  "aria-disabled",
+  "aria-hidden",
+  "aria-haspopup",
+  "aria-controls",
+  "aria-owns",
+  "aria-live",
+  "role",
+  "title",
+  "alt",
+  "type",
+  "value",
+  "placeholder",
+  "href",
+  "action",
+  "method",
+  "src",
+]);
+
+export function condenseDom(html: string): CondenseDomResult {
+  const originalLength = html.length;
+  const reductions: Record<string, number> = {};
+
+  function track(label: string, before: string, after: string): string {
+    const diff = before.length - after.length;
+    if (diff > 0) {
+      reductions[label] = (reductions[label] ?? 0) + diff;
+    }
+    return after;
+  }
+
+  let result = html;
+
+  // ── Rule 1: Noscript blocks ──────────────────────────────────────────
+  result = track(
+    "noscript",
+    result,
+    result.replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ""),
+  );
+
+  // ── Rule 2: HTML comments ────────────────────────────────────────────
+  // Keep IE conditional comments (<!--[if ...)
+  result = track(
+    "comments",
+    result,
+    result.replace(/<!--(?!\[if\s)[\s\S]*?-->/g, ""),
+  );
+
+  // ── Rule 3: Script contents ──────────────────────────────────────────
+  result = track(
+    "scripts",
+    result,
+    result.replace(
+      /(<script\b[^>]*>)([\s\S]*?)(<\/script>)/gi,
+      (_match, open: string, content: string, close: string) => {
+        if (!content.trim()) return `${open}${close}`;
+        const isDataScript =
+          /type\s*=\s*["']application\/(json|ld\+json)["']/i.test(open);
+        if (isDataScript) {
+          return `${open}<!-- [JSON data, ${content.length} chars] -->${close}`;
+        }
+        return `${open}<!-- [script, ${content.length} chars] -->${close}`;
+      },
+    ),
+  );
+
+  // ── Rule 4: Style contents ───────────────────────────────────────────
+  result = track(
+    "styles",
+    result,
+    result.replace(
+      /(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi,
+      (_match, open: string, content: string, close: string) => {
+        if (!content.trim()) return `${open}${close}`;
+        return `${open}<!-- [CSS, ${content.length} chars] -->${close}`;
+      },
+    ),
+  );
+
+  // ── Rule 5: Embedded binary data ─────────────────────────────────────
+  result = track(
+    "base64",
+    result,
+    result.replace(
+      /(src|href)\s*=\s*["'](data:[^;]+;base64,)[A-Za-z0-9+/=]{100,}["']/gi,
+      (_match, attr: string, prefix: string) => {
+        const mime = prefix.replace("data:", "").replace(";base64,", "");
+        return `${attr}="[base64 ${mime}]"`;
+      },
+    ),
+  );
+
+  // ── Rule 6: Large opaque attribute values ────────────────────────────
+  // Truncate any attribute value > 200 chars that isn't on the preserve list.
+  result = track(
+    "large-attrs",
+    result,
+    result.replace(
+      /\s([\w-]+)\s*=\s*["']([^"']{200,})["']/gi,
+      (match, attr: string, value: string) => {
+        if (PRESERVED_ATTRS.has(attr.toLowerCase())) return match;
+        return ` ${attr}="[${value.length} chars]"`;
+      },
+    ),
+  );
+
+  // ── Rule 7: SVG elements ─────────────────────────────────────────────
+  // Collapse each <svg> to a single tag, preserving key attributes.
+  // Extract <title>/<desc> text as aria-label if none exists.
+  result = track(
+    "svg-collapse",
+    result,
+    result.replace(
+      /<svg\b([^>]*)>([\s\S]*?)<\/svg>/gi,
+      (_match, attrs: string, inner: string) => {
+        // Extract attributes we want to keep
+        const keepAttrs: string[] = [];
+        const attrPatterns = [
+          "id",
+          "class",
+          "role",
+          "aria-label",
+          "aria-hidden",
+          "title",
+          "data-testid",
+        ];
+        for (const name of attrPatterns) {
+          const attrToken = findAttributeToken(attrs, name);
+          if (attrToken) keepAttrs.push(attrToken);
+        }
+
+        // Extract <title> or <desc> text for aria-label if not already present
+        const hasAriaLabel = /aria-label\s*=/i.test(attrs);
+        if (!hasAriaLabel) {
+          const titleMatch = inner.match(
+            /<title[^>]*>([^<]+)<\/title>/i,
+          );
+          const descMatch = inner.match(
+            /<desc[^>]*>([^<]+)<\/desc>/i,
+          );
+          const labelText = titleMatch?.[1]?.trim() || descMatch?.[1]?.trim();
+          if (labelText) {
+            keepAttrs.push(
+              `aria-label="${escapeHtmlAttribute(labelText)}"`,
+            );
+          }
+        }
+
+        const attrStr = keepAttrs.length > 0 ? ` ${keepAttrs.join(" ")}` : "";
+        return `<svg${attrStr}><!-- [icon] --></svg>`;
+      },
+    ),
+  );
+
+  // ── Rule 8: Inline style properties ──────────────────────────────────
+  // Keep only layout-relevant properties.
+  const layoutProps =
+    /(?:display|visibility|opacity|pointer-events|position|z-index|overflow)(?:-[a-z]+)?\s*:[^;"]*/gi;
+
+  result = track(
+    "inline-styles",
+    result,
+    result.replace(
+      /\sstyle\s*=\s*["']([^"']*)["']/gi,
+      (_match, value: string) => {
+        const kept: string[] = [];
+        let propMatch: RegExpExecArray | null;
+        layoutProps.lastIndex = 0;
+        while ((propMatch = layoutProps.exec(value)) !== null) {
+          kept.push(propMatch[0].trim());
+        }
+        if (kept.length === 0) return "";
+        return ` style="${kept.join("; ")}"`;
+      },
+    ),
+  );
+
+  // ── Rule 9: Non-semantic class names ─────────────────────────────────
+  result = track(
+    "obfuscated-classes",
+    result,
+    result.replace(
+      /\sclass\s*=\s*["']([^"']*)["']/gi,
+      (_match, value: string) => {
+        const classes = value.split(/\s+/).filter(Boolean);
+        const kept = classes.filter((cls) => !isObfuscatedClass(cls));
+        if (kept.length === 0) return "";
+        return ` class="${kept.join(" ")}"`;
+      },
+    ),
+  );
+
+  // ── Rule 10: Cross-reference IDs — no action, preserved by default ──
+
+  // ── Rule 11: Framework-internal and SVG visual attributes ────────────
+  const removableAttrs =
+    /\s(?:xmlns(?::[a-z]+)?|xml:space|xml:lang|fill|stroke|stroke-width|stroke-linecap|stroke-linejoin|stroke-miterlimit|stroke-dasharray|stroke-dashoffset|stroke-opacity|fill-opacity|clip-rule|fill-rule|focusable)\s*=\s*["'][^"']*["']/gi;
+  result = track(
+    "framework-svg-attrs",
+    result,
+    result.replace(removableAttrs, ""),
+  );
+
+  // ── Rule 12: Whitespace ──────────────────────────────────────────────
+  // Collapse runs of spaces/tabs to a single space, multiple blank lines
+  // to a single newline. Preserve <pre> content.
+  const preBlocks: string[] = [];
+  result = result.replace(
+    /(<pre\b[^>]*>)([\s\S]*?)(<\/pre>)/gi,
+    (_match, open: string, content: string, close: string) => {
+      const idx = preBlocks.length;
+      preBlocks.push(`${open}${content}${close}`);
+      return `__PRE_PLACEHOLDER_${idx}__`;
+    },
+  );
+
+  result = track(
+    "whitespace",
+    result,
+    result.replace(/[ \t]+/g, " ").replace(/\n\s*\n/g, "\n"),
+  );
+
+  for (let i = 0; i < preBlocks.length; i++) {
+    result = result.replace(`__PRE_PLACEHOLDER_${i}__`, preBlocks[i]!);
+  }
+
+  return {
+    html: result,
+    originalLength,
+    condensedLength: result.length,
+    reductions,
+  };
+}
+
+/**
+ * Heuristic: a class name is "obfuscated" if it looks like a hash or random ID
+ * rather than a human-readable semantic name.
+ */
+function isObfuscatedClass(cls: string): boolean {
+  // Pure hex-like: _2fde8c88, bf2ad191, a1b2c3d4
+  if (/^_?[0-9a-f]{6,}$/i.test(cls)) return true;
+
+  // CSS module pattern: component_hash (single underscore + hash suffix)
+  if (/^[a-z]+_[0-9a-f]{4,}$/i.test(cls)) return true;
+
+  // Very short random-looking (2-3 chars, not common abbreviations)
+  if (/^[a-z]{1,2}[0-9]+$/i.test(cls)) return true;
+
+  // High ratio of digits to letters (hashes tend to mix digits in)
+  const digits = (cls.match(/[0-9]/g) || []).length;
+  const letters = (cls.match(/[a-zA-Z]/g) || []).length;
+  if (cls.length >= 6 && digits >= letters * 0.5 && digits >= 2) return true;
+
+  return false;
+}
+
+function findAttributeToken(attrs: string, name: string): string | null {
+  const match = attrs.match(
+    new RegExp(
+      `(?:^|\\s)(${escapeRegExp(name)}\\s*=\\s*(?:"[^"]*"|'[^']*'))`,
+      "i",
+    ),
+  );
+  return match?.[1] ?? null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/libretto/src/cli/core/condense-dom.ts
+++ b/packages/libretto/src/cli/core/condense-dom.ts
@@ -154,55 +154,68 @@ export function condenseDom(html: string): CondenseDomResult {
   // ── Rule 7: SVG elements ─────────────────────────────────────────────
   // Collapse each <svg> to a single tag, preserving key attributes.
   // Extract <title>/<desc> text as aria-label if none exists.
+  // Iterate from innermost to outermost to handle nested SVGs correctly.
+  const svgPattern = /<svg\b([^>]*)>((?:(?!<svg\b)[\s\S])*?)<\/svg>/gi;
   result = track(
     "svg-collapse",
     result,
-    result.replace(
-      /<svg\b([^>]*)>([\s\S]*?)<\/svg>/gi,
-      (_match, attrs: string, inner: string) => {
-        // Extract attributes we want to keep
-        const keepAttrs: string[] = [];
-        const attrPatterns = [
-          "id",
-          "class",
-          "role",
-          "aria-label",
-          "aria-hidden",
-          "title",
-          "data-testid",
-        ];
-        for (const name of attrPatterns) {
-          const attrToken = findAttributeToken(attrs, name);
-          if (attrToken) keepAttrs.push(attrToken);
-        }
+    (() => {
+      let prev: string;
+      let current = result;
+      do {
+        prev = current;
+        current = current.replace(
+          svgPattern,
+          (_match, attrs: string, inner: string) => {
+            // Extract attributes we want to keep
+            const keepAttrs: string[] = [];
+            const attrPatterns = [
+              "id",
+              "class",
+              "role",
+              "aria-label",
+              "aria-hidden",
+              "title",
+              "data-testid",
+            ];
+            for (const name of attrPatterns) {
+              const attrToken = findAttributeToken(attrs, name);
+              if (attrToken) keepAttrs.push(attrToken);
+            }
 
-        // Extract <title> or <desc> text for aria-label if not already present
-        const hasAriaLabel = /aria-label\s*=/i.test(attrs);
-        if (!hasAriaLabel) {
-          const titleMatch = inner.match(
-            /<title[^>]*>([^<]+)<\/title>/i,
-          );
-          const descMatch = inner.match(
-            /<desc[^>]*>([^<]+)<\/desc>/i,
-          );
-          const labelText = titleMatch?.[1]?.trim() || descMatch?.[1]?.trim();
-          if (labelText) {
-            keepAttrs.push(
-              `aria-label="${escapeHtmlAttribute(labelText)}"`,
-            );
-          }
-        }
+            // Extract <title> or <desc> text for aria-label if not already present
+            const hasAriaLabel = /aria-label\s*=/i.test(attrs);
+            if (!hasAriaLabel) {
+              const titleMatch = inner.match(
+                /<title[^>]*>([^<]+)<\/title>/i,
+              );
+              const descMatch = inner.match(
+                /<desc[^>]*>([^<]+)<\/desc>/i,
+              );
+              const labelText =
+                titleMatch?.[1]?.trim() || descMatch?.[1]?.trim();
+              if (labelText) {
+                keepAttrs.push(
+                  `aria-label="${escapeHtmlAttribute(labelText)}"`,
+                );
+              }
+            }
 
-        const attrStr = keepAttrs.length > 0 ? ` ${keepAttrs.join(" ")}` : "";
-        return `<svg${attrStr}><!-- [icon] --></svg>`;
-      },
-    ),
+            const attrStr =
+              keepAttrs.length > 0 ? ` ${keepAttrs.join(" ")}` : "";
+            return `<svg${attrStr}><!-- [icon] --></svg>`;
+          },
+        );
+        svgPattern.lastIndex = 0;
+      } while (current !== prev);
+      return current;
+    })(),
   );
 
   // ── Rule 8: Inline style properties ──────────────────────────────────
   // Keep only layout-relevant properties.
   const layoutProps =
-    /(?:display|visibility|opacity|pointer-events|position|z-index|overflow)(?:-[a-z]+)?\s*:[^;"]*/gi;
+    /(?:^|;)\s*(?:display|visibility|opacity|pointer-events|position|z-index|overflow)(?:-[a-z]+)?\s*:[^;"]*/gi;
 
   result = track(
     "inline-styles",
@@ -214,7 +227,7 @@ export function condenseDom(html: string): CondenseDomResult {
         let propMatch: RegExpExecArray | null;
         layoutProps.lastIndex = 0;
         while ((propMatch = layoutProps.exec(value)) !== null) {
-          kept.push(propMatch[0].trim());
+          kept.push(propMatch[0].replace(/^[;\s]+/, "").trim());
         }
         if (kept.length === 0) return "";
         return ` style="${kept.join("; ")}"`;
@@ -290,8 +303,8 @@ function isObfuscatedClass(cls: string): boolean {
   // CSS module pattern: component_hash (single underscore + hash suffix)
   if (/^[a-z]+_[0-9a-f]{4,}$/i.test(cls)) return true;
 
-  // Very short random-looking (2-3 chars, not common abbreviations)
-  if (/^[a-z]{1,2}[0-9]+$/i.test(cls)) return true;
+  // Very short random-looking (2-3 chars + 2+ digits, avoids h1/p2/m3 utility classes)
+  if (/^[a-z]{1,2}[0-9]{2,}$/i.test(cls)) return true;
 
   // High ratio of digits to letters (hashes tend to mix digits in)
   const digits = (cls.match(/[0-9]/g) || []).length;

--- a/packages/libretto/src/cli/core/snapshot-analyzer.ts
+++ b/packages/libretto/src/cli/core/snapshot-analyzer.ts
@@ -1,9 +1,4 @@
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -14,13 +9,12 @@ import {
   formatCommandPrefix,
   readAiConfig,
 } from "./ai-config.js";
-import {
-  getLLMClientFactory,
-} from "./context.js";
+import { getLLMClientFactory } from "./context.js";
 
 export type ScreenshotPair = {
   pngPath: string;
   htmlPath: string;
+  condensedHtmlPath: string;
   baseName: string;
 };
 
@@ -30,6 +24,7 @@ export type InterpretArgs = {
   context: string;
   pngPath: string;
   htmlPath: string;
+  condensedHtmlPath: string;
 };
 
 const InterpretResultSchema = z.object({
@@ -93,6 +88,9 @@ abstract class UserCodingAgent {
     return this.config.commandPrefix.slice(1);
   }
 
+  /** Build extra CLI args from config.model, config.reasoning, config.allowedTools. */
+  protected abstract buildExtraArgs(): string[];
+
   protected screenshotHint(pngPath: string): string {
     return (
       `\n\nScreenshot file path: ${pngPath}\n` +
@@ -128,6 +126,19 @@ abstract class UserCodingAgent {
 }
 
 class CodexUserCodingAgent extends UserCodingAgent {
+  protected buildExtraArgs(): string[] {
+    const extra: string[] = [];
+    if (this.config.model) {
+      extra.push("--model", this.config.model);
+    }
+    if (this.config.reasoning !== undefined) {
+      // Codex uses --reasoning-effort <low|medium|high>
+      extra.push("--reasoning-effort", String(this.config.reasoning));
+    }
+    // Codex tool restriction is handled via --sandbox in commandPrefix
+    return extra;
+  }
+
   async analyzeSnapshot(
     prompt: string,
     pngPath: string,
@@ -139,6 +150,7 @@ class CodexUserCodingAgent extends UserCodingAgent {
     );
     const args = [
       ...this.baseArgs,
+      ...this.buildExtraArgs(),
       "--output-last-message",
       outputPath,
       "-i",
@@ -159,21 +171,57 @@ class CodexUserCodingAgent extends UserCodingAgent {
 }
 
 class ClaudeUserCodingAgent extends UserCodingAgent {
+  protected buildExtraArgs(): string[] {
+    const extra: string[] = [];
+    if (this.config.model) {
+      extra.push("--model", this.config.model);
+    }
+    if (this.config.reasoning !== undefined) {
+      // Claude uses --thinking-budget <number>
+      extra.push("--thinking-budget", String(this.config.reasoning));
+    }
+    if (this.config.allowedTools?.length) {
+      // Claude uses --tools "Read,Grep,Glob" to restrict available tools
+      extra.push("--tools", this.config.allowedTools.join(","));
+    }
+    return extra;
+  }
+
   async analyzeSnapshot(
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    const args = [...this.baseArgs, `${prompt}${this.screenshotHint(pngPath)}`];
+    const args = [
+      ...this.baseArgs,
+      ...this.buildExtraArgs(),
+      `${prompt}${this.screenshotHint(pngPath)}`,
+    ];
     return await this.runAndParse(args);
   }
 }
 
 class GeminiUserCodingAgent extends UserCodingAgent {
+  protected buildExtraArgs(): string[] {
+    const extra: string[] = [];
+    if (this.config.model) {
+      extra.push("--model", this.config.model);
+    }
+    if (this.config.allowedTools?.length) {
+      // Gemini uses --allowed-tools "read_file,list_directory,search_file_content,glob"
+      extra.push("--allowed-tools", this.config.allowedTools.join(","));
+    }
+    return extra;
+  }
+
   async analyzeSnapshot(
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    const args = [...this.baseArgs, `${prompt}${this.screenshotHint(pngPath)}`];
+    const args = [
+      ...this.baseArgs,
+      ...this.buildExtraArgs(),
+      `${prompt}${this.screenshotHint(pngPath)}`,
+    ];
     return await this.runAndParse(args);
   }
 }
@@ -441,37 +489,8 @@ function collectSelectorHints(html: string, limit = 120): string[] {
   return candidates;
 }
 
-export async function runInterpret(
-  args: InterpretArgs,
-  logger: LoggerApi,
-): Promise<void> {
-  logger.info("interpret-start", {
-    objective: args.objective,
-    pngPath: args.pngPath,
-    htmlPath: args.htmlPath,
-  });
-  process.env.NODE_ENV = "development";
-
-  const pngPath = resolvePath(args.pngPath);
-  const htmlPath = resolvePath(args.htmlPath);
-  if (!existsSync(pngPath)) {
-    throw new Error(`PNG file not found: ${pngPath}`);
-  }
-  if (!existsSync(htmlPath)) {
-    throw new Error(`HTML file not found: ${htmlPath}`);
-  }
-
-  const htmlContent = readFileSync(htmlPath, "utf-8");
-  const htmlCharLimit = 500_000;
-  const { text: trimmedHtml, truncated } = truncateText(
-    htmlContent,
-    htmlCharLimit,
-  );
-  const selectorHints = collectSelectorHints(htmlContent, 120);
-
-  let prompt = `# Objective\n${args.objective}\n\n`;
-  prompt += `# Context\n${args.context}\n\n`;
-  prompt += `# Instructions\n`;
+function buildInterpretInstructions(): string {
+  let prompt = `# Instructions\n`;
   prompt += `You are analyzing a screenshot and HTML snapshot of the same web page on behalf of an automation agent.\n`;
   prompt += `The agent needs to interact with this page programmatically using Playwright.\n\n`;
   prompt += `Based on the objective and context above:\n`;
@@ -482,25 +501,94 @@ export async function runInterpret(
   prompt += `Output JSON with this shape:\n`;
   prompt += `{"answer": string, "selectors": [{"label": string, "selector": string, "rationale": string}], "notes": string}\n\n`;
   prompt += `Selectors should prefer robust attributes: data-testid, data-test, aria-label, name, id, role. Avoid fragile class-based or positional selectors.\n`;
-  prompt += `Only include selectors that exist in the HTML snapshot.\n\n`;
+  prompt += `Only include selectors that exist in the HTML snapshot.\n`;
+  return prompt;
+}
+
+function buildFileAnalyzerPrompt(
+  args: InterpretArgs,
+  pngPath: string,
+  htmlPath: string,
+  condensedHtmlPath: string,
+): string {
+  let prompt = `# Objective\n${args.objective}\n\n`;
+  prompt += `# Context\n${args.context}\n\n`;
+  prompt += `# Snapshot Files\n`;
+  prompt += `The following snapshot files are available for your analysis. Use your file reading tools to access them.\n\n`;
+  prompt += `- **Screenshot (PNG):** ${pngPath}\n`;
+  prompt += `- **Condensed DOM (HTML):** ${condensedHtmlPath} — Start with this file. It is the primary HTML snapshot for analysis.\n`;
+  prompt += `- **Full DOM (HTML):** ${htmlPath} — Use this only if the condensed DOM is missing detail needed to answer the objective or verify a selector.\n\n`;
+  prompt += buildInterpretInstructions();
+  prompt += `\nReturn only a JSON object. Do not include markdown code fences or extra commentary.`;
+  return prompt;
+}
+
+function buildInlineHtmlPrompt(
+  args: InterpretArgs,
+  htmlContent: string,
+): string {
+  const htmlCharLimit = 500_000;
+  const { text: trimmedHtml, truncated } = truncateText(
+    htmlContent,
+    htmlCharLimit,
+  );
+  const selectorHints = collectSelectorHints(htmlContent, 120);
+
+  let prompt = `# Objective\n${args.objective}\n\n`;
+  prompt += `# Context\n${args.context}\n\n`;
+  prompt += buildInterpretInstructions();
 
   if (selectorHints.length > 0) {
-    prompt += `Selector hints from HTML attributes (use if relevant):\n`;
+    prompt += `\nSelector hints from HTML attributes (use if relevant):\n`;
     prompt += selectorHints.map((hint) => `- ${hint}`).join("\n");
-    prompt += "\n\n";
+    prompt += "\n";
   }
 
   if (truncated) {
-    prompt += `HTML content is truncated to fit token limits.\n\n`;
+    prompt += `\nHTML content is truncated to fit token limits.\n`;
   }
 
-  prompt += `HTML snapshot:\n\n${trimmedHtml}`;
+  prompt += `\nHTML snapshot (condensed DOM):\n\n${trimmedHtml}`;
   prompt +=
     "\n\nReturn only a JSON object. Do not include markdown code fences or extra commentary.";
+  return prompt;
+}
+
+export async function runInterpret(
+  args: InterpretArgs,
+  logger: LoggerApi,
+): Promise<void> {
+  logger.info("interpret-start", {
+    objective: args.objective,
+    pngPath: args.pngPath,
+    htmlPath: args.htmlPath,
+    condensedHtmlPath: args.condensedHtmlPath,
+  });
+  process.env.NODE_ENV = "development";
+
+  const pngPath = resolvePath(args.pngPath);
+  const htmlPath = resolvePath(args.htmlPath);
+  const condensedHtmlPath = resolvePath(args.condensedHtmlPath);
+
+  if (!existsSync(pngPath)) {
+    throw new Error(`PNG file not found: ${pngPath}`);
+  }
+  if (!existsSync(htmlPath)) {
+    throw new Error(`HTML file not found: ${htmlPath}`);
+  }
+  if (!existsSync(condensedHtmlPath)) {
+    throw new Error(`Condensed HTML file not found: ${condensedHtmlPath}`);
+  }
 
   let parsed: InterpretResult;
   const configuredAgent = UserCodingAgent.getConfigured();
   if (configuredAgent) {
+    const prompt = buildFileAnalyzerPrompt(
+      args,
+      pngPath,
+      htmlPath,
+      condensedHtmlPath,
+    );
     const configuredAnalyzer = configuredAgent.snapshotAnalyzerConfig;
     logger.info("interpret-analyzer-config", {
       preset: configuredAnalyzer.preset,
@@ -516,8 +604,13 @@ export async function runInterpret(
     }
 
     logger.info("interpret-analyzer-factory-fallback", {});
+    const condensedHtmlContent = readFileSync(condensedHtmlPath, "utf-8");
+    const prompt = buildInlineHtmlPrompt(args, condensedHtmlContent);
     const imageBase64 = readFileAsBase64(pngPath);
-    const client = await llmClientFactory(logger, "google/gemini-3-flash-preview");
+    const client = await llmClientFactory(
+      logger,
+      "google/gemini-3-flash-preview",
+    );
     const result = await client.generateObjectFromMessages({
       schema: InterpretResultSchema,
       messages: [
@@ -564,5 +657,7 @@ export async function runInterpret(
 }
 
 export function canAnalyzeSnapshots(): boolean {
-  return UserCodingAgent.getConfigured() !== null || getLLMClientFactory() !== null;
+  return (
+    UserCodingAgent.getConfigured() !== null || getLLMClientFactory() !== null
+  );
 }

--- a/packages/libretto/src/runtime/extract/extract.ts
+++ b/packages/libretto/src/runtime/extract/extract.ts
@@ -2,6 +2,7 @@ import type { Page } from "playwright";
 import type z from "zod";
 import { type MinimalLogger, defaultLogger } from "../../shared/logger/logger.js";
 import type { LLMClient } from "../../shared/llm/types.js";
+import { condenseDom } from "../../cli/core/condense-dom.js";
 
 export type ExtractOptions<T extends z.ZodType> = {
 	page: Page;
@@ -35,10 +36,14 @@ export async function extractFromPage<T extends z.ZodType>(
 		screenshot = screenshotBuffer.toString("base64");
 
 		try {
-			domContent = await element.innerHTML();
-			if (domContent.length > 30000) {
-				domContent = domContent.slice(0, 30000) + "\n... [truncated]";
+			let rawDom = await element.innerHTML();
+			if (rawDom.length > 30000) {
+				rawDom = condenseDom(rawDom).html;
 			}
+			if (rawDom.length > 30000) {
+				rawDom = rawDom.slice(0, 30000) + "\n... [truncated]";
+			}
+			domContent = rawDom;
 		} catch {
 			domContent = undefined;
 		}
@@ -51,11 +56,14 @@ export async function extractFromPage<T extends z.ZodType>(
 		screenshot = data;
 
 		try {
-			const htmlContent = await page.content();
-			domContent =
-				htmlContent.length > 50000
-					? htmlContent.slice(0, 50000) + "\n... [truncated]"
-					: htmlContent;
+			let htmlContent = await page.content();
+			if (htmlContent.length > 50000) {
+				htmlContent = condenseDom(htmlContent).html;
+			}
+			if (htmlContent.length > 50000) {
+				htmlContent = htmlContent.slice(0, 50000) + "\n... [truncated]";
+			}
+			domContent = htmlContent;
 		} catch {
 			domContent = undefined;
 		}

--- a/packages/libretto/src/runtime/recovery/errors.ts
+++ b/packages/libretto/src/runtime/recovery/errors.ts
@@ -2,6 +2,7 @@ import type { Page } from "playwright";
 import { type MinimalLogger, defaultLogger } from "../../shared/logger/logger.js";
 import type { LLMClient } from "../../shared/llm/types.js";
 import { z } from "zod";
+import { condenseDom } from "../../cli/core/condense-dom.js";
 
 /**
  * Known error type for classifying submission errors.
@@ -70,11 +71,14 @@ export async function detectSubmissionError(
 
 	// Capture DOM snapshot for additional context
 	try {
-		const htmlContent = await page.content();
-		domSnapshot =
-			htmlContent.length > 50000
-				? htmlContent.slice(0, 50000) + "\n... [truncated]"
-				: htmlContent;
+		let htmlContent = await page.content();
+		if (htmlContent.length > 50000) {
+			htmlContent = condenseDom(htmlContent).html;
+		}
+		if (htmlContent.length > 50000) {
+			htmlContent = htmlContent.slice(0, 50000) + "\n... [truncated]";
+		}
+		domSnapshot = htmlContent;
 	} catch (domError) {
 		log.warn("Failed to capture DOM snapshot", {
 			domError: domError instanceof Error ? domError.message : String(domError),

--- a/packages/libretto/test/condense-dom.spec.ts
+++ b/packages/libretto/test/condense-dom.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { condenseDom } from "../src/cli/core/condense-dom.js";
+
+describe("condenseDom SVG collapsing", () => {
+  it("does not invent preserved attributes from similarly named attributes", () => {
+    const result = condenseDom(
+      `<svg data-id="fake" data-testid="icon"><title>Label</title><path d="M0 0" /></svg>`,
+    );
+
+    expect(result.html).toContain(`data-testid="icon"`);
+    expect(result.html).not.toContain(` id="fake"`);
+  });
+
+  it("escapes promoted SVG labels so output remains valid HTML", () => {
+    const result = condenseDom(
+      `<svg><title>5" widget & more</title><path d="M0 0" /></svg>`,
+    );
+
+    expect(result.html).toBe(
+      `<svg aria-label="5&quot; widget &amp; more"><!-- [icon] --></svg>`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a `condenseDom()` pipeline for snapshot, extract, and recovery DOM consumers
- write condensed snapshot artifacts and update snapshot analysis to prefer condensed HTML while preserving DOM context for non-file-reading analyzers
- add focused regression coverage for SVG condensation edge cases and remove accidental local-state files from the branch

## Verification
- `pnpm --filter libretto type-check`
- `pnpm --filter libretto exec vitest run test/condense-dom.spec.ts`
- `pnpm --filter libretto build`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
