### PR TITLE
Simplify exports and route pnpm cli through dist entry

### DIFF
--- a/.agents/skills/fix-merge-conflicts/SKILL.md
+++ b/.agents/skills/fix-merge-conflicts/SKILL.md
@@ -7,13 +7,42 @@ Resolve conflicts by intent, not by line order.
 
 ## Workflow
 
-1. Identify conflicted files and candidate commits.
-2. Map each conflicting commit to its PR.
-3. Read PR title and description to extract intent.
-4. Detect intent divergence and request user intervention.
-5. Resolve conflicts to preserve both intents when compatible.
-6. Validate behavior with targeted checks.
-7. Summarize decisions and any tradeoffs.
+1. Run preflight conflict detection. If no local merge/rebase/cherry-pick conflicts are present, automatically fetch and merge `origin/main`.
+2. Identify conflicted files and candidate commits.
+3. Map each conflicting commit to its PR.
+4. Read PR title and description to extract intent.
+5. Detect intent divergence and request user intervention.
+6. Resolve conflicts to preserve both intents when compatible.
+7. Validate behavior with targeted checks.
+8. Summarize decisions and any tradeoffs.
+
+## 0) Preflight: Ensure a Conflict Exists
+
+If there are no active unmerged paths, proactively merge latest `origin/main` to surface conflicts:
+
+```bash
+git status --porcelain
+git diff --name-only --diff-filter=U
+```
+
+Decision rule:
+
+- If `git diff --name-only --diff-filter=U` returns files, skip auto-merge and continue to conflict analysis.
+- If it returns nothing, run:
+
+```bash
+git fetch origin
+git merge origin/main
+```
+
+Then re-check:
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+- If conflicts now exist, continue with the rest of this workflow.
+- If still no conflicts, report that no merge conflicts were detected and stop.
 
 ## 1) Identify Conflict Scope
 

--- a/package.json
+++ b/package.json
@@ -25,66 +25,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./logger": {
-      "types": "./dist/shared/logger/index.d.ts",
-      "import": "./dist/shared/logger/index.js",
-      "require": "./dist/shared/logger/index.cjs"
-    },
-    "./recovery": {
-      "types": "./dist/runtime/recovery/index.d.ts",
-      "import": "./dist/runtime/recovery/index.js",
-      "require": "./dist/runtime/recovery/index.cjs"
-    },
-    "./extract": {
-      "types": "./dist/runtime/extract/index.d.ts",
-      "import": "./dist/runtime/extract/index.js",
-      "require": "./dist/runtime/extract/index.cjs"
-    },
-    "./network": {
-      "types": "./dist/runtime/network/index.d.ts",
-      "import": "./dist/runtime/network/index.js",
-      "require": "./dist/runtime/network/index.cjs"
-    },
-    "./download": {
-      "types": "./dist/runtime/download/index.d.ts",
-      "import": "./dist/runtime/download/index.js",
-      "require": "./dist/runtime/download/index.cjs"
-    },
-    "./debug": {
-      "types": "./dist/shared/debug/index.d.ts",
-      "import": "./dist/shared/debug/index.js",
-      "require": "./dist/shared/debug/index.cjs"
-    },
-    "./config": {
-      "types": "./dist/shared/config/index.d.ts",
-      "import": "./dist/shared/config/index.js",
-      "require": "./dist/shared/config/index.cjs"
-    },
-    "./instrumentation": {
-      "types": "./dist/shared/instrumentation/index.d.ts",
-      "import": "./dist/shared/instrumentation/index.js",
-      "require": "./dist/shared/instrumentation/index.cjs"
-    },
-    "./visualization": {
-      "types": "./dist/shared/visualization/index.d.ts",
-      "import": "./dist/shared/visualization/index.js",
-      "require": "./dist/shared/visualization/index.cjs"
-    },
-    "./llm": {
-      "types": "./dist/shared/llm/index.d.ts",
-      "import": "./dist/shared/llm/index.js",
-      "require": "./dist/shared/llm/index.cjs"
-    },
-    "./state": {
-      "types": "./dist/shared/state/index.d.ts",
-      "import": "./dist/shared/state/index.js",
-      "require": "./dist/shared/state/index.cjs"
-    },
-    "./run": {
-      "types": "./dist/shared/run/api.d.ts",
-      "import": "./dist/shared/run/api.js",
-      "require": "./dist/shared/run/api.cjs"
     }
   },
   "scripts": {
@@ -96,7 +36,7 @@
     "test": "pnpm run build && vitest run",
     "eval": "pnpm run build && vitest run --config vitest.evals.config.ts",
     "test:watch": "vitest",
-    "cli": "tsx src/cli/index.ts",
+    "cli": "node dist/index.js",
     "prepack": "pnpm run build"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { normalize, sep } from "node:path";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // Logger
 export { Logger, defaultLogger, type LoggerApi, type MinimalLogger, type LoggerSink, type LogOptions } from "./shared/logger/logger.js";
@@ -102,16 +103,16 @@ export {
 	type LibrettoWorkflowHandler,
 } from "./shared/workflow/workflow.js";
 
-const isDistIndexEntrypoint = (): boolean => {
+const isDirectExecution = (): boolean => {
 	const entryArg = process.argv[1];
 	if (!entryArg) {
 		return false;
 	}
-	return normalize(entryArg).endsWith(`${sep}dist${sep}index.js`);
+	return pathToFileURL(resolve(entryArg)).href === import.meta.url;
 };
 
-if (isDistIndexEntrypoint()) {
-	void import("./cli/index.js")
+if (isDirectExecution()) {
+	void import("./cli/cli.js")
 		.then(({ runLibrettoCLI }) => runLibrettoCLI())
 		.catch((error: unknown) => {
 			const message = error instanceof Error ? error.stack ?? error.message : String(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,9 +112,7 @@ const isDirectExecution = (): boolean => {
 };
 
 if (isDirectExecution()) {
-	void import("./cli/cli.js")
-		.then(({ runLibrettoCLI }) => runLibrettoCLI())
-		.catch((error: unknown) => {
+	void import("./cli/index.js").catch((error: unknown) => {
 			const message = error instanceof Error ? error.stack ?? error.message : String(error);
 			process.stderr.write(`${message}\n`);
 			process.exitCode = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { normalize, sep } from "node:path";
+
 // Logger
 export { Logger, defaultLogger, type LoggerApi, type MinimalLogger, type LoggerSink, type LogOptions } from "./shared/logger/logger.js";
 export {
@@ -99,3 +101,21 @@ export {
 	type LibrettoWorkflowContext,
 	type LibrettoWorkflowHandler,
 } from "./shared/workflow/workflow.js";
+
+const isDistIndexEntrypoint = (): boolean => {
+	const entryArg = process.argv[1];
+	if (!entryArg) {
+		return false;
+	}
+	return normalize(entryArg).endsWith(`${sep}dist${sep}index.js`);
+};
+
+if (isDistIndexEntrypoint()) {
+	void import("./cli/index.js")
+		.then(({ runLibrettoCLI }) => runLibrettoCLI())
+		.catch((error: unknown) => {
+			const message = error instanceof Error ? error.stack ?? error.message : String(error);
+			process.stderr.write(`${message}\n`);
+			process.exitCode = 1;
+		});
+}


### PR DESCRIPTION
## Summary
- reduce package exports to a single root export (`.`) so the package has one public entrypoint
- change `pnpm cli` to run `node dist/index.js`
- add direct-entry handling in `src/index.ts` so executing `dist/index.js` dispatches to the CLI
- update the `fix-merge-conflicts` skill to auto-merge `origin/main` when no local conflicts are present

## Validation
- `pnpm build`
- `pnpm type-check`
- `pnpm cli help`
