### PR TITLE
chore: bump version to 0.3.1 for republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version from `0.3.0` to `0.3.1`
- carry forward publish fix after merging `main` single-package flatten

## Verification
- `pnpm type-check`
- `npm pack --dry-run` (confirms `prepack` runs and `dist/*` is included)
