### PR TITLE
Use dedicated benchmark Anthropic secret

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.LIBRETTO_BENCHMARKS_ANTHROPIC_API_KEY }}
       LIBRETTO_BENCHMARK_MODEL: claude-opus-4-6
       LIBRETTO_BENCHMARK_ANALYZER_MODEL: claude-sonnet-4-6
     steps:
@@ -68,7 +68,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "ANTHROPIC_API_KEY secret is required to run benchmarks." >&2
+            echo "LIBRETTO_BENCHMARKS_ANTHROPIC_API_KEY secret is required to run benchmarks." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- switch the Benchmarks workflow to use the `LIBRETTO_BENCHMARKS_ANTHROPIC_API_KEY` GitHub secret
- keep exporting it to the workflow runtime as `ANTHROPIC_API_KEY` so benchmark code does not change
- update the workflow validation message to reference the dedicated benchmark secret name

## Validation
- inspected the workflow diff in `.github/workflows/benchmarks.yml`
