### PR TITLE
Track benchmark duration and cost in summaries

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -122,6 +122,7 @@ jobs:
           if-no-files-found: warn
           path: |
             benchmark-summary.md
+            benchmarks/run-history.jsonl
             benchmarks/${{ inputs.benchmark }}/runs/**/transcript.json
             benchmarks/${{ inputs.benchmark }}/runs/**/transcript.md
             benchmarks/${{ inputs.benchmark }}/runs/**/results.json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -42,17 +42,6 @@ benchmarks/<benchmark>/runs/<test-name>/
 - overall wall-clock duration for the benchmark command
 - total benchmark cost for the invocation when Claude reports usage
 
-Per-case artifacts still live under:
-
-```text
-benchmarks/<benchmark>/runs/<test-name>/
-  logs/
-  workspace/
-  results.json
-  transcript.json
-  transcript.md
-```
-
 Each run gets its own isolated benchmark workspace. That workspace contains:
 
 - a copied `dist/` build of the Libretto CLI

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,6 +25,26 @@ Current status:
 Run artifacts are written to:
 
 ```text
+benchmarks/run-history.jsonl
+benchmarks/<benchmark>/runs/<test-name>/
+  logs/
+  workspace/
+  results.json
+  transcript.json
+  transcript.md
+```
+
+`benchmarks/run-history.jsonl` appends one entry per `pnpm benchmark ...` invocation, including:
+
+- requested benchmark selection
+- passthrough Vitest args
+- exit code
+- overall wall-clock duration for the benchmark command
+- total benchmark cost for the invocation when Claude reports usage
+
+Per-case artifacts still live under:
+
+```text
 benchmarks/<benchmark>/runs/<test-name>/
   logs/
   workspace/
@@ -39,6 +59,8 @@ Each run gets its own isolated benchmark workspace. That workspace contains:
 - a local `package.json` with `pnpm cli` pointing directly at `dist/cli/index.js`
 - a copied `.agents/skills/libretto/SKILL.md`
 - its own `.libretto/` runtime state and benchmark snapshot-analyzer config
+
+Each per-case `results.json` now also records Claude-reported usage and `totalCostUsd`, and the generated benchmark summary includes a run-level duration/cost table plus per-case duration and cost.
 
 Model overrides:
 

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -1,3 +1,10 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -5,14 +12,71 @@ import { dirname, resolve } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
 
-const BENCHMARK_PATHS: Record<string, string> = {
-  onlineMind2Web: "benchmarks/onlineMind2Web",
-  onlinemind2web: "benchmarks/onlineMind2Web",
-  webVoyager: "benchmarks/webVoyager",
-  webvoyager: "benchmarks/webVoyager",
-  webBench: "benchmarks/webBench",
-  webbench: "benchmarks/webBench",
+const BENCHMARK_DEFINITIONS = [
+  {
+    name: "onlineMind2Web",
+    path: "benchmarks/onlineMind2Web",
+    aliases: ["onlineMind2Web", "onlinemind2web"],
+  },
+  {
+    name: "webVoyager",
+    path: "benchmarks/webVoyager",
+    aliases: ["webVoyager", "webvoyager"],
+  },
+  {
+    name: "webBench",
+    path: "benchmarks/webBench",
+    aliases: ["webBench", "webbench"],
+  },
+] as const;
+
+const BENCHMARK_LOOKUP = new Map<
+  string,
+  (typeof BENCHMARK_DEFINITIONS)[number]
+>(
+  BENCHMARK_DEFINITIONS.flatMap((definition) =>
+    definition.aliases.map((alias) => [alias, definition] as const),
+  ),
+);
+
+const ALL_BENCHMARK_NAMES = BENCHMARK_DEFINITIONS.map(
+  (definition) => definition.name,
+);
+
+export type ParsedBenchmarkArgs = {
+  benchmarkFilters: string[];
+  passthroughArgs: string[];
+  benchmarks: string[];
+  isAllBenchmarks: boolean;
 };
+
+export type BenchmarkRunRecord = {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  durationText: string;
+  totalCostUsd: number | null;
+  exitCode: number;
+  requestedArgs: string[];
+  passthroughArgs: string[];
+  benchmarkFilters: string[];
+  benchmarks: string[];
+  scope: "all" | "selected";
+  resultFileCount: number;
+  costTrackedResultCount: number;
+};
+
+type PersistedBenchmarkResult = {
+  benchmark?: string;
+  caseId?: string;
+  totalCostUsd?: number | null;
+};
+
+function pushUnique(values: string[], value: string): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
 
 function printUsage(): void {
   console.log(
@@ -27,43 +91,230 @@ function printUsage(): void {
   );
 }
 
-const requestedArgs = process.argv.slice(2);
+export function parseBenchmarkArgs(requestedArgs: string[]): ParsedBenchmarkArgs {
+  const benchmarkFilters: string[] = [];
+  const passthroughArgs: string[] = [];
+  const selectedBenchmarks: string[] = [];
 
-if (requestedArgs.includes("help") || requestedArgs.includes("--help") || requestedArgs.includes("-h")) {
-  printUsage();
-  process.exit(0);
+  for (const arg of requestedArgs) {
+    if (arg === "--") {
+      continue;
+    }
+
+    const benchmark = BENCHMARK_LOOKUP.get(arg);
+    if (benchmark) {
+      pushUnique(benchmarkFilters, benchmark.path);
+      pushUnique(selectedBenchmarks, benchmark.name);
+      continue;
+    }
+
+    passthroughArgs.push(arg);
+  }
+
+  const isAllBenchmarks = selectedBenchmarks.length === 0;
+  return {
+    benchmarkFilters,
+    passthroughArgs,
+    benchmarks: isAllBenchmarks ? [...ALL_BENCHMARK_NAMES] : selectedBenchmarks,
+    isAllBenchmarks,
+  };
 }
 
-const benchmarkFilters: string[] = [];
-const passthroughArgs: string[] = [];
+export function formatDuration(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    return "n/a";
+  }
 
-for (const arg of requestedArgs) {
-  if (arg === "--") {
-    continue;
-  }
-  const mappedPath = BENCHMARK_PATHS[arg];
-  if (mappedPath) {
-    benchmarkFilters.push(mappedPath);
-    continue;
-  }
-  passthroughArgs.push(arg);
+  const totalSeconds = Math.round(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
 }
 
-const result = spawnSync(
-  "pnpm",
-  [
-    "exec",
-    "vitest",
-    "run",
-    "--config",
-    "vitest.benchmarks.config.ts",
-    ...passthroughArgs,
-    ...benchmarkFilters,
-  ],
-  {
-    cwd: repoRoot,
-    stdio: "inherit",
-  },
-);
+function walkResultPaths(root: string): string[] {
+  const resultPaths: string[] = [];
+  const stack = [root];
 
-process.exit(result.status ?? 1);
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = resolve(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name === "results.json") {
+        resultPaths.push(entryPath);
+      }
+    }
+  }
+
+  return resultPaths.sort();
+}
+
+function readPersistedBenchmarkResult(
+  resultPath: string,
+): PersistedBenchmarkResult | null {
+  try {
+    return JSON.parse(readFileSync(resultPath, "utf8")) as PersistedBenchmarkResult;
+  } catch {
+    return null;
+  }
+}
+
+export function collectRunBenchmarkResults(args: {
+  root: string;
+  benchmarks: string[];
+  startedAt: Date;
+  finishedAt: Date;
+}): PersistedBenchmarkResult[] {
+  const startedAtMs = args.startedAt.getTime();
+  const finishedAtMs = args.finishedAt.getTime();
+  const rows: PersistedBenchmarkResult[] = [];
+
+  for (const benchmark of args.benchmarks) {
+    const runsRoot = resolve(args.root, "benchmarks", benchmark, "runs");
+    for (const resultPath of walkResultPaths(runsRoot)) {
+      let stats;
+      try {
+        stats = statSync(resultPath);
+      } catch {
+        continue;
+      }
+
+      if (stats.mtimeMs < startedAtMs || stats.mtimeMs > finishedAtMs) {
+        continue;
+      }
+
+      const row = readPersistedBenchmarkResult(resultPath);
+      if (row) {
+        rows.push(row);
+      }
+    }
+  }
+
+  return rows;
+}
+
+export function buildBenchmarkRunRecord(args: {
+  requestedArgs: string[];
+  parsedArgs: ParsedBenchmarkArgs;
+  startedAt: Date;
+  finishedAt: Date;
+  exitCode: number;
+  results?: PersistedBenchmarkResult[];
+}): BenchmarkRunRecord {
+  const durationMs = args.finishedAt.getTime() - args.startedAt.getTime();
+  const results = args.results ?? [];
+  const resultCosts = results
+    .map((result) => result.totalCostUsd)
+    .filter((cost): cost is number => typeof cost === "number");
+
+  return {
+    startedAt: args.startedAt.toISOString(),
+    finishedAt: args.finishedAt.toISOString(),
+    durationMs,
+    durationText: formatDuration(durationMs),
+    totalCostUsd:
+      resultCosts.length > 0
+        ? resultCosts.reduce((sum, cost) => sum + cost, 0)
+        : null,
+    exitCode: args.exitCode,
+    requestedArgs: [...args.requestedArgs],
+    passthroughArgs: [...args.parsedArgs.passthroughArgs],
+    benchmarkFilters: [...args.parsedArgs.benchmarkFilters],
+    benchmarks: [...args.parsedArgs.benchmarks],
+    scope: args.parsedArgs.isAllBenchmarks ? "all" : "selected",
+    resultFileCount: results.length,
+    costTrackedResultCount: resultCosts.length,
+  };
+}
+
+export function getBenchmarkRunHistoryPath(root: string): string {
+  return resolve(root, "benchmarks", "run-history.jsonl");
+}
+
+export function appendBenchmarkRunRecord(
+  root: string,
+  record: BenchmarkRunRecord,
+): void {
+  const historyPath = getBenchmarkRunHistoryPath(root);
+  mkdirSync(dirname(historyPath), { recursive: true });
+  appendFileSync(historyPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+function isExecutedAsScript(): boolean {
+  return (
+    typeof process.argv[1] === "string" &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+  if (argv.includes("help") || argv.includes("--help") || argv.includes("-h")) {
+    printUsage();
+    return 0;
+  }
+
+  const parsedArgs = parseBenchmarkArgs(argv);
+  const startedAt = new Date();
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "vitest",
+      "run",
+      "--config",
+      "vitest.benchmarks.config.ts",
+      ...parsedArgs.passthroughArgs,
+      ...parsedArgs.benchmarkFilters,
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+    },
+  );
+  const exitCode = result.status ?? 1;
+  const finishedAt = new Date();
+  const persistedResults = collectRunBenchmarkResults({
+    root: repoRoot,
+    benchmarks: parsedArgs.benchmarks,
+    startedAt,
+    finishedAt,
+  });
+
+  try {
+    appendBenchmarkRunRecord(
+      repoRoot,
+      buildBenchmarkRunRecord({
+        requestedArgs: argv,
+        parsedArgs,
+        startedAt,
+        finishedAt,
+        exitCode,
+        results: persistedResults,
+      }),
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error ?? "Unknown error");
+    console.warn(`Warning: failed to write benchmark run history: ${message}`);
+  }
+
+  return exitCode;
+}
+
+if (isExecutedAsScript()) {
+  process.exit(main());
+}

--- a/benchmarks/shared/cases.ts
+++ b/benchmarks/shared/cases.ts
@@ -7,6 +7,7 @@ import {
   EvalResponse,
   type ClaudeEvalHarness,
 } from "../../evals/harness.js";
+import type { ModelUsage, NonNullableUsage } from "@anthropic-ai/claude-agent-sdk";
 import {
   createClaudeBenchmarkHarness,
   getBenchmarkAnalyzerPath,
@@ -45,6 +46,9 @@ type BenchmarkRunArtifacts = {
   startedAt: string;
   finishedAt: string;
   durationMs: number;
+  totalCostUsd: number | null;
+  usage: NonNullableUsage | null;
+  modelUsage: Record<string, ModelUsage> | null;
   status: "running" | "passed" | "failed";
 };
 
@@ -498,6 +502,9 @@ async function persistArtifacts(
         startedAt: artifacts.startedAt,
         finishedAt: artifacts.finishedAt,
         durationMs: artifacts.durationMs,
+        totalCostUsd: artifacts.totalCostUsd,
+        usage: artifacts.usage,
+        modelUsage: artifacts.modelUsage,
         status: artifacts.status,
         completed,
         success,
@@ -522,6 +529,9 @@ async function persistArtifacts(
         startedAt: artifacts.startedAt,
         finishedAt: artifacts.finishedAt,
         durationMs: artifacts.durationMs,
+        totalCostUsd: artifacts.totalCostUsd,
+        usage: artifacts.usage,
+        modelUsage: artifacts.modelUsage,
         status: artifacts.status,
         completed,
         transcript,
@@ -552,6 +562,7 @@ async function persistArtifacts(
       `- Started: ${artifacts.startedAt}`,
       `- Finished: ${artifacts.finishedAt}`,
       `- Duration (ms): ${artifacts.durationMs}`,
+      `- Total Cost (USD): ${artifacts.totalCostUsd ?? "n/a"}`,
       "",
       "## Transcript",
       "",
@@ -578,6 +589,7 @@ async function persistArtifacts(
       startedAt: artifacts.startedAt,
       finishedAt: artifacts.finishedAt,
       durationMs: artifacts.durationMs,
+      totalCostUsd: artifacts.totalCostUsd,
       sessionId: artifacts.response?.sessionId ?? null,
       status: artifacts.status,
       completed,
@@ -652,6 +664,9 @@ class BenchmarkRunPersister {
       startedAt: this.startedAt.toISOString(),
       finishedAt: finishedAt.toISOString(),
       durationMs: finishedAt.getTime() - this.startedAt.getTime(),
+      totalCostUsd: this.response?.totalCostUsd ?? null,
+      usage: this.response?.usage ?? null,
+      modelUsage: this.response?.modelUsage ?? null,
       status: this.status,
     };
   }

--- a/benchmarks/summarize-results.mjs
+++ b/benchmarks/summarize-results.mjs
@@ -1,7 +1,8 @@
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { basename, join, resolve } from "node:path";
 
-function walkResults(root) {
+export function walkResults(root) {
   const results = [];
   const stack = [root];
 
@@ -29,11 +30,11 @@ function walkResults(root) {
   return results.sort();
 }
 
-function readJson(path) {
+export function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
-function formatDuration(durationMs) {
+export function formatDuration(durationMs) {
   if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) {
     return "n/a";
   }
@@ -41,6 +42,48 @@ function formatDuration(durationMs) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+export function formatCost(costUsd) {
+  if (typeof costUsd !== "number" || !Number.isFinite(costUsd)) {
+    return "n/a";
+  }
+  return `$${costUsd.toFixed(4)}`;
+}
+
+export function getRowCostUsd(row) {
+  if (typeof row.totalCostUsd === "number" && Number.isFinite(row.totalCostUsd)) {
+    return row.totalCostUsd;
+  }
+  if (typeof row.costUsd === "number" && Number.isFinite(row.costUsd)) {
+    return row.costUsd;
+  }
+  return null;
+}
+
+export function readJsonl(path) {
+  try {
+    const contents = readFileSync(path, "utf8");
+    return contents
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+export function getLatestBenchmarkRunRecord(root, benchmark) {
+  const historyPath = resolve(root, "benchmarks", "run-history.jsonl");
+  const records = readJsonl(historyPath)
+    .filter((record) => Array.isArray(record.benchmarks) && record.benchmarks.includes(benchmark))
+    .sort((a, b) => {
+      const aFinished = typeof a.finishedAt === "string" ? Date.parse(a.finishedAt) : 0;
+      const bFinished = typeof b.finishedAt === "string" ? Date.parse(b.finishedAt) : 0;
+      return bFinished - aFinished;
+    });
+  return records[0] ?? null;
 }
 
 function clip(text, maxChars = 120) {
@@ -69,7 +112,7 @@ function getStatusEmoji(status) {
   }
 }
 
-function buildMarkdown({
+export function buildMarkdown({
   benchmark,
   runMode,
   sampleSize,
@@ -77,10 +120,16 @@ function buildMarkdown({
   runUrl,
   artifactName,
   rows,
+  runRecord,
 }) {
   const passed = rows.filter((row) => row.status === "passed").length;
   const failed = rows.filter((row) => row.status === "failed").length;
   const running = rows.filter((row) => row.status === "running").length;
+  const totalCostUsd = rows.reduce((sum, row) => {
+    const rowCostUsd = getRowCostUsd(row);
+    return rowCostUsd == null ? sum : sum + rowCostUsd;
+  }, 0);
+  const costTracked = rows.filter((row) => getRowCostUsd(row) != null).length;
 
   const lines = [
     "# Benchmark Results",
@@ -93,6 +142,8 @@ function buildMarkdown({
     `- Passed: \`${passed}\``,
     `- Failed: \`${failed}\``,
     `- Incomplete: \`${running}\``,
+    `- Cost tracked: \`${costTracked}\``,
+    `- Total cost: \`${costTracked > 0 ? formatCost(totalCostUsd) : "n/a"}\``,
   ];
 
   if (runUrl) {
@@ -102,10 +153,21 @@ function buildMarkdown({
     lines.push(`- Artifact: \`${artifactName}\``);
   }
 
-  lines.push("", "| Case | Status | Duration | Summary |", "| --- | --- | --- | --- |");
+  lines.push(
+    "",
+    "| Benchmark Run | Duration | Cost | Result files | Cost tracked |",
+    "| --- | --- | --- | --- | --- |",
+    `| \`${benchmark}\` | \`${formatDuration(runRecord?.durationMs)}\` | \`${formatCost(runRecord?.totalCostUsd ?? (costTracked > 0 ? totalCostUsd : null))}\` | \`${rows.length}\` | \`${costTracked}\` |`,
+  );
+
+  lines.push(
+    "",
+    "| Case | Status | Duration | Cost | Summary |",
+    "| --- | --- | --- | --- | --- |",
+  );
 
   if (rows.length === 0) {
-    lines.push("| n/a | n/a | n/a | No results.json files were generated. |");
+    lines.push("| n/a | n/a | n/a | n/a | No results.json files were generated. |");
     return lines.join("\n");
   }
 
@@ -116,7 +178,7 @@ function buildMarkdown({
       row.error?.name ||
       "No final result recorded.";
     lines.push(
-      `| \`${row.caseId ?? basename(row.runRoot ?? "unknown")}\` | ${getStatusEmoji(row.status)} \`${row.status ?? "unknown"}\` | \`${formatDuration(row.durationMs)}\` | ${escapeMarkdownTableCell(clip(summarySource))} |`,
+      `| \`${row.caseId ?? basename(row.runRoot ?? "unknown")}\` | ${getStatusEmoji(row.status)} \`${row.status ?? "unknown"}\` | \`${formatDuration(row.durationMs)}\` | \`${formatCost(getRowCostUsd(row))}\` | ${escapeMarkdownTableCell(clip(summarySource))} |`,
     );
   }
 
@@ -138,6 +200,7 @@ function main() {
   const runsRoot = resolve(repoRoot, "benchmarks", benchmark, "runs");
   const resultPaths = walkResults(runsRoot);
   const rows = resultPaths.map((path) => readJson(path));
+  const runRecord = getLatestBenchmarkRunRecord(repoRoot, benchmark);
 
   rows.sort((a, b) => {
     const caseA = String(a.caseId ?? "");
@@ -153,10 +216,20 @@ function main() {
     runUrl: process.env.BENCHMARK_RUN_URL ?? "",
     artifactName: process.env.BENCHMARK_ARTIFACT_NAME ?? "",
     rows,
+    runRecord,
   });
 
   writeFileSync(outputPath, markdown, "utf8");
   process.stdout.write(markdown);
 }
 
-main();
+function isExecutedAsScript() {
+  return (
+    typeof process.argv[1] === "string" &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isExecutedAsScript()) {
+  main();
+}

--- a/benchmarks/summarize-results.mjs
+++ b/benchmarks/summarize-results.mjs
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { basename, join, resolve } from "node:path";
 
@@ -94,6 +94,31 @@ export function getLatestBenchmarkRunRecord(root, benchmark) {
   return records[0] ?? null;
 }
 
+export function filterResultPathsForRunRecord(resultPaths, runRecord) {
+  if (
+    !runRecord ||
+    typeof runRecord.startedAt !== "string" ||
+    typeof runRecord.finishedAt !== "string"
+  ) {
+    return resultPaths;
+  }
+
+  const startedAtMs = Date.parse(runRecord.startedAt);
+  const finishedAtMs = Date.parse(runRecord.finishedAt);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(finishedAtMs)) {
+    return resultPaths;
+  }
+
+  return resultPaths.filter((path) => {
+    try {
+      const stats = statSync(path);
+      return stats.mtimeMs >= startedAtMs && stats.mtimeMs <= finishedAtMs;
+    } catch {
+      return false;
+    }
+  });
+}
+
 function clip(text, maxChars = 120) {
   if (typeof text !== "string" || text.trim().length === 0) {
     return "n/a";
@@ -130,6 +155,10 @@ export function buildMarkdown({
   rows,
   runRecord,
 }) {
+  const resultFileCount =
+    typeof runRecord?.resultFileCount === "number"
+      ? runRecord.resultFileCount
+      : rows.length;
   const passed = rows.filter((row) => row.status === "passed").length;
   const failed = rows.filter((row) => row.status === "failed").length;
   const running = rows.filter((row) => row.status === "running").length;
@@ -137,7 +166,16 @@ export function buildMarkdown({
     const rowCostUsd = getRowCostUsd(row);
     return rowCostUsd == null ? sum : sum + rowCostUsd;
   }, 0);
-  const costTracked = rows.filter((row) => getRowCostUsd(row) != null).length;
+  const costTracked =
+    typeof runRecord?.costTrackedResultCount === "number"
+      ? runRecord.costTrackedResultCount
+      : rows.filter((row) => getRowCostUsd(row) != null).length;
+  const runTotalCostUsd =
+    typeof runRecord?.totalCostUsd === "number"
+      ? runRecord.totalCostUsd
+      : costTracked > 0
+        ? totalCostUsd
+        : null;
 
   const lines = [
     "# Benchmark Results",
@@ -146,12 +184,12 @@ export function buildMarkdown({
     `- Mode: \`${runMode}\``,
     `- Sample size: \`${sampleSize}\``,
     `- Seed: \`${randomSeed}\``,
-    `- Result files: \`${rows.length}\``,
+    `- Result files: \`${resultFileCount}\``,
     `- Passed: \`${passed}\``,
     `- Failed: \`${failed}\``,
     `- Incomplete: \`${running}\``,
     `- Cost tracked: \`${costTracked}\``,
-    `- Total cost: \`${costTracked > 0 ? formatCost(totalCostUsd) : "n/a"}\``,
+    `- Total cost: \`${formatCost(runTotalCostUsd)}\``,
   ];
 
   if (runUrl) {
@@ -165,7 +203,7 @@ export function buildMarkdown({
     "",
     "| Benchmark Run | Duration | Cost | Result files | Cost tracked |",
     "| --- | --- | --- | --- | --- |",
-    `| \`${benchmark}\` | \`${formatDuration(runRecord?.durationMs)}\` | \`${formatCost(runRecord?.totalCostUsd ?? (costTracked > 0 ? totalCostUsd : null))}\` | \`${rows.length}\` | \`${costTracked}\` |`,
+    `| \`${benchmark}\` | \`${formatDuration(runRecord?.durationMs)}\` | \`${formatCost(runTotalCostUsd)}\` | \`${resultFileCount}\` | \`${costTracked}\` |`,
   );
 
   lines.push(
@@ -206,9 +244,12 @@ function main() {
 
   const repoRoot = process.cwd();
   const runsRoot = resolve(repoRoot, "benchmarks", benchmark, "runs");
-  const resultPaths = walkResults(runsRoot);
-  const rows = resultPaths.map((path) => readJson(path));
   const runRecord = getLatestBenchmarkRunRecord(repoRoot, benchmark);
+  const resultPaths = filterResultPathsForRunRecord(
+    walkResults(runsRoot),
+    runRecord,
+  );
+  const rows = resultPaths.map((path) => readJson(path));
 
   rows.sort((a, b) => {
     const caseA = String(a.caseId ?? "");

--- a/benchmarks/summarize-results.mjs
+++ b/benchmarks/summarize-results.mjs
@@ -77,7 +77,15 @@ export function readJsonl(path) {
 export function getLatestBenchmarkRunRecord(root, benchmark) {
   const historyPath = resolve(root, "benchmarks", "run-history.jsonl");
   const records = readJsonl(historyPath)
-    .filter((record) => Array.isArray(record.benchmarks) && record.benchmarks.includes(benchmark))
+    .filter((record) => {
+      if (!Array.isArray(record.benchmarks)) {
+        return false;
+      }
+      if (record.scope !== "selected") {
+        return false;
+      }
+      return record.benchmarks.length === 1 && record.benchmarks[0] === benchmark;
+    })
     .sort((a, b) => {
       const aFinished = typeof a.finishedAt === "string" ? Date.parse(a.finishedAt) : 0;
       const bFinished = typeof b.finishedAt === "string" ? Date.parse(b.finishedAt) : 0;

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -4,6 +4,8 @@ import {
   query,
   type Options,
   type PermissionMode,
+  type NonNullableUsage,
+  type ModelUsage,
   type SDKAssistantMessage,
   type SDKMessage,
   type SDKResultMessage,
@@ -423,6 +425,9 @@ export class EvalResponse {
   readonly sessionId: string | null;
   readonly transcript: string;
   readonly result: SDKResultMessage | null;
+  readonly totalCostUsd: number | null;
+  readonly usage: NonNullableUsage | null;
+  readonly modelUsage: Record<string, ModelUsage> | null;
   private readonly cwd: string;
   private readonly model?: string;
 
@@ -438,6 +443,12 @@ export class EvalResponse {
     this.sessionId = opts.sessionId;
     this.transcript = formatMessagesForEvaluation(opts.messages);
     this.result = extractResultMessage(opts.messages);
+    this.totalCostUsd =
+      this.result && typeof this.result.total_cost_usd === "number"
+        ? this.result.total_cost_usd
+        : null;
+    this.usage = this.result?.usage ?? null;
+    this.modelUsage = this.result?.modelUsage ?? null;
     this.cwd = opts.cwd;
     this.model = opts.model;
   }

--- a/test/benchmark-run.spec.ts
+++ b/test/benchmark-run.spec.ts
@@ -1,0 +1,140 @@
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  appendBenchmarkRunRecord,
+  buildBenchmarkRunRecord,
+  collectRunBenchmarkResults,
+  getBenchmarkRunHistoryPath,
+  parseBenchmarkArgs,
+} from "../benchmarks/run.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("benchmark launcher history", () => {
+  test("defaults to all benchmarks when no benchmark filter is provided", () => {
+    const parsed = parseBenchmarkArgs(["--testNamePattern", "FINAL_RESULT"]);
+
+    expect(parsed.benchmarkFilters).toEqual([]);
+    expect(parsed.passthroughArgs).toEqual([
+      "--testNamePattern",
+      "FINAL_RESULT",
+    ]);
+    expect(parsed.benchmarks).toEqual([
+      "onlineMind2Web",
+      "webVoyager",
+      "webBench",
+    ]);
+    expect(parsed.isAllBenchmarks).toBe(true);
+  });
+
+  test("writes one jsonl record per benchmark invocation", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "libretto-benchmark-run-"));
+    tempRoots.push(tempRoot);
+
+    const resultPath = join(
+      tempRoot,
+      "benchmarks",
+      "webVoyager",
+      "runs",
+      "sample-case",
+      "results.json",
+    );
+    await mkdir(dirname(resultPath), { recursive: true });
+    await writeFile(
+      resultPath,
+      JSON.stringify({
+        benchmark: "webVoyager",
+        caseId: "sample-case",
+        totalCostUsd: 0.4321,
+      }),
+      "utf8",
+    );
+    await utimes(
+      resultPath,
+      new Date("2026-03-12T20:01:00.000Z"),
+      new Date("2026-03-12T20:01:00.000Z"),
+    );
+
+    const parsed = parseBenchmarkArgs([
+      "webVoyager",
+      "--",
+      "--testNamePattern",
+      "FINAL_RESULT",
+    ]);
+    const results = collectRunBenchmarkResults({
+      root: tempRoot,
+      benchmarks: parsed.benchmarks,
+      startedAt: new Date("2026-03-12T20:00:00.000Z"),
+      finishedAt: new Date("2026-03-12T20:02:03.000Z"),
+    });
+    const record = buildBenchmarkRunRecord({
+      requestedArgs: ["webVoyager", "--", "--testNamePattern", "FINAL_RESULT"],
+      parsedArgs: parsed,
+      startedAt: new Date("2026-03-12T20:00:00.000Z"),
+      finishedAt: new Date("2026-03-12T20:02:03.000Z"),
+      exitCode: 0,
+      results,
+    });
+
+    appendBenchmarkRunRecord(tempRoot, record);
+
+    const historyPath = getBenchmarkRunHistoryPath(tempRoot);
+    const contents = await readFile(historyPath, "utf8");
+    expect(contents).toBe(`${JSON.stringify(record)}\n`);
+
+    const persisted = JSON.parse(contents.trim());
+    expect(persisted).toMatchObject({
+      durationMs: 123_000,
+      durationText: "2m 03s",
+      exitCode: 0,
+      totalCostUsd: 0.4321,
+      benchmarkFilters: ["benchmarks/webVoyager"],
+      benchmarks: ["webVoyager"],
+      resultFileCount: 1,
+      costTrackedResultCount: 1,
+      passthroughArgs: ["--testNamePattern", "FINAL_RESULT"],
+      requestedArgs: ["webVoyager", "--", "--testNamePattern", "FINAL_RESULT"],
+      scope: "selected",
+    });
+  });
+
+  test("summary includes run-level duration and cost table", async () => {
+    // @ts-expect-error -- benchmark summary helper is authored as plain .mjs
+    const { buildMarkdown } = await import("../benchmarks/summarize-results.mjs");
+    const markdown = buildMarkdown({
+      benchmark: "webVoyager",
+      runMode: "small-random",
+      sampleSize: "3",
+      randomSeed: "20260313",
+      runUrl: "",
+      artifactName: "",
+      runRecord: {
+        durationMs: 321_000,
+        totalCostUsd: 1.2345,
+      },
+      rows: [
+        {
+          caseId: "sample-case",
+          status: "passed",
+          durationMs: 123_000,
+          totalCostUsd: 0.4321,
+          finalResult: "FINAL_RESULT: https://example.com | Example",
+        },
+      ],
+    });
+
+    expect(markdown).toContain("| Benchmark Run | Duration | Cost | Result files | Cost tracked |");
+    expect(markdown).toContain("| `webVoyager` | `5m 21s` | `$1.2345` | `1` | `1` |");
+    expect(markdown).toContain("| `sample-case` | pass `passed` | `2m 03s` | `$0.4321` |");
+  });
+});

--- a/test/benchmark-run.spec.ts
+++ b/test/benchmark-run.spec.ts
@@ -137,4 +137,40 @@ describe("benchmark launcher history", () => {
     expect(markdown).toContain("| `webVoyager` | `5m 21s` | `$1.2345` | `1` | `1` |");
     expect(markdown).toContain("| `sample-case` | pass `passed` | `2m 03s` | `$0.4321` |");
   });
+
+  test("summary lookup ignores all-benchmark history entries", async () => {
+    // @ts-expect-error -- benchmark summary helper is authored as plain .mjs
+    const { getLatestBenchmarkRunRecord } = await import("../benchmarks/summarize-results.mjs");
+    const tempRoot = await mkdtemp(join(tmpdir(), "libretto-benchmark-summary-"));
+    tempRoots.push(tempRoot);
+
+    await mkdir(join(tempRoot, "benchmarks"), { recursive: true });
+    await writeFile(
+      join(tempRoot, "benchmarks", "run-history.jsonl"),
+      [
+        JSON.stringify({
+          finishedAt: "2026-03-12T20:05:00.000Z",
+          scope: "selected",
+          benchmarks: ["webVoyager"],
+          durationMs: 123_000,
+          totalCostUsd: 0.4321,
+        }),
+        JSON.stringify({
+          finishedAt: "2026-03-12T20:06:00.000Z",
+          scope: "all",
+          benchmarks: ["onlineMind2Web", "webVoyager", "webBench"],
+          durationMs: 999_000,
+          totalCostUsd: 9.9999,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    expect(getLatestBenchmarkRunRecord(tempRoot, "webVoyager")).toMatchObject({
+      scope: "selected",
+      benchmarks: ["webVoyager"],
+      durationMs: 123_000,
+      totalCostUsd: 0.4321,
+    });
+  });
 });

--- a/test/benchmark-run.spec.ts
+++ b/test/benchmark-run.spec.ts
@@ -121,6 +121,8 @@ describe("benchmark launcher history", () => {
       runRecord: {
         durationMs: 321_000,
         totalCostUsd: 1.2345,
+        resultFileCount: 3,
+        costTrackedResultCount: 2,
       },
       rows: [
         {
@@ -133,8 +135,11 @@ describe("benchmark launcher history", () => {
       ],
     });
 
+    expect(markdown).toContain("- Result files: `3`");
+    expect(markdown).toContain("- Cost tracked: `2`");
+    expect(markdown).toContain("- Total cost: `$1.2345`");
     expect(markdown).toContain("| Benchmark Run | Duration | Cost | Result files | Cost tracked |");
-    expect(markdown).toContain("| `webVoyager` | `5m 21s` | `$1.2345` | `1` | `1` |");
+    expect(markdown).toContain("| `webVoyager` | `5m 21s` | `$1.2345` | `3` | `2` |");
     expect(markdown).toContain("| `sample-case` | pass `passed` | `2m 03s` | `$0.4321` |");
   });
 
@@ -172,5 +177,34 @@ describe("benchmark launcher history", () => {
       durationMs: 123_000,
       totalCostUsd: 0.4321,
     });
+  });
+
+  test("summary scopes result files to the selected run window", async () => {
+    // @ts-expect-error -- benchmark summary helper is authored as plain .mjs
+    const { filterResultPathsForRunRecord } = await import("../benchmarks/summarize-results.mjs");
+    const tempRoot = await mkdtemp(join(tmpdir(), "libretto-benchmark-results-"));
+    tempRoots.push(tempRoot);
+
+    const earlierPath = join(tempRoot, "earlier-results.json");
+    const currentPath = join(tempRoot, "current-results.json");
+    await writeFile(earlierPath, "{}", "utf8");
+    await writeFile(currentPath, "{}", "utf8");
+    await utimes(
+      earlierPath,
+      new Date("2026-03-12T19:59:00.000Z"),
+      new Date("2026-03-12T19:59:00.000Z"),
+    );
+    await utimes(
+      currentPath,
+      new Date("2026-03-12T20:01:00.000Z"),
+      new Date("2026-03-12T20:01:00.000Z"),
+    );
+
+    expect(
+      filterResultPathsForRunRecord([earlierPath, currentPath], {
+        startedAt: "2026-03-12T20:00:00.000Z",
+        finishedAt: "2026-03-12T20:02:00.000Z",
+      }),
+    ).toEqual([currentPath]);
   });
 });


### PR DESCRIPTION
## Summary
- add benchmark run history entries with wall-clock duration and rolled-up cost for each `pnpm benchmark` invocation
- persist Claude-reported usage and total cost in per-case benchmark artifacts and include cost in the generated benchmark summary
- show run-level duration and cost in the GitHub benchmark workflow summary and upload the run history artifact

## Testing
- `pnpm type-check`
- `pnpm test -- test/benchmark-run.spec.ts`
- `node --check benchmarks/summarize-results.mjs`
