### PR TITLE
Set benchmark workflow seed default to 0

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ on:
       random_seed:
         description: Seed for random sampling
         required: true
-        default: "20260313"
+        default: "0"
         type: string
 
 permissions:


### PR DESCRIPTION
## Summary
- change the benchmarks workflow `random_seed` input default from `20260313` to `0`
