### PR TITLE
Use stdin for snapshot analyzer prompts

### DIFF
--- a/src/cli/core/snapshot-analyzer.ts
+++ b/src/cli/core/snapshot-analyzer.ts
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
@@ -54,6 +55,11 @@ type ExternalCommandResult = {
   stderr: string;
 };
 
+type ExternalCommandInput = {
+  stdinText?: string;
+  stdinFilePath?: string;
+};
+
 abstract class UserCodingAgent {
   protected constructor(protected readonly config: AiConfig) {}
 
@@ -102,9 +108,9 @@ abstract class UserCodingAgent {
 
   protected async runAnalyzer(
     args: string[],
-    stdinText?: string,
+    input: ExternalCommandInput = {},
   ): Promise<ExternalCommandResult> {
-    const result = await runExternalCommand(this.command, args, stdinText);
+    const result = await runExternalCommand(this.command, args, input);
     if (result.exitCode !== 0) {
       throw new Error(
         `Analyzer command failed (${formatCommandPrefix([this.command, ...args])}).\n${stripAnsi(result.stderr).trim() || stripAnsi(result.stdout).trim() || "No error output."}`,
@@ -115,10 +121,27 @@ abstract class UserCodingAgent {
 
   protected async runAndParse(
     args: string[],
-    stdinText?: string,
+    input: ExternalCommandInput = {},
   ): Promise<InterpretResult> {
-    const result = await this.runAnalyzer(args, stdinText);
+    const result = await this.runAnalyzer(args, input);
     return parseInterpretResultFromText(result.stdout);
+  }
+
+  protected async runAndParseFromTempPromptFile(
+    args: string[],
+    prompt: string,
+  ): Promise<InterpretResult> {
+    const tempDir = mkdtempSync(join(tmpdir(), "libretto-cli-analyzer-"));
+    const promptPath = join(
+      tempDir,
+      `snapshot-analyzer-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
+    );
+    writeFileSync(promptPath, prompt, "utf-8");
+    try {
+      return await this.runAndParse(args, { stdinFilePath: promptPath });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   }
 
   abstract analyzeSnapshot(
@@ -145,7 +168,7 @@ class CodexUserCodingAgent extends UserCodingAgent {
       pngPath,
       "-",
     ];
-    const result = await this.runAnalyzer(args, prompt);
+    const result = await this.runAnalyzer(args, { stdinText: prompt });
     let outputText = result.stdout;
     try {
       if (existsSync(outputPath)) {
@@ -163,8 +186,10 @@ class ClaudeUserCodingAgent extends UserCodingAgent {
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    const args = [...this.baseArgs, `${prompt}${this.screenshotHint(pngPath)}`];
-    return await this.runAndParse(args);
+    return await this.runAndParseFromTempPromptFile(
+      [...this.baseArgs],
+      `${prompt}${this.screenshotHint(pngPath)}`,
+    );
   }
 }
 
@@ -173,15 +198,17 @@ class GeminiUserCodingAgent extends UserCodingAgent {
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    const args = [...this.baseArgs, `${prompt}${this.screenshotHint(pngPath)}`];
-    return await this.runAndParse(args);
+    return await this.runAndParseFromTempPromptFile(
+      [...this.baseArgs],
+      `${prompt}${this.screenshotHint(pngPath)}`,
+    );
   }
 }
 
 async function runExternalCommand(
   command: string,
   args: string[],
-  stdinText?: string,
+  input: ExternalCommandInput = {},
 ): Promise<ExternalCommandResult> {
   return await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -220,8 +247,16 @@ async function runExternalCommand(
       });
     });
 
-    if (stdinText !== undefined) {
-      child.stdin.write(stdinText);
+    if (input.stdinText !== undefined && input.stdinFilePath !== undefined) {
+      reject(new Error("Analyzer input cannot use both stdinText and stdinFilePath."));
+      child.stdin.destroy();
+      return;
+    }
+
+    if (input.stdinFilePath !== undefined) {
+      child.stdin.write(readFileSync(input.stdinFilePath, "utf-8"));
+    } else if (input.stdinText !== undefined) {
+      child.stdin.write(input.stdinText);
     }
     child.stdin.end();
   });

--- a/src/cli/core/snapshot-analyzer.ts
+++ b/src/cli/core/snapshot-analyzer.ts
@@ -3,7 +3,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  writeFileSync,
 } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
@@ -55,11 +54,6 @@ type ExternalCommandResult = {
   stderr: string;
 };
 
-type ExternalCommandInput = {
-  stdinText?: string;
-  stdinFilePath?: string;
-};
-
 abstract class UserCodingAgent {
   protected constructor(protected readonly config: AiConfig) {}
 
@@ -108,9 +102,9 @@ abstract class UserCodingAgent {
 
   protected async runAnalyzer(
     args: string[],
-    input: ExternalCommandInput = {},
+    stdinText?: string,
   ): Promise<ExternalCommandResult> {
-    const result = await runExternalCommand(this.command, args, input);
+    const result = await runExternalCommand(this.command, args, stdinText);
     if (result.exitCode !== 0) {
       throw new Error(
         `Analyzer command failed (${formatCommandPrefix([this.command, ...args])}).\n${stripAnsi(result.stderr).trim() || stripAnsi(result.stdout).trim() || "No error output."}`,
@@ -121,27 +115,10 @@ abstract class UserCodingAgent {
 
   protected async runAndParse(
     args: string[],
-    input: ExternalCommandInput = {},
+    stdinText?: string,
   ): Promise<InterpretResult> {
-    const result = await this.runAnalyzer(args, input);
+    const result = await this.runAnalyzer(args, stdinText);
     return parseInterpretResultFromText(result.stdout);
-  }
-
-  protected async runAndParseFromTempPromptFile(
-    args: string[],
-    prompt: string,
-  ): Promise<InterpretResult> {
-    const tempDir = mkdtempSync(join(tmpdir(), "libretto-cli-analyzer-"));
-    const promptPath = join(
-      tempDir,
-      `snapshot-analyzer-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
-    );
-    writeFileSync(promptPath, prompt, "utf-8");
-    try {
-      return await this.runAndParse(args, { stdinFilePath: promptPath });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
   }
 
   abstract analyzeSnapshot(
@@ -168,7 +145,7 @@ class CodexUserCodingAgent extends UserCodingAgent {
       pngPath,
       "-",
     ];
-    const result = await this.runAnalyzer(args, { stdinText: prompt });
+    const result = await this.runAnalyzer(args, prompt);
     let outputText = result.stdout;
     try {
       if (existsSync(outputPath)) {
@@ -186,7 +163,7 @@ class ClaudeUserCodingAgent extends UserCodingAgent {
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    return await this.runAndParseFromTempPromptFile(
+    return await this.runAndParse(
       [...this.baseArgs],
       `${prompt}${this.screenshotHint(pngPath)}`,
     );
@@ -198,7 +175,7 @@ class GeminiUserCodingAgent extends UserCodingAgent {
     prompt: string,
     pngPath: string,
   ): Promise<InterpretResult> {
-    return await this.runAndParseFromTempPromptFile(
+    return await this.runAndParse(
       [...this.baseArgs],
       `${prompt}${this.screenshotHint(pngPath)}`,
     );
@@ -208,7 +185,7 @@ class GeminiUserCodingAgent extends UserCodingAgent {
 async function runExternalCommand(
   command: string,
   args: string[],
-  input: ExternalCommandInput = {},
+  stdinText?: string,
 ): Promise<ExternalCommandResult> {
   return await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -247,16 +224,8 @@ async function runExternalCommand(
       });
     });
 
-    if (input.stdinText !== undefined && input.stdinFilePath !== undefined) {
-      reject(new Error("Analyzer input cannot use both stdinText and stdinFilePath."));
-      child.stdin.destroy();
-      return;
-    }
-
-    if (input.stdinFilePath !== undefined) {
-      child.stdin.write(readFileSync(input.stdinFilePath, "utf-8"));
-    } else if (input.stdinText !== undefined) {
-      child.stdin.write(input.stdinText);
+    if (stdinText !== undefined) {
+      child.stdin.write(stdinText);
     }
     child.stdin.end();
   });

--- a/test/stateful.spec.ts
+++ b/test/stateful.spec.ts
@@ -28,12 +28,17 @@ import { writeFileSync } from "node:fs";
 
 const preset = process.argv[2] ?? "unknown";
 const args = process.argv.slice(3);
+const stdinChunks = [];
+for await (const chunk of process.stdin) {
+  stdinChunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+}
+const stdinText = Buffer.concat(stdinChunks).toString("utf8");
 const outputIndex = args.indexOf("--output-last-message");
 const outputPath = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
 const payload = JSON.stringify({
   answer: "snapshot-ok-" + preset,
   selectors: [],
-  notes: "",
+  notes: "stdin-has-objective=" + stdinText.includes("Find heading") + ";argv-has-objective=" + args.some((arg) => arg.includes("Find heading")),
 });
 
 if (outputPath) {
@@ -138,6 +143,31 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(snapshot.stdout).toContain("Interpretation:");
     expect(snapshot.stdout).toContain("Answer: snapshot-ok-objective-only");
   }, 45_000);
+
+  for (const preset of ["claude", "gemini"] as const) {
+    test(`${preset} snapshot analysis sends prompt via stdin instead of argv`, async ({
+      librettoCli,
+      workspaceDir,
+    }) => {
+      const session = `snapshot-${preset}-stdin`;
+      const analyzerPath = await writeFakeAnalyzer(workspaceDir);
+      await librettoCli(
+        `ai configure ${preset} -- "${process.execPath}" "${analyzerPath}" "${preset}"`,
+      );
+
+      const opened = await librettoCli(
+        `open https://example.com --headless --session ${session}`,
+      );
+      expect(opened.stdout).toContain("Browser open");
+
+      const snapshot = await librettoCli(
+        `snapshot --objective "Find heading" --context "${preset} stdin verification" --session ${session}`,
+      );
+      expect(snapshot.stdout).toContain("Interpretation:");
+      expect(snapshot.stdout).toContain("stdin-has-objective=true");
+      expect(snapshot.stdout).toContain("argv-has-objective=false");
+    }, 45_000);
+  }
 
   test("shows a clear error when --context is provided without --objective", async ({
     librettoCli,


### PR DESCRIPTION
## Summary
- send snapshot analyzer prompts to Codex, Claude, and Gemini over stdin instead of argv
- keep Claude/Gemini snapshot analysis behavior intact while avoiding `E2BIG` from oversized prompt arguments
- add stateful tests that verify Claude/Gemini snapshot analysis still works and that the objective reaches the analyzer over stdin instead of argv

## Testing
- `pnpm type-check`
- `pnpm test -- test/stateful.spec.ts`
- `pnpm run build && pnpm vitest run test/stateful.spec.ts -t "(configures (claude|gemini) and snapshot analysis works|(claude|gemini) snapshot analysis sends prompt via stdin instead of argv)"`
