### PR TITLE
fix: handle blocked/interstitial states in snapshot viewport recovery

### DIFF
--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -23,6 +23,10 @@ export function registerBrowserCommands(yargs: Argv, logger: LoggerApi): Argv {
           .option("headless", {
             type: "boolean",
             default: false,
+          })
+          .option("viewport", {
+            type: "string",
+            describe: "Viewport size as WIDTHxHEIGHT (e.g. 1920x1080)",
           }),
       async (argv) => {
         const hasHeadedFlag = Boolean(argv.headed);
@@ -34,10 +38,21 @@ export function registerBrowserCommands(yargs: Argv, logger: LoggerApi): Argv {
         const url = argv.url as string | undefined;
         if (!url) {
           throw new Error(
-            "Usage: libretto-cli open <url> [--headless] [--session <name>]",
+            "Usage: libretto-cli open <url> [--headless] [--viewport WxH] [--session <name>]",
           );
         }
-        await runOpen(url, headed, String(argv.session), logger);
+        const viewportArg = argv.viewport as string | undefined;
+        let viewport: { width: number; height: number } | undefined;
+        if (viewportArg) {
+          const match = viewportArg.match(/^(\d+)x(\d+)$/i);
+          if (!match) {
+            throw new Error(
+              "Invalid --viewport format. Expected WIDTHxHEIGHT (e.g. 1920x1080).",
+            );
+          }
+          viewport = { width: Number(match[1]), height: Number(match[2]) };
+        }
+        await runOpen(url, headed, String(argv.session), logger, { viewport });
       },
     )
     .command(

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -50,7 +50,14 @@ export function registerBrowserCommands(yargs: Argv, logger: LoggerApi): Argv {
               "Invalid --viewport format. Expected WIDTHxHEIGHT (e.g. 1920x1080).",
             );
           }
-          viewport = { width: Number(match[1]), height: Number(match[2]) };
+          const w = Number(match[1]);
+          const h = Number(match[2]);
+          if (w < 1 || h < 1) {
+            throw new Error(
+              "Invalid --viewport dimensions. Width and height must be at least 1.",
+            );
+          }
+          viewport = { width: w, height: h };
         }
         await runOpen(url, headed, String(argv.session), logger, { viewport });
       },

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -3,6 +3,7 @@ import type { Argv } from "yargs";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { connect, disconnectBrowser } from "../core/browser.js";
 import { getSessionSnapshotRunDir } from "../core/context.js";
+import { readSessionState } from "../core/session.js";
 import {
   canAnalyzeSnapshots,
   runInterpret,
@@ -10,8 +11,103 @@ import {
 } from "../core/snapshot-analyzer.js";
 
 const DEFAULT_SNAPSHOT_CONTEXT = "No additional user context provided.";
+const FALLBACK_SNAPSHOT_VIEWPORT = { width: 1280, height: 800 } as const;
+
 function generateSnapshotRunId(): string {
   return `snapshot-${Date.now()}`;
+}
+
+type SnapshotViewportMetrics = {
+  configuredWidth: number | null;
+  configuredHeight: number | null;
+  innerWidth: number | null;
+  innerHeight: number | null;
+};
+
+function isZeroViewport(value: number | null): boolean {
+  return typeof value === "number" && value <= 0;
+}
+
+function shouldForceSnapshotViewport(metrics: SnapshotViewportMetrics): boolean {
+  return (
+    isZeroViewport(metrics.configuredWidth)
+    || isZeroViewport(metrics.configuredHeight)
+    || isZeroViewport(metrics.innerWidth)
+    || isZeroViewport(metrics.innerHeight)
+  );
+}
+
+function isZeroWidthScreenshotError(error: unknown): boolean {
+  return (
+    error instanceof Error
+    && error.message.includes("Cannot take screenshot with 0 width")
+  );
+}
+
+async function readSnapshotViewportMetrics(
+  page: {
+    viewportSize(): { width: number; height: number } | null;
+    evaluate<T>(pageFunction: () => T | Promise<T>): Promise<T>;
+  },
+): Promise<SnapshotViewportMetrics> {
+  const configuredViewport = page.viewportSize();
+  let innerWidth: number | null = null;
+  let innerHeight: number | null = null;
+
+  try {
+    const innerViewport = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    innerWidth = innerViewport.width;
+    innerHeight = innerViewport.height;
+  } catch {}
+
+  return {
+    configuredWidth: configuredViewport?.width ?? null,
+    configuredHeight: configuredViewport?.height ?? null,
+    innerWidth,
+    innerHeight,
+  };
+}
+
+function resolveSnapshotViewport(
+  session: string,
+  logger: LoggerApi,
+): { width: number; height: number } {
+  const state = readSessionState(session, logger);
+  if (state?.viewport) {
+    logger.info("screenshot-viewport-from-session-state", {
+      session,
+      viewport: state.viewport,
+    });
+    return state.viewport;
+  }
+  logger.info("screenshot-viewport-fallback", {
+    session,
+    reason: "no viewport in session state",
+    viewport: FALLBACK_SNAPSHOT_VIEWPORT,
+  });
+  return FALLBACK_SNAPSHOT_VIEWPORT;
+}
+
+async function forceSnapshotViewport(
+  page: {
+    setViewportSize(size: { width: number; height: number }): Promise<void>;
+  },
+  viewport: { width: number; height: number },
+  logger: LoggerApi,
+  session: string,
+  pageId?: string,
+  reason?: string,
+): Promise<void> {
+  await page.setViewportSize(viewport);
+  logger.warn("screenshot-viewport-forced", {
+    session,
+    pageId,
+    reason,
+    viewport,
+  });
 }
 
 async function captureScreenshot(
@@ -29,12 +125,66 @@ async function captureScreenshot(
   });
 
   try {
-    const title = await page.title();
-    const pageUrl = page.url();
+    let title: string | null = null;
+    try {
+      title = await page.title();
+    } catch (error) {
+      logger.warn("screenshot-title-read-failed", {
+        session,
+        pageId,
+        error,
+      });
+    }
+
+    let pageUrl: string | null = null;
+    try {
+      pageUrl = page.url();
+    } catch (error) {
+      logger.warn("screenshot-url-read-failed", {
+        session,
+        pageId,
+        error,
+      });
+    }
+
     const pngPath = `${snapshotRunDir}/page.png`;
     const htmlPath = `${snapshotRunDir}/page.html`;
 
-    await page.screenshot({ path: pngPath });
+    const restoreViewport = resolveSnapshotViewport(session, logger);
+    const viewportMetrics = await readSnapshotViewportMetrics(page);
+    logger.info("screenshot-viewport-metrics", {
+      session,
+      pageId,
+      restoreViewport,
+      ...viewportMetrics,
+    });
+    await forceSnapshotViewport(
+      page,
+      restoreViewport,
+      logger,
+      session,
+      pageId,
+      shouldForceSnapshotViewport(viewportMetrics)
+        ? "preflight-invalid-viewport"
+        : "preflight-normalize-viewport",
+    );
+
+    try {
+      await page.screenshot({ path: pngPath });
+    } catch (error) {
+      if (!isZeroWidthScreenshotError(error)) {
+        throw error;
+      }
+      await forceSnapshotViewport(
+        page,
+        restoreViewport,
+        logger,
+        session,
+        pageId,
+        "retry-after-zero-width-screenshot-error",
+      );
+      await page.screenshot({ path: pngPath });
+    }
 
     const htmlContent = await page.content();
     const fs = await import("node:fs/promises");
@@ -61,7 +211,13 @@ async function captureScreenshot(
       session,
       pageAlive,
       browserConnected,
-      pageUrl: page.url(),
+      pageUrl: (() => {
+        try {
+          return page.url();
+        } catch {
+          return null;
+        }
+      })(),
     });
     throw err;
   } finally {

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -18,10 +18,17 @@ export const AiConfigSchema = z
   .strict();
 export type AiConfig = z.infer<typeof AiConfigSchema>;
 
+export const ViewportConfigSchema = z.object({
+  width: z.number().int().min(1),
+  height: z.number().int().min(1),
+});
+export type ViewportConfig = z.infer<typeof ViewportConfigSchema>;
+
 export const LibrettoConfigSchema = z
   .object({
     version: z.literal(CURRENT_CONFIG_VERSION),
     ai: AiConfigSchema.optional(),
+    viewport: ViewportConfigSchema.optional(),
   })
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
@@ -103,10 +110,11 @@ export function writeAiConfig(
 export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolean {
   const librettoConfig = readLibrettoConfig(configPath);
   if (!librettoConfig.ai) return false;
-  // Keep the top-level config file and version while removing only AI state.
+  // Keep all config fields except AI state.
+  const { ai: _ai, ...rest } = librettoConfig;
   writeLibrettoConfig(
     {
-      version: librettoConfig.version,
+      ...rest,
     },
     configPath,
   );

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -11,6 +11,7 @@ import {
   getSessionNetworkLogPath,
   PROFILES_DIR,
 } from "./context.js";
+import { readLibrettoConfig } from "./ai-config.js";
 import {
   assertSessionAvailableForStart,
   clearSessionState,
@@ -285,14 +286,35 @@ export async function runPages(session: string, logger: LoggerApi): Promise<void
   });
 }
 
+const DEFAULT_VIEWPORT = { width: 1366, height: 768 } as const;
+
+function resolveViewport(
+  cliViewport: { width: number; height: number } | undefined,
+  logger: LoggerApi,
+): { width: number; height: number } {
+  if (cliViewport) {
+    logger.info("viewport-source", { source: "cli", viewport: cliViewport });
+    return cliViewport;
+  }
+  const config = readLibrettoConfig();
+  if (config.viewport) {
+    logger.info("viewport-source", { source: "config", viewport: config.viewport });
+    return config.viewport;
+  }
+  logger.info("viewport-source", { source: "default", viewport: DEFAULT_VIEWPORT });
+  return DEFAULT_VIEWPORT;
+}
+
 export async function runOpen(
   rawUrl: string,
   headed: boolean,
   session: string,
   logger: LoggerApi,
+  options?: { viewport?: { width: number; height: number } },
 ): Promise<void> {
   const url = normalizeUrl(rawUrl);
-  logger.info("open-start", { url, headed, session });
+  const viewport = resolveViewport(options?.viewport, logger);
+  logger.info("open-start", { url, headed, session, viewport });
   assertSessionAvailableForStart(session, logger);
 
   const port = await pickFreePort();
@@ -385,7 +407,7 @@ browser.on('disconnected', () => {
 
 const context = await browser.newContext({
 	${storageStateCode}
-	viewport: { width: 1366, height: 768 },
+	viewport: { width: ${viewport.width}, height: ${viewport.height} },
 	userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
 });
 
@@ -507,6 +529,7 @@ await new Promise(() => {});
         session,
         startedAt: new Date().toISOString(),
         status: "active",
+        viewport,
       }, logger);
       logger.info("open-success", {
         url,

--- a/src/cli/core/snapshot-analyzer.ts
+++ b/src/cli/core/snapshot-analyzer.ts
@@ -233,11 +233,15 @@ async function runExternalCommand(
 
     child.stdin.on("error", (err) => {
       stdinError = err as NodeJS.ErrnoException;
-      logger.error("interpret-analyzer-stdin-error", {
+      logger.warn("interpret-analyzer-stdin-pipe-error", {
         command,
         args,
         code: stdinError.code ?? null,
         message: stdinError.message,
+        hint:
+          stdinError.code === "EPIPE"
+            ? "Child process exited before consuming all stdin data"
+            : "Unexpected stdin write error",
       });
     });
 
@@ -288,11 +292,15 @@ async function runExternalCommand(
       }
     } catch (err) {
       stdinError = err as NodeJS.ErrnoException;
-      logger.error("interpret-analyzer-stdin-write-error", {
+      logger.warn("interpret-analyzer-stdin-write-error", {
         command,
         args,
         code: stdinError.code ?? null,
         message: stdinError.message,
+        hint:
+          stdinError.code === "EPIPE"
+            ? "Child process exited before consuming all stdin data"
+            : "Unexpected stdin write error",
       });
     }
   });

--- a/src/shared/state/session-state.ts
+++ b/src/shared/state/session-state.ts
@@ -9,6 +9,11 @@ export const SessionStatusSchema = z.enum([
 	"failed",
 	"exited",
 ]);
+export const SessionViewportSchema = z.object({
+	width: z.number().int().min(1),
+	height: z.number().int().min(1),
+});
+
 export const SessionStateFileSchema = z.object({
 	version: z.literal(SESSION_STATE_VERSION),
 	port: z.number().int().min(0).max(65535),
@@ -16,6 +21,7 @@ export const SessionStateFileSchema = z.object({
 	session: z.string().min(1),
 	startedAt: z.string().datetime({ offset: true }),
 	status: SessionStatusSchema.optional(),
+	viewport: SessionViewportSchema.optional(),
 });
 
 export type SessionStatus = z.infer<typeof SessionStatusSchema>;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -50,6 +50,7 @@ type CliFixtures = {
     session: string,
     mode: "read-only" | "full-access",
   ) => Promise<string>;
+  seedProfile: (domain: string, sourcePath: string) => Promise<string>;
 };
 
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -489,6 +490,16 @@ export const test = base.extend<CliFixtures>({
       };
       await writeFile(path, JSON.stringify(payload, null, 2), "utf8");
       return path;
+    });
+  },
+
+  seedProfile: async ({ workspacePath }, use) => {
+    await use(async (domain: string, sourcePath: string) => {
+      const profileDir = workspacePath(".libretto", "profiles");
+      await mkdir(profileDir, { recursive: true });
+      const destPath = workspacePath(".libretto", "profiles", `${domain}.json`);
+      await copyFile(sourcePath, destPath);
+      return destPath;
     });
   },
 });

--- a/test/snapshot-e2e.spec.ts
+++ b/test/snapshot-e2e.spec.ts
@@ -76,7 +76,7 @@ describe("snapshot e2e – live site analysis", () => {
 
       // Uses saved profile from .libretto/profiles/linkedin.com.json if available
       await librettoCli(
-        `open https://www.linkedin.com/feed/ --session ${session}`,
+        `open https://www.linkedin.com/feed/ --headless --session ${session}`,
       );
 
       await sleep(PAGE_SETTLE_MS);

--- a/test/snapshot-e2e.spec.ts
+++ b/test/snapshot-e2e.spec.ts
@@ -77,7 +77,7 @@ describe("snapshot e2e – live site analysis", () => {
       await librettoCli(`ai configure codex`, snapshotEnv);
 
       // Uses saved profile from .libretto/profiles/linkedin.com.json if available
-      const open = await librettoCli(
+      await librettoCli(
         `open https://www.linkedin.com/feed/ --session ${session}`,
       );
 
@@ -89,15 +89,12 @@ describe("snapshot e2e – live site analysis", () => {
         snapshotEnv,
       );
       const snapshotDurationMs = Date.now() - snapshotStart;
-      const snapshotSuccess = snapshot.exitCode === 0;
 
       await librettoCli(`close --session ${session}`);
 
       const output = snapshot.stdout + "\n" + snapshot.stderr;
 
-      console.log(
-        `[linkedin] snapshot took ${snapshotDurationMs}ms (success=${snapshotSuccess})`,
-      );
+      console.log(`[linkedin] snapshot took ${snapshotDurationMs}ms`);
       console.log(`[linkedin] selectors output:\n${output}`);
 
       await evaluate(output).toMatch(

--- a/test/snapshot-e2e.spec.ts
+++ b/test/snapshot-e2e.spec.ts
@@ -1,0 +1,113 @@
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect } from "vitest";
+import { test } from "./fixtures";
+
+/**
+ * End-to-end snapshot tests.
+ *
+ * Tests cover:
+ * - Snapshot analysis on real sites with saved profiles (LinkedIn).
+ *
+ * Requirements:
+ * - An AI preset must be configured (codex, claude, or gemini) for snapshot analysis.
+ * - Network access to the target sites.
+ * - Playwright Chromium installed.
+ * - Saved profile in .libretto/profiles/linkedin.com.json for authenticated LinkedIn test.
+ */
+
+const SNAPSHOT_TIMEOUT = 120_000;
+const PAGE_SETTLE_MS = 8_000;
+
+/** Load API keys from repo root .env so the CLI subprocess can use them. */
+function loadEnvFile(): Record<string, string> {
+  const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+  const envPath = resolve(repoRoot, ".env");
+  const env: Record<string, string> = {};
+  if (!existsSync(envPath)) return env;
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (key) env[key] = value;
+  }
+  return env;
+}
+
+const dotEnv = loadEnvFile();
+
+/** Env vars forwarded to snapshot CLI calls so the analyzer can authenticate. */
+const snapshotEnv: Record<string, string> = {
+  ...(dotEnv.OPENAI_API_KEY ? { OPENAI_API_KEY: dotEnv.OPENAI_API_KEY } : {}),
+  ...(dotEnv.ANTHROPIC_API_KEY
+    ? { ANTHROPIC_API_KEY: dotEnv.ANTHROPIC_API_KEY }
+    : {}),
+  ...(process.env.OPENAI_API_KEY
+    ? { OPENAI_API_KEY: process.env.OPENAI_API_KEY }
+    : {}),
+  ...(process.env.ANTHROPIC_API_KEY
+    ? { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY }
+    : {}),
+};
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("snapshot e2e – live site analysis", () => {
+  test(
+    "linkedin feed: identifies post content and poster name selectors",
+    async ({ librettoCli, evaluate }) => {
+      const session = "snapshot-e2e-linkedin";
+
+      // Configure AI preset for snapshot analysis
+      await librettoCli(`ai configure codex`, snapshotEnv);
+
+      // Uses saved profile from .libretto/profiles/linkedin.com.json if available
+      const open = await librettoCli(
+        `open https://www.linkedin.com/feed/ --session ${session}`,
+      );
+
+      await sleep(PAGE_SETTLE_MS);
+
+      const snapshotStart = Date.now();
+      const snapshot = await librettoCli(
+        `snapshot --session ${session} --objective "Identify CSS selectors for: (1) individual post content text and (2) the name of the poster for each post in the LinkedIn feed."`,
+        snapshotEnv,
+      );
+      const snapshotDurationMs = Date.now() - snapshotStart;
+      const snapshotSuccess = snapshot.exitCode === 0;
+      console.log(
+        `[linkedin] snapshot took ${snapshotDurationMs}ms (success=${snapshotSuccess})`,
+      );
+
+      await librettoCli(`close --session ${session}`);
+
+      const output = snapshot.stdout + "\n" + snapshot.stderr;
+
+      await evaluate(output).toMatch(
+        "The output identifies CSS selectors for post content text AND poster names, AND explains the nesting structure for how to chain them. " +
+          "Specifically: (1) post content should use [data-testid='expandable-text-box'] or similar data-testid attribute, " +
+          "(2) poster names should target anchor elements with href containing '/in/' within feed list items, " +
+          "(3) the output must explain nesting — e.g. that the feed container is [data-testid='mainFeed'], individual posts are [role='listitem'] within it, " +
+          "and the content/name selectors should be scoped within each post item. " +
+          "All selectors must reference real HTML attributes visible in a LinkedIn feed page.",
+      );
+    },
+    SNAPSHOT_TIMEOUT,
+  );
+
+  // Not included in this PR:
+  // - Cambridge Dictionary (dictionary.cambridge.org) — ad interstitial/popup
+  //   resilience test. Nondeterministic; popup doesn't always appear.
+  // - Amazon (amazon.com) — search result extraction test. Amazon's anti-bot
+  //   detection replaces the DOM with a CAPTCHA script, making the HTML
+  //   snapshot unreliable even though the screenshot renders correctly.
+  // - Cloudflare challenge sites: g2.com, nowsecure.nl, crunchbase.com.
+  //   Useful for testing challenge detection but unreliable for CI.
+  // These could be added in a future PR with appropriate handling.
+});

--- a/test/snapshot-e2e.spec.ts
+++ b/test/snapshot-e2e.spec.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, existsSync, mkdirSync, copyFileSync } from "node:fs";
+import { resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
@@ -17,8 +17,8 @@ import { test } from "./fixtures";
  * - Saved profile in .libretto/profiles/linkedin.com.json for authenticated LinkedIn test.
  */
 
-const SNAPSHOT_TIMEOUT = 120_000;
-const PAGE_SETTLE_MS = 8_000;
+const SNAPSHOT_TIMEOUT = 180_000;
+const PAGE_SETTLE_MS = 15_000;
 
 /** Load API keys from repo root .env so the CLI subprocess can use them. */
 function loadEnvFile(): Record<string, string> {
@@ -61,8 +61,17 @@ async function sleep(ms: number): Promise<void> {
 describe("snapshot e2e – live site analysis", () => {
   test(
     "linkedin feed: identifies post content and poster name selectors",
-    async ({ librettoCli, evaluate }) => {
+    async ({ librettoCli, evaluate, workspaceDir }) => {
       const session = "snapshot-e2e-linkedin";
+
+      // Copy saved LinkedIn profile into test workspace so the browser loads authenticated state
+      const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+      const srcProfile = resolve(repoRoot, ".libretto/profiles/linkedin.com.json");
+      if (existsSync(srcProfile)) {
+        const destDir = join(workspaceDir, ".libretto", "profiles");
+        mkdirSync(destDir, { recursive: true });
+        copyFileSync(srcProfile, join(destDir, "linkedin.com.json"));
+      }
 
       // Configure AI preset for snapshot analysis
       await librettoCli(`ai configure codex`, snapshotEnv);
@@ -81,13 +90,15 @@ describe("snapshot e2e – live site analysis", () => {
       );
       const snapshotDurationMs = Date.now() - snapshotStart;
       const snapshotSuccess = snapshot.exitCode === 0;
-      console.log(
-        `[linkedin] snapshot took ${snapshotDurationMs}ms (success=${snapshotSuccess})`,
-      );
 
       await librettoCli(`close --session ${session}`);
 
       const output = snapshot.stdout + "\n" + snapshot.stderr;
+
+      console.log(
+        `[linkedin] snapshot took ${snapshotDurationMs}ms (success=${snapshotSuccess})`,
+      );
+      console.log(`[linkedin] selectors output:\n${output}`);
 
       await evaluate(output).toMatch(
         "The output identifies CSS selectors for post content text AND poster names, AND explains the nesting structure for how to chain them. " +

--- a/test/snapshot-e2e.spec.ts
+++ b/test/snapshot-e2e.spec.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync, mkdirSync, copyFileSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
@@ -61,16 +61,14 @@ async function sleep(ms: number): Promise<void> {
 describe("snapshot e2e – live site analysis", () => {
   test(
     "linkedin feed: identifies post content and poster name selectors",
-    async ({ librettoCli, evaluate, workspaceDir }) => {
+    async ({ librettoCli, evaluate, seedProfile }) => {
       const session = "snapshot-e2e-linkedin";
 
       // Copy saved LinkedIn profile into test workspace so the browser loads authenticated state
       const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
       const srcProfile = resolve(repoRoot, ".libretto/profiles/linkedin.com.json");
       if (existsSync(srcProfile)) {
-        const destDir = join(workspaceDir, ".libretto", "profiles");
-        mkdirSync(destDir, { recursive: true });
-        copyFileSync(srcProfile, join(destDir, "linkedin.com.json"));
+        await seedProfile("linkedin.com", srcProfile);
       }
 
       // Configure AI preset for snapshot analysis


### PR DESCRIPTION
## Summary
- Fixes `Page.captureScreenshot: Cannot take screenshot with 0 width` when page viewport collapses to 0px due to interstitials or blocked states
- Adds viewport persistence in session state and normalization before every screenshot with retry on zero-width errors
- Adds `--viewport WIDTHxHEIGHT` CLI arg and libretto config support for configurable viewport (CLI > config > default precedence)
- Makes `page.title()` and `page.url()` best-effort so blocked pages don't crash the snapshot pipeline
- Fixes `clearAiConfig` silently dropping viewport config when clearing AI state
- Improves stdin pipe error logging with human-readable hints for EPIPE vs unexpected errors
- Adds LinkedIn e2e snapshot test

## Test plan
- [x] All 20 `stateful.spec.ts` tests pass
- [ ] LinkedIn e2e snapshot test (requires saved profile + network access)
- [ ] Manual test: open blocked page, verify snapshot recovers viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
