### PR TITLE
Fix CLI shebang and improve README for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@ It is designed for engineering teams that automate workflows in web apps and wan
 npm install --save-dev libretto
 ```
 
-This installs Libretto along with Playwright and Chromium. The Chromium browser binary is downloaded automatically via a `postinstall` script — this may take a minute on first install.
-
-Then initialize Libretto:
+Chromium is downloaded automatically via a `postinstall` script. If postinstall scripts are disabled (e.g. `--ignore-scripts`, common in monorepos), run init manually:
 
 ```bash
 npx libretto init
 ```
 
-This verifies your Chromium installation and optionally configures an AI runtime for snapshot analysis.
+This installs the Chromium browser binary and optionally configures an AI runtime for snapshot analysis.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ npx libretto run ./integration.ts main
 
 ## The `.libretto/` directory
 
-Libretto stores local runtime state in a `.libretto/` directory at your project root. Add it to your `.gitignore`:
+Libretto stores local runtime state in a `.libretto/` directory at your project root. Sensitive directories (`sessions/` and `profiles/`) are automatically git-ignored via `.libretto/.gitignore`.
 
-```
-.libretto/
-```
-
-This directory contains:
-
-- **`profiles/<domain>.json`** — Saved browser sessions (cookies, localStorage) for authenticated sites. Created by `npx libretto save <domain>`. These are machine-local and should never be committed.
-- **`sessions/<name>/state.json`** — Active session metadata (debug port, PID, status). Each CLI session or `launchBrowser()` call creates one.
-- **`sessions/<name>/logs.jsonl`** — Session logs including captured network requests and user actions (clicks, fills, navigations). Useful for debugging and for converting browser automations to direct network calls.
-- **`ai.json`** — AI runtime configuration (which model/command to use for snapshot analysis).
+- **`profiles/<domain>.json`** — Saved browser sessions (cookies, localStorage) for authenticated sites. Created via `npx libretto save <domain>`. Machine-local and never committed.
+- **`sessions/<name>/`** — Per-session runtime state:
+  - `state.json` — Session metadata (debug port, PID, status)
+  - `logs.jsonl` — Structured session logs
+  - `network.jsonl` — Captured network requests (URLs, methods, headers, response status)
+  - `actions.jsonl` — Recorded user actions (clicks, fills, navigations)
+  - `snapshots/` — Screenshot PNGs and HTML snapshots captured via `npx libretto snapshot`
+- **`ai.json`** — AI runtime configuration set via `npx libretto ai configure`.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Chromium is downloaded automatically via a `postinstall` script. If postinstall 
 npx libretto init
 ```
 
-This installs the Chromium browser binary and optionally configures an AI runtime for snapshot analysis.
+This installs the Chromium browser binary and optionally configures an AI subagent (Gemini, Claude, or Codex) that can analyze page snapshots without consuming the coding agent's context window.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ It is designed for engineering teams that automate workflows in web apps and wan
 npm install --save-dev libretto
 ```
 
+This installs Libretto along with Playwright and Chromium. The Chromium browser binary is downloaded automatically via a `postinstall` script — this may take a minute on first install.
+
 Then initialize Libretto:
 
 ```bash
 npx libretto init
 ```
+
+This verifies your Chromium installation and optionally configures an AI runtime for snapshot analysis.
 
 ## Usage
 
@@ -50,6 +54,21 @@ You can also run workflows directly from the CLI:
 npx libretto help
 npx libretto run ./integration.ts main
 ```
+
+## The `.libretto/` directory
+
+Libretto stores local runtime state in a `.libretto/` directory at your project root. Add it to your `.gitignore`:
+
+```
+.libretto/
+```
+
+This directory contains:
+
+- **`profiles/<domain>.json`** — Saved browser sessions (cookies, localStorage) for authenticated sites. Created by `npx libretto save <domain>`. These are machine-local and should never be committed.
+- **`sessions/<name>/state.json`** — Active session metadata (debug port, PID, status). Each CLI session or `launchBrowser()` call creates one.
+- **`sessions/<name>/logs.jsonl`** — Session logs including captured network requests and user actions (clicks, fills, navigations). Useful for debugging and for converting browser automations to direct network calls.
+- **`ai.json`** — AI runtime configuration (which model/command to use for snapshot analysis).
 
 ## Authors
 

--- a/tsup.cli.config.ts
+++ b/tsup.cli.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import { writeFileSync, readFileSync, chmodSync } from "node:fs";
 
 export default defineConfig({
 	entry: ["src/cli/**/*.ts", "!src/cli/**/*.test.ts"],
@@ -8,4 +9,12 @@ export default defineConfig({
 	minify: false,
 	clean: false,
 	outDir: "dist/cli",
+	onSuccess: async () => {
+		const entryPath = "dist/cli/index.js";
+		const content = readFileSync(entryPath, "utf-8");
+		if (!content.startsWith("#!/")) {
+			writeFileSync(entryPath, `#!/usr/bin/env node\n${content}`);
+		}
+		chmodSync(entryPath, 0o755);
+	},
 });


### PR DESCRIPTION
## Summary
- **Fix broken `npx libretto` CLI**: tsup was stripping the `#!/usr/bin/env node` shebang from `dist/cli/index.js` during build. Added an `onSuccess` hook to `tsup.cli.config.ts` that re-adds the shebang after compilation. Without this, every `npx libretto` command fails (on macOS it triggers ImageMagick's `import` command instead).
- **README improvements**: Clarify that Chromium is auto-installed via `postinstall`, explain what `npx libretto init` does, document the `.libretto/` directory structure (profiles, sessions, logs, ai config), and add `.gitignore` guidance.

## Test plan
- [ ] Run `pnpm build` and verify `dist/cli/index.js` starts with `#!/usr/bin/env node`
- [ ] Run `npx libretto --help` from a consumer project and verify it works
- [ ] Run `npx libretto run ./integration.ts <export> --headless` and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
