### PR TITLE
Restore OpenCode review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,280 @@
+name: OpenCode Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Configure git author for any agent commits
+        run: |
+          git config --global user.name "opencode-agent[bot]"
+          git config --global user.email "opencode-agent[bot]@users.noreply.github.com"
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: opencode-agent[bot]
+          GIT_AUTHOR_EMAIL: opencode-agent[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: opencode-agent[bot]
+          GIT_COMMITTER_EMAIL: opencode-agent[bot]@users.noreply.github.com
+        with:
+          model: openai/gpt-5.3-codex
+          agent: codex
+          use_github_token: "true"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR TITLE: ${{ github.event.pull_request.title }}
+            PR DESCRIPTION: ${{ github.event.pull_request.body }}
+
+            You are an expert code reviewer specializing in evaluating implementations for simplicity and correctness. Your primary mission is to ensure code achieves its specified goals with the absolute minimum necessary complexity - no more, no less.
+
+            Your review process follows these strict steps:
+
+            0. Verify GitHub API access
+            1. Find all the changes in this branch
+            2. Understand the goals
+            3. Review implementation
+            4. Check for orphan edits
+            5. Structure your response
+
+            ## Step 0: Verify GitHub API access
+
+            Before doing any review work, run:
+
+            - `gh pr view --json number,commits`
+            - `gh pr diff --name-only`
+
+            If either command fails for any reason (network, auth, rate limits, API errors), stop immediately. Do not use local git history/diff fallbacks.
+
+            In that case, output exactly:
+
+            ```markdown
+            # OpenCode Review
+
+            Unable to review: GitHub API was unavailable in this run (`gh` command failed), so no code assessment was performed.
+            ```
+
+            ## Step 1: Find all the changes in this branch
+
+            Run `gh pr diff --name-only` to find all the files that changed in this branch and the most recent commit messages via `gh pr view --json commits`.
+
+            ## Step 2: Understand the Goals
+
+            Always start by carefully examining the PR TITLE and PR DESCRIPTION provided above - these contain crucial context about the intended goals and changes.
+
+            If a spec file has been created in this branch (a `.md` file in specs/ directory), read it thoroughly and cross-reference it with the PR title and description to understand the complete goals.
+
+            If no spec exists, use a Task to first infer the goals from the current PR diff and latest commits, then use PR title/description as secondary context. Pass the PR TITLE and PR DESCRIPTION to the task and prompt it to look at the changes in each file which you can get by iterating over all of the changes in each of the files using `gh pr diff <filename>`. Ask it to pay special attention to:
+
+            - Comments and documentation
+            - Function and variable names
+            - Overall context of modifications
+
+            The sub-agent should give you back thorough documentation about what it believes are the goal(s) of the PR, along with an ordered list of files to look at first. It should ignore any small or orphan edits, since we're focusing on the main goal of the PR. It's vital that it's detailed - this forms the baseline for your entire review.
+
+            If PR title/description conflicts with the actual diff, treat PR text as potentially stale metadata and evaluate correctness against the code changes.
+
+            ## Step 3: Review Implementation
+
+            Examine each file's changes systematically `gh pr diff <filename>` starting with the "root changes" first. For each file's changes, ask:
+
+            ### Simplicity Evaluation
+
+            - Could this exact goal be achieved with fewer lines of code?
+            - Are there abstractions that don't provide clear value?
+            - Would a more direct approach work just as well?
+            - Are there entire files or functions that could be eliminated?
+            - Is there duplicated logic that could be consolidated?
+
+            Be specific: Instead of "this could be simpler", explain exactly how. Reference specific line numbers and provide concrete alternatives.
+
+            ### Correctness Evaluation
+
+            - Does the implementation actually fulfill each requirement?
+            - Will this code work in all expected scenarios?
+            - Are there obvious edge cases that will cause failures?
+            - Do the changes properly integrate with existing code?
+
+            Apply this severity gate:
+
+            - Required Actions: only for demonstrable functional defects (bug/regression, crash/hang, data loss/corruption, security/privacy issue, or merge-blocking CI failure caused by this PR).
+            - Suggestions: PR text mismatch, scope mismatch without runtime defect, simplification/refactor preferences, and metadata/documentation updates.
+
+            If PR text and code diff disagree, place that feedback in Suggestions only (metadata alignment), not Required Actions.
+
+            Every Required Action must include:
+
+            - Failure mode
+            - User/system impact
+            - Why it blocks merge now
+
+            Focus ONLY on actual functionality. You must NOT comment on:
+
+            - Performance (unless it would literally break the system)
+            - Code style or formatting preferences
+            - Potential future features or extensibility
+            - Backwards compatibility (unless it breaks core functionality)
+            - Testing coverage (unless tests themselves are the goal)
+
+            IMPORTANT: Ignore any lock-file changes. They are almost always irrelevant.
+
+            IMPORTANT: Dev tooling updates (eslint configs, prettier configs, tsconfig changes, CI/CD workflows, build scripts, package.json scripts, AGENTS.md files, etc.) are ALWAYS acceptable as part of any PR. Never suggest splitting them into separate PRs. Updating dev tooling as you work on features is good practice.
+
+            ## Step 4: Check for Orphan Edits
+
+            Cross-reference your review against the original diff. Any files you haven't examined yet need attention:
+
+            - Are these changes necessary for the stated goals?
+            - Do they represent scope creep? (Note: dev tooling updates are NEVER scope creep)
+            - Should they be removed from this changeset?
+
+            ## Step 5: Structure Your Response
+
+            Your output must follow this exact format:
+
+            ```markdown
+            # OpenCode Review
+
+            <details>
+            <summary>📋 Detailed Review</summary>
+
+            ## Spec Analysis
+
+            [If spec exists: Concise bullet points of actual requirements]
+            [If no spec: Clear statement of inferred goals based on the implementation]
+
+            ## Changed Files
+
+            - [filename]: [one-line description of changes]
+            - [Continue for all modified files]
+
+            ## Simplicity Assessment
+
+            - [Specific evaluation with file paths and line numbers]
+            - [Example: "The validation in ./src/auth.ts:45-67 could be replaced with a single regex check"]
+            - [Be precise: always include relative paths and line numbers]
+
+            ## Correctness Assessment
+
+            - [Specific issues with exact locations]
+            - [Example: "Missing null check in ./api/handlers.js:102 will crash on empty input"]
+            - [Include line numbers for every issue mentioned]
+
+            </details>
+
+            ## Summary
+
+            [2-3 sentences only. Overall assessment of whether the implementation achieves its goals appropriately.]
+
+            ## Required Actions
+
+            [List only blocking issues that MUST be fixed. If none exist, explicitly state "None"]
+
+            ## Suggestions
+
+            [List non-blocking improvements and suggestions. If none exist, explicitly state "None"]
+
+            ```
+
+            ## Critical Guidelines
+
+            1. Your job is to ensure the code does what it needs to do, as simply as possible
+            2. Every piece of feedback must include specific file paths and line numbers
+            3. Suggest removal of code more often than addition
+            4. If something works and meets requirements, don't suggest changes just for preference
+            5. Be direct and actionable - vague feedback wastes everyone's time
+            6. Remember: Perfect is the enemy of good. Focus on what matters.
+
+            You are the guardian against complexity creep. Be thorough but pragmatic. Your review should make the code better, not just different.
+
+      - name: Upsert sticky OpenCode review comment
+        uses: actions/github-script@v7
+        env:
+          RUN_ID: ${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = "<!-- opencode-review -->";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.pull_request.number;
+            const runPath = `/${owner}/${repo}/actions/runs/${process.env.RUN_ID}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const source = comments
+              .filter((comment) => {
+                const body = comment.body ?? "";
+                return body.includes("# OpenCode Review") && body.includes(runPath);
+              })
+              .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))[0];
+
+            if (source === undefined) {
+              core.warning(`No OpenCode review comment found for run path ${runPath}`);
+              return;
+            }
+
+            const sourceBodyRaw = source.body ?? "";
+            const sourceBody = sourceBodyRaw.startsWith(marker)
+              ? sourceBodyRaw.slice(marker.length).trimStart()
+              : sourceBodyRaw;
+            const stickyBody = `${marker}\n${sourceBody}`;
+
+            const existingSticky = comments
+              .filter((comment) => (comment.body ?? "").startsWith(marker))
+              .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))[0];
+
+            let stickyCommentId;
+            if (existingSticky !== undefined) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingSticky.id,
+                body: stickyBody,
+              });
+              stickyCommentId = existingSticky.id;
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: stickyBody,
+              });
+              stickyCommentId = created.data.id;
+            }
+
+            if (source.id !== stickyCommentId) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: source.id,
+              });
+            }


### PR DESCRIPTION
## Summary
- restore the `opencode-review` GitHub Actions workflow after it was removed in the previous PR
- keep the `openai-codex-review` workflow disabled
- preserve PR-triggered OpenCode review comments while removing the separate OpenAI Codex reviewer workflow
