### PR TITLE
Use Claude skills in benchmark harness

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,7 @@
 Benchmarks are live browser-agent tasks that run a coding agent with:
 
 - the repo-local Libretto CLI via `pnpm cli`
-- the Libretto skill injected through the Claude eval harness
+- the Libretto skill discovered through Claude's filesystem Skills API
 - a preconfigured snapshot analyzer so `pnpm cli snapshot` works during the run
 - default benchmark models of `claude-opus-4-6` for the main agent and `claude-sonnet-4-6` for snapshot analysis
 
@@ -46,7 +46,7 @@ Each run gets its own isolated benchmark workspace. That workspace contains:
 
 - a copied `dist/` build of the Libretto CLI
 - a local `package.json` with `pnpm cli` pointing directly at `dist/cli/index.js`
-- a copied `.agents/skills/libretto/SKILL.md`
+- a copied `.claude/skills/libretto/` skill directory
 - its own `.libretto/` runtime state and benchmark snapshot-analyzer config
 
 Each per-case `results.json` now also records Claude-reported usage and `totalCostUsd`, and the generated benchmark summary includes a run-level duration/cost table plus per-case duration and cost.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,9 +2,9 @@
 
 Benchmarks are live browser-agent tasks that run a coding agent with:
 
-- the repo-local Libretto CLI via `pnpm cli`
+- the repo-local Libretto CLI via `pnpm -s cli`
 - the Libretto skill discovered through Claude's filesystem Skills API
-- a preconfigured snapshot analyzer so `pnpm cli snapshot` works during the run
+- a preconfigured snapshot analyzer so `pnpm -s cli snapshot` works during the run
 - default benchmark models of `claude-opus-4-6` for the main agent and `claude-sonnet-4-6` for snapshot analysis
 
 Usage:
@@ -45,8 +45,9 @@ benchmarks/<benchmark>/runs/<test-name>/
 Each run gets its own isolated benchmark workspace. That workspace contains:
 
 - a copied `dist/` build of the Libretto CLI
-- a local `package.json` with `pnpm cli` pointing directly at `dist/cli/index.js`
+- a local `package.json` with `pnpm -s cli` pointing directly at `dist/cli/index.js`
 - a copied `.claude/skills/libretto/` skill directory
+- an empty `node_modules/` directory to suppress misleading pnpm script warnings
 - its own `.libretto/` runtime state and benchmark snapshot-analyzer config
 
 Each per-case `results.json` now also records Claude-reported usage and `totalCostUsd`, and the generated benchmark summary includes a run-level duration/cost table plus per-case duration and cost.

--- a/benchmarks/onlineMind2Web/cases.ts
+++ b/benchmarks/onlineMind2Web/cases.ts
@@ -1,5 +1,6 @@
 import {
   formatBenchmarkSessionName,
+  getBenchmarkCliCommandPrefix,
   type BrowserBenchmarkCase,
 } from "../shared/cases.js";
 
@@ -7,6 +8,7 @@ const sessionName = formatBenchmarkSessionName(
   "onlineMind2Web",
   "fb7b4f784cfde003e2548fdf4e8d6b4f",
 );
+const cli = getBenchmarkCliCommandPrefix();
 
 export const onlineMind2WebCases: BrowserBenchmarkCase[] = [
   {
@@ -17,13 +19,13 @@ export const onlineMind2WebCases: BrowserBenchmarkCase[] = [
     instruction:
       "Open the page with an overview of the submission of releases on Discogs.",
     requiredTranscriptSnippets: [
-      `pnpm cli open https://www.discogs.com/ --headless --session ${sessionName}`,
-      `pnpm cli snapshot --session ${sessionName}`,
+      `${cli} open https://www.discogs.com/ --headless --session ${sessionName}`,
+      `${cli} snapshot --session ${sessionName}`,
       "FINAL_RESULT:",
     ],
     successAssertion: [
       "The agent solved the task by using the Libretto CLI against the live Discogs site.",
-      "The transcript includes a pnpm cli open command for https://www.discogs.com/ and at least one pnpm cli snapshot command.",
+      `The transcript includes a ${cli} open command for https://www.discogs.com/ and at least one ${cli} snapshot command.`,
       "The final result line identifies the Discogs support article for 'Overview of Submission Guidelines for Releases' by URL, page title, or both.",
       "Treat the task as successful if the final page is clearly the Discogs support article even if the URL uses different capitalization or includes support.discogs.com redirects.",
     ].join(" "),

--- a/benchmarks/shared/cases.ts
+++ b/benchmarks/shared/cases.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { expect } from "vitest";
 import { writeAiConfig } from "../../src/cli/core/ai-config.js";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
@@ -10,10 +10,10 @@ import {
 import type { ModelUsage, NonNullableUsage } from "@anthropic-ai/claude-agent-sdk";
 import {
   createClaudeBenchmarkHarness,
-  getBenchmarkAnalyzerPath,
   getBenchmarkDistPath,
   getBenchmarkPackageRoot,
-  getBenchmarkSkillPath,
+  getBenchmarkSkillSourcePath,
+  getBenchmarkWorkspaceSkillRelativePath,
 } from "./fixtures.js";
 
 export type BrowserBenchmarkCase = {
@@ -146,13 +146,16 @@ function extractFinalResultLine(transcript: string): string | null {
   return finalResultLine ?? null;
 }
 
-function buildPrompt(testCase: BrowserBenchmarkCase): string {
+export function buildBrowserBenchmarkPrompt(
+  testCase: BrowserBenchmarkCase,
+): string {
   const session = getSessionName(testCase);
+  const skillPath = `${getBenchmarkWorkspaceSkillRelativePath()}/SKILL.md`;
 
   return [
     `Run the ${testCase.benchmark} browser benchmark case "${testCase.title}".`,
     "Solve it by browsing the live website with the Libretto CLI installed in the current workspace.",
-    "The current workspace already contains the built Libretto CLI and the Libretto skill at .agents/skills/libretto/SKILL.md.",
+    `The current workspace already contains the built Libretto CLI and a Claude filesystem skill at ${skillPath}.`,
     "Do not change directories or reference any other libretto checkout.",
     "Run all commands from the current working directory and use `pnpm cli ...` directly.",
     "Do not inspect files under benchmarks/ to discover the answer.",
@@ -431,7 +434,7 @@ async function createWorkspaceAgentsFile(workspaceDir: string): Promise<void> {
       "",
       "- Stay in this workspace. Do not `cd` into any other directory or checkout.",
       "- Use the local Libretto CLI via `pnpm cli ...` from this directory.",
-      "- Use the local Libretto skill at `.agents/skills/libretto/SKILL.md`.",
+      "- Use the Claude-discovered Libretto skill at `.claude/skills/libretto/SKILL.md`.",
       "- Do not rely on any external libretto checkout or globally installed repo copy.",
       "",
     ].join("\n"),
@@ -450,15 +453,12 @@ async function createWorkspaceFiles(
   const distDestination = join(paths.workspaceDir, "dist");
   const skillDestination = join(
     paths.workspaceDir,
-    ".agents",
-    "skills",
-    "libretto",
-    "SKILL.md",
+    getBenchmarkWorkspaceSkillRelativePath(),
   );
 
   await cp(getBenchmarkDistPath(), distDestination, { recursive: true });
   await mkdir(dirname(skillDestination), { recursive: true });
-  await cp(getBenchmarkSkillPath(), skillDestination);
+  await cp(getBenchmarkSkillSourcePath(), skillDestination, { recursive: true });
   await createWorkspacePackageJson(paths.workspaceDir, testCase);
   await createWorkspaceAgentsFile(paths.workspaceDir);
 
@@ -676,18 +676,14 @@ async function withHarness<T>(
   run: (harness: ClaudeEvalHarness) => Promise<T>,
 ): Promise<T> {
   const harness = await createClaudeBenchmarkHarness(workspaceDir);
-  try {
-    return await run(harness);
-  } finally {
-    await harness.close();
-  }
+  return await run(harness);
 }
 
 export async function runBrowserBenchmarkCase(
   testCase: BrowserBenchmarkCase,
 ): Promise<EvalResponse> {
   const paths = getRunPaths(testCase);
-  const prompt = buildPrompt(testCase);
+  const prompt = buildBrowserBenchmarkPrompt(testCase);
   const startedAt = new Date();
 
   await createWorkspaceFiles(testCase, paths);

--- a/benchmarks/shared/cases.ts
+++ b/benchmarks/shared/cases.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { expect } from "vitest";
 import { writeAiConfig } from "../../src/cli/core/ai-config.js";
@@ -52,6 +52,8 @@ type BenchmarkRunArtifacts = {
   status: "running" | "passed" | "failed";
 };
 
+const BENCHMARK_CLI_PREFIX = "pnpm -s cli";
+
 function slugify(value: string): string {
   return value
     .trim()
@@ -66,6 +68,14 @@ export function formatBenchmarkSessionName(
   caseId: string,
 ): string {
   return slugify(`${benchmark}-${caseId}`);
+}
+
+export function getBenchmarkCliCommandPrefix(): string {
+  return BENCHMARK_CLI_PREFIX;
+}
+
+export function rewriteBenchmarkSkillCommands(markdown: string): string {
+  return markdown.replaceAll("npx libretto", BENCHMARK_CLI_PREFIX);
 }
 
 function deriveRunGroup(testCase: BrowserBenchmarkCase): string {
@@ -148,25 +158,25 @@ function extractFinalResultLine(transcript: string): string | null {
 
 export function buildBrowserBenchmarkPrompt(
   testCase: BrowserBenchmarkCase,
+  currentWorkingDirectory?: string,
 ): string {
   const session = getSessionName(testCase);
-  const skillPath = `${getBenchmarkWorkspaceSkillRelativePath()}/SKILL.md`;
+  const cli = getBenchmarkCliCommandPrefix();
 
   return [
     `Run the ${testCase.benchmark} browser benchmark case "${testCase.title}".`,
     "Solve it by browsing the live website with the Libretto CLI installed in the current workspace.",
-    `The current workspace already contains the built Libretto CLI and a Claude filesystem skill at ${skillPath}.`,
-    "Do not change directories or reference any other libretto checkout.",
-    "Run all commands from the current working directory and use `pnpm cli ...` directly.",
+    "Use the libretto skill.",
     "Do not inspect files under benchmarks/ to discover the answer.",
-    "Do not use curl, raw fetches, search engines, or non-Libretto browser tooling to solve the task.",
     `Use exactly one Libretto session named "${session}".`,
-    `Open the site with: pnpm cli open ${testCase.startUrl} --headless --session ${session}`,
-    `Use pnpm cli snapshot --session ${session} --objective "<...>" at least once before your final answer.`,
-    `Before finishing, run: pnpm cli exec --session ${session} "return { url: await page.url(), title: await page.title() }"`,
-    `Then close the browser with: pnpm cli close --session ${session}`,
+    `Open the site with: ${cli} open ${testCase.startUrl} --headless --session ${session}`,
+    `Before finishing, run: ${cli} exec --session ${session} "return { url: await page.url(), title: await page.title() }"`,
+    `Then close the browser with: ${cli} close --session ${session}`,
     testCase.finalResultInstruction ??
       'End with exactly one line in this format: FINAL_RESULT: <url> | <title>',
+    ...(currentWorkingDirectory
+      ? [`Current working directory: ${currentWorkingDirectory}`]
+      : []),
     "",
     "Task:",
     testCase.instruction,
@@ -424,20 +434,33 @@ async function createWorkspacePackageJson(
     ),
     "utf8",
   );
+
+  // Suppress pnpm's misleading "node_modules missing" warning for failed script runs.
+  await mkdir(join(workspaceDir, "node_modules"), { recursive: true });
 }
 
 async function createWorkspaceAgentsFile(workspaceDir: string): Promise<void> {
+  const cli = getBenchmarkCliCommandPrefix();
   await writeFile(
     join(workspaceDir, "AGENTS.md"),
     [
       "# Benchmark Workspace Rules",
       "",
-      "- Stay in this workspace. Do not `cd` into any other directory or checkout.",
-      "- Use the local Libretto CLI via `pnpm cli ...` from this directory.",
-      "- Use the Claude-discovered Libretto skill at `.claude/skills/libretto/SKILL.md`.",
-      "- Do not rely on any external libretto checkout or globally installed repo copy.",
+      "- Use the libretto skill available in this workspace.",
+      `- Use the local Libretto CLI via \`${cli} ...\` from this directory.`,
+      "- Do not inspect files under benchmarks/ to discover the answer.",
       "",
     ].join("\n"),
+    "utf8",
+  );
+}
+
+async function rewriteWorkspaceSkillCommands(skillDestination: string): Promise<void> {
+  const skillPath = join(skillDestination, "SKILL.md");
+  const skillMarkdown = await readFile(skillPath, "utf8");
+  await writeFile(
+    skillPath,
+    rewriteBenchmarkSkillCommands(skillMarkdown),
     "utf8",
   );
 }
@@ -459,6 +482,7 @@ async function createWorkspaceFiles(
   await cp(getBenchmarkDistPath(), distDestination, { recursive: true });
   await mkdir(dirname(skillDestination), { recursive: true });
   await cp(getBenchmarkSkillSourcePath(), skillDestination, { recursive: true });
+  await rewriteWorkspaceSkillCommands(skillDestination);
   await createWorkspacePackageJson(paths.workspaceDir, testCase);
   await createWorkspaceAgentsFile(paths.workspaceDir);
 
@@ -683,7 +707,7 @@ export async function runBrowserBenchmarkCase(
   testCase: BrowserBenchmarkCase,
 ): Promise<EvalResponse> {
   const paths = getRunPaths(testCase);
-  const prompt = buildBrowserBenchmarkPrompt(testCase);
+  const prompt = buildBrowserBenchmarkPrompt(testCase, paths.workspaceDir);
   const startedAt = new Date();
 
   await createWorkspaceFiles(testCase, paths);

--- a/benchmarks/shared/claude-snapshot-analyzer.mjs
+++ b/benchmarks/shared/claude-snapshot-analyzer.mjs
@@ -34,15 +34,32 @@ function extractPromptAndScreenshotPath(rawPrompt) {
   };
 }
 
+async function readPromptInput() {
+  const argvPrompt = process.argv.slice(2).join(" ").trim();
+  if (argvPrompt) {
+    return argvPrompt;
+  }
+
+  if (process.stdin.isTTY) {
+    return "";
+  }
+
+  let stdinPrompt = "";
+  for await (const chunk of process.stdin) {
+    stdinPrompt += chunk.toString();
+  }
+  return stdinPrompt.trim();
+}
+
 async function main() {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     throw new Error("Missing ANTHROPIC_API_KEY for benchmark snapshot analysis.");
   }
 
-  const rawPrompt = process.argv.slice(2).join(" ").trim();
+  const rawPrompt = await readPromptInput();
   if (!rawPrompt) {
-    throw new Error("Benchmark snapshot analyzer expected a prompt argument.");
+    throw new Error("Benchmark snapshot analyzer expected a prompt on argv or stdin.");
   }
 
   const { prompt, pngPath } = extractPromptAndScreenshotPath(rawPrompt);
@@ -72,7 +89,7 @@ async function main() {
           },
           {
             type: "image",
-            image: `data:image/png;base64,${imageBuffer.toString("base64")}`,
+            image: imageBuffer,
           },
         ],
       },

--- a/benchmarks/shared/fixtures.ts
+++ b/benchmarks/shared/fixtures.ts
@@ -50,5 +50,6 @@ export async function createClaudeBenchmarkHarness(
     maxTurns: 30,
     settingSources: ["project"],
     allowedTools: [BENCHMARK_SKILL_TOOL_NAME],
+    stopOnFinalResult: true,
   });
 }

--- a/benchmarks/shared/fixtures.ts
+++ b/benchmarks/shared/fixtures.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import {
@@ -8,22 +7,22 @@ import {
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 const packageRoot = resolve(here, "../..");
-const skillPath = resolve(packageRoot, ".agents/skills/libretto/SKILL.md");
+const skillSourcePath = resolve(packageRoot, ".agents/skills/libretto");
 const analyzerPath = resolve(
   packageRoot,
   "benchmarks/shared/claude-snapshot-analyzer.mjs",
 );
 const distPath = resolve(packageRoot, "dist");
 
-let cachedSkillMarkdown: string | null = null;
 const DEFAULT_BENCHMARK_MODEL = "claude-opus-4-6";
+const BENCHMARK_SKILL_TOOL_NAME = "Skill";
 
 export function getBenchmarkPackageRoot(): string {
   return packageRoot;
 }
 
-export function getBenchmarkSkillPath(): string {
-  return skillPath;
+export function getBenchmarkSkillSourcePath(): string {
+  return skillSourcePath;
 }
 
 export function getBenchmarkAnalyzerPath(): string {
@@ -34,24 +33,22 @@ export function getBenchmarkDistPath(): string {
   return distPath;
 }
 
-export async function getBenchmarkSkillMarkdown(): Promise<string> {
-  if (cachedSkillMarkdown !== null) return cachedSkillMarkdown;
-  cachedSkillMarkdown = await readFile(skillPath, "utf8");
-  return cachedSkillMarkdown;
+export function getBenchmarkWorkspaceSkillRelativePath(): string {
+  return ".claude/skills/libretto";
 }
 
 export async function createClaudeBenchmarkHarness(
   cwd: string,
 ): Promise<ClaudeEvalHarness> {
   ensureClaudeAuthConfigured();
-  const librettoSkillMarkdown = await getBenchmarkSkillMarkdown();
   return new ClaudeEvalHarness({
     cwd,
     model:
       process.env.LIBRETTO_BENCHMARK_MODEL?.trim() ||
       process.env.LIBRETTO_EVAL_MODEL?.trim() ||
       DEFAULT_BENCHMARK_MODEL,
-    librettoSkillMarkdown,
     maxTurns: 30,
+    settingSources: ["project"],
+    allowedTools: [BENCHMARK_SKILL_TOOL_NAME],
   });
 }

--- a/benchmarks/webVoyager/cases.ts
+++ b/benchmarks/webVoyager/cases.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   formatBenchmarkSessionName,
+  getBenchmarkCliCommandPrefix,
   type BrowserBenchmarkCase,
 } from "../shared/cases.js";
 
@@ -109,6 +110,7 @@ function readDatasetRows(): WebVoyagerRow[] {
 }
 
 export function getWebVoyagerCases(): BrowserBenchmarkCase[] {
+  const cli = getBenchmarkCliCommandPrefix();
   const rows = readDatasetRows();
   const sampledRows = parseBooleanEnv("LIBRETTO_WEBVOYAGER_RANDOM_SAMPLE")
     ? shuffleRows(rows, parseSeed())
@@ -127,7 +129,7 @@ export function getWebVoyagerCases(): BrowserBenchmarkCase[] {
       finalResultInstruction:
         'End with exactly one line in this format: FINAL_RESULT: <answer> | <url> | <title>',
       requiredTranscriptSnippets: [
-        `pnpm cli open ${row.web} --headless --session ${sessionName}`,
+        `${cli} open ${row.web} --headless --session ${sessionName}`,
         "FINAL_RESULT:",
       ],
       successAssertion: [

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -45,6 +45,15 @@ async function getSkillMarkdown(): Promise<string> {
   return cachedSkillMarkdown;
 }
 
+async function getInlineSkillSystemPrompt(): Promise<string> {
+  return [
+    "Use the following Libretto skill documentation as in-session guidance.",
+    "<libretto_skill>",
+    await getSkillMarkdown(),
+    "</libretto_skill>",
+  ].join("\n");
+}
+
 function stableHash(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
@@ -123,13 +132,9 @@ export const test = base.extend<EvalFixtures>({
     const harness = new ClaudeEvalHarness({
       cwd: evalWorkspaceDir,
       model: process.env.LIBRETTO_EVAL_MODEL?.trim() || undefined,
-      librettoSkillMarkdown: await getSkillMarkdown(),
+      systemPromptAppend: await getInlineSkillSystemPrompt(),
     });
-    try {
-      await use(harness);
-    } finally {
-      await harness.close();
-    }
+    await use(harness);
   },
 });
 

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -408,11 +408,12 @@ export function ensureClaudeAuthConfigured(): void {
 
 export type ClaudeEvalHarnessOptions = {
   cwd: string;
-  librettoSkillMarkdown: string;
+  systemPromptAppend?: string;
   model?: string;
   maxTurns?: number;
   permissionMode?: PermissionMode;
   settingSources?: SettingSource[];
+  allowedTools?: string[];
 };
 
 export type ClaudeEvalHarnessSendOptions = {
@@ -482,10 +483,10 @@ export class ClaudeEvalHarness {
   private readonly maxTurns: number;
   private readonly permissionMode: PermissionMode;
   private readonly settingSources: SettingSource[];
-  private readonly systemPromptAppend: string;
+  private readonly systemPromptAppend: string | null;
+  private readonly allowedTools: string[];
   private sessionId: string;
   private hasStarted = false;
-  private isClosed = false;
 
   constructor(options: ClaudeEvalHarnessOptions) {
     this.cwd = options.cwd;
@@ -493,12 +494,9 @@ export class ClaudeEvalHarness {
     this.maxTurns = options.maxTurns ?? 20;
     this.permissionMode = options.permissionMode ?? "bypassPermissions";
     this.settingSources = options.settingSources ?? ["project"];
-    this.systemPromptAppend = [
-      "Use the following Libretto skill documentation as in-session guidance.",
-      "<libretto_skill>",
-      options.librettoSkillMarkdown,
-      "</libretto_skill>",
-    ].join("\n");
+    this.allowedTools = options.allowedTools ?? [];
+    this.systemPromptAppend = options.systemPromptAppend?.trim() || null;
+
     this.sessionId = randomUUID();
   }
 
@@ -506,10 +504,6 @@ export class ClaudeEvalHarness {
     prompt: string,
     sendOptions: ClaudeEvalHarnessSendOptions = {},
   ): Promise<EvalResponse> {
-    if (this.isClosed) {
-      throw new Error("Cannot send prompts after harness is closed.");
-    }
-
     const options: Options = {
       cwd: this.cwd,
       model: this.model,
@@ -517,12 +511,16 @@ export class ClaudeEvalHarness {
       tools: { type: "preset", preset: "claude_code" },
       settingSources: this.settingSources,
       permissionMode: this.permissionMode,
-      systemPrompt: {
+      allowedTools: this.allowedTools,
+    };
+
+    if (this.systemPromptAppend) {
+      options.systemPrompt = {
         type: "preset",
         preset: "claude_code",
         append: this.systemPromptAppend,
-      },
-    };
+      };
+    }
 
     if (this.permissionMode === "bypassPermissions") {
       options.allowDangerouslySkipPermissions = true;
@@ -571,9 +569,5 @@ export class ClaudeEvalHarness {
       model: this.model,
     });
     return response;
-  }
-
-  async close(): Promise<void> {
-    this.isClosed = true;
   }
 }

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -54,6 +54,14 @@ function clip(text: string, maxChars: number): string {
   ].join("\n");
 }
 
+function extractFinalResultLine(transcript: string): string | null {
+  const finalResultLine = transcript
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("FINAL_RESULT:"));
+  return finalResultLine ?? null;
+}
+
 function asJson(value: unknown): string {
   try {
     return JSON.stringify(value);
@@ -414,6 +422,7 @@ export type ClaudeEvalHarnessOptions = {
   permissionMode?: PermissionMode;
   settingSources?: SettingSource[];
   allowedTools?: string[];
+  stopOnFinalResult?: boolean;
 };
 
 export type ClaudeEvalHarnessSendOptions = {
@@ -485,6 +494,7 @@ export class ClaudeEvalHarness {
   private readonly settingSources: SettingSource[];
   private readonly systemPromptAppend: string | null;
   private readonly allowedTools: string[];
+  private readonly stopOnFinalResult: boolean;
   private sessionId: string;
   private hasStarted = false;
 
@@ -496,6 +506,7 @@ export class ClaudeEvalHarness {
     this.settingSources = options.settingSources ?? ["project"];
     this.allowedTools = options.allowedTools ?? [];
     this.systemPromptAppend = options.systemPromptAppend?.trim() || null;
+    this.stopOnFinalResult = options.stopOnFinalResult === true;
 
     this.sessionId = randomUUID();
   }
@@ -552,6 +563,15 @@ export class ClaudeEvalHarness {
             model: this.model,
           }),
         );
+      }
+
+      if (
+        this.stopOnFinalResult &&
+        message.type === "result" &&
+        message.subtype === "success" &&
+        extractFinalResultLine(message.result) !== null
+      ) {
+        break;
       }
     }
 

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -197,9 +197,15 @@ export async function connect(
       port: state.port,
       pid: state.pid,
     });
-    clearSessionState(session, logger);
+    if (!isPidRunning(state.pid)) {
+      clearSessionState(session, logger);
+      throw new Error(
+        `No browser running for session "${session}". Run 'libretto-cli open <url> --session ${session}' first.`,
+      );
+    }
+
     throw new Error(
-      `No browser running for session "${session}". Run 'libretto-cli open <url> --session ${session}' first.`,
+      `Could not connect to the browser for session "${session}" at http://127.0.0.1:${state.port}, but the session process (pid ${state.pid}) is still running. Try the command again, or close and reopen the session if it stays stuck.`,
     );
   }
 

--- a/test/benchmark-run.spec.ts
+++ b/test/benchmark-run.spec.ts
@@ -9,7 +9,10 @@ import {
   getBenchmarkRunHistoryPath,
   parseBenchmarkArgs,
 } from "../benchmarks/run.js";
-import { buildBrowserBenchmarkPrompt } from "../benchmarks/shared/cases.js";
+import {
+  buildBrowserBenchmarkPrompt,
+  rewriteBenchmarkSkillCommands,
+} from "../benchmarks/shared/cases.js";
 
 const tempRoots: string[] = [];
 
@@ -22,7 +25,7 @@ afterEach(async () => {
 });
 
 describe("benchmark launcher history", () => {
-  test("benchmark prompt points Claude to the filesystem skill path", () => {
+  test("benchmark prompt tells Claude to use the libretto skill", () => {
     const prompt = buildBrowserBenchmarkPrompt({
       benchmark: "webVoyager",
       id: "sample-case",
@@ -31,10 +34,30 @@ describe("benchmark launcher history", () => {
       instruction: "Inspect the page and report the final title.",
       successAssertion:
         "The transcript includes the final page URL and title in FINAL_RESULT format.",
-    });
+    }, "/tmp/libretto-benchmark-workspace");
 
-    expect(prompt).toContain(".claude/skills/libretto/SKILL.md");
+    expect(prompt).toContain("Use the libretto skill.");
+    expect(prompt).toContain("pnpm -s cli open https://example.com --headless --session webvoyager-sample-case");
+    expect(prompt).toContain("Current working directory: /tmp/libretto-benchmark-workspace");
+    expect(prompt).not.toContain("Run all commands from the current working directory");
+    expect(prompt).not.toContain(".claude/skills/libretto/SKILL.md");
     expect(prompt).not.toContain(".agents/skills/libretto/SKILL.md");
+  });
+
+  test("rewrites copied benchmark skill commands to use the local cli script", () => {
+    const rewritten = rewriteBenchmarkSkillCommands(
+      [
+        "Use the `npx libretto` CLI.",
+        "",
+        "npx libretto open https://example.com",
+        "npx libretto snapshot --objective \"inspect\"",
+      ].join("\n"),
+    );
+
+    expect(rewritten).toContain("Use the `pnpm -s cli` CLI.");
+    expect(rewritten).toContain("pnpm -s cli open https://example.com");
+    expect(rewritten).toContain('pnpm -s cli snapshot --objective "inspect"');
+    expect(rewritten).not.toContain("npx libretto");
   });
 
   test("defaults to all benchmarks when no benchmark filter is provided", () => {

--- a/test/benchmark-run.spec.ts
+++ b/test/benchmark-run.spec.ts
@@ -9,6 +9,7 @@ import {
   getBenchmarkRunHistoryPath,
   parseBenchmarkArgs,
 } from "../benchmarks/run.js";
+import { buildBrowserBenchmarkPrompt } from "../benchmarks/shared/cases.js";
 
 const tempRoots: string[] = [];
 
@@ -21,6 +22,21 @@ afterEach(async () => {
 });
 
 describe("benchmark launcher history", () => {
+  test("benchmark prompt points Claude to the filesystem skill path", () => {
+    const prompt = buildBrowserBenchmarkPrompt({
+      benchmark: "webVoyager",
+      id: "sample-case",
+      title: "Sample benchmark case",
+      startUrl: "https://example.com",
+      instruction: "Inspect the page and report the final title.",
+      successAssertion:
+        "The transcript includes the final page URL and title in FINAL_RESULT format.",
+    });
+
+    expect(prompt).toContain(".claude/skills/libretto/SKILL.md");
+    expect(prompt).not.toContain(".agents/skills/libretto/SKILL.md");
+  });
+
   test("defaults to all benchmarks when no benchmark filter is provided", () => {
     const parsed = parseBenchmarkArgs(["--testNamePattern", "FINAL_RESULT"]);
 


### PR DESCRIPTION
## Summary
- keep benchmark runs on Claude filesystem skills while rewriting the copied Libretto skill to use `pnpm -s cli`
- slim the benchmark prompt down to skill-driven guidance, stop collecting late tool notifications after `FINAL_RESULT`, and record the assigned cwd in the prompt
- clean up benchmark transcript expectations and docs around the local CLI wrapper and workspace setup

## Verification
- `pnpm type-check`
- `pnpm exec vitest run test/benchmark-run.spec.ts`
- `LIBRETTO_WEBVOYAGER_RANDOM_SAMPLE=1 LIBRETTO_WEBVOYAGER_RANDOM_SEED=20260316 LIBRETTO_WEBVOYAGER_LIMIT=1 pnpm benchmark webVoyager`
