### PR TITLE
Improve snapshot analyzer config errors

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -105,7 +105,7 @@ function printSnapshotApiStatus(): void {
     "      GOOGLE_CLOUD_PROJECT=...  # plus application default credentials for Vertex",
   );
   console.log(
-    "    Or run `npx libretto ai configure <provider>` to set a specific model.",
+    "    Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
   );
   console.log("    Run `npx libretto init` interactively to set up credentials.");
 }
@@ -153,7 +153,7 @@ async function runInteractiveApiSetup(): Promise<void> {
       console.log("    ANTHROPIC_API_KEY=...");
       console.log("    GEMINI_API_KEY=...");
       console.log(
-        "    Or run `npx libretto ai configure <provider>` to set a specific model.",
+        "    Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
       );
       return;
     }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -63,6 +63,18 @@ function safeReadAiConfig(): ReturnType<typeof readAiConfig> {
   }
 }
 
+function printInvalidAiConfigWarning(): void {
+  try {
+    readAiConfig();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log("  ! Existing AI config is invalid:");
+    for (const line of message.split("\n")) {
+      console.log(`    ${line}`);
+    }
+  }
+}
+
 function printSnapshotApiStatus(): void {
   const config = safeReadAiConfig();
   const selection = resolveSnapshotApiModel(config);
@@ -73,6 +85,7 @@ function printSnapshotApiStatus(): void {
     "  Libretto uses direct API calls for snapshot analysis when supported credentials are available.",
   );
   console.log(`  Credentials are loaded from process env and ${envPath}.`);
+  printInvalidAiConfigWarning();
 
   if (selection && hasProviderCredentials(selection.provider)) {
     console.log(
@@ -107,6 +120,7 @@ async function runInteractiveApiSetup(): Promise<void> {
     "  Libretto uses direct API calls for snapshot analysis.",
   );
   console.log(`  Credentials are loaded from process env and ${envPath}.`);
+  printInvalidAiConfigWarning();
 
   if (selection && hasProviderCredentials(selection.provider)) {
     console.log(

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -11,6 +11,7 @@ import {
 } from "../core/snapshot-analyzer.js";
 import { runApiInterpret } from "../core/api-snapshot-analyzer.js";
 import { readAiConfig } from "../core/ai-config.js";
+import { resolveSnapshotApiModelOrThrow } from "../core/snapshot-api-config.js";
 
 const DEFAULT_SNAPSHOT_CONTEXT = "No additional user context provided.";
 const FALLBACK_SNAPSHOT_VIEWPORT = { width: 1280, height: 800 } as const;
@@ -253,6 +254,11 @@ async function runSnapshot(
     );
   }
 
+  const configuredAi = normalizedObjective ? readAiConfig() : null;
+  if (normalizedObjective) {
+    resolveSnapshotApiModelOrThrow(configuredAi);
+  }
+
   const { pngPath, htmlPath, condensedHtmlPath } = await captureScreenshot(
     session,
     logger,
@@ -282,7 +288,7 @@ async function runSnapshot(
   // The legacy CLI-agent path (spawning codex/claude/gemini as a subprocess) is preserved
   // in snapshot-analyzer.ts — to switch back, replace this call with:
   //   await runInterpret(interpretArgs, logger);
-  await runApiInterpret(interpretArgs, logger, readAiConfig());
+  await runApiInterpret(interpretArgs, logger, configuredAi);
 }
 
 export function registerSnapshotCommands(yargs: Argv, logger: LoggerApi): Argv {

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -9,7 +9,7 @@ export const CURRENT_CONFIG_VERSION = 1;
  * AI configuration schema.
  *
  * The `model` field is a provider/model-id string (e.g. "openai/gpt-5.4",
- * "anthropic/claude-sonnet-4-6", "google/gemini-2.5-flash", "vertex/gemini-2.5-pro").
+ * "anthropic/claude-sonnet-4-6", "google/gemini-3-flash-preview", "vertex/gemini-2.5-pro").
  *
  * Legacy note: earlier versions stored a `preset` (codex|claude|gemini) and
  * `commandPrefix` (CLI args to spawn a sub-agent process). That approach has
@@ -44,25 +44,63 @@ export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
 const DEFAULT_MODELS: Record<string, string> = {
   openai: "openai/gpt-5.4",
   anthropic: "anthropic/claude-sonnet-4-6",
-  gemini: "google/gemini-2.5-flash",
-  google: "google/gemini-2.5-flash",
+  gemini: "google/gemini-3-flash-preview",
   vertex: "vertex/gemini-2.5-pro",
 };
 
-const CONFIGURE_PROVIDERS = Object.keys(DEFAULT_MODELS);
+const PROVIDER_ALIASES: Record<string, string> = {
+  claude: DEFAULT_MODELS.anthropic,
+  google: DEFAULT_MODELS.gemini,
+};
 
-function invalidConfigError(configPath: string): Error {
+const CONFIGURE_PROVIDERS = ["openai", "anthropic", "gemini", "vertex"] as const;
+
+function formatConfigureProviders(separator = " | "): string {
+  return CONFIGURE_PROVIDERS.join(separator);
+}
+
+function formatConfigIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `  - ${issue.path.join(".") || "root"}: ${issue.message}`)
+    .join("\n");
+}
+
+function formatExpectedConfigShape(): string {
+  return JSON.stringify(z.toJSONSchema(LibrettoConfigSchema), null, 2);
+}
+
+function invalidConfigError(configPath: string, detail?: string): Error {
   return new Error(
-    `AI config is invalid at ${configPath}. Fix the file to match the expected schema or delete it.`,
+    [
+      `AI config is invalid at ${configPath}.`,
+      detail ? `Problems:\n${detail}` : null,
+      "Expected JSON schema:",
+      formatExpectedConfigShape(),
+      "Notes:",
+      '  - "ai" and "viewport" are optional.',
+      '  - "ai.model" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".',
+      "Fix the file to match this schema, or delete it and rerun:",
+      `  npx libretto ai configure ${formatConfigureProviders()}`,
+    ].filter(Boolean).join("\n"),
   );
 }
 
 function parseConfig(raw: string, configPath: string): LibrettoConfig {
+  let parsedJson: unknown;
   try {
-    return LibrettoConfigSchema.parse(JSON.parse(raw));
-  } catch {
-    throw invalidConfigError(configPath);
+    parsedJson = JSON.parse(raw);
+  } catch (error) {
+    throw invalidConfigError(
+      configPath,
+      `  - root: Invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
+
+  const parsed = LibrettoConfigSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    throw invalidConfigError(configPath, formatConfigIssues(parsed.error));
+  }
+  return parsed.data;
 }
 
 export function readLibrettoConfig(
@@ -140,7 +178,8 @@ function resolveModelFromInput(input: string): string | null {
   if (trimmed.includes("/")) return trimmed;
 
   // Provider shorthand
-  return DEFAULT_MODELS[trimmed.toLowerCase()] ?? null;
+  const normalized = trimmed.toLowerCase();
+  return DEFAULT_MODELS[normalized] ?? PROVIDER_ALIASES[normalized] ?? null;
 }
 
 export function runAiConfigure(
@@ -162,7 +201,10 @@ export function runAiConfigure(
   if (!presetArg && !input.clear) {
     const config = readAiConfig(configPath);
     if (!config) {
-      console.log(`No AI config set. Run '${configureCommandName} openai' to set one.`);
+      console.log(
+        `No AI config set. Choose a default model: ${configureCommandName} ${formatConfigureProviders()}`,
+      );
+      console.log("Provider credentials still come from your shell or .env file.");
       return;
     }
     printAiConfig(config, configPath);
@@ -187,7 +229,7 @@ export function runAiConfigure(
       `       ${configureCommandName} --clear`,
     );
     throw new Error(
-      `Invalid provider or model. Use one of: ${CONFIGURE_PROVIDERS.join(", ")}, or a full model string like "openai/gpt-4o".`,
+      `Invalid provider or model. Use one of: ${formatConfigureProviders()}, or a full model string like "openai/gpt-4o".`,
     );
   }
 

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -65,8 +65,22 @@ function formatConfigIssues(error: z.ZodError): string {
     .join("\n");
 }
 
-function formatExpectedConfigShape(): string {
-  return JSON.stringify(z.toJSONSchema(LibrettoConfigSchema), null, 2);
+function formatExpectedConfigExample(): string {
+  return JSON.stringify(
+    {
+      version: CURRENT_CONFIG_VERSION,
+      ai: {
+        model: "openai/gpt-5.4",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+    },
+    null,
+    2,
+  );
 }
 
 function invalidConfigError(configPath: string, detail?: string): Error {
@@ -74,12 +88,12 @@ function invalidConfigError(configPath: string, detail?: string): Error {
     [
       `AI config is invalid at ${configPath}.`,
       detail ? `Problems:\n${detail}` : null,
-      "Expected JSON schema:",
-      formatExpectedConfigShape(),
+      "Expected config example:",
+      formatExpectedConfigExample(),
       "Notes:",
       '  - "ai" and "viewport" are optional.',
       '  - "ai.model" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".',
-      "Fix the file to match this schema, or delete it and rerun:",
+      "Fix the file to match this shape, or delete it and rerun:",
       `  npx libretto ai configure ${formatConfigureProviders()}`,
     ].filter(Boolean).join("\n"),
   );

--- a/src/cli/core/snapshot-api-config.ts
+++ b/src/cli/core/snapshot-api-config.ts
@@ -4,7 +4,7 @@ import {
 	type AiConfig,
 	readAiConfig,
 } from "./ai-config.js";
-import { REPO_ROOT } from "./context.js";
+import { LIBRETTO_CONFIG_PATH, REPO_ROOT } from "./context.js";
 import {
 	hasProviderCredentials,
 	missingProviderCredentialsMessage,
@@ -15,7 +15,7 @@ import {
 const DEFAULT_SNAPSHOT_MODELS = {
 	openai: "openai/gpt-5.4",
 	anthropic: "anthropic/claude-sonnet-4-6",
-	google: "google/gemini-2.5-flash",
+	google: "google/gemini-3-flash-preview",
 	vertex: "vertex/gemini-2.5-pro",
 } as const satisfies Record<Provider, string>;
 
@@ -35,6 +35,101 @@ export class SnapshotApiUnavailableError extends Error {
 		super(message);
 		this.name = "SnapshotApiUnavailableError";
 	}
+}
+
+function formatIndented(lines: readonly string[], indent = "  "): string {
+	return lines.map((line) => `${indent}${line}`).join("\n");
+}
+
+function configuredSourceDescription(
+	source: SnapshotApiModelSelection["source"],
+): string {
+	switch (source) {
+		case "config":
+			return LIBRETTO_CONFIG_PATH;
+		case "env:auto-openai":
+		case "env:auto-anthropic":
+		case "env:auto-google":
+		case "env:auto-vertex":
+			return "process env / .env auto-detection";
+	}
+}
+
+function providerSetupLines(provider: Provider): string[] {
+	switch (provider) {
+		case "openai":
+			return [
+				"Set OPENAI_API_KEY in your shell or .env file.",
+				"Example: OPENAI_API_KEY=...",
+			];
+		case "anthropic":
+			return [
+				"Set ANTHROPIC_API_KEY in your shell or .env file.",
+				"Example: ANTHROPIC_API_KEY=...",
+			];
+		case "google":
+			return [
+				"Set GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY in your shell or .env file.",
+				"Example: GEMINI_API_KEY=...",
+			];
+		case "vertex":
+			return [
+				"Set GOOGLE_CLOUD_PROJECT (or GCLOUD_PROJECT).",
+				"Then run: gcloud auth application-default login",
+			];
+	}
+}
+
+function defaultModelCommandLine(): string {
+	return "npx libretto ai configure openai | anthropic | gemini | vertex";
+}
+
+function noSnapshotApiConfiguredMessage(): string {
+	return [
+		"No API snapshot analyzer is configured.",
+		"",
+		"Libretto checks for:",
+		formatIndented([
+			`a default model in ${LIBRETTO_CONFIG_PATH}`,
+			"provider credentials in process env or .env",
+		]),
+		"",
+		"To enable snapshot analysis:",
+		formatIndented([
+			"1. Add one provider credential:",
+			"   OPENAI_API_KEY=...",
+			"   ANTHROPIC_API_KEY=...",
+			"   GEMINI_API_KEY=...  # or GOOGLE_GENERATIVE_AI_API_KEY",
+			"   GOOGLE_CLOUD_PROJECT=...  # plus gcloud application-default login for Vertex",
+			"2. (Optional) Choose a default model:",
+			`   ${defaultModelCommandLine()}`,
+		]),
+		"",
+		"Then rerun:",
+		'  npx libretto snapshot --objective "<your objective>"',
+	].join("\n");
+}
+
+function missingProviderSnapshotMessage(
+	selection: SnapshotApiModelSelection,
+): string {
+	return [
+		`Snapshot analysis is configured to use ${selection.model} (${configuredSourceDescription(selection.source)}),`,
+		`but ${missingProviderCredentialsMessage(selection.provider)}`,
+		"",
+		"To fix it:",
+		formatIndented([
+			"1. Add the missing provider credential:",
+			...providerSetupLines(selection.provider).map((line) => `   ${line}`),
+			"2. Or switch the default model:",
+			`   ${defaultModelCommandLine()}`,
+			"3. Or clear the default model and rely on env auto-detection:",
+			"   npx libretto ai configure --clear",
+		]),
+		"",
+		"Then rerun:",
+		'  npx libretto snapshot --objective "<your objective>"',
+	].join("\n");
 }
 
 function readWorktreeEnvPath(): string | null {
@@ -167,13 +262,13 @@ export function resolveSnapshotApiModelOrThrow(
 	const selection = resolveSnapshotApiModel(config);
 	if (!selection) {
 		throw new SnapshotApiUnavailableError(
-			"No API snapshot analyzer is available. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT, or run `npx libretto ai configure <provider>` to set a default model.",
+			noSnapshotApiConfiguredMessage(),
 		);
 	}
 
 	if (!hasProviderCredentials(selection.provider)) {
 		throw new SnapshotApiUnavailableError(
-			missingProviderCredentialsMessage(selection.provider),
+			missingProviderSnapshotMessage(selection),
 		);
 	}
 

--- a/src/cli/core/snapshot-api-config.ts
+++ b/src/cli/core/snapshot-api-config.ts
@@ -7,7 +7,6 @@ import {
 import { LIBRETTO_CONFIG_PATH, REPO_ROOT } from "./context.js";
 import {
 	hasProviderCredentials,
-	missingProviderCredentialsMessage,
 	parseModel,
 	type Provider,
 } from "../../shared/llm/client.js";
@@ -37,46 +36,16 @@ export class SnapshotApiUnavailableError extends Error {
 	}
 }
 
-function formatIndented(lines: readonly string[], indent = "  "): string {
-	return lines.map((line) => `${indent}${line}`).join("\n");
-}
-
-function configuredSourceDescription(
-	source: SnapshotApiModelSelection["source"],
-): string {
-	switch (source) {
-		case "config":
-			return LIBRETTO_CONFIG_PATH;
-		case "env:auto-openai":
-		case "env:auto-anthropic":
-		case "env:auto-google":
-		case "env:auto-vertex":
-			return "process env / .env auto-detection";
-	}
-}
-
-function providerSetupLines(provider: Provider): string[] {
+function providerSetupSentence(provider: Provider): string {
 	switch (provider) {
 		case "openai":
-			return [
-				"Set OPENAI_API_KEY in your shell or .env file.",
-				"Example: OPENAI_API_KEY=...",
-			];
+			return "Add OPENAI_API_KEY to .env or as a shell environment variable.";
 		case "anthropic":
-			return [
-				"Set ANTHROPIC_API_KEY in your shell or .env file.",
-				"Example: ANTHROPIC_API_KEY=...",
-			];
+			return "Add ANTHROPIC_API_KEY to .env or as a shell environment variable.";
 		case "google":
-			return [
-				"Set GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY in your shell or .env file.",
-				"Example: GEMINI_API_KEY=...",
-			];
+			return "Add GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY to .env or as a shell environment variable.";
 		case "vertex":
-			return [
-				"Set GOOGLE_CLOUD_PROJECT (or GCLOUD_PROJECT).",
-				"Then run: gcloud auth application-default login",
-			];
+			return "Add GOOGLE_CLOUD_PROJECT or GCLOUD_PROJECT to .env or as a shell environment variable, and make sure application default credentials are configured.";
 	}
 }
 
@@ -84,52 +53,39 @@ function defaultModelCommandLine(): string {
 	return "npx libretto ai configure openai | anthropic | gemini | vertex";
 }
 
+function providerMissingCredentialSummary(provider: Provider): string {
+	switch (provider) {
+		case "openai":
+			return "OPENAI_API_KEY is missing";
+		case "anthropic":
+			return "ANTHROPIC_API_KEY is missing";
+		case "google":
+			return "GEMINI_API_KEY and GOOGLE_GENERATIVE_AI_API_KEY are missing";
+		case "vertex":
+			return "GOOGLE_CLOUD_PROJECT and GCLOUD_PROJECT are missing";
+	}
+}
+
 function noSnapshotApiConfiguredMessage(): string {
 	return [
-		"No API snapshot analyzer is configured.",
-		"",
-		"Libretto checks for:",
-		formatIndented([
-			`a default model in ${LIBRETTO_CONFIG_PATH}`,
-			"provider credentials in process env or .env",
-		]),
-		"",
-		"To enable snapshot analysis:",
-		formatIndented([
-			"1. Add one provider credential:",
-			"   OPENAI_API_KEY=...",
-			"   ANTHROPIC_API_KEY=...",
-			"   GEMINI_API_KEY=...  # or GOOGLE_GENERATIVE_AI_API_KEY",
-			"   GOOGLE_CLOUD_PROJECT=...  # plus gcloud application-default login for Vertex",
-			"2. (Optional) Choose a default model:",
-			`   ${defaultModelCommandLine()}`,
-		]),
-		"",
-		"Then rerun:",
-		'  npx libretto snapshot --objective "<your objective>"',
-	].join("\n");
+		"Failed to analyze snapshot because no snapshot analyzer is configured.",
+		`Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with \`${defaultModelCommandLine()}\`.`,
+		"For more info, run `npx libretto init`.",
+	].join(" ");
 }
 
 function missingProviderSnapshotMessage(
 	selection: SnapshotApiModelSelection,
 ): string {
+	const configuredSource =
+		selection.source === "config"
+			? ` in ${LIBRETTO_CONFIG_PATH}`
+			: " from process env or .env";
 	return [
-		`Snapshot analysis is configured to use ${selection.model} (${configuredSourceDescription(selection.source)}),`,
-		`but ${missingProviderCredentialsMessage(selection.provider)}`,
-		"",
-		"To fix it:",
-		formatIndented([
-			"1. Add the missing provider credential:",
-			...providerSetupLines(selection.provider).map((line) => `   ${line}`),
-			"2. Or switch the default model:",
-			`   ${defaultModelCommandLine()}`,
-			"3. Or clear the default model and rely on env auto-detection:",
-			"   npx libretto ai configure --clear",
-		]),
-		"",
-		"Then rerun:",
-		'  npx libretto snapshot --objective "<your objective>"',
-	].join("\n");
+		`Failed to analyze snapshot because ${selection.provider} is configured${configuredSource}, but ${providerMissingCredentialSummary(selection.provider)}.`,
+		providerSetupSentence(selection.provider),
+		"For more info, run `npx libretto init`.",
+	].join(" ");
 }
 
 function readWorktreeEnvPath(): string | null {

--- a/src/shared/llm/client.ts
+++ b/src/shared/llm/client.ts
@@ -38,7 +38,7 @@ export function parseModel(model: string): { provider: Provider; modelId: string
 	const slashIndex = model.indexOf("/");
 	if (slashIndex === -1) {
 		throw new Error(
-			`Invalid model string "${model}". Expected format: "provider/model-id" (for example "openai/gpt-5.4", "anthropic/claude-sonnet-4-6", "google/gemini-2.5-pro", or "vertex/gemini-2.5-pro").`,
+			`Invalid model string "${model}". Expected format: "provider/model-id" (for example "openai/gpt-5.4", "anthropic/claude-sonnet-4-6", "google/gemini-3-flash-preview", or "vertex/gemini-2.5-pro").`,
 		);
 	}
 	const providerInput = model.slice(0, slashIndex).toLowerCase();
@@ -75,14 +75,14 @@ export function hasProviderCredentials(
 export function missingProviderCredentialsMessage(provider: Provider): string {
 	switch (provider) {
 		case "google":
-			return "Missing Gemini API key. Set GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY.";
+			return "Gemini API key is missing. Set GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY.";
 		case "vertex":
-			return "Missing Vertex AI project. Set GOOGLE_CLOUD_PROJECT (or GCLOUD_PROJECT) and ensure application default credentials are configured.";
+			return "Vertex AI project is missing. Set GOOGLE_CLOUD_PROJECT (or GCLOUD_PROJECT) and ensure application default credentials are configured.";
 		case "anthropic": {
-			return "Missing Anthropic API key. Set ANTHROPIC_API_KEY.";
+			return "Anthropic API key is missing. Set ANTHROPIC_API_KEY.";
 		}
 		case "openai": {
-			return "Missing OpenAI API key. Set OPENAI_API_KEY.";
+			return "OpenAI API key is missing. Set OPENAI_API_KEY.";
 		}
 	}
 }

--- a/test/ai-config.spec.ts
+++ b/test/ai-config.spec.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readLibrettoConfig } from "../src/cli/core/ai-config.js";
+
+describe("ai config validation output", () => {
+  it("prints a valid config example instead of raw JSON schema", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "libretto-ai-config-"));
+    const configPath = join(tempDir, "config.json");
+
+    try {
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 2,
+          ai: {
+            preset: "codex",
+          },
+        }),
+      );
+
+      let message = "";
+      try {
+        readLibrettoConfig(configPath);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(message).toContain(`AI config is invalid at ${configPath}.`);
+      expect(message).toContain("Expected config example:");
+      expect(message).toContain('"version": 1');
+      expect(message).toContain('"model": "openai/gpt-5.4"');
+      expect(message).toContain('"updatedAt": "2026-01-01T00:00:00.000Z"');
+      expect(message).toContain('"viewport": {');
+      expect(message).not.toContain('"$schema"');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/snapshot-api-config.spec.ts
+++ b/test/snapshot-api-config.spec.ts
@@ -5,9 +5,10 @@ import {
 } from "../src/cli/core/snapshot-analyzer.js";
 import {
   parseDotEnvAssignment,
-  resolveSnapshotApiModel,
   resolveSnapshotApiModelOrThrow,
+  resolveSnapshotApiModel,
 } from "../src/cli/core/snapshot-api-config.js";
+import { LIBRETTO_CONFIG_PATH } from "../src/cli/core/context.js";
 
 function makeConfig(model: string): AiConfig {
   return {
@@ -32,6 +33,7 @@ function clearProviderEnv(): void {
 describe("snapshot API model resolution", () => {
   it("prefers OpenAI automatically when only OPENAI_API_KEY is present", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
@@ -43,6 +45,7 @@ describe("snapshot API model resolution", () => {
 
   it("uses config model when set", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 
     const config = makeConfig("openai/gpt-5.4");
@@ -56,6 +59,7 @@ describe("snapshot API model resolution", () => {
 
   it("uses config model for anthropic", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
 
     const config = makeConfig("anthropic/claude-sonnet-4-6");
@@ -69,6 +73,7 @@ describe("snapshot API model resolution", () => {
 
   it("auto-detects Gemini when GEMINI_API_KEY is present", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("GEMINI_API_KEY", "test-gemini-key");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
@@ -80,6 +85,7 @@ describe("snapshot API model resolution", () => {
 
   it("auto-detects Gemini when GOOGLE_GENERATIVE_AI_API_KEY is present", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "test-gemini-key");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
@@ -91,6 +97,7 @@ describe("snapshot API model resolution", () => {
 
   it("auto-detects Vertex when only GOOGLE_CLOUD_PROJECT is present", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "test-project");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
@@ -102,6 +109,7 @@ describe("snapshot API model resolution", () => {
 
   it("falls back to auto-detection even when config exists", () => {
     vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
     vi.stubEnv("OPENAI_API_KEY", "test-key");
 
     // Config with no model — should still auto-detect from env
@@ -126,7 +134,7 @@ describe("snapshot API model resolution", () => {
     clearProviderEnv();
 
     expect(() => resolveSnapshotApiModelOrThrow(makeConfig("openai/gpt-5.4"))).toThrowError(
-      "Failed to analyze snapshot because openai is configured in /Users/tanishqkancharla/.codex/worktrees/111e/libretto/.libretto/config.json, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run `npx libretto init`.",
+      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto init\`.`,
     );
   });
 });

--- a/test/snapshot-api-config.spec.ts
+++ b/test/snapshot-api-config.spec.ts
@@ -62,7 +62,7 @@ describe("snapshot API model resolution", () => {
     vi.stubEnv("GEMINI_API_KEY", "test-gemini-key");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
-      model: "google/gemini-2.5-flash",
+      model: "google/gemini-3-flash-preview",
       provider: "google",
       source: "env:auto-google",
     });
@@ -73,7 +73,7 @@ describe("snapshot API model resolution", () => {
     vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "test-gemini-key");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
-      model: "google/gemini-2.5-flash",
+      model: "google/gemini-3-flash-preview",
       provider: "google",
       source: "env:auto-google",
     });

--- a/test/snapshot-api-config.spec.ts
+++ b/test/snapshot-api-config.spec.ts
@@ -6,6 +6,7 @@ import {
 import {
   parseDotEnvAssignment,
   resolveSnapshotApiModel,
+  resolveSnapshotApiModelOrThrow,
 } from "../src/cli/core/snapshot-api-config.js";
 
 function makeConfig(model: string): AiConfig {
@@ -18,6 +19,15 @@ function makeConfig(model: string): AiConfig {
 afterEach(() => {
   vi.unstubAllEnvs();
 });
+
+function clearProviderEnv(): void {
+  vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("ANTHROPIC_API_KEY", "");
+  vi.stubEnv("GEMINI_API_KEY", "");
+  vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "");
+  vi.stubEnv("GOOGLE_CLOUD_PROJECT", "");
+  vi.stubEnv("GCLOUD_PROJECT", "");
+}
 
 describe("snapshot API model resolution", () => {
   it("prefers OpenAI automatically when only OPENAI_API_KEY is present", () => {
@@ -100,6 +110,24 @@ describe("snapshot API model resolution", () => {
       provider: "openai",
       source: "env:auto-openai",
     });
+  });
+
+  it("explains how to configure snapshot analysis when no analyzer is available", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+
+    expect(() => resolveSnapshotApiModelOrThrow(null)).toThrowError(
+      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex`. For more info, run `npx libretto init`.",
+    );
+  });
+
+  it("explains how to fix a configured provider with missing credentials", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+
+    expect(() => resolveSnapshotApiModelOrThrow(makeConfig("openai/gpt-5.4"))).toThrowError(
+      "Failed to analyze snapshot because openai is configured in /Users/tanishqkancharla/.codex/worktrees/111e/libretto/.libretto/config.json, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run `npx libretto init`.",
+    );
   });
 });
 

--- a/test/stateful.spec.ts
+++ b/test/stateful.spec.ts
@@ -50,7 +50,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(configure.stdout).toContain("AI config saved.");
 
     const show = await librettoCli("ai configure");
-    expect(show.stdout).toContain("Model: google/gemini-2.5-flash");
+    expect(show.stdout).toContain("Model: google/gemini-3-flash-preview");
   });
 
   test("configures vertex provider", async ({ librettoCli }) => {
@@ -107,7 +107,7 @@ describe("state-driven CLI subprocess behavior", () => {
         GCLOUD_PROJECT: "",
       },
     );
-    expect(snapshot.stderr).toContain("No API snapshot analyzer is available");
+    expect(snapshot.stderr).toContain("No API snapshot analyzer is configured.");
   }, 45_000);
 
   test("shows a clear error when --context is provided without --objective", async ({

--- a/test/stateful.spec.ts
+++ b/test/stateful.spec.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
 
@@ -89,6 +90,7 @@ describe("state-driven CLI subprocess behavior", () => {
 
   test("snapshot --objective requires API credentials", async ({
     librettoCli,
+    workspacePath,
   }) => {
     const session = "snapshot-no-creds";
     await librettoCli(
@@ -107,7 +109,15 @@ describe("state-driven CLI subprocess behavior", () => {
         GCLOUD_PROJECT: "",
       },
     );
-    expect(snapshot.stderr).toContain("No API snapshot analyzer is configured.");
+    expect(snapshot.exitCode).not.toBe(0);
+    expect(snapshot.stdout).not.toContain("Screenshot saved:");
+    expect(snapshot.stderr).toContain(
+      "Failed to analyze snapshot because no snapshot analyzer is configured.",
+    );
+    expect(snapshot.stderr).toContain("For more info, run `npx libretto init`.");
+    expect(
+      existsSync(workspacePath(".libretto", "sessions", session, "snapshots")),
+    ).toBe(false);
   }, 45_000);
 
   test("shows a clear error when --context is provided without --objective", async ({


### PR DESCRIPTION
## Summary
- preflight snapshot analyzer configuration before capture so `snapshot --objective ...` fails without writing snapshot files when analysis cannot run
- condense model-selection guidance into `openai | anthropic | gemini | vertex`
- show a valid `.libretto/config.json` example instead of dumping full JSON Schema for config lint errors
- switch the default Google snapshot model to `google/gemini-3-flash-preview`

## Verification
- `pnpm type-check`
- `pnpm test -- test/ai-config.spec.ts test/snapshot-api-config.spec.ts`
- `pnpm test -- test/stateful.spec.ts`

## Error Message Table
<table>
  <tr>
    <th>Case</th>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><code>ai configure</code> with no config</td>
    <td><pre>No AI config set. Run 'npx libretto ai configure openai' to set one.</pre></td>
    <td><pre>No AI config set. Choose a default model: npx libretto ai configure openai | anthropic | gemini | vertex
Provider credentials still come from your shell or .env file.</pre></td>
  </tr>
  <tr>
    <td><code>snapshot --objective ...</code> with no analyzer configured</td>
    <td><pre>Screenshot saved:
  PNG:             /private/tmp/libretto-sample-no-analyzer/.libretto/sessions/s1/snapshots/snapshot-1773696141817/page.png
  HTML:            /private/tmp/libretto-sample-no-analyzer/.libretto/sessions/s1/snapshots/snapshot-1773696141817/page.html
  Condensed HTML:  /private/tmp/libretto-sample-no-analyzer/.libretto/sessions/s1/snapshots/snapshot-1773696141817/page.condensed.html
No API snapshot analyzer is available. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT, or run `npx libretto ai configure &lt;provider&gt;` to set a default model.</pre></td>
    <td><pre>Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex`. For more info, run `npx libretto init`.</pre></td>
  </tr>
  <tr>
    <td><code>snapshot --objective ...</code> with configured model but missing provider key</td>
    <td><pre>Screenshot saved:
  PNG:             /private/tmp/libretto-sample-provider/.libretto/sessions/s1/snapshots/snapshot-1773696160724/page.png
  HTML:            /private/tmp/libretto-sample-provider/.libretto/sessions/s1/snapshots/snapshot-1773696160724/page.html
  Condensed HTML:  /private/tmp/libretto-sample-provider/.libretto/sessions/s1/snapshots/snapshot-1773696160724/page.condensed.html
Missing OpenAI API key. Set OPENAI_API_KEY.</pre></td>
    <td><pre>Failed to analyze snapshot because openai is configured in /path/to/.libretto/config.json, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run `npx libretto init`.</pre></td>
  </tr>
  <tr>
    <td>Invalid <code>.libretto/config.json</code> schema</td>
    <td><pre>AI config is invalid at /path/.libretto/config.json. Fix the file to match the expected schema or delete it.</pre></td>
    <td><pre>AI config is invalid at /path/.libretto/config.json.
Problems:
  - version: Invalid input: expected 1
  - ai.model: Invalid input: expected string, received undefined
  - ai: Unrecognized keys: "preset", "commandPrefix"
Expected config example:
{
  "version": 1,
  "ai": {
    "model": "openai/gpt-5.4",
    "updatedAt": "2026-01-01T00:00:00.000Z"
  },
  "viewport": {
    "width": 1280,
    "height": 800
  }
}
Notes:
  - "ai" and "viewport" are optional.
  - "ai.model" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".
Fix the file to match this shape, or delete it and rerun:
  npx libretto ai configure openai | anthropic | gemini | vertex</pre></td>
  </tr>
</table>
