### PR TITLE
fix: clean skill directory before overwrite to remove stale files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,5 +1,5 @@
 import { createInterface } from "node:readline";
-import { appendFileSync, cpSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, cpSync, existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -271,6 +271,10 @@ async function copySkills(): Promise<void> {
   }
 
   for (const { name, skillDest } of agentDirs) {
+    // Remove existing dir first so stale files from prior versions don't persist
+    if (existsSync(skillDest)) {
+      rmSync(skillDest, { recursive: true });
+    }
     cpSync(sourceDir, skillDest, { recursive: true });
     const fileCount = readdirSync(skillDest).length;
     console.log(`  ✓ Copied ${fileCount} skill files to ${name}/skills/libretto/`);


### PR DESCRIPTION
## Summary
- `cpSync` merges into the destination without deleting files absent from the source, leaving stale skill files from prior versions after an "overwrite"
- Now `rmSync` the target directory before copying so the result is a clean replacement

## Test plan
- [x] Created a test dir with `.agents/skills/libretto/old-file.md` and `.claude/skills/libretto/old-file.md`
- [x] Ran the fixed copy logic — stale `old-file.md` removed, only current 3 skill files remain
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
