### PR TITLE
Require explicit pause session IDs

### DIFF
--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -417,7 +417,7 @@ async function runResume(
 
   if (!existsSync(pausedSignalPath)) {
     throw new Error(
-      `Session "${session}" is not paused. Run "libretto-cli run ... --session ${session}" and call pause() first.`,
+      `Session "${session}" is not paused. Run "libretto-cli run ... --session ${session}" and call pause("${session}") first.`,
     );
   }
 

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -7,7 +7,6 @@ import {
   launchBrowser,
   type LibrettoWorkflowContext,
 } from "../../index.js";
-import { setSessionForPause } from "../../shared/debug/pause.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { parseSessionStateContent } from "../../shared/state/index.js";
 import { getProfilePath, normalizeDomain } from "../core/browser.js";
@@ -257,9 +256,6 @@ async function runIntegrationInternal(
       appendFileSync(networkLogPath, JSON.stringify(entry) + "\n");
     },
   });
-
-  // Make session available to standalone pause() before running the workflow.
-  setSessionForPause(args.session);
 
   const workflowContext: LibrettoWorkflowContext = {
     logger: integrationLogger,

--- a/src/shared/debug/index.ts
+++ b/src/shared/debug/index.ts
@@ -1,1 +1,1 @@
-export { pause, setSessionForPause } from "./pause.js";
+export { pause } from "./pause.js";

--- a/src/shared/debug/pause.ts
+++ b/src/shared/debug/pause.ts
@@ -1,32 +1,37 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 
-/**
- * Module-level session name, set by the CLI runtime before invoking the workflow.
- * Standalone `pause()` reads this to locate signal files.
- */
-let _sessionName: string | undefined;
-
-/**
- * Called by the CLI runtime to make the session name available to `pause()`.
- */
-export function setSessionForPause(session: string): void {
-	_sessionName = session;
-}
-
-function getSessionFromProcessArgs(): string | undefined {
-	const rawPayload = process.argv[2];
-	if (!rawPayload) return undefined;
+function isPidRunning(pid: number): boolean {
 	try {
-		const parsed = JSON.parse(rawPayload) as { session?: string };
-		return typeof parsed.session === "string" ? parsed.session : undefined;
+		process.kill(pid, 0);
+		return true;
 	} catch {
-		return undefined;
+		return false;
 	}
 }
 
-function resolveSession(): string | undefined {
-	return _sessionName ?? getSessionFromProcessArgs();
+async function getRunningSessions(): Promise<string[]> {
+	const { listSessionsWithStateFile, readSessionState } = await import(
+		"../../cli/core/session.js"
+	);
+	return listSessionsWithStateFile().filter((candidate) => {
+		const state = readSessionState(candidate);
+		return state !== null && isPidRunning(state.pid);
+	});
+}
+
+async function throwMissingSessionError(): Promise<never> {
+	const runningSessions = await getRunningSessions();
+	const lines = ["pause(session) requires a non-empty session ID."];
+
+	if (runningSessions.length > 0) {
+		lines.push("", "Running sessions:");
+		for (const runningSession of runningSessions) {
+			lines.push(`  ${runningSession}`);
+		}
+	}
+
+	throw new Error(lines.join("\n"));
 }
 
 /**
@@ -38,16 +43,13 @@ function resolveSession(): string | undefined {
  *
  * Import directly: `import { pause } from "libretto";`
  */
-export async function pause(): Promise<void> {
+export async function pause(session: string): Promise<void> {
 	if (process.env.NODE_ENV === "production") {
 		return;
 	}
 
-	const session = resolveSession();
-	if (!session) {
-		// No session context available — likely running outside the CLI runner.
-		// Behave as a no-op to avoid crashing the workflow.
-		return;
+	if (typeof session !== "string" || session.trim().length === 0) {
+		await throwMissingSessionError();
 	}
 
 	// Dynamically import pause-signals to avoid circular dependency issues.

--- a/src/shared/debug/pause.ts
+++ b/src/shared/debug/pause.ts
@@ -1,5 +1,8 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
+import { getSessionDir } from "../../cli/core/context.js";
+import { getPauseSignalPaths, removeSignalIfExists } from "../../cli/core/pause-signals.js";
+import { listSessionsWithStateFile, readSessionState } from "../../cli/core/session.js";
 
 function isPidRunning(pid: number): boolean {
 	try {
@@ -10,18 +13,15 @@ function isPidRunning(pid: number): boolean {
 	}
 }
 
-async function getRunningSessions(): Promise<string[]> {
-	const { listSessionsWithStateFile, readSessionState } = await import(
-		"../../cli/core/session.js"
-	);
+function getRunningSessions(): string[] {
 	return listSessionsWithStateFile().filter((candidate) => {
 		const state = readSessionState(candidate);
 		return state !== null && isPidRunning(state.pid);
 	});
 }
 
-async function throwMissingSessionError(): Promise<never> {
-	const runningSessions = await getRunningSessions();
+function throwMissingSessionError(): never {
+	const runningSessions = getRunningSessions();
 	const lines = ["pause(session) requires a non-empty session ID."];
 
 	if (runningSessions.length > 0) {
@@ -49,15 +49,8 @@ export async function pause(session: string): Promise<void> {
 	}
 
 	if (typeof session !== "string" || session.trim().length === 0) {
-		await throwMissingSessionError();
+		throwMissingSessionError();
 	}
-
-	// Dynamically import pause-signals to avoid circular dependency issues.
-	// These are CLI-internal modules available in the worker process.
-	const { getPauseSignalPaths, removeSignalIfExists } = await import(
-		"../../cli/core/pause-signals.js"
-	);
-	const { getSessionDir } = await import("../../cli/core/context.js");
 
 	const signalPaths = getPauseSignalPaths(session);
 	const { pausedSignalPath, resumeSignalPath } = signalPaths;

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -429,7 +429,7 @@ export const main = workflow({}, async () => "ok");
       `
 export const main = workflow({}, async (ctx) => {
   console.log("WORKFLOW_BEFORE_PAUSE");
-  await pause();
+  await pause("default");
   console.log("WORKFLOW_AFTER_PAUSE");
 });
 `,
@@ -443,6 +443,30 @@ export const main = workflow({}, async (ctx) => {
     expect(result.stdout).toContain("Workflow paused.");
     expect(result.stdout).not.toContain("WORKFLOW_AFTER_PAUSE");
     expect(result.stdout).not.toContain("Integration completed.");
+  }, 45_000);
+
+  test("pause reports running sessions when session id is missing", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const integrationFilePath = await writeWorkflow(
+      "integration-pause-missing-session.mjs",
+      `
+export const main = workflow({}, async () => {
+  await pause("");
+});
+`,
+      ["workflow", "pause"],
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" main --session default --headless`,
+    );
+    expect(result.stderr).toContain(
+      "pause(session) requires a non-empty session ID.",
+    );
+    expect(result.stderr).toContain("Running sessions:");
+    expect(result.stderr).toContain("default");
   }, 45_000);
 
   test("completes workflow run when no pause is triggered", async ({


### PR DESCRIPTION
## Summary
- require `pause(session)` callers to pass an explicit session ID instead of relying on hidden fallbacks
- remove the CLI runtime plumbing that injected pause session context implicitly
- include currently running sessions in the missing-session error and cover that behavior in `test/basic.spec.ts`

## Testing
- `pnpm type-check`
- `pnpm test -- test/basic.spec.ts`
