### PR TITLE
feat: configurable skill installation directories

### DIFF
--- a/.libretto/config.json
+++ b/.libretto/config.json
@@ -1,14 +1,7 @@
 {
   "version": 1,
   "ai": {
-    "preset": "codex",
-    "commandPrefix": [
-      "codex",
-      "exec",
-      "--skip-git-repo-check",
-      "--sandbox",
-      "read-only"
-    ],
-    "updatedAt": "2026-03-06T04:10:02.651Z"
+    "model": "openai/gpt-5.4",
+    "updatedAt": "2026-03-16T00:00:00.000Z"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {
@@ -14,6 +14,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "skills/libretto"
   ],
   "bin": {
@@ -28,7 +29,7 @@
     }
   },
   "scripts": {
-    "postinstall": "playwright install chromium",
+    "postinstall": "node scripts/postinstall.mjs",
     "build": "pnpm run build:runtime && pnpm run build:cli",
     "build:runtime": "tsup --config tsup.config.ts",
     "build:cli": "tsup --config tsup.cli.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(__dirname, "..");
+
+// Install Playwright Chromium
+spawnSync("npx", ["playwright", "install", "chromium"], {
+  stdio: "inherit",
+  shell: true,
+});
+
+// Find git repo root
+const gitResult = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf-8",
+  stdio: ["pipe", "pipe", "pipe"],
+});
+const repoRoot = gitResult.status === 0 && gitResult.stdout
+  ? gitResult.stdout.trim()
+  : null;
+if (!repoRoot) process.exit(0);
+
+// Sync skills to any agent dirs at repo root
+const sourceDir = join(packageRoot, "skills", "libretto");
+if (!existsSync(sourceDir)) process.exit(0);
+
+const agentDirNames = [".agents", ".claude"];
+for (const name of agentDirNames) {
+  const agentDir = join(repoRoot, name);
+  if (!existsSync(agentDir)) continue;
+  const dest = join(agentDir, "skills", "libretto");
+  if (existsSync(dest)) rmSync(dest, { recursive: true });
+  mkdirSync(dirname(dest), { recursive: true });
+  cpSync(sourceDir, dest, { recursive: true });
+  const count = readdirSync(dest).length;
+  console.log(`libretto: synced ${count} skill files to ${dest}`);
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,9 +1,9 @@
 import { createInterface } from "node:readline";
 import { appendFileSync, cpSync, existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readAiConfig, readSkillDirs, writeSkillDirs } from "../core/ai-config.js";
+import { readAiConfig } from "../core/ai-config.js";
 import { REPO_ROOT } from "../core/context.js";
 import {
   loadSnapshotEnv,
@@ -237,78 +237,22 @@ function detectAgentDirs(root: string): string[] {
   return dirs;
 }
 
-/**
- * Resolve the skill directories to copy into.
- * Uses saved config if available, otherwise auto-detects and prompts the user.
- */
-async function resolveSkillDirs(): Promise<string[] | null> {
-  const saved = readSkillDirs();
-  if (saved && saved.length > 0) {
-    // Validate saved dirs still exist
-    const valid = saved.filter((d) => existsSync(d));
-    if (valid.length > 0) return valid;
-    console.log("  Previously configured skill directories no longer exist.");
-  }
-
-  // Auto-detect from cwd
-  const cwd = process.cwd();
-  const detected = detectAgentDirs(cwd);
-
-  if (detected.length > 0) {
-    const names = detected.map((d) => d.replace(cwd + "/", "")).join(", ");
-    console.log(`  Detected agent directories: ${names}`);
-    const useDetected = await askYesNo("  Use these for skill installation?");
-    if (useDetected) {
-      writeSkillDirs(detected);
-      return detected;
-    }
-  }
-
-  // Prompt for custom path
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    const customRoot = await new Promise<string>((resolve) => {
-      rl.question(
-        "  Enter path to directory containing .agents/ and/or .claude/ (or press Enter to skip): ",
-        (answer) => resolve(answer.trim()),
-      );
-    });
-
-    if (!customRoot) return null;
-
-    const resolved = resolve(customRoot);
-    const found = detectAgentDirs(resolved);
-    if (found.length === 0) {
-      console.log(`  No .agents/ or .claude/ found in ${resolved} — skipping.`);
-      return null;
-    }
-
-    const names = found.map((d) => d.replace(resolved + "/", "")).join(", ");
-    console.log(`  Found: ${names}`);
-    writeSkillDirs(found);
-    return found;
-  } finally {
-    rl.close();
-  }
-}
-
 async function copySkills(): Promise<void> {
-  console.log("\nSkill installation:");
+  const agentDirs = detectAgentDirs(REPO_ROOT);
 
-  const skillDirs = await resolveSkillDirs();
-  if (!skillDirs || skillDirs.length === 0) {
-    console.log("  Skipping skill copy.");
+  if (agentDirs.length === 0) {
+    console.log("\nSkills: No .agents/ or .claude/ directory found in repo root — skipping.");
     return;
   }
 
-  const destinations = skillDirs.map((d) => join(d, "skills", "libretto"));
-  const dirNames = skillDirs.map((d) => basename(d)).join(" and ");
+  const destinations = agentDirs.map((d) => join(d, "skills", "libretto"));
+  const dirNames = agentDirs.map((d) => basename(d)).join(" and ");
   // Say "Overwrite" if skills already exist in ANY target dir — skills must
   // be identical across coding agents, so we always copy to all of them.
   const existing = destinations.filter((d) => existsSync(d));
   const verb = existing.length > 0 ? "Overwrite" : "Install";
 
-  const proceed = await askYesNo(`  ${verb} libretto skills in ${dirNames}?`);
+  const proceed = await askYesNo(`\n${verb} libretto skills in ${dirNames}?`);
   if (!proceed) {
     console.log("  Skipping skill copy.");
     return;
@@ -322,9 +266,9 @@ async function copySkills(): Promise<void> {
     return;
   }
 
-  for (let i = 0; i < skillDirs.length; i++) {
+  for (let i = 0; i < agentDirs.length; i++) {
     const skillDest = destinations[i];
-    const name = basename(skillDirs[i]);
+    const name = basename(agentDirs[i]);
     // Remove existing dir first so stale files from prior versions don't persist
     if (existsSync(skillDest)) {
       rmSync(skillDest, { recursive: true });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,9 +1,9 @@
 import { createInterface } from "node:readline";
 import { appendFileSync, cpSync, existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readAiConfig } from "../core/ai-config.js";
+import { readAiConfig, readSkillDirs, writeSkillDirs } from "../core/ai-config.js";
 import { REPO_ROOT } from "../core/context.js";
 import {
   loadSnapshotEnv,
@@ -227,36 +227,88 @@ function getPackageSkillsDir(): string {
   throw new Error("Could not locate libretto skill files in package");
 }
 
-async function copySkills(): Promise<void> {
+/**
+ * Auto-detect .agents/ and .claude/ directories at a given root path.
+ */
+function detectAgentDirs(root: string): string[] {
+  const dirs: string[] = [];
+  if (existsSync(join(root, ".agents"))) dirs.push(join(root, ".agents"));
+  if (existsSync(join(root, ".claude"))) dirs.push(join(root, ".claude"));
+  return dirs;
+}
+
+/**
+ * Resolve the skill directories to copy into.
+ * Uses saved config if available, otherwise auto-detects and prompts the user.
+ */
+async function resolveSkillDirs(): Promise<string[] | null> {
+  const saved = readSkillDirs();
+  if (saved && saved.length > 0) {
+    // Validate saved dirs still exist
+    const valid = saved.filter((d) => existsSync(d));
+    if (valid.length > 0) return valid;
+    console.log("  Previously configured skill directories no longer exist.");
+  }
+
+  // Auto-detect from cwd
   const cwd = process.cwd();
-  const agentDirs: { name: string; skillDest: string }[] = [];
+  const detected = detectAgentDirs(cwd);
 
-  // Detect existing coding agent directories
-  if (existsSync(join(cwd, ".agents"))) {
-    agentDirs.push({
-      name: ".agents",
-      skillDest: join(cwd, ".agents", "skills", "libretto"),
-    });
-  }
-  if (existsSync(join(cwd, ".claude"))) {
-    agentDirs.push({
-      name: ".claude",
-      skillDest: join(cwd, ".claude", "skills", "libretto"),
-    });
+  if (detected.length > 0) {
+    const names = detected.map((d) => d.replace(cwd + "/", "")).join(", ");
+    console.log(`  Detected agent directories: ${names}`);
+    const useDetected = await askYesNo("  Use these for skill installation?");
+    if (useDetected) {
+      writeSkillDirs(detected);
+      return detected;
+    }
   }
 
-  if (agentDirs.length === 0) {
-    console.log("\nSkills: No .agents/ or .claude/ directory found — skipping skill copy.");
+  // Prompt for custom path
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const customRoot = await new Promise<string>((resolve) => {
+      rl.question(
+        "  Enter path to directory containing .agents/ and/or .claude/ (or press Enter to skip): ",
+        (answer) => resolve(answer.trim()),
+      );
+    });
+
+    if (!customRoot) return null;
+
+    const resolved = resolve(customRoot);
+    const found = detectAgentDirs(resolved);
+    if (found.length === 0) {
+      console.log(`  No .agents/ or .claude/ found in ${resolved} — skipping.`);
+      return null;
+    }
+
+    const names = found.map((d) => d.replace(resolved + "/", "")).join(", ");
+    console.log(`  Found: ${names}`);
+    writeSkillDirs(found);
+    return found;
+  } finally {
+    rl.close();
+  }
+}
+
+async function copySkills(): Promise<void> {
+  console.log("\nSkill installation:");
+
+  const skillDirs = await resolveSkillDirs();
+  if (!skillDirs || skillDirs.length === 0) {
+    console.log("  Skipping skill copy.");
     return;
   }
 
-  const dirNames = agentDirs.map((d) => d.name).join(" and ");
+  const destinations = skillDirs.map((d) => join(d, "skills", "libretto"));
+  const dirNames = skillDirs.map((d) => basename(d)).join(" and ");
   // Say "Overwrite" if skills already exist in ANY target dir — skills must
   // be identical across coding agents, so we always copy to all of them.
-  const existing = agentDirs.filter((d) => existsSync(d.skillDest));
+  const existing = destinations.filter((d) => existsSync(d));
   const verb = existing.length > 0 ? "Overwrite" : "Install";
 
-  const proceed = await askYesNo(`\n${verb} libretto skills in ${dirNames}?`);
+  const proceed = await askYesNo(`  ${verb} libretto skills in ${dirNames}?`);
   if (!proceed) {
     console.log("  Skipping skill copy.");
     return;
@@ -270,7 +322,9 @@ async function copySkills(): Promise<void> {
     return;
   }
 
-  for (const { name, skillDest } of agentDirs) {
+  for (let i = 0; i < skillDirs.length; i++) {
+    const skillDest = destinations[i];
+    const name = basename(skillDirs[i]);
     // Remove existing dir first so stale files from prior versions don't persist
     if (existsSync(skillDest)) {
       rmSync(skillDest, { recursive: true });

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -17,12 +17,10 @@ export const CURRENT_CONFIG_VERSION = 1;
  * code is preserved in snapshot-analyzer.ts but is not wired into the snapshot
  * command.
  */
-export const AiConfigSchema = z
-  .object({
-    model: z.string().min(1),
-    updatedAt: z.string(),
-  })
-  .strict();
+export const AiConfigSchema = z.object({
+  model: z.string().min(1).optional(),
+  updatedAt: z.string(),
+});
 export type AiConfig = z.infer<typeof AiConfigSchema>;
 
 export const ViewportConfigSchema = z.object({
@@ -31,15 +29,11 @@ export const ViewportConfigSchema = z.object({
 });
 export type ViewportConfig = z.infer<typeof ViewportConfigSchema>;
 
-export const SkillDirsSchema = z.array(z.string().min(1));
-export type SkillDirs = z.infer<typeof SkillDirsSchema>;
-
 export const LibrettoConfigSchema = z
   .object({
     version: z.literal(CURRENT_CONFIG_VERSION),
     ai: AiConfigSchema.optional(),
     viewport: ViewportConfigSchema.optional(),
-    skillDirs: SkillDirsSchema.optional(),
   })
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
@@ -88,7 +82,9 @@ export function writeLibrettoConfig(
   return parsed;
 }
 
-export function readAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): AiConfig | null {
+export function readAiConfig(
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): AiConfig | null {
   return readLibrettoConfig(configPath).ai ?? null;
 }
 
@@ -112,7 +108,9 @@ export function writeAiConfig(
   return ai;
 }
 
-export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolean {
+export function clearAiConfig(
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): boolean {
   const librettoConfig = readLibrettoConfig(configPath);
   if (!librettoConfig.ai) return false;
   const { ai: _ai, ...rest } = librettoConfig;
@@ -123,27 +121,6 @@ export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolea
     configPath,
   );
   return true;
-}
-
-export function readSkillDirs(configPath: string = LIBRETTO_CONFIG_PATH): string[] | null {
-  return readLibrettoConfig(configPath).skillDirs ?? null;
-}
-
-export function writeSkillDirs(
-  dirs: string[],
-  configPath: string = LIBRETTO_CONFIG_PATH,
-): string[] {
-  const librettoConfig = readLibrettoConfig(configPath);
-  const skillDirs = SkillDirsSchema.parse(dirs);
-  writeLibrettoConfig(
-    {
-      ...librettoConfig,
-      version: CURRENT_CONFIG_VERSION,
-      skillDirs,
-    },
-    configPath,
-  );
-  return skillDirs;
 }
 
 function printAiConfig(config: AiConfig, configPath: string): void {
@@ -187,7 +164,9 @@ export function runAiConfigure(
   if (!presetArg && !input.clear) {
     const config = readAiConfig(configPath);
     if (!config) {
-      console.log(`No AI config set. Run '${configureCommandName} openai' to set one.`);
+      console.log(
+        `No AI config set. Run '${configureCommandName} openai' to set one.`,
+      );
       return;
     }
     printAiConfig(config, configPath);
@@ -208,8 +187,8 @@ export function runAiConfigure(
   if (!model) {
     console.log(
       `Usage: ${configureCommandName} <${CONFIGURE_PROVIDERS.join("|")}|provider/model-id>\n` +
-      `       ${configureCommandName}\n` +
-      `       ${configureCommandName} --clear`,
+        `       ${configureCommandName}\n` +
+        `       ${configureCommandName} --clear`,
     );
     throw new Error(
       `Invalid provider or model. Use one of: ${CONFIGURE_PROVIDERS.join(", ")}, or a full model string like "openai/gpt-4o".`,

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -18,7 +18,7 @@ export const CURRENT_CONFIG_VERSION = 1;
  * command.
  */
 export const AiConfigSchema = z.object({
-  model: z.string().min(1).optional(),
+  model: z.string().min(1),
   updatedAt: z.string(),
 });
 export type AiConfig = z.infer<typeof AiConfigSchema>;

--- a/src/cli/core/ai-config.ts
+++ b/src/cli/core/ai-config.ts
@@ -31,11 +31,15 @@ export const ViewportConfigSchema = z.object({
 });
 export type ViewportConfig = z.infer<typeof ViewportConfigSchema>;
 
+export const SkillDirsSchema = z.array(z.string().min(1));
+export type SkillDirs = z.infer<typeof SkillDirsSchema>;
+
 export const LibrettoConfigSchema = z
   .object({
     version: z.literal(CURRENT_CONFIG_VERSION),
     ai: AiConfigSchema.optional(),
     viewport: ViewportConfigSchema.optional(),
+    skillDirs: SkillDirsSchema.optional(),
   })
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
@@ -119,6 +123,27 @@ export function clearAiConfig(configPath: string = LIBRETTO_CONFIG_PATH): boolea
     configPath,
   );
   return true;
+}
+
+export function readSkillDirs(configPath: string = LIBRETTO_CONFIG_PATH): string[] | null {
+  return readLibrettoConfig(configPath).skillDirs ?? null;
+}
+
+export function writeSkillDirs(
+  dirs: string[],
+  configPath: string = LIBRETTO_CONFIG_PATH,
+): string[] {
+  const librettoConfig = readLibrettoConfig(configPath);
+  const skillDirs = SkillDirsSchema.parse(dirs);
+  writeLibrettoConfig(
+    {
+      ...librettoConfig,
+      version: CURRENT_CONFIG_VERSION,
+      skillDirs,
+    },
+    configPath,
+  );
+  return skillDirs;
 }
 
 function printAiConfig(config: AiConfig, configPath: string): void {


### PR DESCRIPTION
## Summary
- Adds `skillDirs` field to `.libretto/config.json` — an array of absolute paths to agent directories (e.g. `["/monorepo/.agents", "/monorepo/.claude"]`)
- During `init`, the flow is:
  1. If `skillDirs` already saved in config and dirs still exist → use them
  2. Otherwise auto-detect `.agents/` and `.claude/` in cwd → ask user to confirm
  3. If not found locally → prompt for a custom path (e.g. monorepo root)
  4. Save chosen dirs to config for future runs
- Adds `readSkillDirs()` and `writeSkillDirs()` helpers to ai-config.ts following existing patterns

## Motivation
In monorepos where skills live at the root but libretto is installed in a sub-package, the old auto-detect (cwd only) couldn't find the agent directories. This lets users point to the right location once and have it persist.

## Test plan
- [x] Auto-detect works when `.agents/` and `.claude/` exist in cwd
- [x] Custom path resolution finds agent dirs in a different location
- [x] Config round-trips correctly with `skillDirs` field
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
