### PR TITLE
fix: restore postinstall skill sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist",
-    "skills/libretto"
+    "skills/libretto",
+    "scripts/postinstall.mjs"
   ],
   "bin": {
     "libretto": "./dist/cli/index.js",
@@ -28,7 +29,7 @@
     }
   },
   "scripts": {
-    "postinstall": "playwright install chromium",
+    "postinstall": "node ./scripts/postinstall.mjs && playwright install chromium",
     "build": "pnpm run build:runtime && pnpm run build:cli",
     "build:runtime": "tsup --config tsup.config.ts",
     "build:cli": "tsup --config tsup.cli.config.ts",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,43 @@
+import { cpSync, existsSync, lstatSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function isDirectory(path) {
+  if (!existsSync(path)) return false;
+  return lstatSync(path).isDirectory();
+}
+
+function log(message) {
+  console.log(`[libretto postinstall] ${message}`);
+}
+
+function main() {
+  const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const initCwd = process.env.INIT_CWD ? resolve(process.env.INIT_CWD) : null;
+  const installRoot = initCwd ?? process.cwd();
+
+  const skillsRoot = join(installRoot, ".agents", "skills");
+  if (!isDirectory(skillsRoot)) {
+    log(`Skipped: "${skillsRoot}" does not exist.`);
+    return;
+  }
+
+  const sourceSkillDir = join(packageDir, "skills", "libretto");
+  if (!isDirectory(sourceSkillDir)) {
+    log(`Skipped: source skill directory not found at "${sourceSkillDir}".`);
+    return;
+  }
+
+  const destinationSkillDir = join(skillsRoot, "libretto");
+  mkdirSync(destinationSkillDir, { recursive: true });
+  cpSync(sourceSkillDir, destinationSkillDir, { recursive: true, force: true });
+
+  log(`Synced skill to "${destinationSkillDir}".`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[libretto postinstall] Warning: ${message}`);
+}

--- a/test/postinstall.spec.ts
+++ b/test/postinstall.spec.ts
@@ -1,0 +1,82 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const postinstallScript = join(repoRoot, "scripts", "postinstall.mjs");
+const sourceSkillDir = join(repoRoot, "skills", "libretto");
+const tempDirs: string[] = [];
+
+async function runPostinstall(initCwd: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  return await new Promise((resolveResult, reject) => {
+    execFile(
+      "node",
+      [postinstallScript],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          INIT_CWD: initCwd,
+        },
+      },
+      (error, stdout, stderr) => {
+        if (error && error.name === "AbortError") {
+          reject(error);
+          return;
+        }
+
+        const code = typeof error?.code === "number" ? error.code : error ? 1 : 0;
+
+        resolveResult({
+          exitCode: code,
+          stdout: String(stdout),
+          stderr: String(stderr),
+        });
+      },
+    );
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("postinstall skill sync", () => {
+  test("package.json publishes and runs the postinstall helper", async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(repoRoot, "package.json"), "utf8"),
+    ) as {
+      files: string[];
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.files).toContain("scripts/postinstall.mjs");
+    expect(packageJson.scripts.postinstall).toContain("node ./scripts/postinstall.mjs");
+  });
+
+  test("syncs the bundled skill into the consuming repo", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "libretto-postinstall-"));
+    tempDirs.push(workspace);
+
+    await mkdir(join(workspace, ".agents", "skills"), { recursive: true });
+
+    const result = await runPostinstall(workspace);
+    const destinationSkillDir = join(workspace, ".agents", "skills", "libretto");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Synced skill to "${destinationSkillDir}".`);
+    expect(existsSync(join(destinationSkillDir, "SKILL.md"))).toBe(true);
+    expect(await readFile(join(destinationSkillDir, "SKILL.md"), "utf8")).toBe(
+      await readFile(join(sourceSkillDir, "SKILL.md"), "utf8"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- restore the historical `postinstall` helper that syncs `skills/libretto` into the consuming repo's `.agents/skills/libretto`
- keep the existing Playwright Chromium install in `postinstall`
- add coverage for the helper itself and verify the packaged tarball installs the skill into a fresh npm consumer repo

## Verification
- `pnpm type-check`
- `pnpm test -- test/postinstall.spec.ts`
- packed the package with `pnpm pack`
- installed the tarball into a fresh temp npm project with `.agents/skills` and confirmed `.agents/skills/libretto/SKILL.md` matched the packaged source
