### PR TITLE
Fix monorepo session state paths

### DIFF
--- a/src/cli/core/context.ts
+++ b/src/cli/core/context.ts
@@ -1,28 +1,12 @@
 import { Logger, createFileLogSink } from "../../shared/logger/index.js";
 import type { LLMClient } from "../../shared/llm/index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
-import { spawnSync } from "node:child_process";
-import { cwd } from "node:process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { resolveLibrettoRepoRoot } from "../../shared/paths/repo-root.js";
 import { validateSessionName } from "./session.js";
 
-function getRepoRoot(): string {
-  const override = process.env.LIBRETTO_REPO_ROOT?.trim();
-  if (override) {
-    return resolve(override);
-  }
-
-  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
-    encoding: "utf-8",
-  });
-  if (result.status === 0 && result.stdout) {
-    return result.stdout.trim();
-  }
-  return cwd();
-}
-
-export const REPO_ROOT = getRepoRoot();
+export const REPO_ROOT = resolveLibrettoRepoRoot();
 export const LIBRETTO_CONFIG_DIR = join(REPO_ROOT, ".libretto");
 export const LIBRETTO_CONFIG_PATH = join(LIBRETTO_CONFIG_DIR, "config.json");
 export const PROFILES_DIR = join(LIBRETTO_CONFIG_DIR, "profiles");

--- a/src/shared/paths/paths.ts
+++ b/src/shared/paths/paths.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { resolveLibrettoRepoRoot } from "./repo-root.js";
 
 const LIBRETTO_DIRNAME = ".libretto";
 const LIBRETTO_SESSIONS_DIRNAME = "sessions";
@@ -10,7 +11,7 @@ const PAUSED_SIGNAL_SUFFIX = "paused";
 const RESUME_SIGNAL_SUFFIX = "resume";
 
 function getLibrettoRoot(cwd: string = process.cwd()): string {
-	return join(cwd, LIBRETTO_DIRNAME);
+	return join(resolveLibrettoRepoRoot(cwd), LIBRETTO_DIRNAME);
 }
 
 function getLibrettoSessionsDir(cwd: string = process.cwd()): string {

--- a/src/shared/paths/repo-root.ts
+++ b/src/shared/paths/repo-root.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const repoRootCache = new Map<string, string>();
+
+export function resolveLibrettoRepoRoot(cwd: string = process.cwd()): string {
+	const override = process.env.LIBRETTO_REPO_ROOT?.trim();
+	if (override) {
+		return resolve(override);
+	}
+
+	const normalizedCwd = resolve(cwd);
+	const cached = repoRootCache.get(normalizedCwd);
+	if (cached) {
+		return cached;
+	}
+
+	const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+		cwd: normalizedCwd,
+		encoding: "utf-8",
+	});
+
+	const repoRoot =
+		result.status === 0 && result.stdout ? result.stdout.trim() : normalizedCwd;
+	repoRootCache.set(normalizedCwd, repoRoot);
+	return repoRoot;
+}

--- a/test/session-paths.spec.ts
+++ b/test/session-paths.spec.ts
@@ -1,0 +1,45 @@
+import { mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { ensureLibrettoSessionStatePath } from "../src/shared/paths/paths.js";
+
+describe("session path resolution", () => {
+  test("anchors session state at the git repo root when invoked from a nested package", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "libretto-monorepo-"));
+    const nestedPackageDir = join(repoRoot, "apps", "browser-agent");
+    mkdirSync(nestedPackageDir, { recursive: true });
+    await writeFile(join(repoRoot, "package.json"), '{"name":"repo-root"}\n', "utf8");
+
+    execFileSync("git", ["init"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+
+    const statePath = ensureLibrettoSessionStatePath("browser-agent", nestedPackageDir);
+    const resolvedStatePath = join(await realpath(dirname(statePath)), "state.json");
+    const resolvedRepoRoot = await realpath(repoRoot);
+    const resolvedNestedPackageDir = await realpath(nestedPackageDir);
+
+    expect(resolvedStatePath).toBe(
+      join(
+        resolvedRepoRoot,
+        ".libretto",
+        "sessions",
+        "browser-agent",
+        "state.json",
+      ),
+    );
+    expect(resolvedStatePath).not.toBe(
+      join(
+        resolvedNestedPackageDir,
+        ".libretto",
+        "sessions",
+        "browser-agent",
+        "state.json",
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- centralize repo-root resolution in a shared helper used by both CLI context and shared session path helpers
- make shared session state paths resolve relative to the repo root instead of the nested working directory in monorepo setups
- add a regression test covering nested package invocation inside a git repo

## Testing
- pnpm type-check
- pnpm test -- test/session-paths.spec.ts
