### PR TITLE
Replace libretto-cli references with libretto

### DIFF
--- a/benchmarks/core/agent-clients.mjs
+++ b/benchmarks/core/agent-clients.mjs
@@ -82,7 +82,7 @@ function buildTaskPrompt(options) {
     "- Do not modify repository source files or docs.",
     "- Do not ask user questions.",
     "- Solve from current page state only.",
-    "- For CLI commands in this repo, use prefix: pnpm --filter libretto-cli exec node dist/index.js",
+    "- For CLI commands in this repo, use prefix: pnpm --filter libretto exec node dist/index.js",
     "- Useful commands: snapshot, exec, actions, network.",
     `- Max meaningful browser actions: ${options.maxSteps}`,
     modelLine,

--- a/benchmarks/onlineMind2Web/index.mjs
+++ b/benchmarks/onlineMind2Web/index.mjs
@@ -342,21 +342,21 @@ async function runCommand(command, args, options = {}) {
   });
 }
 
-const LIBRETTO_CLI_DIST = resolve("packages", "libretto-cli", "dist", "index.js");
+const LIBRETTO_CLI_DIST = resolve("packages", "libretto", "dist", "index.js");
 
 async function ensureLibrettoCliBuilt() {
   if (existsSync(LIBRETTO_CLI_DIST)) return;
   const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-  const buildResult = await runCommand(pnpmBin, ["--filter", "libretto-cli", "build"]);
+  const buildResult = await runCommand(pnpmBin, ["--filter", "libretto", "build"]);
   if (buildResult.exitCode !== 0 || !existsSync(LIBRETTO_CLI_DIST)) {
     throw new Error(
-      "libretto-cli dist build is missing and build failed. Run 'pnpm --filter libretto-cli build' manually.",
+      "libretto dist build is missing and build failed. Run 'pnpm --filter libretto build' manually.",
     );
   }
 }
 
 function getLibrettoCliArgs(command, ...rest) {
-  return ["--filter", "libretto-cli", "exec", "node", "dist/index.js", command, ...rest];
+  return ["--filter", "libretto", "exec", "node", "dist/index.js", command, ...rest];
 }
 
 async function openSession({ startUrl, sessionName, headed }) {

--- a/benchmarks/onlineMind2Web/index.mjs
+++ b/benchmarks/onlineMind2Web/index.mjs
@@ -342,26 +342,26 @@ async function runCommand(command, args, options = {}) {
   });
 }
 
-const LIBRETTO_CLI_DIST = resolve("packages", "libretto", "dist", "index.js");
+const LIBRETTO_DIST = resolve("packages", "libretto", "dist", "index.js");
 
-async function ensureLibrettoCliBuilt() {
-  if (existsSync(LIBRETTO_CLI_DIST)) return;
+async function ensureLibrettoBuilt() {
+  if (existsSync(LIBRETTO_DIST)) return;
   const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
   const buildResult = await runCommand(pnpmBin, ["--filter", "libretto", "build"]);
-  if (buildResult.exitCode !== 0 || !existsSync(LIBRETTO_CLI_DIST)) {
+  if (buildResult.exitCode !== 0 || !existsSync(LIBRETTO_DIST)) {
     throw new Error(
       "libretto dist build is missing and build failed. Run 'pnpm --filter libretto build' manually.",
     );
   }
 }
 
-function getLibrettoCliArgs(command, ...rest) {
+function getLibrettoArgs(command, ...rest) {
   return ["--filter", "libretto", "exec", "node", "dist/index.js", command, ...rest];
 }
 
 async function openSession({ startUrl, sessionName, headed }) {
   const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-  const args = getLibrettoCliArgs(
+  const args = getLibrettoArgs(
     "open",
     startUrl,
     "--session",
@@ -373,7 +373,7 @@ async function openSession({ startUrl, sessionName, headed }) {
 
 async function closeSession(sessionName) {
   const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-  const args = getLibrettoCliArgs("close", "--session", sessionName);
+  const args = getLibrettoArgs("close", "--session", sessionName);
   return await runCommand(pnpmBin, args, { captureOutput: true });
 }
 
@@ -562,7 +562,7 @@ export async function runOnlineMind2WebBenchmark(rawArgs) {
   });
 
   console.log(`Loading dataset: ${args.dataset}`);
-  await ensureLibrettoCliBuilt();
+  await ensureLibrettoBuilt();
   const datasetText = await readDatasetText(args.dataset);
   const rows = parseDataset(datasetText);
   if (rows.length === 0) {

--- a/benchmarks/shared/cases.ts
+++ b/benchmarks/shared/cases.ts
@@ -425,8 +425,7 @@ async function createWorkspacePackageJson(
           cli: "LIBRETTO_REPO_ROOT=. node ./dist/cli/index.js",
         },
         bin: {
-          libretto: "./dist/cli/index.js",
-          "libretto-cli": "./dist/cli/index.js",
+          "libretto": "./dist/cli/index.js",
         },
       },
       null,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   ],
   "types": "./dist/index.d.ts",
   "bin": {
-    "libretto": "./dist/cli/index.js",
-    "libretto-cli": "./dist/cli/index.js"
+    "libretto": "./dist/cli/index.js"
   },
   "exports": {
     ".": {

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-The CLI currently stores analyzer configuration in a snapshot-specific file (`.libretto-cli/snapshot-config.json`) and snapshot-specific code paths. That makes it hard to reuse the same model configuration for new commands like `analyze-media`, and it prevents future non-media AI workflows from sharing one stable runtime config.
+The CLI currently stores analyzer configuration in a snapshot-specific file (`.libretto/snapshot-config.json`) and snapshot-specific code paths. That makes it hard to reuse the same model configuration for new commands like `analyze-media`, and it prevents future non-media AI workflows from sharing one stable runtime config.
 
 We need one generic config location and schema that is explicitly AI-focused, not snapshot-focused.
 
@@ -22,7 +22,7 @@ Snapshot analysis will consume shared AI config, but this spec only covers AI co
 ## Non-goals
 
 - No migrations or backfills.
-- No compatibility read path for legacy `.libretto-cli/snapshot-config.json`.
+- No compatibility read path for legacy `.libretto/snapshot-config.json`.
 - No scope/profile system (global AI config only).
 - No changes to prompt design for snapshot or future analyze-media features.
 - No implementation of analyze-media command behavior in this spec.
@@ -35,12 +35,12 @@ Snapshot analysis will consume shared AI config, but this spec only covers AI co
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/core/context.ts` — currently defines `.libretto-cli` paths; must be updated to `.libretto/config.json` constants.
-- `packages/libretto-cli/src/core/snapshot-analyzer.ts` — currently owns snapshot-specific config schema and IO; AI config logic should be extracted from here.
-- `packages/libretto-cli/src/commands/snapshot.ts` — currently exposes `snapshot configure`; should be rewired to shared AI config handlers or alias behavior.
-- `packages/libretto-cli/src/cli.ts` — root usage text and command registration; add/adjust AI command help text.
-- `packages/libretto-cli/src/cli-stateful.test.ts` — stateful config tests must move from snapshot wording/path to AI wording/path.
-- `packages/libretto-cli/src/test-fixtures.ts` — fixture helper currently seeds `snapshot-config.json`; must seed `.libretto/config.json`.
+- `packages/libretto/src/core/context.ts` — currently defines `.libretto` paths; must be updated to `.libretto/config.json` constants.
+- `packages/libretto/src/core/snapshot-analyzer.ts` — currently owns snapshot-specific config schema and IO; AI config logic should be extracted from here.
+- `packages/libretto/src/commands/snapshot.ts` — currently exposes `snapshot configure`; should be rewired to shared AI config handlers or alias behavior.
+- `packages/libretto/src/cli.ts` — root usage text and command registration; add/adjust AI command help text.
+- `packages/libretto/src/cli-stateful.test.ts` — stateful config tests must move from snapshot wording/path to AI wording/path.
+- `packages/libretto/src/test-fixtures.ts` — fixture helper currently seeds `snapshot-config.json`; must seed `.libretto/config.json`.
 - `README.md` — user-facing docs currently snapshot-specific; update to generic AI config instructions.
 - [yargs command API](https://yargs.js.org/docs/#api-reference-commandcmd-desc-builder-handler) — reference for adding `ai` command surface cleanly.
 
@@ -75,10 +75,10 @@ Move configuration behavior out of snapshot-specific code and into shared AI han
 Add a first-class `ai` command entry point so users configure model behavior in one obvious place. This phase is focused on discoverable CLI UX, not analyzer internals.
 
 - [x] Add `ai configure [preset]` command in CLI registration with `--clear` and optional custom prefix via `--` separator.
-- [x] Update root usage text/examples to show `libretto-cli ai configure ...`.
+- [x] Update root usage text/examples to show `libretto ai configure ...`.
 - [x] Keep command behavior deterministic and aligned with existing configure UX semantics.
 - [x] Decide whether to keep `snapshot configure` as temporary alias in this phase; if kept, ensure help text labels it as compatibility behavior.
-- [x] Success criteria: `libretto-cli ai configure codex`, bare `libretto-cli ai configure` (show), and `--clear` all run successfully with expected stdout and exit code `0`.
+- [x] Success criteria: `libretto ai configure codex`, bare `libretto ai configure` (show), and `--clear` all run successfully with expected stdout and exit code `0`.
 
 ### Phase 4: Rewire snapshot analyzer to shared AI config resolver
 
@@ -86,7 +86,7 @@ Switch snapshot analysis to consume the new shared AI config path and helpers. B
 
 - [x] Replace snapshot-specific config reads in `snapshot-analyzer.ts` with shared AI config resolver calls.
 - [x] Keep existing analyzer execution adapters (`codex`, `opencode`, `claude`, `gemini`) but source their command prefix from shared AI config.
-- [x] Update missing-config and command-not-found error strings to point users to `libretto-cli ai configure ...`.
+- [x] Update missing-config and command-not-found error strings to point users to `libretto ai configure ...`.
 - [x] Do not change prompt/schema generation logic for snapshot interpretation in this phase.
 - [x] Success criteria: snapshot analysis still works when AI config exists and fails with actionable `ai configure` guidance when missing.
 
@@ -97,5 +97,5 @@ Finalize the contract by updating automated coverage and user documentation. Thi
 - [x] Update `cli-stateful.test.ts` config tests from snapshot-specific command/path terminology to AI command/path terminology.
 - [x] Update `test-fixtures.ts` seed helper to write `.libretto/config.json` with the new schema.
 - [x] Update README section from “snapshot analyzer configuration” to generic “AI configuration”.
-- [x] Run `pnpm --filter libretto-cli test` and ensure all CLI tests pass with the new config path and messages.
+- [x] Run `pnpm --filter libretto test` and ensure all CLI tests pass with the new config path and messages.
 - [x] Success criteria: test suite passes and docs/examples consistently reference `.libretto/config.json` and `ai configure`.

--- a/specs/ai-config-unification-spec.md
+++ b/specs/ai-config-unification-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-The CLI currently stores analyzer configuration in a snapshot-specific file (`.libretto/snapshot-config.json`) and snapshot-specific code paths. That makes it hard to reuse the same model configuration for new commands like `analyze-media`, and it prevents future non-media AI workflows from sharing one stable runtime config.
+The CLI currently stores analyzer configuration in a snapshot-specific file name (`.libretto/snapshot-config.json`) and snapshot-specific code paths. That makes it hard to reuse the same model configuration for new commands like `analyze-media`, and it prevents future non-media AI workflows from sharing one stable runtime config.
 
 We need one generic config location and schema that is explicitly AI-focused, not snapshot-focused.
 

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -4,12 +4,12 @@ Integration creation can involve a manual login during browser exploration, but 
 
 ## Solution overview
 
-Add an explicit `LibrettoWorkflow` class to carry integration metadata and run logic together, with `authProfile.type = "local"` support in v1. When `libretto run` executes a `LibrettoWorkflow` that declares a local auth profile domain, it resolves `.libretto-cli/profiles/<hostname>.json` and loads it as Playwright `storageState` before creating the browser context. If the profile is declared but missing, fail fast with an actionable error.
+Add an explicit `LibrettoWorkflow` class to carry integration metadata and run logic together, with `authProfile.type = "local"` support in v1. When `libretto run` executes a `LibrettoWorkflow` that declares a local auth profile domain, it resolves `.libretto/profiles/<hostname>.json` and loads it as Playwright `storageState` before creating the browser context. If the profile is declared but missing, fail fast with an actionable error.
 
 ## Goals
 
 - Integrations can declare `authProfile` metadata with `type: "local"` and `domain` through a typed `LibrettoWorkflow` export.
-- `libretto run` automatically loads `.libretto-cli/profiles/<domain>.json` when local auth metadata is present.
+- `libretto run` automatically loads `.libretto/profiles/<domain>.json` when local auth metadata is present.
 - Runtime fails early with a clear error when declared local auth profile data is unavailable.
 - Authoring/generation guidance prompts for auth handling and records local auth metadata when a saved profile is chosen.
 - User-facing guidance clearly warns that local profiles are machine-local and may expire/re-authenticate.
@@ -30,14 +30,14 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/commands/execution.ts` - `run` command/module loading path; add auth metadata resolution and fail-fast behavior.
+- `packages/libretto/src/commands/execution.ts` - `run` command/module loading path; add auth metadata resolution and fail-fast behavior.
 - `packages/libretto/src/run/browser.ts` - browser context creation; accept optional `storageState` input so runtime can preload auth state.
 - `packages/libretto/src/run/api.ts` - export surface for updated browser launch args.
 - `packages/libretto/src/index.ts` - export workflow/auth metadata helper if introduced for integration authoring ergonomics.
-- `packages/libretto-cli/src/core/context.ts` - source of `.libretto-cli/profiles` location and path conventions.
-- `packages/libretto-cli/src/cli.ts` - usage/help text updates for `run` auth profile behavior.
-- `packages/libretto-cli/src/cli-basic.test.ts` - subprocess-level guard and usage behavior assertions.
-- `packages/libretto-cli/src/test-fixtures.ts` - fixture helpers for creating integration/profile files in isolated workspaces.
+- `packages/libretto/src/core/context.ts` - source of `.libretto/profiles` location and path conventions.
+- `packages/libretto/src/cli.ts` - usage/help text updates for `run` auth profile behavior.
+- `packages/libretto/src/cli-basic.test.ts` - subprocess-level guard and usage behavior assertions.
+- `packages/libretto/src/test-fixtures.ts` - fixture helpers for creating integration/profile files in isolated workspaces.
 - `packages/libretto/skills/libretto-network-skill/SKILL.md` - update auth prompt guidance during workflow creation.
 - `packages/libretto/skills/original-skill/SKILL.md` - keep legacy skill variant aligned with new auth flow.
 
@@ -50,7 +50,7 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 - [x] Update `libretto run` loader to require that the selected export is a `LibrettoWorkflow` instance.
 - [x] Read auth metadata only from the `LibrettoWorkflow` instance.
 - [x] Extend `launchBrowser` args to accept optional `storageStatePath` and pass it to `browser.newContext({ storageState })` when provided.
-- [x] Ensure domain normalization uses hostname (e.g., `app.example.com`) and maps to `.libretto-cli/profiles/<domain>.json`.
+- [x] Ensure domain normalization uses hostname (e.g., `app.example.com`) and maps to `.libretto/profiles/<domain>.json`.
 - [x] Success criteria: subprocess tests confirm `run` returns a clear error when the export is not a Libretto workflow instance, and type checks pass for the new workflow + storage-state plumbing.
 
 ### Phase 2: Enforce fail-fast runtime behavior for declared local auth
@@ -70,6 +70,6 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 ### Phase 4: End-to-end verification and docs alignment
 
 - [x] Add/adjust tests for: metadata present + missing profile error, metadata absent default behavior, and storageState handoff path.
-- [x] Run `pnpm --filter libretto-cli test`.
-- [x] Run `pnpm --filter libretto-cli type-check` and `pnpm --filter libretto type-check`.
+- [x] Run `pnpm --filter libretto test`.
+- [x] Run `pnpm --filter libretto type-check` and `pnpm --filter libretto type-check`.
 - [x] Success criteria: all listed test/type-check commands pass and spec changes are reflected in relevant usage docs.

--- a/specs/auth-profile-local-run-spec.md
+++ b/specs/auth-profile-local-run-spec.md
@@ -70,6 +70,6 @@ Add an explicit `LibrettoWorkflow` class to carry integration metadata and run l
 ### Phase 4: End-to-end verification and docs alignment
 
 - [x] Add/adjust tests for: metadata present + missing profile error, metadata absent default behavior, and storageState handoff path.
-- [x] Run `pnpm --filter libretto test`.
-- [x] Run `pnpm --filter libretto type-check` and `pnpm --filter libretto type-check`.
+- [x] Run `pnpm test`.
+- [x] Run `pnpm type-check`.
 - [x] Success criteria: all listed test/type-check commands pass and spec changes are reflected in relevant usage docs.

--- a/specs/cli-router-middleware-spec.md
+++ b/specs/cli-router-middleware-spec.md
@@ -178,7 +178,7 @@ const app = SimpleCLI.define("libretto", {
 - [x] Example target shape:
 
 ```ts
-const app = SimpleCLI.define("libretto-cli", {
+const app = SimpleCLI.define("libretto", {
   ai: SimpleCLI.group({
     description: "AI commands",
     routes: {
@@ -195,7 +195,7 @@ await app.run(["help", "ai", "configure"]);
 // =>
 // Configure AI runtime
 //
-// Usage: libretto-cli ai configure [preset] [options]
+// Usage: libretto ai configure [preset] [options]
 //
 // Arguments:
 //   [preset]  AI preset
@@ -299,7 +299,7 @@ const runInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.integrationFile && input.integrationExport),
-    "Usage: libretto-cli run <integrationFile> <integrationExport> ...",
+    "Usage: libretto run <integrationFile> <integrationExport> ...",
   );
 
 const resumeCommand = SimpleCLI.command({

--- a/specs/cli-vitest-testing-spec.md
+++ b/specs/cli-vitest-testing-spec.md
@@ -8,7 +8,7 @@ The focus of this worktree is to establish reliable test infrastructure for CLI 
 
 Set up Vitest at the workspace level, add CLI-focused fixtures that isolate each test in its own workspace, and run the built CLI as a subprocess for black-box assertions.
 
-Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests should validate current behavior from the outside.
+Do not refactor or edit `packages/libretto/src/index.ts` in this spec. Tests should validate current behavior from the outside.
 
 ## Goals
 
@@ -21,7 +21,7 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 ## Non-goals
 
 - No migrations or backfills.
-- No edits to `packages/libretto-cli/src/index.ts` in this worktree.
+- No edits to `packages/libretto/src/index.ts` in this worktree.
 - No broad core-library test expansion in `packages/libretto` yet.
 - No real browser end-to-end automation against external websites.
 - No parser/helper extraction refactor for testability in this phase.
@@ -36,9 +36,9 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 
 - `package.json` — workspace scripts and shared dev dependencies.
 - `pnpm-workspace.yaml` — workspace package boundaries.
-- `packages/libretto-cli/package.json` — CLI package scripts and dependencies.
-- `packages/libretto-cli/vitest.config.ts` — package-local Vitest configuration for inline CLI tests.
-- `packages/libretto-cli/src/index.ts` — CLI runtime behavior under test (read-only for this spec).
+- `packages/libretto/package.json` — CLI package scripts and dependencies.
+- `packages/libretto/vitest.config.ts` — package-local Vitest configuration for inline CLI tests.
+- `packages/libretto/src/index.ts` — CLI runtime behavior under test (read-only for this spec).
 - `README.md` — top-level project context.
 
 ## Implementation
@@ -54,7 +54,7 @@ Do not refactor or edit `packages/libretto-cli/src/index.ts` in this spec. Tests
 ### Phase 2: Add scoped-workspace CLI fixtures
 
 - [x] Add a fixture that creates a unique temp workspace per test and switches subprocess cwd into it.
-- [x] Add seed helpers for `.libretto-cli` and `tmp/libretto-cli` state files and run directories.
+- [x] Add seed helpers for `.libretto` and `tmp/libretto` state files and run directories.
 - [x] Add a `spawnCli` fixture that executes the built CLI and captures `exitCode`, `stdout`, and `stderr`.
 - [x] Add teardown cleanup that removes temp workspace artifacts after each test.
 - [x] Success criteria: two tests can run in parallel without shared state collisions.

--- a/specs/cli-yargs-cleanup-spec.md
+++ b/specs/cli-yargs-cleanup-spec.md
@@ -30,10 +30,10 @@ Keep user-visible behavior stable: same usage/error text where currently asserte
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/cli.ts` — current command bootstrap, usage printing, and pre-parse argument handling.
-- `packages/libretto-cli/src/commands/browser.ts` — current browser command registration factory to convert.
-- `packages/libretto-cli/src/cli-basic.test.ts` — assertions on error/help behavior that must remain stable.
-- `packages/libretto-cli/src/cli-stateful.test.ts` — stateful command assertions to guard regressions.
+- `packages/libretto/src/cli.ts` — current command bootstrap, usage printing, and pre-parse argument handling.
+- `packages/libretto/src/commands/browser.ts` — current browser command registration factory to convert.
+- `packages/libretto/src/cli-basic.test.ts` — assertions on error/help behavior that must remain stable.
+- `packages/libretto/src/cli-stateful.test.ts` — stateful command assertions to guard regressions.
 - [yargs command modules](https://yargs.js.org/docs/#api-reference-commandmodule) — canonical pattern for exporting command objects.
 - [yargs command API](https://yargs.js.org/docs/#api-reference-commandcmd-desc-builder-handler) — details for command registration and handlers.
 
@@ -44,7 +44,7 @@ Keep user-visible behavior stable: same usage/error text where currently asserte
 - [ ] Remove `filterSessionArgs` and replace it with a cleaner command-token derivation approach that does not mutate argv arrays manually.
 - [ ] Keep `validateLegacySessionArg` semantics for the existing `--session` error contract.
 - [ ] Ensure help/unknown-command fast paths continue to print the same root usage text and exit codes.
-- [ ] Success criteria: `pnpm --filter libretto-cli test` still passes `cli-basic.test.ts` assertions for `--help`, `help`, unknown command, and invalid `--session` cases.
+- [ ] Success criteria: `pnpm --filter libretto test` still passes `cli-basic.test.ts` assertions for `--help`, `help`, unknown command, and invalid `--session` cases.
 
 ### Phase 2: Convert browser commands to direct command modules
 
@@ -55,7 +55,7 @@ Keep user-visible behavior stable: same usage/error text where currently asserte
 
 ### Phase 3: Validation and regression guardrails
 
-- [ ] Run `pnpm --filter libretto-cli type-check`.
-- [ ] Run `pnpm --filter libretto-cli test`.
-- [ ] Run `pnpm --filter libretto-cli build`.
+- [ ] Run `pnpm --filter libretto type-check`.
+- [ ] Run `pnpm --filter libretto test`.
+- [ ] Run `pnpm --filter libretto build`.
 - [ ] Success criteria: all three commands pass with no new test failures and no output-contract changes in existing tests.

--- a/specs/debug-pause-ipc-run-spec.md
+++ b/specs/debug-pause-ipc-run-spec.md
@@ -1,18 +1,18 @@
 ## Problem overview
 
-`debugPause` currently blocks inside the same process that runs `libretto-cli run`, so `run` hangs indefinitely when a workflow hits `debugPause`. The current implementation also relies on `.paused/.resume` files, which are implementation-heavy and not aligned with the desired runtime contract.
+`debugPause` currently blocks inside the same process that runs `libretto run`, so `run` hangs indefinitely when a workflow hits `debugPause`. The current implementation also relies on `.paused/.resume` files, which are implementation-heavy and not aligned with the desired runtime contract.
 
-The desired behavior is: `libretto-cli run` starts workflow execution in a child process, waits until that child either completes or pauses, then returns immediately. `debugPause` should never block `libretto run`.
+The desired behavior is: `libretto run` starts workflow execution in a child process, waits until that child either completes or pauses, then returns immediately. `debugPause` should never block `libretto run`.
 
 ## Solution overview
 
 Move workflow execution for `run` into a dedicated worker child process and use Node IPC for status signaling (`completed`, `paused`, `failed`). Replace file-based `debugPause` behavior with an in-process pause signal (typed error) that the worker catches and reports to the parent via IPC, then keeps the worker alive in paused state.
 
-`libretto-cli run` becomes a supervisor: it launches the worker, streams worker stdout/stderr, and exits when it receives either completion or pause outcome. On pause, it exits successfully and prints a clear paused status message while the worker remains running (hung) at pause.
+`libretto run` becomes a supervisor: it launches the worker, streams worker stdout/stderr, and exits when it receives either completion or pause outcome. On pause, it exits successfully and prints a clear paused status message while the worker remains running (hung) at pause.
 
 ## Goals
 
-- `libretto-cli run ... --debug` returns instead of hanging when workflow code calls `debugPause(...)`.
+- `libretto run ... --debug` returns instead of hanging when workflow code calls `debugPause(...)`.
 - `debugPause` no longer uses `.paused/.resume` files.
 - `run` uses parent/child IPC to detect paused/completed/failed outcomes.
 - CLI output clearly indicates paused outcome (for example, `Workflow paused.`), while still surfacing workflow logs before the pause.
@@ -34,14 +34,14 @@ Move workflow execution for `run` into a dedicated worker child process and use 
 
 - `packages/libretto/src/debug/pause.ts` — current blocking, file-based pause implementation to replace.
 - `packages/libretto/src/debug/index.ts` — debug export surface.
-- `packages/libretto-cli/src/commands/execution.ts` — current inline `run` execution path; will become parent supervisor path.
-- `packages/libretto-cli/src/workers/run-integration-runtime.ts` — worker-owned workflow runtime and pause handling.
-- `packages/libretto-cli/src/workers/run-integration-worker.ts` — worker IPC entrypoint and lifecycle behavior.
-- `packages/libretto-cli/src/workers/run-integration-worker-protocol.ts` — parent/worker message contract.
-- `packages/libretto-cli/src/cli.ts` — run help text/output contract updates.
-- `packages/libretto-cli/src/cli-basic.test.ts` — add/adjust subprocess assertions for run paused/completed behavior.
-- `packages/libretto-cli/src/test-fixtures.ts` — CLI fixture contract used by subprocess tests.
-- `packages/libretto-cli/tsup.config.ts` — include worker entrypoint in build outputs.
+- `packages/libretto/src/commands/execution.ts` — current inline `run` execution path; will become parent supervisor path.
+- `packages/libretto/src/workers/run-integration-runtime.ts` — worker-owned workflow runtime and pause handling.
+- `packages/libretto/src/workers/run-integration-worker.ts` — worker IPC entrypoint and lifecycle behavior.
+- `packages/libretto/src/workers/run-integration-worker-protocol.ts` — parent/worker message contract.
+- `packages/libretto/src/cli.ts` — run help text/output contract updates.
+- `packages/libretto/src/cli-basic.test.ts` — add/adjust subprocess assertions for run paused/completed behavior.
+- `packages/libretto/src/test-fixtures.ts` — CLI fixture contract used by subprocess tests.
+- `packages/libretto/tsup.config.ts` — include worker entrypoint in build outputs.
 - [Node child_process.fork docs](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) — worker process creation with IPC.
 - [Node child process IPC/stdin/stdout docs](https://nodejs.org/api/child_process.html#optionsstdio) — required `stdio`/`ipc` wiring.
 - [Node process.send docs](https://nodejs.org/api/process.html#processsendmessage-sendhandle-options-callback) — child-to-parent messaging contract.
@@ -61,17 +61,17 @@ Move workflow execution for `run` into a dedicated worker child process and use 
 
 ### Phase 2: Add `run` worker entrypoint with IPC status messages
 
-- [x] Create a dedicated worker module in `packages/libretto-cli/src` for running one workflow invocation.
+- [x] Create a dedicated worker module in `packages/libretto/src` for running one workflow invocation.
 - [x] Move the existing inline workflow execution logic (import workflow export, launch browser, run handler, close browser) into worker-owned code.
 - [x] In worker, catch typed pause signal, send IPC `{ type: "paused", ... }` to parent, then deliberately stay alive in paused state (do not exit).
 - [x] Ensure paused-state worker keeps browser/context open for inspection while hung.
 - [x] In worker, send/emit failure details for non-pause errors and exit non-zero.
-- [x] Update `packages/libretto-cli/tsup.config.ts` to build this worker entry as a runnable output.
+- [x] Update `packages/libretto/tsup.config.ts` to build this worker entry as a runnable output.
 - [x] Success criteria: worker can be launched by Node with IPC and emits deterministic message payloads for paused/completed/failed paths, and paused path does not terminate worker.
 
 ### Phase 3: Convert `run` command into supervisor parent process
 
-- [x] In `packages/libretto-cli/src/commands/execution.ts`, replace direct `runIntegrationFromFile(...)` invocation with worker launch via `child_process.fork(...)` using IPC enabled stdio.
+- [x] In `packages/libretto/src/commands/execution.ts`, replace direct `runIntegrationFromFile(...)` invocation with worker launch via `child_process.fork(...)` using IPC enabled stdio.
 - [x] Stream worker stdout/stderr through parent stdout/stderr so existing logs remain visible.
 - [x] Handle worker outcomes:
   - on paused message: print `Workflow paused.` (or the chosen exact status string) and treat command as success,
@@ -79,15 +79,15 @@ Move workflow execution for `run` into a dedicated worker child process and use 
   - on failed outcome/non-zero exit: preserve actionable error path and non-zero CLI exit.
 - [x] Ensure parent does not hang waiting for a resume signal once paused is reported.
 - [x] Ensure parent pause-return path does not kill/cleanup the paused worker process.
-- [x] Success criteria: `pnpm --filter libretto-cli test -- src/cli-basic.test.ts` passes with paused and completion e2e coverage and no timeout occurs.
+- [x] Success criteria: `pnpm --filter libretto test -- src/cli-basic.test.ts` passes with paused and completion e2e coverage and no timeout occurs.
 
 ### Phase 4: Regression coverage and output contract updates
 
 - [x] Add/adjust `cli-basic.test.ts` e2e coverage so one run test asserts paused-status output in addition to `WORKFLOW_BEFORE_PAUSE`.
 - [x] Add/adjust a `cli-basic.test.ts` case verifying `run` still reports completion on a workflow with no pause signal.
-- [ ] Update help text/docs (`packages/libretto-cli/src/cli.ts` and relevant README snippets) so `--debug` behavior is described as returning paused status rather than blocking.
+- [ ] Update help text/docs (`packages/libretto/src/cli.ts` and relevant README snippets) so `--debug` behavior is described as returning paused status rather than blocking.
 - [x] Cleanup: remove obsolete file-pause API surface (`signalDir`, pause/resume file references) and update all dependent callsites; do not leave deprecated shims.
 - [ ] Success criteria:
-  - `pnpm --filter libretto-cli test -- src/cli-basic.test.ts`
-  - `pnpm --filter libretto-cli test`
-  - `pnpm --filter libretto-cli build`
+  - `pnpm --filter libretto test -- src/cli-basic.test.ts`
+  - `pnpm --filter libretto test`
+  - `pnpm --filter libretto build`

--- a/specs/libretto-runtime-dotlibretto-migration-spec.md
+++ b/specs/libretto-runtime-dotlibretto-migration-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-`packages/libretto` still writes default runtime state to `tmp/libretto`, even after the broader `.libretto` state centralization work in `libretto-cli`.
+`packages/libretto` still writes default runtime state to `tmp/libretto`, even after the broader `.libretto` state centralization work in `libretto`.
 
 Current gaps:
 - `run/browser.ts` writes browser metadata to `tmp/libretto/<session>.json`.
@@ -75,6 +75,6 @@ Use one shared internal path helper module in `packages/libretto` so `launchBrow
 
 - [ ] Update `packages/libretto/README.md` to document new `.libretto/sessions/<session>/...` defaults.
 - [ ] Mark corresponding Phase 5 checklist items in `specs/libretto-state-centralization-spec.md` as complete once implemented.
-- [ ] Run `pnpm --filter libretto type-check` and `pnpm --filter libretto-cli type-check`.
+- [ ] Run `pnpm --filter libretto type-check` and `pnpm --filter libretto type-check`.
 - [ ] Perform one local smoke run that exercises `launchBrowser`, `debugPause`, and runner logging defaults, then verify no new `tmp/libretto/*` files were created.
 - [ ] Success criteria: docs and runtime behavior are aligned on `.libretto` defaults and validation commands pass.

--- a/specs/libretto-runtime-dotlibretto-migration-spec.md
+++ b/specs/libretto-runtime-dotlibretto-migration-spec.md
@@ -75,6 +75,6 @@ Use one shared internal path helper module in `packages/libretto` so `launchBrow
 
 - [ ] Update `packages/libretto/README.md` to document new `.libretto/sessions/<session>/...` defaults.
 - [ ] Mark corresponding Phase 5 checklist items in `specs/libretto-state-centralization-spec.md` as complete once implemented.
-- [ ] Run `pnpm --filter libretto type-check` and `pnpm --filter libretto type-check`.
+- [ ] Run `pnpm type-check`.
 - [ ] Perform one local smoke run that exercises `launchBrowser`, `debugPause`, and runner logging defaults, then verify no new `tmp/libretto/*` files were created.
 - [ ] Success criteria: docs and runtime behavior are aligned on `.libretto` defaults and validation commands pass.

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -114,5 +114,5 @@ Target layout:
 - [ ] Update CLI fixtures/tests to seed/assert the new `.libretto` layout.
 - [ ] Add regression coverage that asserts commands do not create legacy temp runtime paths outside `.libretto/`.
 - [x] Update usage/help text and README references from old paths to `.libretto`.
-- [ ] Update root `.gitignore` policy to stop relying on `.libretto/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
+- [ ] Update root `.gitignore` policy to stop relying on root-level `.libretto/` and `tmp/` ignore entries for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
 - [ ] Success criteria: `pnpm test` and `pnpm type-check` pass with updated path expectations.

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-Libretto runtime state is currently split across multiple roots: `.libretto-cli/`, `tmp/libretto-cli/`, and `tmp/libretto/`. This makes state hard to inspect, hard to clean up, and inconsistent between CLI and library runtime behavior.
+Libretto runtime state is currently split across multiple roots: `.libretto/`, `tmp/libretto/`, and `tmp/libretto/`. This makes state hard to inspect, hard to clean up, and inconsistent between CLI and library runtime behavior.
 
 `main` already moved AI/snapshot analyzer config into `.libretto/config.json`, but session metadata, profiles, logs, telemetry, debug signals, and snapshot artifacts are still spread across the legacy locations.
 
@@ -29,7 +29,7 @@ Target layout:
 
 ## Goals
 
-- All runtime/persistent state used by `libretto-cli` and default `libretto` runtime helpers is stored under `.libretto/`.
+- All runtime/persistent state used by `libretto` and default `libretto` runtime helpers is stored under `.libretto/`.
 - Each session has an isolated directory at `.libretto/sessions/<session-name>/`.
 - Per-session logging uses `logs.jsonl` instead of per-run `session.log`.
 - Profiles are stored under `.libretto/profiles/`.
@@ -39,7 +39,7 @@ Target layout:
 
 ## Non-goals
 
-- No migrations or backfills of old state from `.libretto-cli/` or `tmp/`.
+- No migrations or backfills of old state from `.libretto/` or `tmp/`.
 - No compatibility shims that continue writing to old paths in parallel.
 - No schema/versioning redesign beyond what is needed to add session permission data to existing `.libretto/config.json`.
 - No changes to Playwright behavior, browser launch semantics, or command UX beyond path and storage location updates.
@@ -50,20 +50,20 @@ Target layout:
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/core/context.ts` — defines global state roots and currently contains legacy profile migration logic.
-- `packages/libretto-cli/src/core/session.ts` — session state read/write, run directory helpers, and session permission persistence.
-- `packages/libretto-cli/src/core/telemetry.ts` — network/actions log paths and read/clear behavior.
-- `packages/libretto-cli/src/core/browser.ts` — `open/save/close` flow and child browser logging file paths.
-- `packages/libretto-cli/src/commands/snapshot.ts` — snapshot PNG/HTML capture locations.
-- `packages/libretto-cli/src/core/snapshot-analyzer.ts` — temporary analyzer output file handling and snapshot pair discovery.
-- `packages/libretto-cli/src/core/ai-config.ts` — `.libretto/config.json` schema and read/write helpers to extend with session permissions.
-- `packages/libretto-cli/src/cli.ts` — logger initialization path and usage text that currently documents legacy paths.
+- `packages/libretto/src/core/context.ts` — defines global state roots and currently contains legacy profile migration logic.
+- `packages/libretto/src/core/session.ts` — session state read/write, run directory helpers, and session permission persistence.
+- `packages/libretto/src/core/telemetry.ts` — network/actions log paths and read/clear behavior.
+- `packages/libretto/src/core/browser.ts` — `open/save/close` flow and child browser logging file paths.
+- `packages/libretto/src/commands/snapshot.ts` — snapshot PNG/HTML capture locations.
+- `packages/libretto/src/core/snapshot-analyzer.ts` — temporary analyzer output file handling and snapshot pair discovery.
+- `packages/libretto/src/core/ai-config.ts` — `.libretto/config.json` schema and read/write helpers to extend with session permissions.
+- `packages/libretto/src/cli.ts` — logger initialization path and usage text that currently documents legacy paths.
 - `packages/libretto/src/run/browser.ts` — writes browser metadata to `tmp/libretto`.
 - `packages/libretto/src/debug/pause.ts` — default pause/resume signal directory under `tmp/libretto`.
 - `packages/libretto/src/step/runner.ts` — default `logDir` under `tmp/libretto/logs`.
-- `packages/libretto-cli/src/test-fixtures.ts` and `packages/libretto-cli/src/cli-stateful.test.ts` — fixture seeding and assertions that encode current filesystem layout.
+- `packages/libretto/src/test-fixtures.ts` and `packages/libretto/src/cli-stateful.test.ts` — fixture seeding and assertions that encode current filesystem layout.
 - `README.md` and `packages/libretto/README.md` — user-facing documentation of state file locations.
-- `.gitignore` — root ignore policy that currently ignores `.libretto-cli/` and `tmp/`.
+- `.gitignore` — root ignore policy that currently ignores `.libretto/` and `tmp/`.
 
 ## Implementation
 
@@ -73,14 +73,14 @@ Target layout:
 - [x] Define canonical helpers for `.libretto` root, session directory resolution, and per-session file paths (`state.json`, `logs.jsonl`, `network.jsonl`, `actions.jsonl`, snapshot root).
 - [x] Invoke setup bootstrap from CLI startup and any runtime entry points that can write state before command handlers execute.
 - [x] Remove `.playwriter` and `.browser-tap` migration code from startup path handling.
-- [x] Success criteria: running `libretto-cli --help` in a fresh repo creates `.libretto/.gitignore` and subdirectories without creating `.libretto-cli/` or `tmp/libretto-cli/`.
+- [x] Success criteria: running `libretto --help` in a fresh repo creates `.libretto/.gitignore` and subdirectories without creating `.libretto/` or `tmp/libretto/`.
 
 ### Phase 2: Move CLI session state and logs into per-session directories
 
-- [x] Move session state file from `tmp/libretto-cli/<session>.json` to `.libretto/sessions/<session>/state.json`.
+- [x] Move session state file from `tmp/libretto/<session>.json` to `.libretto/sessions/<session>/state.json`.
 - [x] Replace run-directory/per-run log helpers with session-directory helpers and `logs.jsonl`.
 - [x] Update logger initialization in `cli.ts` to write to per-session `logs.jsonl`.
-- [x] After logger defaults move off `tmp/libretto-cli`, allow early `getLog()` usage on help/error paths without recreating legacy dirs.
+- [x] After logger defaults move off `tmp/libretto`, allow early `getLog()` usage on help/error paths without recreating legacy dirs.
 - [x] Update `open` child process logging path to append JSONL entries to `.libretto/sessions/<session>/logs.jsonl`.
 - [x] Success criteria: session commands (`open`, `close`, `exec` guard paths) operate using only `.libretto/sessions/<session>/state.json` + `logs.jsonl`.
 
@@ -91,14 +91,14 @@ Target layout:
 - [x] Move snapshot captures to `.libretto/sessions/<session>/snapshots/<snapshot-run-id>/page.png` and `page.html`.
 - [x] Require explicit snapshot PNG/HTML paths from the current `snapshot` command flow; remove implicit latest-pair lookup from previous runs.
 - [x] Remove repository-scoped analyzer temp directories; use transient OS temp files and delete them after parse.
-- [x] Success criteria: stateful tests prove network/actions/snapshot files are created under `.libretto/sessions/<session>/...` and no files are created in `tmp/libretto-cli/`.
+- [x] Success criteria: stateful tests prove network/actions/snapshot files are created under `.libretto/sessions/<session>/...` and no files are created in `tmp/libretto/`.
 
 ### Phase 4: Consolidate session permission state into `.libretto/config.json`
 
 - [x] Extend `LibrettoConfigSchema` to include a `permissions` object keyed by session name with `read-only|interactive` values.
-- [x] Replace `.libretto-cli/session-permissions.json` reads/writes with config-backed reads/writes in `ai-config.ts` + `session.ts`.
+- [x] Replace `.libretto/session-permissions.json` reads/writes with config-backed reads/writes in `ai-config.ts` + `session.ts`.
 - [x] Ensure `session-mode` command behavior remains unchanged from a user perspective.
-- [x] Remove any remaining references to `.libretto-cli/session-permissions.json` from code and tests.
+- [x] Remove any remaining references to `.libretto/session-permissions.json` from code and tests.
 - [x] Success criteria: `session-mode interactive --session <name>` persists mode in `.libretto/config.json` and `run/exec` guards still enforce the same rules.
 
 ### Phase 5: Move default `libretto` package runtime state out of `tmp/libretto`
@@ -112,7 +112,7 @@ Target layout:
 ### Phase 6: Tests, docs, and cleanup
 
 - [ ] Update CLI fixtures/tests to seed/assert the new `.libretto` layout.
-- [ ] Add regression coverage that asserts commands do not create `.libretto-cli/` or `tmp/libretto-cli/` paths.
+- [ ] Add regression coverage that asserts commands do not create `.libretto/` or `tmp/libretto/` paths.
 - [x] Update usage/help text and README references from old paths to `.libretto`.
-- [ ] Update root `.gitignore` policy to stop relying on `.libretto-cli/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
-- [ ] Success criteria: `pnpm --filter libretto-cli test`, `pnpm --filter libretto-cli type-check`, and `pnpm --filter libretto type-check` pass with updated path expectations.
+- [ ] Update root `.gitignore` policy to stop relying on `.libretto/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
+- [ ] Success criteria: `pnpm --filter libretto test`, `pnpm --filter libretto type-check`, and `pnpm --filter libretto type-check` pass with updated path expectations.

--- a/specs/libretto-state-centralization-spec.md
+++ b/specs/libretto-state-centralization-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-Libretto runtime state is currently split across multiple roots: `.libretto/`, `tmp/libretto/`, and `tmp/libretto/`. This makes state hard to inspect, hard to clean up, and inconsistent between CLI and library runtime behavior.
+Libretto runtime state is currently split across multiple roots: `.libretto/`, `tmp/libretto/`, and other legacy temp-state locations. This makes state hard to inspect, hard to clean up, and inconsistent between CLI and library runtime behavior.
 
 `main` already moved AI/snapshot analyzer config into `.libretto/config.json`, but session metadata, profiles, logs, telemetry, debug signals, and snapshot artifacts are still spread across the legacy locations.
 
@@ -39,7 +39,7 @@ Target layout:
 
 ## Non-goals
 
-- No migrations or backfills of old state from `.libretto/` or `tmp/`.
+- No migrations or backfills of old state from legacy runtime directories.
 - No compatibility shims that continue writing to old paths in parallel.
 - No schema/versioning redesign beyond what is needed to add session permission data to existing `.libretto/config.json`.
 - No changes to Playwright behavior, browser launch semantics, or command UX beyond path and storage location updates.
@@ -73,7 +73,7 @@ Target layout:
 - [x] Define canonical helpers for `.libretto` root, session directory resolution, and per-session file paths (`state.json`, `logs.jsonl`, `network.jsonl`, `actions.jsonl`, snapshot root).
 - [x] Invoke setup bootstrap from CLI startup and any runtime entry points that can write state before command handlers execute.
 - [x] Remove `.playwriter` and `.browser-tap` migration code from startup path handling.
-- [x] Success criteria: running `libretto --help` in a fresh repo creates `.libretto/.gitignore` and subdirectories without creating `.libretto/` or `tmp/libretto/`.
+- [x] Success criteria: running `libretto --help` in a fresh repo creates `.libretto/.gitignore` and subdirectories without creating any additional legacy runtime directories under `tmp/`.
 
 ### Phase 2: Move CLI session state and logs into per-session directories
 
@@ -112,7 +112,7 @@ Target layout:
 ### Phase 6: Tests, docs, and cleanup
 
 - [ ] Update CLI fixtures/tests to seed/assert the new `.libretto` layout.
-- [ ] Add regression coverage that asserts commands do not create `.libretto/` or `tmp/libretto/` paths.
+- [ ] Add regression coverage that asserts commands do not create legacy temp runtime paths outside `.libretto/`.
 - [x] Update usage/help text and README references from old paths to `.libretto`.
 - [ ] Update root `.gitignore` policy to stop relying on `.libretto/` and `tmp/` for libretto runtime state; keep ignores aligned with new `.libretto/.gitignore`.
-- [ ] Success criteria: `pnpm --filter libretto test`, `pnpm --filter libretto type-check`, and `pnpm --filter libretto type-check` pass with updated path expectations.
+- [ ] Success criteria: `pnpm test` and `pnpm type-check` pass with updated path expectations.

--- a/specs/open-read-only-mode-spec.md
+++ b/specs/open-read-only-mode-spec.md
@@ -1,6 +1,6 @@
 ## Problem overview
 
-`libretto-cli open` currently starts sessions that always allow `exec`, which means an agent can immediately run arbitrary Playwright code against live websites. That default is risky for sensitive workflows where accidental clicks, form submissions, or mutation requests are not acceptable.
+`libretto open` currently starts sessions that always allow `exec`, which means an agent can immediately run arbitrary Playwright code against live websites. That default is risky for sensitive workflows where accidental clicks, form submissions, or mutation requests are not acceptable.
 
 ## Solution overview
 
@@ -20,7 +20,7 @@ Make `open` sessions read-only by default and enforce the safety boundary in `ex
 
 - No migrations or backfills.
 - No AST-level parsing of `exec` code to allow a subset of read-only Playwright APIs.
-- No changes to browser-agent runtime semantics outside `libretto-cli` session state/guards.
+- No changes to browser-agent runtime semantics outside `libretto` session state/guards.
 
 ## Future work
 
@@ -29,10 +29,10 @@ Make `open` sessions read-only by default and enforce the safety boundary in `ex
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/index.ts` — Open/exec runtime behavior, usage text, and session state writes.
-- `packages/libretto-cli/src/cli-basic.test.ts` — Usage error assertions for CLI command help strings.
-- `packages/libretto-cli/src/cli-stateful.test.ts` — Seeded-state subprocess tests for mode-based exec behavior.
-- `packages/libretto-cli/src/test-fixtures.ts` — Session state fixture typing used by stateful tests.
+- `packages/libretto/src/index.ts` — Open/exec runtime behavior, usage text, and session state writes.
+- `packages/libretto/src/cli-basic.test.ts` — Usage error assertions for CLI command help strings.
+- `packages/libretto/src/cli-stateful.test.ts` — Seeded-state subprocess tests for mode-based exec behavior.
+- `packages/libretto/src/test-fixtures.ts` — Session state fixture typing used by stateful tests.
 - `README.md` — Top-level CLI documentation updates for default read-only behavior and explicit opt-in.
 
 ## Implementation
@@ -60,4 +60,4 @@ Make `open` sessions read-only by default and enforce the safety boundary in `ex
 - [x] Update top-level documentation to describe the new default and opt-in behavior.
 - [x] Update Libretto skill docs to require explicit user approval before running `session-mode`.
 - [x] Run the CLI Vitest suite to validate changes.
-- [x] Success criteria: `pnpm --filter libretto-cli test` passes.
+- [x] Success criteria: `pnpm --filter libretto test` passes.

--- a/specs/readonly-exec-spec.md
+++ b/specs/readonly-exec-spec.md
@@ -31,12 +31,12 @@ Add a new `readonly-exec` CLI command that reuses the `exec` runtime pipeline bu
 
 ## Important files/docs/websites for implementation
 
-- `packages/libretto-cli/src/index.ts` — add `readonly-exec` command parsing and runtime.
-- `packages/libretto-cli/src/cli-basic.test.ts` — usage and argument behavior for the new command.
-- `packages/libretto-cli/src/cli-stateful.test.ts` — read-only session behavior tests.
-- `packages/libretto-cli/src/test-fixtures.ts` — seeded session and permission fixtures.
+- `packages/libretto/src/index.ts` — add `readonly-exec` command parsing and runtime.
+- `packages/libretto/src/cli-basic.test.ts` — usage and argument behavior for the new command.
+- `packages/libretto/src/cli-stateful.test.ts` — read-only session behavior tests.
+- `packages/libretto/src/test-fixtures.ts` — seeded session and permission fixtures.
 - `packages/libretto/skills/original-skill/SKILL.md` — switch read-only workflows from `exec` to `readonly-exec`.
-- `packages/libretto/skills/libretto-network-skill/SKILL.md` — same as above for `.bin/libretto-cli` workflow.
+- `packages/libretto/skills/libretto-network-skill/SKILL.md` — same as above for `.bin/libretto` workflow.
 
 ## Implementation
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,30 +18,30 @@ Options:
                           Built-in sessions: default, dev-server, browser-agent
 
 Examples:
-  libretto-cli open https://linkedin.com
+  libretto open https://linkedin.com
 
   # ... manually log in ...
-  libretto-cli save linkedin.com
+  libretto save linkedin.com
   # Next time you open linkedin.com, you'll be logged in automatically
 
-  libretto-cli exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
-  libretto-cli exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
-  libretto-cli ai configure openai
-  libretto-cli ai configure anthropic
-  libretto-cli ai configure gemini
-  libretto-cli ai configure vertex
-  libretto-cli ai configure openai/gpt-4o
-  libretto-cli snapshot
-  libretto-cli snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
-  libretto-cli resume --session default
-  libretto-cli close
-  libretto-cli close --all
-  libretto-cli close --all --force
+  libretto exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
+  libretto exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
+  libretto ai configure openai
+  libretto ai configure anthropic
+  libretto ai configure gemini
+  libretto ai configure vertex
+  libretto ai configure openai/gpt-4o
+  libretto snapshot
+  libretto snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
+  libretto resume --session default
+  libretto close
+  libretto close --all
+  libretto close --all --force
 
   # Multiple sessions
-  libretto-cli open https://site1.com --session test1
-  libretto-cli open https://site2.com --session test2
-  libretto-cli exec "return await page.title()" --session test1
+  libretto open https://site1.com --session test1
+  libretto open https://site2.com --session test2
+  libretto exec "return await page.title()" --session test1
 
 Available in exec:
   page, context, state, browser, networkLog, actionLog
@@ -102,7 +102,7 @@ function validateLegacySessionArg(rawArgs: string[]): void {
   if (value === undefined) return;
   if (value === null) {
     throw new Error(
-      "Usage: libretto-cli <command> [--session <name>]\nMissing or invalid --session value.",
+      `Usage: libretto <command> [--session <name>]\nMissing or invalid --session value.`,
     );
   }
   validateSessionName(value);

--- a/src/cli/commands/ai.ts
+++ b/src/cli/commands/ai.ts
@@ -27,7 +27,7 @@ export const aiCommands = SimpleCLI.group({
             preset: input.preset,
           },
           {
-            configureCommandName: "libretto-cli ai configure",
+            configureCommandName: `libretto ai configure`,
           },
         );
       }),

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -56,7 +56,7 @@ export const openInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.url),
-    "Usage: libretto-cli open <url> [--headless] [--viewport WxH] [--session <name>]",
+    `Usage: libretto open <url> [--headless] [--viewport WxH] [--session <name>]`,
   )
   .refine(
     (input) => !(input.headed && input.headless),
@@ -88,7 +88,7 @@ export const saveInput = SimpleCLI.input({
   },
 }).refine(
   (input) => Boolean(input.urlOrDomain),
-  "Usage: libretto-cli save <url|domain> [--session <name>]",
+  `Usage: libretto save <url|domain> [--session <name>]`,
 );
 
 export function createSaveCommand(logger: LoggerApi) {
@@ -139,7 +139,7 @@ export function createCloseCommand(logger: LoggerApi) {
     .use(resolveSessionMiddleware)
     .handle(async ({ input, ctx }) => {
       if (input.force && !input.all) {
-        throw new Error("Usage: libretto-cli close --all [--force]");
+        throw new Error(`Usage: libretto close --all [--force]`);
       }
       if (input.all) {
         await runCloseAllWithLogger(logger, { force: input.force });

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -417,7 +417,7 @@ async function runResume(
 
   if (!existsSync(pausedSignalPath)) {
     throw new Error(
-      `Session "${session}" is not paused. Run "libretto-cli run ... --session ${session}" and call pause("${session}") first.`,
+      `Session "${session}" is not paused. Run "libretto run ... --session ${session}" and call pause("${session}") first.`,
     );
   }
 
@@ -553,7 +553,7 @@ export const execInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.codeParts.length > 0,
-  "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
+  `Usage: libretto exec <code> [--session <name>] [--visualize]`,
 );
 
 export function createExecCommand(logger: LoggerApi) {
@@ -575,7 +575,7 @@ export function createExecCommand(logger: LoggerApi) {
 }
 
 const runUsage =
-  "Usage: libretto-cli run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless]";
+  `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -26,7 +26,7 @@ async function resolvePageId(session: string, pageId?: string): Promise<string |
   const foundPage = pages.find((page) => page.id === pageId);
   if (!foundPage) {
     throw new Error(
-      `Page "${pageId}" was not found in session "${session}". Run "libretto-cli pages --session ${session}" to list ids.`,
+      `Page "${pageId}" was not found in session "${session}". Run "libretto pages --session ${session}" to list ids.`,
     );
   }
   return pageId;

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -200,7 +200,7 @@ export async function connect(
     if (!isPidRunning(state.pid)) {
       clearSessionState(session, logger);
       throw new Error(
-        `No browser running for session "${session}". Run 'libretto-cli open <url> --session ${session}' first.`,
+        `No browser running for session "${session}". Run 'libretto open <url> --session ${session}' first.`,
       );
     }
 
@@ -236,7 +236,7 @@ export async function connect(
 
   if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
     throw new Error(
-      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto-cli pages --session ${session}" to list ids).`,
+      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto pages --session ${session}" to list ids).`,
     );
   }
 
@@ -246,7 +246,7 @@ export async function connect(
     : pageRefs[pageRefs.length - 1]!;
   if (!pageRef) {
     throw new Error(
-      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto-cli pages --session ${session}" to list ids.`,
+      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto pages --session ${session}" to list ids.`,
     );
   }
   const page = pageRef.page;
@@ -394,7 +394,7 @@ function childLog(level, event, data = {}) {
 			timestamp: new Date().toISOString(),
 			id: Math.random().toString(36).slice(2, 10),
 			level,
-			scope: 'libretto-cli.child',
+			scope: 'libretto.child',
 			event,
 			data,
 		});
@@ -783,7 +783,7 @@ export async function runCloseAll(
       [
         `Failed to close ${survivors.length} session(s) gracefully: ${formatSessionList(survivors)}.`,
         `Closed ${closed} session(s).`,
-        "Retry with: libretto-cli close --all --force",
+        `Retry with: libretto close --all --force`,
       ].join("\n"),
     );
   }

--- a/src/cli/core/context.ts
+++ b/src/cli/core/context.ts
@@ -66,7 +66,7 @@ export function createLoggerForSession(session: string): Logger {
   const sessionDir = getSessionDir(session);
   mkdirSync(sessionDir, { recursive: true });
   const logFilePath = getSessionLogsPath(session);
-  return new Logger(["libretto-cli"], [createFileLogSink({ filePath: logFilePath })]);
+  return new Logger(["libretto"], [createFileLogSink({ filePath: logFilePath })]);
 }
 
 export async function closeLogger(logger: Logger | null | undefined): Promise<void> {

--- a/src/cli/core/session.ts
+++ b/src/cli/core/session.ts
@@ -118,7 +118,7 @@ function throwSessionNotFoundError(session: string): never {
   }
   lines.push("");
   lines.push("Start one with:");
-  lines.push(`  libretto-cli open <url> --session ${session}`);
+  lines.push(`  libretto open <url> --session ${session}`);
   throw new Error(lines.join("\n"));
 }
 
@@ -204,6 +204,6 @@ export function assertSessionAvailableForStart(
   }
   const endpoint = `http://127.0.0.1:${existingState.port}`;
   throw new Error(
-    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto-cli close --session ${session}`,
+    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto close --session ${session}`,
   );
 }

--- a/src/cli/core/snapshot-analyzer.ts
+++ b/src/cli/core/snapshot-analyzer.ts
@@ -178,7 +178,7 @@ class CodexUserCodingAgent extends UserCodingAgent {
     pngPath: string,
     logger: LoggerApi,
   ): Promise<InterpretResult> {
-    const tempDir = mkdtempSync(join(tmpdir(), "libretto-cli-analyzer-"));
+    const tempDir = mkdtempSync(join(tmpdir(), "libretto-analyzer-"));
     const outputPath = join(
       tempDir,
       `snapshot-analyzer-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
@@ -297,7 +297,7 @@ async function runExternalCommand(
       if (error.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: ${command}. Configure AI with 'libretto-cli ai configure'.`,
+            `Command not found: ${command}. Configure AI with 'libretto ai configure'.`,
           ),
         );
         return;

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -20,7 +20,7 @@ export function buildCLIRoutes(logger: Logger) {
 }
 
 export function createCLIApp(logger: Logger) {
-  return SimpleCLI.define("libretto-cli", buildCLIRoutes(logger), {
+  return SimpleCLI.define("libretto", buildCLIRoutes(logger), {
     globalNamed: {
       session: sessionOption(),
     },

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -126,9 +126,9 @@ function getMissingLocalAuthProfileError(args: {
     `Local auth profile not found for domain "${normalizedDomain}".`,
     `Expected profile file: ${args.profilePath}`,
     "To create it:",
-    `  1. libretto-cli open https://${normalizedDomain} --headed --session ${args.session}`,
+    `  1. libretto open https://${normalizedDomain} --headed --session ${args.session}`,
     "  2. Log in manually in the browser window.",
-    `  3. libretto-cli save ${normalizedDomain} --session ${args.session}`,
+    `  3. libretto save ${normalizedDomain} --session ${args.session}`,
   ].join("\n");
 }
 

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -58,7 +58,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("help ai configure");
     expect(result.stdout).toContain("Configure AI runtime");
-    expect(result.stdout).toContain("Usage: libretto-cli ai configure [preset] [options]");
+    expect(result.stdout).toContain("Usage: libretto ai configure [preset] [options]");
     expect(result.stderr).toBe("");
   });
 
@@ -89,7 +89,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("nope-command");
     expect(result.stderr).toContain("Unknown command: nope-command");
-    expect(result.stdout).toContain("Usage: libretto-cli <command>");
+    expect(result.stdout).toContain("Usage: libretto <command>");
   });
 
   test("fails open with missing url usage error", async ({
@@ -97,7 +97,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("open");
     expect(result.stderr).toContain(
-      "Usage: libretto-cli open <url> [--headless] [--viewport WxH] [--session <name>]",
+      "Usage: libretto open <url> [--headless] [--viewport WxH] [--session <name>]",
     );
   });
 
@@ -140,7 +140,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("exec");
     expect(result.stderr).toContain(
-      "Usage: libretto-cli exec <code> [--session <name>] [--visualize]",
+      "Usage: libretto exec <code> [--session <name>] [--visualize]",
     );
   });
 
@@ -209,7 +209,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("pages --session -dash");
     await evaluate(result.stderr).toMatch(
-      'Explains that session "-dash" does not exist, no active sessions are available, and suggests opening a session with libretto-cli open <url> --session -dash.',
+      'Explains that session "-dash" does not exist, no active sessions are available, and suggests opening a session with libretto open <url> --session -dash.',
     );
     expect(result.stderr).not.toContain("Missing value for --session.");
   });
@@ -395,8 +395,8 @@ export const main = workflow(
     expect(result.stderr).toContain(
       'Local auth profile not found for domain "app.example.com".',
     );
-    expect(result.stderr).toContain("libretto-cli open https://app.example.com --headed --session default");
-    expect(result.stderr).toContain("libretto-cli save app.example.com --session default");
+    expect(result.stderr).toContain("libretto open https://app.example.com --headed --session default");
+    expect(result.stderr).toContain("libretto save app.example.com --session default");
   });
 
   test("does not require local auth profile when auth metadata is absent", async ({
@@ -528,7 +528,7 @@ export const main = workflow({}, async (ctx) => {
   }) => {
     const result = await librettoCli("save");
     expect(result.stderr).toContain(
-      "Usage: libretto-cli save <url|domain> [--session <name>]",
+      "Usage: libretto save <url|domain> [--session <name>]",
     );
   });
 
@@ -549,7 +549,7 @@ export const main = workflow({}, async (ctx) => {
     const result = await librettoCli("pages --session open");
     expect(result.stdout).toBe("");
     await evaluate(result.stderr).toMatch(
-      'Explains that session "open" does not exist, no active sessions are available, and suggests opening a session with libretto-cli open <url> --session open.',
+      'Explains that session "open" does not exist, no active sessions are available, and suggests opening a session with libretto open <url> --session open.',
     );
   });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -58,7 +58,7 @@ const cliEntry = resolve(packageRoot, "dist/cli/index.js");
 const librettoEntry = resolve(packageRoot, "dist/index.js");
 const librettoRuntimePath = new URL("../dist/index.js", import.meta.url)
   .href;
-const DETERMINISTIC_WORKSPACE_ROOT = join(tmpdir(), "libretto-cli-test-workspaces");
+const DETERMINISTIC_WORKSPACE_ROOT = join(tmpdir(), "libretto-test-workspaces");
 const EVALUATE_MODEL = "local-evaluate-v1";
 
 let didBuild = false;
@@ -223,7 +223,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
     check: (actual) =>
       runChecks(
         actual,
-        requireIncludes(actual, "Usage: libretto-cli <command>"),
+        requireIncludes(actual, "Usage: libretto <command>"),
         requireIncludes(actual, "snapshot"),
         requireIncludes(actual, "Capture PNG + HTML"),
       ),
@@ -233,7 +233,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
     check: (actual) =>
       runChecks(
         actual,
-        requireIncludes(actual, "Usage: libretto-cli <command>"),
+        requireIncludes(actual, "Usage: libretto <command>"),
         requireIncludes(actual, "Commands:"),
         requireIncludes(actual, "open"),
         requireIncludes(actual, "ai"),
@@ -269,7 +269,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
   {
     pattern: /^Shows usage for exec command requiring code with optional session and visualize flags\.$/,
     check: (actual) =>
-      requireIncludes(actual, "Usage: libretto-cli exec <code> [--session <name>] [--visualize]"),
+      requireIncludes(actual, "Usage: libretto exec <code> [--session <name>] [--visualize]"),
   },
   {
     pattern: /^Explains that the integration file does not exist and mentions the integration\.ts path\.$/,
@@ -377,13 +377,13 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
       ),
   },
   {
-    pattern: /^Explains that session "([^"]+)" does not exist, no active sessions are available, and suggests opening a session with libretto-cli open <url> --session ([^".]+)\.$/,
+    pattern: /^Explains that session "([^"]+)" does not exist, no active sessions are available, and suggests opening a session with libretto open <url> --session ([^".]+)\.$/,
     check: (actual, match) =>
       runChecks(
         actual,
         requireIncludes(actual, `No session "${match[1]!}" found.`),
         requireIncludes(actual, "No active sessions."),
-        requireIncludes(actual, `libretto-cli open <url> --session ${match[2]!}`),
+        requireIncludes(actual, `libretto open <url> --session ${match[2]!}`),
       ),
   },
   {
@@ -426,7 +426,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
       runChecks(
         actual,
         requireIncludes(actual, `Session "${match[1]!}" is already open and connected to`),
-        requireIncludes(actual, `libretto-cli close --session ${match[1]!}`),
+        requireIncludes(actual, `libretto close --session ${match[1]!}`),
       ),
   },
   {
@@ -439,13 +439,13 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
       ),
   },
   {
-    pattern: /^Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto-cli open <url> --session default"\.$/,
+    pattern: /^Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto open <url> --session default"\.$/,
     check: (actual) =>
       runChecks(
         actual,
         requireIncludes(actual, 'No session "default" found.'),
         requireIncludes(actual, "No active sessions."),
-        requireIncludes(actual, "libretto-cli open <url> --session default"),
+        requireIncludes(actual, "libretto open <url> --session default"),
       ),
   },
   {
@@ -454,7 +454,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
       runChecks(
         actual,
         requireIncludes(actual, `Session "${match[1]!}" is already open and connected to`),
-        requireIncludes(actual, `libretto-cli close --session ${match[1]!}`),
+        requireIncludes(actual, `libretto close --session ${match[1]!}`),
       ),
   },
 ];

--- a/test/multi-session.spec.ts
+++ b/test/multi-session.spec.ts
@@ -88,7 +88,7 @@ export const main = workflow({}, async () => {
   }) => {
     const result = await librettoCli(`exec "return 1"`);
     await evaluate(result.stderr).toMatch(
-      'Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto-cli open <url> --session default".',
+      'Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto open <url> --session default".',
     );
   });
 
@@ -98,7 +98,7 @@ export const main = workflow({}, async () => {
   }) => {
     const result = await librettoCli("exec await page.title()");
     await evaluate(result.stderr).toMatch(
-      'Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto-cli open <url> --session default".',
+      'Explains that the default session is missing, that no active sessions exist, and suggests starting one with "libretto open <url> --session default".',
     );
     expect(result.stderr).not.toContain("Unexpected arguments for exec.");
   });

--- a/test/simple-cli-framework.spec.ts
+++ b/test/simple-cli-framework.spec.ts
@@ -397,16 +397,16 @@ describe("SimpleCLI framework", () => {
         headless: SimpleCLI.flag(),
       },
     })
-      .refine((input) => Boolean(input.url), "Usage: libretto-cli open <url>")
+      .refine((input) => Boolean(input.url), "Usage: libretto open <url>")
       .refine((input) => !(input.headed && input.headless), "Cannot pass both --headed and --headless.");
 
-    const app = SimpleCLI.define("libretto-cli", {
+    const app = SimpleCLI.define("libretto", {
       open: SimpleCLI.command({ description: "open" })
         .input(openInput)
         .handle(async () => {}),
     });
 
-    await expect(app.run(["open"])).rejects.toThrow("Usage: libretto-cli open <url>");
+    await expect(app.run(["open"])).rejects.toThrow("Usage: libretto open <url>");
     await expect(app.run(["open", "https://example.com", "--headed", "--headless"])).rejects.toThrow(
       "Cannot pass both --headed and --headless.",
     );
@@ -414,7 +414,7 @@ describe("SimpleCLI framework", () => {
 
   test("renders root and group help from route paths and descriptions", async () => {
     const noInput = SimpleCLI.input({ positionals: [], named: {} });
-    const app = SimpleCLI.define("libretto-cli", {
+    const app = SimpleCLI.define("libretto", {
       ai: SimpleCLI.group({
         description: "AI commands",
         routes: {
@@ -433,7 +433,7 @@ describe("SimpleCLI framework", () => {
     const rootHelp = await app.run(["help"]);
     expect(rootHelp).toBe(
       [
-        "Usage: libretto-cli <command>",
+        "Usage: libretto <command>",
         "",
         "Commands:",
         "  ai <subcommand>  AI commands",
@@ -446,7 +446,7 @@ describe("SimpleCLI framework", () => {
       [
         "AI commands",
         "",
-        "Usage: libretto-cli ai <subcommand>",
+        "Usage: libretto ai <subcommand>",
         "",
         "Commands:",
         "  configure  Configure AI runtime",
@@ -473,7 +473,7 @@ describe("SimpleCLI framework", () => {
       },
     });
 
-    const app = SimpleCLI.define("libretto-cli", {
+    const app = SimpleCLI.define("libretto", {
       ai: SimpleCLI.group({
         description: "AI commands",
         routes: {
@@ -491,7 +491,7 @@ describe("SimpleCLI framework", () => {
       [
         "Configure AI runtime",
         "",
-        "Usage: libretto-cli ai configure [preset] [options]",
+        "Usage: libretto ai configure [preset] [options]",
         "",
         "Arguments:",
         "  [preset]  AI preset",

--- a/test/stateful.spec.ts
+++ b/test/stateful.spec.ts
@@ -169,7 +169,7 @@ describe("state-driven CLI subprocess behavior", () => {
       `Session "${session}" is already open and connected to`,
     );
     expect(secondOpen.stderr).toContain(
-      `libretto-cli close --session ${session}`,
+      `libretto close --session ${session}`,
     );
   }, 45_000);
 
@@ -182,7 +182,7 @@ describe("state-driven CLI subprocess behavior", () => {
 
     expect(result.stdout).toBe("");
     await evaluate(result.stderr).toMatch(
-      'Explains that session "missing-session" does not exist, no active sessions are available, and suggests opening a session with libretto-cli open <url> --session missing-session.',
+      'Explains that session "missing-session" does not exist, no active sessions are available, and suggests opening a session with libretto open <url> --session missing-session.',
     );
     expect(result.stderr.trimEnd().split("\n")).toEqual([
       `No session "${session}" found.`,
@@ -190,7 +190,7 @@ describe("state-driven CLI subprocess behavior", () => {
       "No active sessions.",
       "",
       "Start one with:",
-      `  libretto-cli open <url> --session ${session}`,
+      `  libretto open <url> --session ${session}`,
     ]);
   });
 
@@ -215,7 +215,7 @@ describe("state-driven CLI subprocess behavior", () => {
     librettoCli,
   }) => {
     const result = await librettoCli("close --force");
-    expect(result.stderr).toContain("Usage: libretto-cli close --all [--force]");
+    expect(result.stderr).toContain("Usage: libretto close --all [--force]");
   });
 
   test("close --all closes active sessions", async ({


### PR DESCRIPTION
## Summary
- replace `libretto-cli` with `libretto` across CLI help text, recovery messages, tests, specs, and benchmark references
- update the CLI router and related assertions to render `libretto` directly
- remove the extra `libretto-cli` bin alias so package metadata matches the renamed command

## Verification
- `pnpm type-check`
- `pnpm test -- test/basic.spec.ts test/multi-session.spec.ts test/stateful.spec.ts test/simple-cli-framework.spec.ts`
