### PR TITLE
Require snapshot context in skill docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {

--- a/skills/libretto/SKILL.md
+++ b/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for inspecting live pages, prototyping inte
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Libretto
@@ -59,13 +59,15 @@ npx libretto exec --visualize "await page.locator('button:has-text(\"Continue\")
 ### `snapshot`
 
 - Use `snapshot` as the primary page observation tool.
-- Provide `--objective` unless you intentionally want capture-only output. Add `--context` when the current page state is not obvious.
+- When you want analysis, provide both `--objective` and `--context`.
 - If you only need the PNG and HTML files, omit `--objective`. That runs capture-only mode and skips AI analysis.
 - When using `--objective`, expect analysis to take time. Use a timeout of at least 2 minutes for shell-wrapped calls.
 
 ```bash
 npx libretto snapshot
-npx libretto snapshot --objective "Find the sign-in form and submit button"
+npx libretto snapshot \
+  --objective "Find the sign-in form and submit button" \
+  --context "I just opened the login page and need the email field, password field, and submit button."
 npx libretto snapshot \
   --objective "Explain why the table is empty" \
   --context "I opened the referrals page and expected rows after applying filters."

--- a/skills/libretto/SKILL.md
+++ b/skills/libretto/SKILL.md
@@ -128,7 +128,7 @@ Assistant: I found the relevant requests. I'll recreate the workflow from those 
 Assistant: I'll reproduce the failure first so we can inspect the exact browser state it leaves behind.
 Assistant: [Runs `npx libretto run ./integration.ts main --session debug-flow --headed`]
 Assistant: The workflow failed and Libretto kept the browser open. I'll inspect the page state before changing code.
-Assistant: [Runs `npx libretto snapshot --session debug-flow --objective "Find the blocking error or broken selector target"`]
+Assistant: [Runs `npx libretto snapshot --session debug-flow --objective "Find the blocking error or broken selector target" --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: I found the issue. I'll patch the workflow code, then rerun `npx libretto run ...` to verify the fix.
 </example>


### PR DESCRIPTION
## Summary
- require `--context` alongside `--objective` in analyzed `snapshot` examples and guidance
- bump the package version to `0.5.0`
- bump the Libretto skill metadata version to `0.4.0`

## Verification
- `pnpm type-check`
- `pnpm build`
