### PR TITLE
Default ghost cursor in headed run

### DIFF
--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -498,6 +498,7 @@ async function runIntegrationFromFile(
     session: args.session,
     params: args.params,
     headless: args.headless,
+    visualize: args.visualize,
     authProfileDomain: args.authProfileDomain,
   } satisfies RunIntegrationWorkerRequest);
   const worker = spawn(process.execPath, [
@@ -575,7 +576,7 @@ export function createExecCommand(logger: LoggerApi) {
 }
 
 const runUsage =
-  `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless]`;
+  `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--no-visualize]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [
@@ -600,6 +601,10 @@ export const runInput = SimpleCLI.input({
     }),
     headed: SimpleCLI.flag({ help: "Run in headed mode" }),
     headless: SimpleCLI.flag({ help: "Run in headless mode" }),
+    noVisualize: SimpleCLI.flag({
+      name: "no-visualize",
+      help: "Disable ghost cursor + highlight visualization in headed mode",
+    }),
     authProfile: SimpleCLI.option(z.string().optional(), {
       name: "auth-profile",
       help: "Domain for local auth profile (e.g. apps.example.com)",
@@ -650,6 +655,7 @@ export function createRunCommand(logger: LoggerApi) {
         : input.headless
           ? true
           : undefined;
+      const visualize = !input.noVisualize;
 
       await runIntegrationFromFile({
         integrationPath: input.integrationFile!,
@@ -658,6 +664,7 @@ export function createRunCommand(logger: LoggerApi) {
         params,
         tsconfigPath: input.tsconfig,
         headless: headlessMode ?? false,
+        visualize,
         authProfileDomain: input.authProfile,
       }, logger);
     });

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -1,9 +1,11 @@
+import type { BrowserContext } from "playwright";
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  instrumentContext,
   launchBrowser,
   type LibrettoWorkflowContext,
 } from "../../index.js";
@@ -198,6 +200,24 @@ async function loadWorkflowExport(
   return targetExport;
 }
 
+export async function installHeadedWorkflowVisualization(args: {
+  context: BrowserContext;
+  headless: boolean;
+  visualize?: boolean;
+  logger: LoggerApi;
+  instrument?: typeof instrumentContext;
+}): Promise<boolean> {
+  if (args.headless || args.visualize === false) {
+    return false;
+  }
+
+  await (args.instrument ?? instrumentContext)(args.context, {
+    visualize: true,
+    logger: args.logger,
+  });
+  return true;
+}
+
 async function runIntegrationInternal(
   args: RunIntegrationWorkerRequest,
   options: {
@@ -242,6 +262,12 @@ async function runIntegrationInternal(
     sessionName: args.session,
     headless: args.headless,
     storageStatePath,
+  });
+  await installHeadedWorkflowVisualization({
+    context: browserSession.context,
+    headless: args.headless,
+    visualize: args.visualize,
+    logger: integrationLogger,
   });
   const actionsLogPath = getSessionActionsLogPath(args.session);
   const networkLogPath = getSessionNetworkLogPath(args.session);

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -202,20 +202,13 @@ async function loadWorkflowExport(
 
 export async function installHeadedWorkflowVisualization(args: {
   context: BrowserContext;
-  headless: boolean;
-  visualize?: boolean;
   logger: LoggerApi;
   instrument?: typeof instrumentContext;
-}): Promise<boolean> {
-  if (args.headless || args.visualize === false) {
-    return false;
-  }
-
+}): Promise<void> {
   await (args.instrument ?? instrumentContext)(args.context, {
     visualize: true,
     logger: args.logger,
   });
-  return true;
 }
 
 async function runIntegrationInternal(
@@ -263,12 +256,12 @@ async function runIntegrationInternal(
     headless: args.headless,
     storageStatePath,
   });
-  await installHeadedWorkflowVisualization({
-    context: browserSession.context,
-    headless: args.headless,
-    visualize: args.visualize,
-    logger: integrationLogger,
-  });
+  if (!args.headless && args.visualize !== false) {
+    await installHeadedWorkflowVisualization({
+      context: browserSession.context,
+      logger: integrationLogger,
+    });
+  }
   const actionsLogPath = getSessionActionsLogPath(args.session);
   const networkLogPath = getSessionNetworkLogPath(args.session);
   await installSessionTelemetry({

--- a/src/cli/workers/run-integration-worker-protocol.ts
+++ b/src/cli/workers/run-integration-worker-protocol.ts
@@ -6,6 +6,7 @@ export const RunIntegrationWorkerRequestSchema = z.object({
   session: z.string().min(1),
   params: z.unknown(),
   headless: z.boolean(),
+  visualize: z.boolean().default(true),
   authProfileDomain: z.string().optional(),
 });
 

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -62,6 +62,19 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("prints run help with explicit visualization disable flag", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("help run");
+    expect(result.stdout).toContain("Run an exported Libretto workflow from a file");
+    expect(result.stdout).toContain("Usage: libretto run [integrationFile] [integrationExport] [options]");
+    expect(result.stdout).toContain("--no-visualize");
+    expect(result.stdout).toContain(
+      "Disable ghost cursor + highlight visualization in headed mode",
+    );
+    expect(result.stderr).toBe("");
+  });
+
   test("accepts global --session on non-session commands", async ({
     librettoCli,
     evaluate,

--- a/test/run-integration-runtime.spec.ts
+++ b/test/run-integration-runtime.spec.ts
@@ -30,50 +30,15 @@ describe("installHeadedWorkflowVisualization", () => {
     const context = {} as never;
     const instrument = vi.fn(async () => {});
 
-    const enabled = await installHeadedWorkflowVisualization({
+    await installHeadedWorkflowVisualization({
       context,
-      headless: false,
-      visualize: true,
       logger,
       instrument,
     });
 
-    expect(enabled).toBe(true);
     expect(instrument).toHaveBeenCalledWith(context, {
       visualize: true,
       logger,
     });
-  });
-
-  it("skips visualization for headless runs", async () => {
-    const logger = createLogger();
-    const instrument = vi.fn(async () => {});
-
-    const enabled = await installHeadedWorkflowVisualization({
-      context: {} as never,
-      headless: true,
-      visualize: true,
-      logger,
-      instrument,
-    });
-
-    expect(enabled).toBe(false);
-    expect(instrument).not.toHaveBeenCalled();
-  });
-
-  it("skips visualization when disabled explicitly", async () => {
-    const logger = createLogger();
-    const instrument = vi.fn(async () => {});
-
-    const enabled = await installHeadedWorkflowVisualization({
-      context: {} as never,
-      headless: false,
-      visualize: false,
-      logger,
-      instrument,
-    });
-
-    expect(enabled).toBe(false);
-    expect(instrument).not.toHaveBeenCalled();
   });
 });

--- a/test/run-integration-runtime.spec.ts
+++ b/test/run-integration-runtime.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LoggerApi } from "../src/shared/logger/index.js";
+import {
+  installHeadedWorkflowVisualization,
+} from "../src/cli/workers/run-integration-runtime.js";
+
+function createLogger(): LoggerApi {
+  const logger: LoggerApi = {
+    log() {},
+    info() {},
+    warn() {},
+    error(event, data) {
+      return data instanceof Error ? data : new Error(String(event));
+    },
+    withScope() {
+      return logger;
+    },
+    withContext() {
+      return logger;
+    },
+    async flush() {},
+  };
+
+  return logger;
+}
+
+describe("installHeadedWorkflowVisualization", () => {
+  it("enables visualization for headed runs", async () => {
+    const logger = createLogger();
+    const context = {} as never;
+    const instrument = vi.fn(async () => {});
+
+    const enabled = await installHeadedWorkflowVisualization({
+      context,
+      headless: false,
+      visualize: true,
+      logger,
+      instrument,
+    });
+
+    expect(enabled).toBe(true);
+    expect(instrument).toHaveBeenCalledWith(context, {
+      visualize: true,
+      logger,
+    });
+  });
+
+  it("skips visualization for headless runs", async () => {
+    const logger = createLogger();
+    const instrument = vi.fn(async () => {});
+
+    const enabled = await installHeadedWorkflowVisualization({
+      context: {} as never,
+      headless: true,
+      visualize: true,
+      logger,
+      instrument,
+    });
+
+    expect(enabled).toBe(false);
+    expect(instrument).not.toHaveBeenCalled();
+  });
+
+  it("skips visualization when disabled explicitly", async () => {
+    const logger = createLogger();
+    const instrument = vi.fn(async () => {});
+
+    const enabled = await installHeadedWorkflowVisualization({
+      context: {} as never,
+      headless: false,
+      visualize: false,
+      logger,
+      instrument,
+    });
+
+    expect(enabled).toBe(false);
+    expect(instrument).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- enable ghost cursor visualization by default for headed `libretto run` sessions
- add `libretto run --no-visualize` to disable the visualization explicitly
- add focused CLI help and runtime tests for the new behavior
