### PR TITLE
fix: self-heal stale sessions caused by manual browser close or orphaned workers

### DIFF
--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -8,7 +8,6 @@ import {
   runSave,
 } from "../core/browser.js";
 import { withSessionLogger } from "../core/context.js";
-import { assertSessionAvailableForStart } from "../core/session.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   loadSessionStateMiddleware,
@@ -70,7 +69,6 @@ export function createOpenCommand(logger: LoggerApi) {
     .input(openInput)
     .use(resolveSessionMiddleware)
     .handle(async ({ input, ctx }) => {
-      assertSessionAvailableForStart(ctx.session, logger);
       const headed = input.headed || !input.headless;
       const viewport = parseViewportArg(input.viewport);
       await runOpen(input.url!, headed, ctx.session, logger, { viewport });

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -11,8 +11,8 @@ import {
 } from "../core/browser.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
-  assertSessionAvailableForStart,
   clearSessionState,
+  ensureSessionAvailableForStart,
   readSessionState,
   setSessionStatus,
   type SessionState,
@@ -642,7 +642,7 @@ export function createRunCommand(logger: LoggerApi) {
     .use(resolveSessionMiddleware)
     .handle(async ({ input, ctx }) => {
       await stopExistingFailedRunSession(ctx.session, logger);
-      assertSessionAvailableForStart(ctx.session, logger);
+      await ensureSessionAvailableForStart(ctx.session, logger);
 
       const params = resolveRunParams(input.params, input.paramsFile);
       const headlessMode = input.headed

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -13,8 +13,8 @@ import {
 } from "./context.js";
 import { readLibrettoConfig } from "./ai-config.js";
 import {
-  assertSessionAvailableForStart,
   clearSessionState,
+  ensureSessionAvailableForStart,
   listSessionsWithStateFile,
   readSessionStateOrThrow,
   logFileForSession,
@@ -231,7 +231,17 @@ export async function connect(
       session,
       allPageUrls: allPages.map((p) => p.url()),
     });
-    throw new Error("No pages found.");
+    disconnectBrowser(browser, logger, session);
+    throw new Error(
+      [
+        `Session "${session}" has no open pages.`,
+        "",
+        "This usually happens when the browser window was closed manually.",
+        "To recover, close and re-open the session:",
+        `  libretto close --session ${session}`,
+        `  libretto open <url> --session ${session}`,
+      ].join("\n"),
+    );
   }
 
   if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
@@ -321,7 +331,7 @@ export async function runOpen(
   const url = normalizeUrl(rawUrl);
   const viewport = resolveViewport(options?.viewport, logger);
   logger.info("open-start", { url, headed, session, viewport });
-  assertSessionAvailableForStart(session, logger);
+  await ensureSessionAvailableForStart(session, logger);
 
   const port = await pickFreePort();
   const runLogPath = logFileForSession(session);
@@ -409,6 +419,7 @@ const browser = await chromium.launch({
 
 browser.on('disconnected', () => {
 	childLog('warn', 'browser-disconnected', { port: ${port} });
+	process.exit(0);
 });
 
 const context = await browser.newContext({
@@ -431,6 +442,29 @@ await installSessionTelemetry({
 
 
 await page.goto('${escapedUrl}');
+
+function checkRemainingPages() {
+	const remaining = context.pages().filter(p => {
+		const u = p.url();
+		return !u.startsWith('devtools://') && !u.startsWith('chrome-error://');
+	});
+	if (remaining.length === 0) {
+		childLog('info', 'all-pages-closed', { port: ${port} });
+		browser.close().then(() => process.exit(0)).catch(() => process.exit(1));
+	}
+}
+
+context.on('page', (newPage) => {
+	newPage.on('close', () => {
+		childLog('info', 'page-closed', { url: newPage.url() });
+		setTimeout(checkRemainingPages, 200);
+	});
+});
+
+page.on('close', () => {
+	childLog('info', 'initial-page-closed');
+	setTimeout(checkRemainingPages, 200);
+});
 
 process.on('SIGTERM', async () => {
 	childLog('info', 'child-sigterm');

--- a/src/cli/core/session.ts
+++ b/src/cli/core/session.ts
@@ -178,6 +178,136 @@ function isPidRunning(pid: number): boolean {
   }
 }
 
+export type SessionHealthStatus =
+  | "missing"
+  | "healthy"
+  | "stale-no-process"
+  | "stale-no-browser"
+  | "stale-no-pages";
+
+function isOperationalTarget(target: { type?: string; url?: string }): boolean {
+  return (
+    target.type === "page" &&
+    typeof target.url === "string" &&
+    !target.url.startsWith("devtools://") &&
+    !target.url.startsWith("chrome-error://")
+  );
+}
+
+export async function probeSessionHealth(
+  session: string,
+  logger?: LoggerApi,
+): Promise<{ status: SessionHealthStatus; state: SessionState | null }> {
+  const state = readSessionState(session, logger);
+  if (!state) return { status: "missing", state: null };
+
+  if (!isPidRunning(state.pid)) {
+    return { status: "stale-no-process", state };
+  }
+
+  try {
+    const versionRes = await fetch(
+      `http://127.0.0.1:${state.port}/json/version`,
+      { signal: AbortSignal.timeout(3000) },
+    );
+    if (!versionRes.ok) {
+      return { status: "stale-no-browser", state };
+    }
+  } catch {
+    return { status: "stale-no-browser", state };
+  }
+
+  try {
+    const listRes = await fetch(
+      `http://127.0.0.1:${state.port}/json/list`,
+      { signal: AbortSignal.timeout(3000) },
+    );
+    if (!listRes.ok) {
+      return { status: "stale-no-pages", state };
+    }
+    const targets = (await listRes.json()) as Array<{
+      type?: string;
+      url?: string;
+    }>;
+    const hasOperational = targets.some(isOperationalTarget);
+    return {
+      status: hasOperational ? "healthy" : "stale-no-pages",
+      state,
+    };
+  } catch {
+    return { status: "stale-no-pages", state };
+  }
+}
+
+export async function reclaimStaleSession(
+  session: string,
+  logger?: LoggerApi,
+): Promise<void> {
+  const state = readSessionState(session, logger);
+  if (!state) return;
+
+  logger?.info("session-reclaim-start", {
+    session,
+    pid: state.pid,
+    port: state.port,
+  });
+
+  if (isPidRunning(state.pid)) {
+    try {
+      process.kill(state.pid, "SIGTERM");
+    } catch {}
+    const deadline = Date.now() + 2000;
+    while (isPidRunning(state.pid) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (isPidRunning(state.pid)) {
+      try {
+        process.kill(state.pid, "SIGKILL");
+      } catch {}
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  }
+
+  clearSessionState(session, logger);
+  logger?.info("session-reclaim-complete", { session });
+}
+
+export async function ensureSessionAvailableForStart(
+  session: string,
+  logger?: LoggerApi,
+): Promise<void> {
+  const { status, state } = await probeSessionHealth(session, logger);
+
+  if (status === "missing") return;
+
+  if (status === "stale-no-process") {
+    logger?.info("session-reclaim-dead-process", {
+      session,
+      pid: state!.pid,
+    });
+    clearSessionState(session, logger);
+    return;
+  }
+
+  if (status === "stale-no-browser" || status === "stale-no-pages") {
+    logger?.info("session-reclaim-stale", {
+      session,
+      status,
+      pid: state!.pid,
+    });
+    console.log(
+      `Reclaiming stale session "${session}" (${status === "stale-no-browser" ? "browser unreachable" : "no open pages"}).`,
+    );
+    await reclaimStaleSession(session, logger);
+    return;
+  }
+
+  const endpoint = `http://127.0.0.1:${state!.port}`;
+  throw new Error(
+    `Session "${session}" is already open and connected to ${endpoint} (pid ${state!.pid}). Create a new session or close the current one with: libretto close --session ${session}`,
+  );
+}
+
 export function setSessionStatus(
   session: string,
   status: SessionStatus,

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -17,6 +17,7 @@ import {
   getSessionStatePath,
 } from "../core/context.js";
 import { getPauseSignalPaths, removeSignalIfExists } from "../core/pause-signals.js";
+import { clearSessionState } from "../core/session.js";
 import { installSessionTelemetry } from "../core/session-telemetry.js";
 import type { RunIntegrationWorkerRequest } from "./run-integration-worker-protocol.js";
 
@@ -281,11 +282,33 @@ async function runIntegrationInternal(
         ),
         "utf8",
       );
-      await waitForFailureSessionRelease({
-        session: args.session,
-        expectedPid: process.pid,
-        logger,
+
+      const browserDisconnected = new Promise<"disconnected">((resolve) => {
+        if (!browserSession.browser.isConnected()) {
+          resolve("disconnected");
+          return;
+        }
+        browserSession.browser.on("disconnected", () =>
+          resolve("disconnected"),
+        );
       });
+
+      const releaseReason = await Promise.race([
+        waitForFailureSessionRelease({
+          session: args.session,
+          expectedPid: process.pid,
+          logger,
+        }).then(() => "released" as const),
+        browserDisconnected,
+      ]);
+
+      if (releaseReason === "disconnected") {
+        logger.info("run-failure-browser-disconnected", {
+          session: args.session,
+        });
+        clearSessionState(args.session, logger);
+      }
+
       return { status: "failed-held" };
     }
     await writeFile(

--- a/test/stateful.spec.ts
+++ b/test/stateful.spec.ts
@@ -284,4 +284,98 @@ describe("state-driven CLI subprocess behavior", () => {
     const clear = await librettoCli(`actions --session ${session} --clear`);
     expect(clear.stdout).toContain("Action log cleared.");
   }, 60_000);
+
+  test("open self-heals when session state references a dead process", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    const session = "stale-dead-pid";
+    await seedSessionState({
+      session,
+      pid: 999999,
+      port: 19222,
+    });
+
+    const result = await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
+    expect(result.stdout).toContain("Browser open");
+    expect(result.stdout).toContain("example.com");
+    expect(result.stderr).toBe("");
+  }, 45_000);
+
+  test("run self-heals when session state references a dead process", async ({
+    librettoCli,
+    seedSessionState,
+    writeWorkflow,
+  }) => {
+    const session = "stale-dead-pid-run";
+    await seedSessionState({
+      session,
+      pid: 999999,
+      port: 19222,
+    });
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-stale-run.mjs",
+      `
+export const main = workflow({}, async () => {
+  console.log("STALE_RUN_OK");
+});
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" main --session ${session} --headless`,
+    );
+    expect(result.stdout).toContain("STALE_RUN_OK");
+    expect(result.stdout).toContain("Integration completed.");
+    expect(result.stderr).toBe("");
+  }, 45_000);
+
+  test("exec shows stale-session guidance when session has no open pages", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    const session = "stale-no-pages-exec";
+    await seedSessionState({
+      session,
+      pid: 999999,
+      port: 19222,
+    });
+
+    const result = await librettoCli(
+      `exec "return 1" --session ${session}`,
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      `No browser running for session "${session}".`,
+    );
+    expect(result.stderr).toContain(
+      `libretto open <url> --session ${session}`,
+    );
+  });
+
+  test("snapshot shows stale-session guidance when session has no open pages", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    const session = "stale-no-pages-snapshot";
+    await seedSessionState({
+      session,
+      pid: 999999,
+      port: 19222,
+    });
+
+    const result = await librettoCli(
+      `snapshot --session ${session}`,
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      `No browser running for session "${session}".`,
+    );
+    expect(result.stderr).toContain(
+      `libretto open <url> --session ${session}`,
+    );
+  });
 });


### PR DESCRIPTION
## Problem

When a user manually closes the browser window (or a run worker's browser disconnects), Libretto leaves stale session state behind. Subsequent `open` or `run` commands hit a collision error ("session is already open") even though the session is dead. The open child process hangs forever via `await new Promise(() => {})`, and failed run workers wait indefinitely for session release even after the browser is gone.

## Solution

### 1. Central session health probe (`session.ts`)

New `probeSessionHealth()` function classifies sessions using lightweight CDP HTTP checks (`/json/version` + `/json/list`):

| Status | Meaning |
|--------|---------|
| `missing` | No session state file |
| `healthy` | PID alive, browser reachable, has operational pages |
| `stale-no-process` | PID not running |
| `stale-no-browser` | PID alive but CDP unreachable |
| `stale-no-pages` | CDP reachable but no operational pages |

New `ensureSessionAvailableForStart()` replaces the sync `assertSessionAvailableForStart` for `open` and `run` commands — stale sessions are automatically reclaimed (SIGTERM → SIGKILL → clear state), healthy sessions keep the existing collision error.

### 2. Improved live-session errors (`browser.ts`)

`connect()` now returns multi-line stale-session guidance instead of the bare "No pages found." error:
```
Session "X" has no open pages.

This usually happens when the browser window was closed manually.
To recover, close and re-open the session:
  libretto close --session X
  libretto open <url> --session X
```

### 3. Owner-side cleanup

- **Open child**: `browser.on('disconnected')` now calls `process.exit(0)` instead of hanging. Added page-close monitoring — when the last operational page closes, the child gracefully exits.
- **Failed run worker**: Races `waitForFailureSessionRelease` against `browser.on('disconnected')`. On browser disconnect, clears session state and exits the hold.

### 4. Tests

5 new tests in `test/stateful.spec.ts`:
- `open` self-heals with dead-PID stale state
- `run` self-heals with dead-PID stale state
- `exec` on dead session shows clear recovery guidance
- `snapshot` on dead session shows clear recovery guidance
