### PR TITLE
Report eval results in PR comments

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -9,7 +9,6 @@ on:
       - "package.json"
       - "evals/**"
       - "scripts/summarize-evals.mjs"
-      - "scripts/compare-eval-summary.mjs"
       - ".github/workflows/evals.yml"
   pull_request:
     branches:
@@ -23,6 +22,7 @@ on:
 permissions:
   contents: read
   actions: read
+  issues: write
 
 jobs:
   evals:
@@ -65,6 +65,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           LIBRETTO_EVAL_SCORE_DIR: ${{ runner.temp }}/eval-scores
+          LIBRETTO_EVAL_STRICT: "false"
         run: |
           mkdir -p "${LIBRETTO_EVAL_SCORE_DIR}"
           pnpm eval
@@ -87,58 +88,63 @@ jobs:
             ${{ runner.temp }}/eval-summary.json
             ${{ runner.temp }}/eval-summary.md
 
-      - name: Download baseline eval summary
-        id: baseline
+      - name: Post sticky eval summary comment
         if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          run_id="$(
-            gh run list \
-              --workflow evals.yml \
-              --branch main \
-              --event push \
-              --status success \
-              --limit 20 \
-              --json databaseId \
-              --jq '.[0].databaseId // ""'
-          )"
-
-          if [ -z "$run_id" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No successful main-branch eval baseline found." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          mkdir -p "${RUNNER_TEMP}/baseline-eval"
-          gh run download "$run_id" --name eval-summary --dir "${RUNNER_TEMP}/baseline-eval"
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
-
-      - name: Compare against baseline
-        id: compare
-        if: always() && github.event_name == 'pull_request' && steps.baseline.outputs.found == 'true'
         continue-on-error: true
-        run: |
-          node scripts/compare-eval-summary.mjs \
-            "${RUNNER_TEMP}/baseline-eval/eval-summary.json" \
-            "${RUNNER_TEMP}/eval-summary.json" \
-            5 \
-            > "${RUNNER_TEMP}/eval-comparison.md"
-          cat "${RUNNER_TEMP}/eval-comparison.md" >> "$GITHUB_STEP_SUMMARY"
+        uses: actions/github-script@v7
+        env:
+          EVAL_SUMMARY_PATH: ${{ runner.temp }}/eval-summary.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- libretto-eval-results -->";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.pull_request.number;
+            const summary = fs.readFileSync(process.env.EVAL_SUMMARY_PATH, "utf8").trim();
+            const body = [
+              marker,
+              "# Eval Report",
+              "",
+              `Run: ${process.env.RUN_URL}`,
+              "",
+              summary,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments
+              .filter((comment) => (comment.body ?? "").startsWith(marker))
+              .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))[0];
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
 
       - name: Enforce eval success
         if: always()
         run: |
           if [ "${{ steps.run_evals.outcome }}" != "success" ]; then
-            echo "Eval run failed." >&2
-            exit 1
-          fi
-
-          if [ "${{ github.event_name }}" = "pull_request" ] && \
-             [ "${{ steps.baseline.outputs.found }}" = "true" ] && \
-             [ "${{ steps.compare.outcome }}" != "success" ]; then
-            echo "Eval score drift exceeded the allowed +/-5% range." >&2
+            echo "Eval run failed. See logs and the eval summary for details." >&2
             exit 1
           fi

--- a/evals/scoring.ts
+++ b/evals/scoring.ts
@@ -1,13 +1,16 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { TranscriptScore } from "./harness.js";
+import type { ScoredCriterion, TranscriptScore } from "./harness.js";
 
-type EvalScoreRecord = {
+type EvalFailureRecord = Pick<ScoredCriterion, "criterion" | "reason">;
+
+export type EvalScoreRecord = {
   name: string;
   passed: number;
   total: number;
   percent: number;
+  failures: EvalFailureRecord[];
 };
 
 function getScoreDir(): string | null {
@@ -23,12 +26,24 @@ function toRecord(name: string, score: TranscriptScore): EvalScoreRecord {
     passed: score.passed,
     total: score.total,
     percent: score.percent,
+    failures: score.criteria
+      .filter((criterion) => !criterion.pass)
+      .map(({ criterion, reason }) => ({ criterion, reason })),
   };
 }
 
-export function recordScore(name: string, score: TranscriptScore): void {
+function shouldEnforcePerfectScore(): boolean {
+  const value = process.env.LIBRETTO_EVAL_STRICT;
+  if (value === undefined) return true;
+
+  const normalized = value.trim().toLowerCase();
+  return !["0", "false", "no", "off"].includes(normalized);
+}
+
+export function recordScore(name: string, score: TranscriptScore): EvalScoreRecord {
+  const record = toRecord(name, score);
   const scoreDir = getScoreDir();
-  if (!scoreDir) return;
+  if (!scoreDir) return record;
 
   mkdirSync(scoreDir, { recursive: true });
 
@@ -39,24 +54,30 @@ export function recordScore(name: string, score: TranscriptScore): void {
 
   writeFileSync(
     join(scoreDir, `${stableId}.json`),
-    `${JSON.stringify(toRecord(name, score), null, 2)}\n`,
+    `${JSON.stringify(record, null, 2)}\n`,
     "utf8",
   );
+
+  return record;
 }
 
-export function assertPerfectScore(name: string, score: TranscriptScore): void {
-  recordScore(name, score);
+export function assertPerfectScore(name: string, score: TranscriptScore): EvalScoreRecord {
+  const record = recordScore(name, score);
 
-  const failures = score.criteria
-    .filter((criterion) => !criterion.pass)
-    .map((criterion) => `- ${criterion.criterion}: ${criterion.reason}`);
+  if (!shouldEnforcePerfectScore()) {
+    return record;
+  }
 
-  if (score.percent === 100 && failures.length === 0) return;
+  if (record.percent === 100 && record.failures.length === 0) {
+    return record;
+  }
 
   throw new Error(
     [
-      `Expected 100% score, got ${score.percent}%.`,
-      failures.length > 0 ? failures.join("\n") : "No failed criteria were returned.",
+      `Expected 100% score, got ${record.percent}%.`,
+      record.failures.length > 0
+        ? record.failures.map((failure) => `- ${failure.criterion}: ${failure.reason}`).join("\n")
+        : "No failed criteria were returned.",
     ].join("\n"),
   );
 }

--- a/scripts/summarize-evals.mjs
+++ b/scripts/summarize-evals.mjs
@@ -2,55 +2,112 @@
 
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 function usage() {
   console.error("Usage: node scripts/summarize-evals.mjs <score-dir> <summary-json-path>");
 }
 
-const [, , scoreDirArg, summaryPathArg] = process.argv;
-
-if (!scoreDirArg || !summaryPathArg) {
-  usage();
-  process.exit(1);
+function normalizeFailureRecord(failure) {
+  return {
+    criterion: String(failure?.criterion ?? "").trim(),
+    reason: String(failure?.reason ?? "").trim(),
+  };
 }
 
-const scoreDir = resolve(scoreDirArg);
-const summaryPath = resolve(summaryPathArg);
+function normalizeRecord(record) {
+  const failures = Array.isArray(record?.failures)
+    ? record.failures
+      .map(normalizeFailureRecord)
+      .filter((failure) => failure.criterion.length > 0 && failure.reason.length > 0)
+    : [];
 
-const records = readdirSync(scoreDir, { withFileTypes: true })
-  .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-  .map((entry) => JSON.parse(readFileSync(join(scoreDir, entry.name), "utf8")))
-  .sort((a, b) => String(a.name).localeCompare(String(b.name)));
+  return {
+    name: String(record?.name ?? "").trim(),
+    passed: Number(record?.passed ?? 0),
+    total: Number(record?.total ?? 0),
+    percent: Number(record?.percent ?? 0),
+    failures,
+  };
+}
 
-const passed = records.reduce((sum, record) => sum + Number(record.passed || 0), 0);
-const total = records.reduce((sum, record) => sum + Number(record.total || 0), 0);
-const percent = total > 0 ? Number(((passed / total) * 100).toFixed(2)) : 0;
+export function loadScoreRecords(scoreDirArg) {
+  const scoreDir = resolve(scoreDirArg);
+  return readdirSync(scoreDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => JSON.parse(readFileSync(join(scoreDir, entry.name), "utf8")))
+    .map(normalizeRecord)
+    .sort((a, b) => String(a.name).localeCompare(String(b.name)));
+}
 
-const summary = {
-  generatedAt: new Date().toISOString(),
-  recordCount: records.length,
-  passed,
-  total,
-  percent,
-  records,
-};
+export function buildSummary(records) {
+  const passed = records.reduce((sum, record) => sum + Number(record.passed || 0), 0);
+  const total = records.reduce((sum, record) => sum + Number(record.total || 0), 0);
+  const percent = total > 0 ? Number(((passed / total) * 100).toFixed(2)) : 0;
+  const failingRecords = records.filter((record) => record.failures.length > 0);
 
-writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  return {
+    generatedAt: new Date().toISOString(),
+    recordCount: records.length,
+    passed,
+    total,
+    percent,
+    failingRecordCount: failingRecords.length,
+    records,
+  };
+}
 
-const lines = [
-  "# Eval Summary",
-  "",
-  `- Overall score: \`${summary.percent}%\``,
-  `- Passed criteria: \`${summary.passed}/${summary.total}\``,
-  `- Recorded score entries: \`${summary.recordCount}\``,
-  `- Summary file: \`${basename(summaryPath)}\``,
-];
+export function buildMarkdown(summary, summaryPathArg) {
+  const lines = [
+    "# Eval Summary",
+    "",
+    `- Overall score: \`${summary.percent}%\``,
+    `- Passed criteria: \`${summary.passed}/${summary.total}\``,
+    `- Recorded score entries: \`${summary.recordCount}\``,
+    `- Failed evals: \`${summary.failingRecordCount}\``,
+    `- Summary file: \`${basename(summaryPathArg)}\``,
+  ];
 
-if (records.length > 0) {
-  lines.push("", "## Breakdown", "");
-  for (const record of records) {
-    lines.push(`- \`${record.name}\`: \`${record.percent}%\` (${record.passed}/${record.total})`);
+  if (summary.records.length > 0) {
+    lines.push("", "## Breakdown", "");
+    for (const record of summary.records) {
+      const status = record.failures.length > 0 ? "fail" : "pass";
+      lines.push(`- ${status} \`${record.name}\`: \`${record.percent}%\` (${record.passed}/${record.total})`);
+    }
   }
+
+  if (summary.failingRecordCount > 0) {
+    lines.push("", "## Failed Evals", "");
+    for (const record of summary.records.filter((candidate) => candidate.failures.length > 0)) {
+      lines.push(`### \`${record.name}\``);
+      lines.push("");
+      lines.push(`- Score: \`${record.percent}%\` (${record.passed}/${record.total})`);
+      for (const failure of record.failures) {
+        lines.push(`- ${failure.criterion}: ${failure.reason}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
 }
 
-process.stdout.write(`${lines.join("\n")}\n`);
+function main(argv) {
+  const [, , scoreDirArg, summaryPathArg] = argv;
+
+  if (!scoreDirArg || !summaryPathArg) {
+    usage();
+    process.exit(1);
+  }
+
+  const summaryPath = resolve(summaryPathArg);
+  const records = loadScoreRecords(scoreDirArg);
+  const summary = buildSummary(records);
+
+  writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  process.stdout.write(buildMarkdown(summary, summaryPath));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv);
+}

--- a/test/eval-summary.spec.ts
+++ b/test/eval-summary.spec.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { assertPerfectScore } from "../evals/scoring.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  delete process.env.LIBRETTO_EVAL_STRICT;
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("eval summary scripts", () => {
+  test("summary reports aggregate score and failed eval details", async () => {
+    // @ts-expect-error -- helper is authored as plain .mjs
+    const { buildSummary, buildMarkdown, loadScoreRecords } = await import("../scripts/summarize-evals.mjs");
+    const tempRoot = await mkdtemp(join(tmpdir(), "libretto-eval-summary-"));
+    tempRoots.push(tempRoot);
+
+    await writeFile(
+      join(tempRoot, "passing.json"),
+      JSON.stringify({
+        name: "passing eval",
+        passed: 10,
+        total: 10,
+        percent: 100,
+        failures: [],
+      }),
+      "utf8",
+    );
+    await writeFile(
+      join(tempRoot, "failing.json"),
+      JSON.stringify({
+        name: "noisy eval",
+        passed: 3,
+        total: 4,
+        percent: 75,
+        failures: [
+          {
+            criterion: "The rerun produced useful output.",
+            reason: "Only a success banner was shown.",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const records = loadScoreRecords(tempRoot);
+    const summary = buildSummary(records);
+    const markdown = buildMarkdown(summary, join(tempRoot, "eval-summary.json"));
+
+    expect(summary.percent).toBe(92.86);
+    expect(summary.failingRecordCount).toBe(1);
+    expect(markdown).toContain("Overall score: `92.86%`");
+    expect(markdown).toContain("### `noisy eval`");
+    expect(markdown).toContain("The rerun produced useful output.: Only a success banner was shown.");
+  });
+
+  test("assertPerfectScore throws by default for local strict runs", () => {
+    delete process.env.LIBRETTO_EVAL_STRICT;
+
+    expect(() =>
+      assertPerfectScore("strict eval", {
+        passed: 3,
+        total: 4,
+        percent: 75,
+        criteria: [
+          {
+            criterion: "The assistant did the thing.",
+            pass: false,
+            reason: "Evidence was incomplete.",
+          },
+        ],
+      }),
+    ).toThrowError("Expected 100% score, got 75%.");
+  });
+
+  test("assertPerfectScore records but does not throw when strict mode is disabled", () => {
+    process.env.LIBRETTO_EVAL_STRICT = "false";
+
+    expect(() =>
+      assertPerfectScore("non-strict eval", {
+        passed: 3,
+        total: 4,
+        percent: 75,
+        criteria: [
+          {
+            criterion: "The assistant did the thing.",
+            pass: false,
+            reason: "Evidence was incomplete.",
+          },
+        ],
+      }),
+    ).not.toThrow();
+
+    delete process.env.LIBRETTO_EVAL_STRICT;
+  });
+});


### PR DESCRIPTION
## Summary
- switch eval CI from score gating to summary reporting with a sticky PR comment
- keep `pnpm eval` strict by default locally, but disable strict score throws in GitHub Actions
- include failed criteria in the generated eval summary and cover the behavior with focused tests

## Verification
- `pnpm type-check`
- `pnpm test -- test/eval-summary.spec.ts`
