### PR TITLE
Restore Libretto skill security preflight guidance

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.0"
+  version: "0.4.1"
 ---
 
 # Libretto
@@ -21,6 +21,7 @@ Use `npx libretto` to build or debug automations by inspecting live browser stat
 - For a new automation, make the workflow file a required deliverable before you finish the task, even if you inspect the site first.
 - If the user does not provide a workflow path, choose a reasonable filename in the current workspace and create it yourself.
 - When building a new integration, prefer reverse-engineering network requests first. Fall back to browser automation when the request path is unclear, too fragile, or blocked by anti-bot systems.
+- Before replaying captured requests, run the security preflight in `references/reverse-engineering-network-requests.md` to assess whether direct browser `fetch` is safe to try.
 
 ## Setup
 
@@ -109,8 +110,8 @@ Assistant: I'll inspect the real site first if needed, but before I finish I'll 
 Assistant: [Runs `npx libretto open https://target.example.com --headed`]
 Assistant: I'll first determine whether this flow can be built from captured network requests instead of UI-only automation.
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page."`]
-Assistant: If the page exposes a clear and stable request path, I'll prioritize that. If the request path is unclear, fragile, or heavily defended, I'll fall back to browser automation.
-Assistant: [Uses `network`, `snapshot`, and `exec` as needed to prove the approach]
+Assistant: I'll inspect the site's request path and security posture before deciding whether direct request replay is safe.
+Assistant: [Uses `network`, `actions`, `snapshot`, and `exec` as needed to produce a site assessment]
 Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
 </example>
 ```

--- a/.agents/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/.agents/skills/libretto/references/reverse-engineering-network-requests.md
@@ -102,7 +102,18 @@ npx libretto exec "return await page.evaluate(() => ({
 }))"
 npx libretto exec "return await page.evaluate(() => ({
   fetchSource: window.fetch.toString(),
-  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchDescriptor: (() => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'fetch');
+    return descriptor
+      ? {
+          writable: descriptor.writable ?? null,
+          enumerable: descriptor.enumerable ?? null,
+          configurable: descriptor.configurable ?? null,
+          hasGetter: typeof descriptor.get === 'function',
+          hasSetter: typeof descriptor.set === 'function',
+        }
+      : null;
+  })(),
   fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
   xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
 }))"

--- a/.agents/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/.agents/skills/libretto/references/reverse-engineering-network-requests.md
@@ -18,6 +18,28 @@ This is the default approach for new integrations when the site exposes a clear 
 - Prefer passive capture plus UI automation when the site appears to wrap `fetch`, shows challenge pages or other bot-protection signals, or only exposes useful requests through normal page interaction.
 - Fall back to DOM extraction when the page is server-rendered or the captured responses are not usable.
 
+## Security Preflight
+
+Run this preflight before replaying captured requests. The goal is to separate what looks safe from what merely looks possible.
+
+### Probe 1: Bot Protection and Challenge Signals
+
+- Check cookies for bot-protection, telemetry, fingerprint, or signed security tokens.
+- Check early-loading scripts and globals for third-party protection services or custom telemetry.
+- Check whether the page is showing a challenge, interstitial, CAPTCHA, or other pre-app state.
+
+### Probe 2: Fetch and XHR Interception
+
+- Check whether `window.fetch` looks native or patched.
+- Check whether `XMLHttpRequest.prototype.open` looks native or patched.
+- Treat any sign of wrapping, proxying, or instrumentation as a reason to avoid direct browser `fetch` unless you have no safer option.
+
+### Probe 3: Behavioral Monitoring
+
+- Look for signs that the page is collecting interaction telemetry such as mouse movement, scroll, or keystroke patterns.
+- If direct inspection is limited, infer behavioral monitoring from security scripts, challenge flows, or heavy bot-protection signals.
+- If monitoring appears heavy, prefer passive capture and normal UI interaction over request replay.
+
 ## Common Bot-Protection Signals
 
 These are examples, not a complete checklist.
@@ -34,14 +56,25 @@ These are examples, not a complete checklist.
 - Unknown cookies can still be relevant if they look like telemetry, fingerprint, or signed security tokens.
 - If cookies suggest bot protection, also check for challenge pages, early-loading security scripts, and wrapped `fetch` or XHR APIs before trying direct request replay.
 
+## Decision Guide
+
+| Site profile | Prefer | Why |
+| --- | --- | --- |
+| No clear bot protection and `fetch` looks native | Direct browser `fetch` | Fastest way to replay stable endpoints |
+| `fetch` or XHR appears patched | Passive capture plus UI automation | Avoids suspicious call stacks and wrapped APIs |
+| Bot protection or challenge flow is present | Passive capture plus UI automation | Lowest-risk way to learn the real request path |
+| Responses are opaque, signed, or highly dynamic | Passive capture plus UI automation | Captures what the site actually sends |
+| No usable API surface | DOM extraction | Browser automation is the only reliable path |
+
 ## Workflow
 
 - Open the page in headed mode.
 - Let the user perform the relevant workflow manually.
+- Read the action log to understand the user-visible transition points.
 - Read the network log after the relevant step.
+- Run the security preflight before deciding whether to replay a request directly.
 - Identify the smallest set of requests that actually carries the data or performs the action.
-- Before replaying a request, check whether direct browser `fetch` looks safe to try.
-- Look for challenge pages, obvious bot-protection signals, or wrapped `fetch` and XHR APIs.
+- Produce a short site assessment that distinguishes the safe approaches from the likely working approaches.
 - Confirm with the user before replaying any request that could mutate data.
 - If direct browser `fetch` looks safe, recreate a key request with `page.evaluate(() => fetch(...))`.
 - If direct browser `fetch` is unsafe or does not work, keep using captured responses and UI automation for the triggering steps.
@@ -52,11 +85,27 @@ These are examples, not a complete checklist.
 
 ```bash
 npx libretto open https://target.example.com --headed
+npx libretto actions --source user --last 20
 npx libretto network --last 20
 npx libretto network --method POST --last 20
 npx libretto network --filter 'referral|patient|search'
 npx libretto exec "return await networkLog({ method: 'POST', last: 10 })"
-npx libretto exec "return await page.evaluate(() => ({ fetch: window.fetch.toString(), xhrOpen: XMLHttpRequest.prototype.open.toString() }))"
+npx libretto exec "return await actionLog({ source: 'user', last: 10 })"
+npx libretto exec "return await page.evaluate(() => ({
+  cookies: document.cookie.split(';').map((value) => value.trim()).filter(Boolean),
+  scripts: [...document.scripts].slice(0, 20).map((script) => script.src || 'inline'),
+  globals: {
+    pxAppId: globalThis._pxAppId ?? null,
+    bmak: globalThis.bmak ? 'present' : null,
+    ddjskey: globalThis.ddjskey ?? null,
+  },
+}))"
+npx libretto exec "return await page.evaluate(() => ({
+  fetchSource: window.fetch.toString(),
+  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
+  xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
+}))"
 npx libretto exec "
   return await page.evaluate(async () => {
     const resp = await fetch('/api/example', { method: 'GET' });
@@ -64,6 +113,35 @@ npx libretto exec "
   });
 "
 ```
+
+## Site Assessment Summary
+
+Write the assessment before choosing a replay strategy. Keep it short and concrete.
+
+```text
+## Site Assessment: https://target.example.com
+
+### Bot Detection Profile
+- Enterprise bot protection: none detected | detected with evidence
+- Fetch/XHR interception: native | patched with evidence
+- Behavioral monitoring: none detected | light | heavy with evidence
+- Challenge pages: none | present with evidence
+- Overall security posture: none | low | moderate | high | very high
+
+### API Surface
+- API calls observed: key endpoints or "none observed"
+- Data format: JSON | GraphQL | HTML fragments | other
+- Pagination or sequencing: how the site advances through results or actions
+
+### Safe Approaches
+- page.evaluate(fetch(...)): safe | unsafe with rationale
+- Passive capture from network logs: viable | not viable with rationale
+- DOM extraction: fallback | primary path with rationale
+- Interaction notes: any precautions for login, paging, or side effects
+```
+
+- Do not treat this assessment as the final strategy recommendation.
+- Use it to narrow the safe options, then choose the working path with the user.
 
 ## Notes
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.0"
+  version: "0.4.1"
 ---
 
 # Libretto
@@ -21,6 +21,7 @@ Use `npx libretto` to build or debug automations by inspecting live browser stat
 - For a new automation, make the workflow file a required deliverable before you finish the task, even if you inspect the site first.
 - If the user does not provide a workflow path, choose a reasonable filename in the current workspace and create it yourself.
 - When building a new integration, prefer reverse-engineering network requests first. Fall back to browser automation when the request path is unclear, too fragile, or blocked by anti-bot systems.
+- Before replaying captured requests, run the security preflight in `references/reverse-engineering-network-requests.md` to assess whether direct browser `fetch` is safe to try.
 
 ## Setup
 
@@ -109,8 +110,8 @@ Assistant: I'll inspect the real site first if needed, but before I finish I'll 
 Assistant: [Runs `npx libretto open https://target.example.com --headed`]
 Assistant: I'll first determine whether this flow can be built from captured network requests instead of UI-only automation.
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page."`]
-Assistant: If the page exposes a clear and stable request path, I'll prioritize that. If the request path is unclear, fragile, or heavily defended, I'll fall back to browser automation.
-Assistant: [Uses `network`, `snapshot`, and `exec` as needed to prove the approach]
+Assistant: I'll inspect the site's request path and security posture before deciding whether direct request replay is safe.
+Assistant: [Uses `network`, `actions`, `snapshot`, and `exec` as needed to produce a site assessment]
 Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
 </example>
 ```

--- a/.claude/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/.claude/skills/libretto/references/reverse-engineering-network-requests.md
@@ -102,7 +102,18 @@ npx libretto exec "return await page.evaluate(() => ({
 }))"
 npx libretto exec "return await page.evaluate(() => ({
   fetchSource: window.fetch.toString(),
-  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchDescriptor: (() => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'fetch');
+    return descriptor
+      ? {
+          writable: descriptor.writable ?? null,
+          enumerable: descriptor.enumerable ?? null,
+          configurable: descriptor.configurable ?? null,
+          hasGetter: typeof descriptor.get === 'function',
+          hasSetter: typeof descriptor.set === 'function',
+        }
+      : null;
+  })(),
   fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
   xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
 }))"

--- a/.claude/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/.claude/skills/libretto/references/reverse-engineering-network-requests.md
@@ -18,6 +18,28 @@ This is the default approach for new integrations when the site exposes a clear 
 - Prefer passive capture plus UI automation when the site appears to wrap `fetch`, shows challenge pages or other bot-protection signals, or only exposes useful requests through normal page interaction.
 - Fall back to DOM extraction when the page is server-rendered or the captured responses are not usable.
 
+## Security Preflight
+
+Run this preflight before replaying captured requests. The goal is to separate what looks safe from what merely looks possible.
+
+### Probe 1: Bot Protection and Challenge Signals
+
+- Check cookies for bot-protection, telemetry, fingerprint, or signed security tokens.
+- Check early-loading scripts and globals for third-party protection services or custom telemetry.
+- Check whether the page is showing a challenge, interstitial, CAPTCHA, or other pre-app state.
+
+### Probe 2: Fetch and XHR Interception
+
+- Check whether `window.fetch` looks native or patched.
+- Check whether `XMLHttpRequest.prototype.open` looks native or patched.
+- Treat any sign of wrapping, proxying, or instrumentation as a reason to avoid direct browser `fetch` unless you have no safer option.
+
+### Probe 3: Behavioral Monitoring
+
+- Look for signs that the page is collecting interaction telemetry such as mouse movement, scroll, or keystroke patterns.
+- If direct inspection is limited, infer behavioral monitoring from security scripts, challenge flows, or heavy bot-protection signals.
+- If monitoring appears heavy, prefer passive capture and normal UI interaction over request replay.
+
 ## Common Bot-Protection Signals
 
 These are examples, not a complete checklist.
@@ -34,14 +56,25 @@ These are examples, not a complete checklist.
 - Unknown cookies can still be relevant if they look like telemetry, fingerprint, or signed security tokens.
 - If cookies suggest bot protection, also check for challenge pages, early-loading security scripts, and wrapped `fetch` or XHR APIs before trying direct request replay.
 
+## Decision Guide
+
+| Site profile | Prefer | Why |
+| --- | --- | --- |
+| No clear bot protection and `fetch` looks native | Direct browser `fetch` | Fastest way to replay stable endpoints |
+| `fetch` or XHR appears patched | Passive capture plus UI automation | Avoids suspicious call stacks and wrapped APIs |
+| Bot protection or challenge flow is present | Passive capture plus UI automation | Lowest-risk way to learn the real request path |
+| Responses are opaque, signed, or highly dynamic | Passive capture plus UI automation | Captures what the site actually sends |
+| No usable API surface | DOM extraction | Browser automation is the only reliable path |
+
 ## Workflow
 
 - Open the page in headed mode.
 - Let the user perform the relevant workflow manually.
+- Read the action log to understand the user-visible transition points.
 - Read the network log after the relevant step.
+- Run the security preflight before deciding whether to replay a request directly.
 - Identify the smallest set of requests that actually carries the data or performs the action.
-- Before replaying a request, check whether direct browser `fetch` looks safe to try.
-- Look for challenge pages, obvious bot-protection signals, or wrapped `fetch` and XHR APIs.
+- Produce a short site assessment that distinguishes the safe approaches from the likely working approaches.
 - Confirm with the user before replaying any request that could mutate data.
 - If direct browser `fetch` looks safe, recreate a key request with `page.evaluate(() => fetch(...))`.
 - If direct browser `fetch` is unsafe or does not work, keep using captured responses and UI automation for the triggering steps.
@@ -52,11 +85,27 @@ These are examples, not a complete checklist.
 
 ```bash
 npx libretto open https://target.example.com --headed
+npx libretto actions --source user --last 20
 npx libretto network --last 20
 npx libretto network --method POST --last 20
 npx libretto network --filter 'referral|patient|search'
 npx libretto exec "return await networkLog({ method: 'POST', last: 10 })"
-npx libretto exec "return await page.evaluate(() => ({ fetch: window.fetch.toString(), xhrOpen: XMLHttpRequest.prototype.open.toString() }))"
+npx libretto exec "return await actionLog({ source: 'user', last: 10 })"
+npx libretto exec "return await page.evaluate(() => ({
+  cookies: document.cookie.split(';').map((value) => value.trim()).filter(Boolean),
+  scripts: [...document.scripts].slice(0, 20).map((script) => script.src || 'inline'),
+  globals: {
+    pxAppId: globalThis._pxAppId ?? null,
+    bmak: globalThis.bmak ? 'present' : null,
+    ddjskey: globalThis.ddjskey ?? null,
+  },
+}))"
+npx libretto exec "return await page.evaluate(() => ({
+  fetchSource: window.fetch.toString(),
+  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
+  xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
+}))"
 npx libretto exec "
   return await page.evaluate(async () => {
     const resp = await fetch('/api/example', { method: 'GET' });
@@ -64,6 +113,35 @@ npx libretto exec "
   });
 "
 ```
+
+## Site Assessment Summary
+
+Write the assessment before choosing a replay strategy. Keep it short and concrete.
+
+```text
+## Site Assessment: https://target.example.com
+
+### Bot Detection Profile
+- Enterprise bot protection: none detected | detected with evidence
+- Fetch/XHR interception: native | patched with evidence
+- Behavioral monitoring: none detected | light | heavy with evidence
+- Challenge pages: none | present with evidence
+- Overall security posture: none | low | moderate | high | very high
+
+### API Surface
+- API calls observed: key endpoints or "none observed"
+- Data format: JSON | GraphQL | HTML fragments | other
+- Pagination or sequencing: how the site advances through results or actions
+
+### Safe Approaches
+- page.evaluate(fetch(...)): safe | unsafe with rationale
+- Passive capture from network logs: viable | not viable with rationale
+- DOM extraction: fallback | primary path with rationale
+- Interaction notes: any precautions for login, paging, or side effects
+```
+
+- Do not treat this assessment as the final strategy recommendation.
+- Use it to narrow the safe options, then choose the working path with the user.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.mjs",
+    "sync-skills": "node scripts/sync-skills.mjs",
     "check:skills": "node scripts/check-skills-sync.mjs",
     "build": "tsup --config tsup.config.ts",
     "type-check": "tsc --noEmit",

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SKILL_DIRS, syncRepoSkills } from "./skills-libretto.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+syncRepoSkills(repoRoot);
+console.log(`libretto: synced skill mirrors across ${SKILL_DIRS.join(", ")}`);

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,11 @@
+# Skills Directory
+
+- `skills/libretto` is the source of truth for the Libretto skill.
+- The mirrored copies in `.agents/skills/libretto` and `.claude/skills/libretto` are generated from `skills/libretto`.
+- Edit files under `skills/libretto` directly. Do not hand-edit the mirrored copies.
+
+## Syncing
+
+- Run `pnpm sync-skills` after changing anything under `skills/libretto`.
+- Run `pnpm check:skills` to verify that `skills/libretto`, `.agents/skills/libretto`, and `.claude/skills/libretto` are identical.
+- `pnpm i` also resyncs the mirrors through `postinstall`, but use `pnpm sync-skills` for local doc edits so you do not need a full install step.

--- a/skills/libretto/SKILL.md
+++ b/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.0"
+  version: "0.4.1"
 ---
 
 # Libretto
@@ -21,6 +21,7 @@ Use `npx libretto` to build or debug automations by inspecting live browser stat
 - For a new automation, make the workflow file a required deliverable before you finish the task, even if you inspect the site first.
 - If the user does not provide a workflow path, choose a reasonable filename in the current workspace and create it yourself.
 - When building a new integration, prefer reverse-engineering network requests first. Fall back to browser automation when the request path is unclear, too fragile, or blocked by anti-bot systems.
+- Before replaying captured requests, run the security preflight in `references/reverse-engineering-network-requests.md` to assess whether direct browser `fetch` is safe to try.
 
 ## Setup
 
@@ -109,8 +110,8 @@ Assistant: I'll inspect the real site first if needed, but before I finish I'll 
 Assistant: [Runs `npx libretto open https://target.example.com --headed`]
 Assistant: I'll first determine whether this flow can be built from captured network requests instead of UI-only automation.
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page."`]
-Assistant: If the page exposes a clear and stable request path, I'll prioritize that. If the request path is unclear, fragile, or heavily defended, I'll fall back to browser automation.
-Assistant: [Uses `network`, `snapshot`, and `exec` as needed to prove the approach]
+Assistant: I'll inspect the site's request path and security posture before deciding whether direct request replay is safe.
+Assistant: [Uses `network`, `actions`, `snapshot`, and `exec` as needed to produce a site assessment]
 Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
 </example>
 ```

--- a/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/skills/libretto/references/reverse-engineering-network-requests.md
@@ -102,7 +102,18 @@ npx libretto exec "return await page.evaluate(() => ({
 }))"
 npx libretto exec "return await page.evaluate(() => ({
   fetchSource: window.fetch.toString(),
-  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchDescriptor: (() => {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'fetch');
+    return descriptor
+      ? {
+          writable: descriptor.writable ?? null,
+          enumerable: descriptor.enumerable ?? null,
+          configurable: descriptor.configurable ?? null,
+          hasGetter: typeof descriptor.get === 'function',
+          hasSetter: typeof descriptor.set === 'function',
+        }
+      : null;
+  })(),
   fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
   xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
 }))"

--- a/skills/libretto/references/reverse-engineering-network-requests.md
+++ b/skills/libretto/references/reverse-engineering-network-requests.md
@@ -18,6 +18,28 @@ This is the default approach for new integrations when the site exposes a clear 
 - Prefer passive capture plus UI automation when the site appears to wrap `fetch`, shows challenge pages or other bot-protection signals, or only exposes useful requests through normal page interaction.
 - Fall back to DOM extraction when the page is server-rendered or the captured responses are not usable.
 
+## Security Preflight
+
+Run this preflight before replaying captured requests. The goal is to separate what looks safe from what merely looks possible.
+
+### Probe 1: Bot Protection and Challenge Signals
+
+- Check cookies for bot-protection, telemetry, fingerprint, or signed security tokens.
+- Check early-loading scripts and globals for third-party protection services or custom telemetry.
+- Check whether the page is showing a challenge, interstitial, CAPTCHA, or other pre-app state.
+
+### Probe 2: Fetch and XHR Interception
+
+- Check whether `window.fetch` looks native or patched.
+- Check whether `XMLHttpRequest.prototype.open` looks native or patched.
+- Treat any sign of wrapping, proxying, or instrumentation as a reason to avoid direct browser `fetch` unless you have no safer option.
+
+### Probe 3: Behavioral Monitoring
+
+- Look for signs that the page is collecting interaction telemetry such as mouse movement, scroll, or keystroke patterns.
+- If direct inspection is limited, infer behavioral monitoring from security scripts, challenge flows, or heavy bot-protection signals.
+- If monitoring appears heavy, prefer passive capture and normal UI interaction over request replay.
+
 ## Common Bot-Protection Signals
 
 These are examples, not a complete checklist.
@@ -34,14 +56,25 @@ These are examples, not a complete checklist.
 - Unknown cookies can still be relevant if they look like telemetry, fingerprint, or signed security tokens.
 - If cookies suggest bot protection, also check for challenge pages, early-loading security scripts, and wrapped `fetch` or XHR APIs before trying direct request replay.
 
+## Decision Guide
+
+| Site profile | Prefer | Why |
+| --- | --- | --- |
+| No clear bot protection and `fetch` looks native | Direct browser `fetch` | Fastest way to replay stable endpoints |
+| `fetch` or XHR appears patched | Passive capture plus UI automation | Avoids suspicious call stacks and wrapped APIs |
+| Bot protection or challenge flow is present | Passive capture plus UI automation | Lowest-risk way to learn the real request path |
+| Responses are opaque, signed, or highly dynamic | Passive capture plus UI automation | Captures what the site actually sends |
+| No usable API surface | DOM extraction | Browser automation is the only reliable path |
+
 ## Workflow
 
 - Open the page in headed mode.
 - Let the user perform the relevant workflow manually.
+- Read the action log to understand the user-visible transition points.
 - Read the network log after the relevant step.
+- Run the security preflight before deciding whether to replay a request directly.
 - Identify the smallest set of requests that actually carries the data or performs the action.
-- Before replaying a request, check whether direct browser `fetch` looks safe to try.
-- Look for challenge pages, obvious bot-protection signals, or wrapped `fetch` and XHR APIs.
+- Produce a short site assessment that distinguishes the safe approaches from the likely working approaches.
 - Confirm with the user before replaying any request that could mutate data.
 - If direct browser `fetch` looks safe, recreate a key request with `page.evaluate(() => fetch(...))`.
 - If direct browser `fetch` is unsafe or does not work, keep using captured responses and UI automation for the triggering steps.
@@ -52,11 +85,27 @@ These are examples, not a complete checklist.
 
 ```bash
 npx libretto open https://target.example.com --headed
+npx libretto actions --source user --last 20
 npx libretto network --last 20
 npx libretto network --method POST --last 20
 npx libretto network --filter 'referral|patient|search'
 npx libretto exec "return await networkLog({ method: 'POST', last: 10 })"
-npx libretto exec "return await page.evaluate(() => ({ fetch: window.fetch.toString(), xhrOpen: XMLHttpRequest.prototype.open.toString() }))"
+npx libretto exec "return await actionLog({ source: 'user', last: 10 })"
+npx libretto exec "return await page.evaluate(() => ({
+  cookies: document.cookie.split(';').map((value) => value.trim()).filter(Boolean),
+  scripts: [...document.scripts].slice(0, 20).map((script) => script.src || 'inline'),
+  globals: {
+    pxAppId: globalThis._pxAppId ?? null,
+    bmak: globalThis.bmak ? 'present' : null,
+    ddjskey: globalThis.ddjskey ?? null,
+  },
+}))"
+npx libretto exec "return await page.evaluate(() => ({
+  fetchSource: window.fetch.toString(),
+  fetchDescriptor: Object.getOwnPropertyDescriptor(window, 'fetch'),
+  fetchHasPrototype: Object.prototype.hasOwnProperty.call(window.fetch, 'prototype'),
+  xhrOpenSource: XMLHttpRequest.prototype.open.toString(),
+}))"
 npx libretto exec "
   return await page.evaluate(async () => {
     const resp = await fetch('/api/example', { method: 'GET' });
@@ -64,6 +113,35 @@ npx libretto exec "
   });
 "
 ```
+
+## Site Assessment Summary
+
+Write the assessment before choosing a replay strategy. Keep it short and concrete.
+
+```text
+## Site Assessment: https://target.example.com
+
+### Bot Detection Profile
+- Enterprise bot protection: none detected | detected with evidence
+- Fetch/XHR interception: native | patched with evidence
+- Behavioral monitoring: none detected | light | heavy with evidence
+- Challenge pages: none | present with evidence
+- Overall security posture: none | low | moderate | high | very high
+
+### API Surface
+- API calls observed: key endpoints or "none observed"
+- Data format: JSON | GraphQL | HTML fragments | other
+- Pagination or sequencing: how the site advances through results or actions
+
+### Safe Approaches
+- page.evaluate(fetch(...)): safe | unsafe with rationale
+- Passive capture from network logs: viable | not viable with rationale
+- DOM extraction: fallback | primary path with rationale
+- Interaction notes: any precautions for login, paging, or side effects
+```
+
+- Do not treat this assessment as the final strategy recommendation.
+- Use it to narrow the safe options, then choose the working path with the user.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- restore the Libretto skill's network security preflight guidance in the source skill and mirrored copies
- add a short `skills/AGENTS.md` describing the source-of-truth workflow for `skills/`
- add `pnpm sync-skills` as an explicit wrapper around the existing skill mirror sync logic

## Verification
- `pnpm sync-skills`
- `pnpm check:skills`
- `pnpm type-check`
