### PR TITLE
Remove stale visualize-changes entry from skills-lock.json

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,11 +5,6 @@
       "source": "tanishqkancharla/glimpse-changes",
       "sourceType": "github",
       "computedHash": "838d3b9485ab8bfb8ca5c6b1280f25f06eab19cd33be963f24826a7d75c95a7c"
-    },
-    "visualize-changes": {
-      "source": "tanishqkancharla/glimpse-changes",
-      "sourceType": "github",
-      "computedHash": "5969895583eee17c3412daef2782432a02f6f9a4f81026abd73ade7ec6981afd"
     }
   }
 }


### PR DESCRIPTION
Remove the leftover `visualize-changes` key from `skills-lock.json` — the skill directories were removed in #116, so this entry is dead metadata.
