### PR TITLE
Add permissions block to cli-tests workflow

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `permissions: contents: read` to `.github/workflows/cli-tests.yml` to satisfy the GitHub Advanced Security code scanning alert about unrestricted `GITHUB_TOKEN` permissions.
