### PR TITLE
Improve exec and snapshot CLI UX

### DIFF
--- a/.pi/npm/.gitignore
+++ b/.pi/npm/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -124,9 +124,9 @@ async function runExec(
   visualize = false,
   pageId?: string,
 ): Promise<void> {
-  const catchPattern = /\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g;
+  const catchPattern = /\??\s*\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g;
   const hadCatch = catchPattern.test(code);
-  const cleanedCode = code.replace(/\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g, "");
+  const cleanedCode = code.replace(/\??\s*\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g, "");
   if (hadCatch) {
     console.log("(Stripped `.catch(() => {})` — letting errors bubble up)");
   }

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -117,6 +117,75 @@ function compileExecFunction(
   return new AsyncFunction(...helperNames, code);
 }
 
+/**
+ * Strip `.catch(() => {})` / `?.catch(() => {})` from executable code,
+ * skipping occurrences inside string literals (single, double, backtick)
+ * and single-line / multi-line comments so we never corrupt non-code text.
+ */
+function stripEmptyCatchHandlers(code: string): { cleaned: string; strippedCount: number } {
+  const catchRe = /\??\s*\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g;
+  let strippedCount = 0;
+  let result = "";
+  let i = 0;
+
+  while (i < code.length) {
+    // Single-line comment
+    if (code[i] === "/" && code[i + 1] === "/") {
+      const end = code.indexOf("\n", i);
+      const slice = end === -1 ? code.slice(i) : code.slice(i, end + 1);
+      result += slice;
+      i += slice.length;
+      continue;
+    }
+    // Multi-line comment
+    if (code[i] === "/" && code[i + 1] === "*") {
+      const end = code.indexOf("*/", i + 2);
+      const slice = end === -1 ? code.slice(i) : code.slice(i, end + 2);
+      result += slice;
+      i += slice.length;
+      continue;
+    }
+    // String literals
+    if (code[i] === '"' || code[i] === "'" || code[i] === "`") {
+      const quote = code[i];
+      let j = i + 1;
+      while (j < code.length) {
+        if (code[j] === "\\" && quote !== "`") { j += 2; continue; }
+        if (code[j] === "\\" && quote === "`") { j += 2; continue; }
+        if (code[j] === quote) { j++; break; }
+        // Template literal interpolation — skip nested braces
+        if (quote === "`" && code[j] === "$" && code[j + 1] === "{") {
+          let depth = 1;
+          j += 2;
+          while (j < code.length && depth > 0) {
+            if (code[j] === "{") depth++;
+            else if (code[j] === "}") depth--;
+            j++;
+          }
+          continue;
+        }
+        j++;
+      }
+      result += code.slice(i, j);
+      i = j;
+      continue;
+    }
+    // Try to match the catch pattern at the current position
+    catchRe.lastIndex = i;
+    const match = catchRe.exec(code);
+    if (match && match.index === i) {
+      strippedCount++;
+      i += match[0].length;
+      continue;
+    }
+    // Regular character
+    result += code[i];
+    i++;
+  }
+
+  return { cleaned: result, strippedCount };
+}
+
 async function runExec(
   code: string,
   session: string,
@@ -124,10 +193,8 @@ async function runExec(
   visualize = false,
   pageId?: string,
 ): Promise<void> {
-  const catchPattern = /\??\s*\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g;
-  const hadCatch = catchPattern.test(code);
-  const cleanedCode = code.replace(/\??\s*\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g, "");
-  if (hadCatch) {
+  const { cleaned: cleanedCode, strippedCount } = stripEmptyCatchHandlers(code);
+  if (strippedCount > 0) {
     console.log("(Stripped `.catch(() => {})` — letting errors bubble up)");
   }
   logger.info("exec-start", {

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -24,9 +24,7 @@ import {
   readNetworkLog,
   wrapPageForActionLogging,
 } from "../core/telemetry.js";
-import type {
-  RunIntegrationWorkerRequest,
-} from "../workers/run-integration-worker-protocol.js";
+import type { RunIntegrationWorkerRequest } from "../workers/run-integration-worker-protocol.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   pageOption,
@@ -126,22 +124,28 @@ async function runExec(
   visualize = false,
   pageId?: string,
 ): Promise<void> {
+  const catchPattern = /\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g;
+  const hadCatch = catchPattern.test(code);
+  const cleanedCode = code.replace(/\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/g, "");
+  if (hadCatch) {
+    console.log("(Stripped `.catch(() => {})` — letting errors bubble up)");
+  }
   logger.info("exec-start", {
     session,
-    codeLength: code.length,
-    codePreview: code.slice(0, 200),
+    codeLength: cleanedCode.length,
+    codePreview: cleanedCode.slice(0, 200),
     visualize,
     pageId,
   });
-  const { browser, context, page, pageId: resolvedPageId } = await connect(
-    session,
-    logger,
-    10000,
-    {
-      pageId,
-      requireSinglePage: true,
-    },
-  );
+  const {
+    browser,
+    context,
+    page,
+    pageId: resolvedPageId,
+  } = await connect(session, logger, 10000, {
+    pageId,
+    requireSinglePage: true,
+  });
 
   const STALL_THRESHOLD_MS = 60_000;
   let lastActivityTs = Date.now();
@@ -155,10 +159,10 @@ async function runExec(
       logger.warn("exec-stall-warning", {
         session,
         silenceMs,
-        codePreview: code.slice(0, 200),
+        codePreview: cleanedCode.slice(0, 200),
       });
       console.warn(
-        `[stall-warning] No Playwright activity for ${Math.round(silenceMs / 1000)}s — exec may be hung (code: ${code.slice(0, 100)}...)`,
+        `[stall-warning] No Playwright activity for ${Math.round(silenceMs / 1000)}s — exec may be hung (code: ${cleanedCode.slice(0, 100)}...)`,
       );
     }
   }, STALL_THRESHOLD_MS);
@@ -168,7 +172,7 @@ async function runExec(
     logger.info("exec-interrupted", {
       session,
       duration: Date.now() - execStartTs,
-      codePreview: code.slice(0, 200),
+      codePreview: cleanedCode.slice(0, 200),
     });
   };
   process.on("SIGINT", sigintHandler);
@@ -183,7 +187,12 @@ async function runExec(
     const execState: Record<string, unknown> = {};
 
     const networkLog = (
-      opts: { last?: number; filter?: string; method?: string; pageId?: string } = {},
+      opts: {
+        last?: number;
+        filter?: string;
+        method?: string;
+        pageId?: string;
+      } = {},
     ) => {
       return readNetworkLog(session, opts);
     };
@@ -218,7 +227,7 @@ async function runExec(
     };
 
     const helperNames = Object.keys(helpers);
-    const fn = compileExecFunction(code, helperNames);
+    const fn = compileExecFunction(cleanedCode, helperNames);
 
     const result = await fn(...Object.values(helpers));
     logger.info("exec-success", { session, hasResult: result !== undefined });
@@ -226,12 +235,14 @@ async function runExec(
       console.log(
         typeof result === "string" ? result : JSON.stringify(result, null, 2),
       );
+    } else {
+      console.log("Executed successfully");
     }
   } catch (err) {
     logger.error("exec-error", {
       error: err,
       session,
-      codePreview: code.slice(0, 200),
+      codePreview: cleanedCode.slice(0, 200),
     });
     throw err;
   } finally {
@@ -373,11 +384,19 @@ async function waitForWorkflowOutcome(
   let outputOffset = 0;
 
   while (true) {
-    outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+    outputOffset = streamOutputSince(
+      signalPaths.outputSignalPath,
+      outputOffset,
+    );
 
     if (existsSync(signalPaths.failedSignalPath)) {
-      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
-      const failureDetails = await waitForFailureDetails(signalPaths.failedSignalPath);
+      outputOffset = streamOutputSince(
+        signalPaths.outputSignalPath,
+        outputOffset,
+      );
+      const failureDetails = await waitForFailureDetails(
+        signalPaths.failedSignalPath,
+      );
       return {
         status: "failed",
         message: failureDetails?.message,
@@ -386,17 +405,26 @@ async function waitForWorkflowOutcome(
     }
 
     if (existsSync(signalPaths.completedSignalPath)) {
-      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      outputOffset = streamOutputSince(
+        signalPaths.outputSignalPath,
+        outputOffset,
+      );
       return { status: "completed" };
     }
 
     if (existsSync(signalPaths.pausedSignalPath)) {
-      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      outputOffset = streamOutputSince(
+        signalPaths.outputSignalPath,
+        outputOffset,
+      );
       return { status: "paused" };
     }
 
     if (!isProcessRunning(args.pid)) {
-      outputOffset = streamOutputSince(signalPaths.outputSignalPath, outputOffset);
+      outputOffset = streamOutputSince(
+        signalPaths.outputSignalPath,
+        outputOffset,
+      );
       return { status: "exited" };
     }
 
@@ -504,16 +532,20 @@ async function runIntegrationFromFile(
     authProfileDomain: args.authProfileDomain,
     viewport: args.viewport,
   } satisfies RunIntegrationWorkerRequest);
-  const worker = spawn(process.execPath, [
-    tsxCliPath,
-    ...(args.tsconfigPath ? ["--tsconfig", args.tsconfigPath] : []),
-    workerEntryPath,
-    payload,
-  ], {
-    detached: true,
-    stdio: "ignore",
-    env: process.env,
-  });
+  const worker = spawn(
+    process.execPath,
+    [
+      tsxCliPath,
+      ...(args.tsconfigPath ? ["--tsconfig", args.tsconfigPath] : []),
+      workerEntryPath,
+      payload,
+    ],
+    {
+      detached: true,
+      stdio: "ignore",
+      env: process.env,
+    },
+  );
   worker.unref();
   const outcome = await waitForWorkflowOutcome({
     session: args.session,
@@ -552,7 +584,9 @@ export const execInput = SimpleCLI.input({
   ],
   named: {
     session: sessionOption(),
-    visualize: SimpleCLI.flag({ help: "Enable ghost cursor + highlight visualization" }),
+    visualize: SimpleCLI.flag({
+      help: "Enable ghost cursor + highlight visualization",
+    }),
     page: pageOption(),
   },
 }).refine(
@@ -575,8 +609,7 @@ export const execCommand = SimpleCLI.command({
     );
   });
 
-const runUsage =
-  `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--no-visualize] [--viewport WxH]`;
+const runUsage = `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--no-visualize] [--viewport WxH]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [
@@ -618,8 +651,14 @@ export const runInput = SimpleCLI.input({
     (input) => Boolean(input.integrationFile && input.integrationExport),
     runUsage,
   )
-  .refine((input) => !(input.params && input.paramsFile), "Pass either --params or --params-file, not both.")
-  .refine((input) => !(input.headed && input.headless), "Cannot pass both --headed and --headless.");
+  .refine(
+    (input) => !(input.params && input.paramsFile),
+    "Pass either --params or --params-file, not both.",
+  )
+  .refine(
+    (input) => !(input.headed && input.headless),
+    "Cannot pass both --headed and --headless.",
+  );
 
 function resolveRunParams(
   rawInlineParams: string | undefined,
@@ -658,19 +697,25 @@ export const runCommand = SimpleCLI.command({
         ? true
         : undefined;
     const visualize = !input.noVisualize;
-    const viewport = resolveViewport(parseViewportArg(input.viewport), ctx.logger);
+    const viewport = resolveViewport(
+      parseViewportArg(input.viewport),
+      ctx.logger,
+    );
 
-    await runIntegrationFromFile({
-      integrationPath: input.integrationFile!,
-      exportName: input.integrationExport!,
-      session: ctx.session,
-      params,
-      tsconfigPath: input.tsconfig,
-      headless: headlessMode ?? false,
-      visualize,
-      authProfileDomain: input.authProfile,
-      viewport,
-    }, ctx.logger);
+    await runIntegrationFromFile(
+      {
+        integrationPath: input.integrationFile!,
+        exportName: input.integrationExport!,
+        session: ctx.session,
+        params,
+        tsconfigPath: input.tsconfig,
+        headless: headlessMode ?? false,
+        visualize,
+        authProfileDomain: input.authProfile,
+        viewport,
+      },
+      ctx.logger,
+    );
   });
 
 export const resumeInput = SimpleCLI.input({

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -159,7 +159,7 @@ async function captureScreenshot(
     const htmlPath = `${snapshotRunDir}/page.html`;
     const condensedHtmlPath = `${snapshotRunDir}/page.condensed.html`;
 
-    const RENDER_SETTLE_TIMEOUT_MS = 20_000;
+    const RENDER_SETTLE_TIMEOUT_MS = 10_000;
     await Promise.race([
       page.waitForLoadState("networkidle").catch(() => {}),
       new Promise((resolve) => setTimeout(resolve, RENDER_SETTLE_TIMEOUT_MS)),

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -159,6 +159,12 @@ async function captureScreenshot(
     const htmlPath = `${snapshotRunDir}/page.html`;
     const condensedHtmlPath = `${snapshotRunDir}/page.condensed.html`;
 
+    const RENDER_SETTLE_TIMEOUT_MS = 20_000;
+    await Promise.race([
+      page.waitForLoadState("networkidle").catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, RENDER_SETTLE_TIMEOUT_MS)),
+    ]);
+
     const restoreViewport = resolveSnapshotViewport(session, logger);
     const viewportMetrics = await readSnapshotViewportMetrics(page);
     logger.info("screenshot-viewport-metrics", {

--- a/src/cli/core/api-snapshot-analyzer.ts
+++ b/src/cli/core/api-snapshot-analyzer.ts
@@ -10,7 +10,6 @@ import { readFileSync } from "node:fs";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { createLLMClient } from "../../shared/llm/client.js";
 import {
-  formatInterpretationOutput,
   InterpretResultSchema,
   buildInlinePromptSelection,
   getMimeType,
@@ -93,5 +92,18 @@ export async function runApiInterpret(
     answer: parsed.answer.slice(0, 200),
   });
 
-  console.log(formatInterpretationOutput(parsed, "Interpretation (via API):"));
+  console.log("");
+  console.log("Analysis:");
+  console.log(parsed.answer);
+  if (parsed.selectors.length > 0) {
+    console.log("");
+    console.log("Selectors:");
+    parsed.selectors.forEach((selector, index) => {
+      console.log(`  ${index + 1}. ${selector.label}: ${selector.selector}`);
+    });
+  }
+  if (parsed.notes?.trim()) {
+    console.log("");
+    console.log(`Notes: ${parsed.notes.trim()}`);
+  }
 }

--- a/src/cli/core/snapshot-analyzer.ts
+++ b/src/cli/core/snapshot-analyzer.ts
@@ -8,7 +8,7 @@
  * to the CLI-agent approach if needed.
  *
  * Shared types and utilities (InterpretResultSchema, buildInlinePromptSelection,
- * formatInterpretationOutput, etc.) are still actively used by the API analyzer.
+ * etc.) are still actively used by the API analyzer.
  */
 
 import {
@@ -794,31 +794,6 @@ export function buildInlinePromptSelection(
   );
 }
 
-export function formatInterpretationOutput(
-  parsed: InterpretResult,
-  header: string = "Interpretation:",
-): string {
-  const outputLines: string[] = [];
-  outputLines.push(header);
-  outputLines.push(`Answer: ${parsed.answer}`);
-  outputLines.push("");
-  if (parsed.selectors.length === 0) {
-    outputLines.push("Selectors: none found.");
-  } else {
-    outputLines.push("Selectors:");
-    parsed.selectors.forEach((selector, index) => {
-      outputLines.push(`  ${index + 1}. ${selector.label}`);
-      outputLines.push(`     selector: ${selector.selector}`);
-      outputLines.push(`     rationale: ${selector.rationale}`);
-    });
-  }
-  if (parsed.notes && parsed.notes.trim()) {
-    outputLines.push("");
-    outputLines.push(`Notes: ${parsed.notes.trim()}`);
-  }
-  return outputLines.join("\n");
-}
-
 export async function runInterpret(
   args: InterpretArgs,
   logger: LoggerApi,
@@ -867,7 +842,7 @@ export async function runInterpret(
   // Preserved for reference — to re-enable, remove the throw above and:
   // const selection = buildInlinePromptSelection(args, fullHtmlContent, condensedHtmlContent, model);
   // const parsed = await configuredAgent.analyzeSnapshot(selection.prompt, pngPath, logger);
-  // console.log(formatInterpretationOutput(parsed));
+  // console.log(parsed.answer);
 }
 
 export function canAnalyzeSnapshots(): boolean {


### PR DESCRIPTION
## Summary

Four quality-of-life improvements to the `exec` and `snapshot` commands:

1. **`exec` success message** — prints "Executed successfully" when code returns no value (previously silent)
2. **Strip `.catch(() => {})`** — removes empty catch handlers from exec code before compilation with a notice, so errors bubble up properly
3. **Simplified snapshot analysis output** — cleaner format with `Screenshot saved:` / `Analysis:` / `Selectors:` sections instead of the verbose `formatInterpretationOutput`
4. **Wait for rendering before screenshot** — `Promise.race` between `page.waitForLoadState("networkidle")` and a 20s timeout before capturing, so React/SPA apps finish rendering
