### PR TITLE
[NTN-208] Add badges and community section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Libretto
 
+[![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![GitHub Discussions](https://img.shields.io/github/discussions/saffron-health/libretto)](https://github.com/saffron-health/libretto/discussions)
+
 Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to:
 
 - Inspect live pages with minimal context overhead
@@ -112,6 +116,17 @@ Each Libretto session gets its own directory under `.libretto/sessions/<name>/` 
 ### Profiles
 
 Profiles save browser sessions (cookies, localStorage) so you can reuse authenticated state across runs. They are stored in `.libretto/profiles/<domain>.json`, created via `npx libretto save <domain>`. Profiles are machine-local and git-ignored.
+
+## Community
+
+Have a question, idea, or want to share what you've built? Join the conversation on [GitHub Discussions](https://github.com/saffron-health/libretto/discussions).
+
+- **[Q&A](https://github.com/saffron-health/libretto/discussions/categories/q-a)** — Ask questions and get help
+- **[Ideas](https://github.com/saffron-health/libretto/discussions/categories/ideas)** — Suggest new features or improvements
+- **[Show and tell](https://github.com/saffron-health/libretto/discussions/categories/show-and-tell)** — Share your workflows and automations
+- **[General](https://github.com/saffron-health/libretto/discussions/categories/general)** — Chat about anything Libretto-related
+
+Found a bug? Please [open an issue](https://github.com/saffron-health/libretto/issues/new).
 
 ## Authors
 


### PR DESCRIPTION
## Summary

Prep the README for community engagement:

- **Badges**: Added npm version, MIT license, and GitHub Discussions badges at the top
- **Community section**: New section linking to GitHub Discussions categories (Q&A, Ideas, Show and tell, General) and issues for bug reports

GitHub Discussions was already enabled with default categories (Announcements, General, Ideas, Polls, Q&A, Show and tell).
