### PR TITLE
[NTN-207] Add connect command

### DIFF
--- a/.agents/skills/external-electron-apps/SKILL.md
+++ b/.agents/skills/external-electron-apps/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: external-electron-apps
+description: |
+  Automate user-installed Electron desktop apps (Slack, Discord, VS Code, Notion, Figma, Spotify, etc.) via CDP using this repo's Libretto CLI. Use when the task is to control a local desktop app on the user's machine, not this repo's own Electron app. Triggers: "desktop Slack app", "connect to Electron app", "remote-debugging-port", "CDP desktop app", "automate VS Code desktop app".
+---
+
+# External Electron App Automation
+
+Use this skill for external Electron desktop apps running on the user's machine.
+Do not default to this for this repository's own Electron app unless the user explicitly asks.
+
+## Core workflow
+
+1. Quit the app if it is already running.
+2. Relaunch the app with `--remote-debugging-port=<port>`.
+3. Connect with `npx libretto connect http://127.0.0.1:<port> --session <session>`.
+4. Verify targets with `npx libretto pages --session <session>`.
+5. Run interactions with `npx libretto exec "<code>" --session <session>`.
+6. Capture evidence with `npx libretto snapshot --session <session>`.
+
+## Launch examples
+
+### macOS
+
+```bash
+open -a "Slack" --args --remote-debugging-port=9222
+open -a "Visual Studio Code" --args --remote-debugging-port=9223
+open -a "Discord" --args --remote-debugging-port=9224
+```
+
+### Linux
+
+```bash
+slack --remote-debugging-port=9222
+code --remote-debugging-port=9223
+discord --remote-debugging-port=9224
+```
+
+### Windows
+
+```bash
+"C:\Users\%USERNAME%\AppData\Local\slack\slack.exe" --remote-debugging-port=9222
+"C:\Users\%USERNAME%\AppData\Local\Programs\Microsoft VS Code\Code.exe" --remote-debugging-port=9223
+```
+
+## Session pattern
+
+Use one session per app:
+
+```bash
+npx libretto connect http://127.0.0.1:9222 --session slack-desktop
+npx libretto pages --session slack-desktop
+npx libretto exec "return await page.title()" --session slack-desktop
+npx libretto snapshot --session slack-desktop \
+  --objective "Identify the main content area" \
+  --context "Connected to the Slack desktop app and need to orient on the current view."
+```
+
+## Interaction examples
+
+```bash
+npx libretto exec "await page.locator('button:has-text(\"Search\")').click()" --session slack-desktop
+npx libretto exec "await page.keyboard.type('incident-123')" --session slack-desktop
+npx libretto exec "await page.keyboard.press('Enter')" --session slack-desktop
+```
+
+When selectors are unstable, inspect first:
+
+```bash
+npx libretto snapshot --session slack-desktop \
+  --objective "Find clickable elements near the search area" \
+  --context "Trying to locate the search input after clicking the search button."
+npx libretto exec "return await page.content()" --session slack-desktop
+```
+
+## Multiple pages
+
+Electron apps often have multiple windows/pages. Use `pages` to list them and `--page` to target a specific one:
+
+```bash
+npx libretto pages --session slack-desktop
+npx libretto exec --session slack-desktop --page <page-id> "return await page.url()"
+npx libretto snapshot --session slack-desktop --page <page-id> \
+  --objective "Describe the current view" \
+  --context "Inspecting a specific Electron window."
+```
+
+## Troubleshooting
+
+- If connection fails, make sure the app was launched with `--remote-debugging-port` and relaunch it.
+- Prefer `127.0.0.1` over `localhost` in CDP URLs.
+- If no pages are listed right after launch, wait 2-5 seconds and retry `pages`.
+- If a session is stale, run `connect` again with the same `--session`.
+
+Use `npx libretto close --session <session>` to clear the session. This does not terminate the external app — it only removes the session state so Libretto stops tracking it.

--- a/.agents/skills/glimpse-changes/SKILL.md
+++ b/.agents/skills/glimpse-changes/SKILL.md
@@ -3,10 +3,10 @@ name: glimpse-changes
 description: Create a visual explanation of the current session diff as a single HTML page and show it in a native Glimpse window. Use when the user wants a visual walkthrough of local code changes instead of a plain text diff.
 metadata:
   author: tanishqkancharla
-  version: "1.0.0"
+  version: "1.2.0"
 ---
 
-# Visualize Changes
+# Glimpse Changes
 
 Use this skill when the user wants a visual explanation of the changes made in the current session.
 
@@ -14,8 +14,7 @@ Use this skill when the user wants a visual explanation of the changes made in t
 
 1. Inspect the current session changes with `git status --short`, `git diff --stat`, `git diff --cached --stat`, and focused `git diff --unified=5 -- <files>` calls.
 2. Write a Markdown explanation of the diff, usually in `/tmp/session-diff-report.md`.
-3. Render that Markdown with `npx glimpse-changes`.
-4. Launch the renderer in a long-lived background terminal session and leave that process running while the Glimpse window is open.
+3. Run `npx glimpse-changes` to render and open the Glimpse window.
 
 ## Page Content
 
@@ -38,11 +37,7 @@ npx glimpse-changes "# Session diff\n\n- Summary"
 cat /tmp/session-diff-report.md | npx glimpse-changes
 ```
 
-When using the renderer from an agent session:
-
-- do not wrap it in a short timeout
-- run it in a background terminal/PTY session
-- leave that session alive until the user is done viewing the Glimpse window
+The CLI detaches the Glimpse window into a background process and exits immediately.
 
 ## Rendering
 
@@ -53,6 +48,8 @@ When using the renderer from an agent session:
 - Diff blocks are capped to about `60%` of the viewport and scroll inside the page when they exceed that size.
 - Prefer command diffs (`!\`git diff ...\``) over pasting raw diff content into fenced blocks.
 - Command diffs execute at render time and always reflect the current state of the working tree.
+- Command diffs **must** start with `git diff`; any other command will be rejected.
+- Command diff output **must** contain valid unified diff hunks (with `diff --git` headers or `@@ ... @@` hunk headers); otherwise the renderer will throw an error.
 - Fenced `diff` blocks with literal patch content are still supported as a fallback.
 
 ## Rules
@@ -60,4 +57,4 @@ When using the renderer from an agent session:
 - Do not use `pnpm cli` or `libretto open` for this workflow.
 - Prefer `npx glimpse-changes` for display and Git for diff inspection.
 - If the diff is large, summarize repeated edits and show only the most informative snippets.
-- Keep the renderer process alive in a background terminal while the Glimpse window is open, or the window may close with the parent process.
+- The CLI exits immediately after launching the Glimpse window in the background.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -48,6 +48,17 @@ npx libretto open https://example.com --headed
 npx libretto open https://example.com --headless --session debug-example
 ```
 
+### `connect`
+
+- Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
+- After connecting, `exec`, `snapshot`, `pages`, and all other session commands work normally.
+- Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
+
+```bash
+npx libretto connect http://127.0.0.1:9222 --session my-session
+npx libretto connect http://127.0.0.1:9223 --session another-session
+```
+
 ### `snapshot`
 
 - Use `snapshot` as the primary page observation tool.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -48,6 +48,17 @@ npx libretto open https://example.com --headed
 npx libretto open https://example.com --headless --session debug-example
 ```
 
+### `connect`
+
+- Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
+- After connecting, `exec`, `snapshot`, `pages`, and all other session commands work normally.
+- Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
+
+```bash
+npx libretto connect http://127.0.0.1:9222 --session my-session
+npx libretto connect http://127.0.0.1:9223 --session another-session
+```
+
 ### `snapshot`
 
 - Use `snapshot` as the primary page observation tool.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "glimpse-changes": {
       "source": "tanishqkancharla/glimpse-changes",
       "sourceType": "github",
-      "computedHash": "838d3b9485ab8bfb8ca5c6b1280f25f06eab19cd33be963f24826a7d75c95a7c"
+      "computedHash": "3719b3bd3db6a0ceea265d892920dc09e9e8e36405889d9baabec86fa2e03bfe"
     }
   }
 }

--- a/skills/libretto/SKILL.md
+++ b/skills/libretto/SKILL.md
@@ -48,6 +48,17 @@ npx libretto open https://example.com --headed
 npx libretto open https://example.com --headless --session debug-example
 ```
 
+### `connect`
+
+- Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
+- After connecting, `exec`, `snapshot`, `pages`, and all other session commands work normally.
+- Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
+
+```bash
+npx libretto connect http://127.0.0.1:9222 --session my-session
+npx libretto connect http://127.0.0.1:9223 --session another-session
+```
+
 ### `snapshot`
 
 - Use `snapshot` as the primary page observation tool.

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   runClose as runCloseWithLogger,
   runCloseAll as runCloseAllWithLogger,
+  runConnect as runConnectWithLogger,
   runOpen,
   runPages,
   runSave,
@@ -75,6 +76,29 @@ export const openCommand = SimpleCLI.command({
     const headed = input.headed || !input.headless;
     const viewport = parseViewportArg(input.viewport);
     await runOpen(input.url!, headed, ctx.session, ctx.logger, { viewport });
+  });
+
+export const connectInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("cdpUrl", z.string().optional(), {
+      help: "CDP endpoint URL (e.g. http://127.0.0.1:9222)",
+    }),
+  ],
+  named: {
+    session: sessionOption(),
+  },
+}).refine(
+  (input) => Boolean(input.cdpUrl),
+  `Usage: libretto connect <cdp-url> --session <name>`,
+);
+
+export const connectCommand = SimpleCLI.command({
+  description: "Connect to an existing Chrome DevTools Protocol (CDP) endpoint",
+})
+  .input(connectInput)
+  .use(withAutoSession())
+  .handle(async ({ input, ctx }) => {
+    await runConnectWithLogger(input.cdpUrl!, ctx.session, ctx.logger);
   });
 
 export const saveInput = SimpleCLI.input({
@@ -152,6 +176,7 @@ export const closeCommand = SimpleCLI.command({
 
 export const browserCommands = {
   open: openCommand,
+  connect: connectCommand,
   save: saveCommand,
   pages: pagesCommand,
   close: closeCommand,

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -365,6 +365,8 @@ async function stopExistingFailedRunSession(
   });
   clearSessionState(session, logger);
 
+  if (existingState.pid == null) return;
+
   const stopDeadline = Date.now() + 3_000;
   while (isProcessRunning(existingState.pid) && Date.now() < stopDeadline) {
     await new Promise((resolveWait) => setTimeout(resolveWait, 100));
@@ -530,9 +532,9 @@ async function runResume(
     );
   }
 
-  if (!isProcessRunning(sessionState.pid)) {
+  if (sessionState.pid == null || !isProcessRunning(sessionState.pid)) {
     throw new Error(
-      `No active paused workflow found for session "${session}" (worker pid ${sessionState.pid} is not running).`,
+      `No active paused workflow found for session "${session}" (worker pid ${sessionState.pid ?? "unknown"} is not running).`,
     );
   }
 
@@ -560,7 +562,7 @@ async function runResume(
 
   const outcome = await waitForWorkflowOutcome({
     session,
-    pid: sessionState.pid,
+    pid: sessionState.pid!,
   });
 
   if (outcome.status === "completed") {

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -72,13 +72,12 @@ export function hasProfile(domain: string): boolean {
   return existsSync(getProfilePath(domain));
 }
 
-async function tryConnectToPort(
-  port: number,
+async function tryConnectToCDP(
+  endpoint: string,
   logger: LoggerApi,
   timeoutMs: number = 5000,
 ): Promise<Browser | null> {
-  const endpoint = `http://localhost:${port}`;
-  logger.info("cdp-connect-attempt", { port, endpoint, timeoutMs });
+  logger.info("cdp-connect-attempt", { endpoint, timeoutMs });
   try {
     const connectPromise = chromium.connectOverCDP(endpoint);
     const timeoutPromise = new Promise<null>((resolve) =>
@@ -87,16 +86,15 @@ async function tryConnectToPort(
     const browser = await Promise.race([connectPromise, timeoutPromise]);
     if (browser) {
       logger.info("cdp-connect-success", {
-        port,
         endpoint,
         contexts: browser.contexts().length,
       });
     } else {
-      logger.warn("cdp-connect-timeout", { port, endpoint, timeoutMs });
+      logger.warn("cdp-connect-timeout", { endpoint, timeoutMs });
     }
     return browser;
   } catch (err) {
-    logger.error("cdp-connect-error", { error: err, port, endpoint });
+    logger.error("cdp-connect-error", { error: err, endpoint });
     return null;
   }
 }
@@ -201,11 +199,12 @@ export async function connect(
 }> {
   logger.info("connect", { session, timeoutMs });
   const state = readSessionStateOrThrow(session);
-  const browser = await tryConnectToPort(state.port, logger, timeoutMs);
+  const endpoint = state.cdpEndpoint ?? `http://localhost:${state.port}`;
+  const browser = await tryConnectToCDP(endpoint, logger, timeoutMs);
   if (!browser) {
     logger.error("connect-no-browser", {
       session,
-      port: state.port,
+      endpoint,
       pid: state.pid,
     });
     if (state.pid == null || !isPidRunning(state.pid)) {
@@ -216,7 +215,7 @@ export async function connect(
     }
 
     throw new Error(
-      `Could not connect to the browser for session "${session}" at http://127.0.0.1:${state.port}, but the session process (pid ${state.pid}) is still running. Try the command again, or close and reopen the session if it stays stuck.`,
+      `Could not connect to the browser for session "${session}" at ${endpoint}, but the session process (pid ${state.pid}) is still running. Try the command again, or close and reopen the session if it stays stuck.`,
     );
   }
 
@@ -881,7 +880,23 @@ export async function runConnect(
   logger.info("connect-start", { cdpUrl, session });
   assertSessionAvailableForStart(session, logger);
 
-  const parsedUrl = new URL(cdpUrl);
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(cdpUrl);
+  } catch {
+    throw new Error(
+      [
+        `Invalid CDP URL: ${cdpUrl}`,
+        ``,
+        `Expected an HTTP URL pointing to a Chrome DevTools Protocol endpoint, for example:`,
+        `  libretto connect http://127.0.0.1:9222`,
+        `  libretto connect http://remote-host:9222`,
+        `  libretto connect http://remote-host:9222/devtools/browser/<id>`,
+      ].join("\n"),
+    );
+  }
+
+  const endpoint = parsedUrl.href;
   const port = parsedUrl.port
     ? Number(parsedUrl.port)
     : parsedUrl.protocol === "https:"
@@ -889,7 +904,7 @@ export async function runConnect(
       : 80;
 
   console.log(
-    `Connecting to CDP endpoint at ${cdpUrl} (session: ${session})...`,
+    `Connecting to CDP endpoint at ${endpoint} (session: ${session})...`,
   );
 
   // Verify the CDP endpoint is reachable
@@ -901,15 +916,15 @@ export async function runConnect(
   } catch (err) {
     logger.error("connect-version-failed", { versionUrl, error: err });
     throw new Error(
-      `Cannot reach CDP endpoint at ${versionUrl}. Make sure the target is running with --remote-debugging-port=${port}.`,
+      `Cannot reach CDP endpoint at ${versionUrl}. Make sure the target is running and accessible at ${parsedUrl.host}.`,
     );
   }
 
-  // Connect via CDP to validate it works
-  const browser = await tryConnectToPort(port, logger, 10_000);
+  // Connect via CDP using the full endpoint URL
+  const browser = await tryConnectToCDP(endpoint, logger, 10_000);
   if (!browser) {
     throw new Error(
-      `CDP endpoint at ${cdpUrl} is reachable but Playwright could not connect. Check that the port is a Chrome DevTools Protocol endpoint.`,
+      `CDP endpoint at ${endpoint} is reachable but Playwright could not connect. Check that the URL is a Chrome DevTools Protocol endpoint.`,
     );
   }
 
@@ -925,6 +940,7 @@ export async function runConnect(
   writeSessionState(
     {
       port,
+      cdpEndpoint: endpoint,
       session,
       startedAt: new Date().toISOString(),
       status: "active",
@@ -932,8 +948,8 @@ export async function runConnect(
     logger,
   );
 
-  logger.info("connect-success", { cdpUrl, session, port });
-  console.log(`Connected to ${cdpUrl} (session: ${session})`);
+  logger.info("connect-success", { cdpUrl: endpoint, session, port });
+  console.log(`Connected to ${endpoint} (session: ${session})`);
   console.log(`  Pages found: ${pages.length}`);
   if (pages.length > 0) {
     for (const p of pages.slice(0, 5)) {

--- a/src/cli/core/browser.ts
+++ b/src/cli/core/browser.ts
@@ -208,7 +208,7 @@ export async function connect(
       port: state.port,
       pid: state.pid,
     });
-    if (!isPidRunning(state.pid)) {
+    if (state.pid == null || !isPidRunning(state.pid)) {
       clearSessionState(session, logger);
       throw new Error(
         `No browser running for session "${session}". Run 'libretto open <url> --session ${session}' first.`,
@@ -683,9 +683,10 @@ export async function runClose(
 
   logger.info("close-killing", { session, pid: state.pid, port: state.port });
 
-  sendSignalToProcessGroupOrPid(state.pid, "SIGTERM", logger, session);
-
-  await waitForCloseSignalWindow(CLOSE_WAIT_MS);
+  if (state.pid != null) {
+    sendSignalToProcessGroupOrPid(state.pid, "SIGTERM", logger, session);
+    await waitForCloseSignalWindow(CLOSE_WAIT_MS);
+  }
 
   clearSessionState(session, logger);
   logger.info("close-success", { session });
@@ -694,7 +695,7 @@ export async function runClose(
 
 type ClosableSession = {
   session: string;
-  pid: number;
+  pid?: number;
   port: number;
 };
 
@@ -769,7 +770,7 @@ function clearStoppedSessionStates(
 ): number {
   let cleared = 0;
   for (const session of sessions) {
-    if (!isPidRunning(session.pid)) {
+    if (session.pid == null || !isPidRunning(session.pid)) {
       clearSessionState(session.session, logger);
       cleared += 1;
     }
@@ -800,17 +801,21 @@ export async function runCloseAll(
       pid: target.pid,
       port: target.port,
     });
-    sendSignalToProcessGroupOrPid(
-      target.pid,
-      "SIGTERM",
-      logger,
-      target.session,
-    );
+    if (target.pid != null) {
+      sendSignalToProcessGroupOrPid(
+        target.pid,
+        "SIGTERM",
+        logger,
+        target.session,
+      );
+    }
   }
 
   await waitForCloseSignalWindow(CLOSE_WAIT_MS);
 
-  let survivors = closable.filter((target) => isPidRunning(target.pid));
+  let survivors = closable.filter(
+    (target) => target.pid != null && isPidRunning(target.pid),
+  );
   if (survivors.length > 0 && !force) {
     const closed = clearStoppedSessionStates(closable, logger);
 
@@ -830,16 +835,20 @@ export async function runCloseAll(
         session: survivor.session,
         pid: survivor.pid,
       });
-      sendSignalToProcessGroupOrPid(
-        survivor.pid,
-        "SIGKILL",
-        logger,
-        survivor.session,
-      );
+      if (survivor.pid != null) {
+        sendSignalToProcessGroupOrPid(
+          survivor.pid,
+          "SIGKILL",
+          logger,
+          survivor.session,
+        );
+      }
       forceKilled += 1;
     }
     await waitForCloseSignalWindow(FORCE_CLOSE_WAIT_MS);
-    survivors = survivors.filter((target) => isPidRunning(target.pid));
+    survivors = survivors.filter(
+      (target) => target.pid != null && isPidRunning(target.pid),
+    );
     if (survivors.length > 0) {
       const closed = clearStoppedSessionStates(closable, logger);
       throw new Error(
@@ -861,6 +870,78 @@ export async function runCloseAll(
   console.log(`Closed ${closable.length} session(s).`);
   if (forceKilled > 0) {
     console.log(`Force-killed ${forceKilled} session(s).`);
+  }
+}
+
+export async function runConnect(
+  cdpUrl: string,
+  session: string,
+  logger: LoggerApi,
+): Promise<void> {
+  logger.info("connect-start", { cdpUrl, session });
+  assertSessionAvailableForStart(session, logger);
+
+  const parsedUrl = new URL(cdpUrl);
+  const port = parsedUrl.port
+    ? Number(parsedUrl.port)
+    : parsedUrl.protocol === "https:"
+      ? 443
+      : 80;
+
+  console.log(
+    `Connecting to CDP endpoint at ${cdpUrl} (session: ${session})...`,
+  );
+
+  // Verify the CDP endpoint is reachable
+  const versionUrl = `${parsedUrl.protocol}//${parsedUrl.host}/json/version`;
+  try {
+    const resp = await fetch(versionUrl);
+    const versionInfo = await resp.json();
+    logger.info("connect-version-ok", { versionUrl, versionInfo });
+  } catch (err) {
+    logger.error("connect-version-failed", { versionUrl, error: err });
+    throw new Error(
+      `Cannot reach CDP endpoint at ${versionUrl}. Make sure the target is running with --remote-debugging-port=${port}.`,
+    );
+  }
+
+  // Connect via CDP to validate it works
+  const browser = await tryConnectToPort(port, logger, 10_000);
+  if (!browser) {
+    throw new Error(
+      `CDP endpoint at ${cdpUrl} is reachable but Playwright could not connect. Check that the port is a Chrome DevTools Protocol endpoint.`,
+    );
+  }
+
+  const pages = resolveOperationalPages(browser);
+  logger.info("connect-pages", {
+    session,
+    pageCount: pages.length,
+    urls: pages.map((p) => p.url()),
+  });
+
+  disconnectBrowser(browser, logger, session);
+
+  writeSessionState(
+    {
+      port,
+      session,
+      startedAt: new Date().toISOString(),
+      status: "active",
+    },
+    logger,
+  );
+
+  logger.info("connect-success", { cdpUrl, session, port });
+  console.log(`Connected to ${cdpUrl} (session: ${session})`);
+  console.log(`  Pages found: ${pages.length}`);
+  if (pages.length > 0) {
+    for (const p of pages.slice(0, 5)) {
+      console.log(`    ${p.url()}`);
+    }
+    if (pages.length > 5) {
+      console.log(`    ... and ${pages.length - 5} more`);
+    }
   }
 }
 

--- a/src/cli/core/session.ts
+++ b/src/cli/core/session.ts
@@ -212,7 +212,7 @@ export function assertSessionAvailableForStart(
 ): void {
   const existingState = readSessionState(session, logger);
   if (!existingState) return;
-  if (!isPidRunning(existingState.pid)) {
+  if (existingState.pid == null || !isPidRunning(existingState.pid)) {
     setSessionStatus(session, "exited", logger);
     return;
   }

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -76,8 +76,10 @@ function readSessionStatePid(session: string): number | null {
   if (!existsSync(statePath)) return null;
 
   try {
-    return parseSessionStateContent(readFileSync(statePath, "utf8"), statePath)
-      .pid;
+    return (
+      parseSessionStateContent(readFileSync(statePath, "utf8"), statePath)
+        .pid ?? null
+    );
   } catch {
     return null;
   }

--- a/src/shared/debug/pause.ts
+++ b/src/shared/debug/pause.ts
@@ -22,7 +22,7 @@ function isPidRunning(pid: number): boolean {
 function getRunningSessions(): string[] {
   return listSessionsWithStateFile().filter((candidate) => {
     const state = readSessionState(candidate);
-    return state !== null && isPidRunning(state.pid);
+    return state !== null && state.pid != null && isPidRunning(state.pid);
   });
 }
 

--- a/src/shared/state/session-state.ts
+++ b/src/shared/state/session-state.ts
@@ -17,7 +17,7 @@ export const SessionViewportSchema = z.object({
 export const SessionStateFileSchema = z.object({
   version: z.literal(SESSION_STATE_VERSION),
   port: z.number().int().min(0).max(65535),
-  pid: z.number().int(),
+  pid: z.number().int().optional(),
   session: z.string().min(1),
   startedAt: z.string().datetime({ offset: true }),
   status: SessionStatusSchema.optional(),

--- a/src/shared/state/session-state.ts
+++ b/src/shared/state/session-state.ts
@@ -18,6 +18,7 @@ export const SessionStateFileSchema = z.object({
   version: z.literal(SESSION_STATE_VERSION),
   port: z.number().int().min(0).max(65535),
   pid: z.number().int().optional(),
+  cdpEndpoint: z.string().url().optional(),
   session: z.string().min(1),
   startedAt: z.string().datetime({ offset: true }),
   status: SessionStatusSchema.optional(),


### PR DESCRIPTION
## Summary

Adds a new `libretto connect <cdp-url>` CLI command that attaches to any existing Chrome DevTools Protocol endpoint and registers it as a Libretto session.

## Changes

- **New `connect` command** (`src/cli/core/browser.ts`, `src/cli/commands/browser.ts`): Validates the CDP URL, probes `/json/version`, connects via Playwright's `connectOverCDP` to verify the endpoint, then writes session state. After connecting, all session commands (`exec`, `snapshot`, `pages`, etc.) work normally.
- **Optional `pid` in session state** (`src/shared/state/session-state.ts`): Connected sessions have no Libretto-managed process, so `pid` is now optional. All callsites (`close`, `close --all`, `resume`, `pause`, etc.) guard with `!= null` checks.
- **Lifecycle semantics**: `libretto close` on a connected session clears the session state but does not attempt to terminate the remote process.

## Usage

```bash
npx libretto connect http://127.0.0.1:9222 --session my-session
npx libretto pages --session my-session
npx libretto exec "return await page.title()" --session my-session
npx libretto close --session my-session
```
