### PR TITLE
[NTN-173] Remove workflow metadata

### DIFF
--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -57,7 +57,6 @@ import { type Transaction } from "./db";
 type MyServices = { tx?: Transaction };
 
 export const myWorkflow = workflow<Input, Output, MyServices>(
-  {},
   async (ctx, input) => {
     if (ctx.services.tx) {
       await ctx.services.tx.insert(/* ... */);

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -23,7 +23,6 @@ type Output = {
 };
 
 export const myWorkflow = workflow<Input, Output>(
-  {},
   async (ctx, input): Promise<Output> => {
     const { session, page, logger } = ctx;
 
@@ -39,8 +38,7 @@ export const myWorkflow = workflow<Input, Output>(
 Key points:
 
 - The named export (e.g., `myWorkflow`) is what you pass as the second arg to `npx libretto run ./file.ts myWorkflow`
-- `workflow(metadata, handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
-- `metadata` is currently an object and is typically `{}` in generated files.
+- `workflow(handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
 - `ctx` provides `session`, `page`, `logger`, and `services` (generic, default `{}`)
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
 - If the site requires a saved login session, pass `--auth-profile <domain>` to the CLI (created via `npx libretto save <domain>`)

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -57,7 +57,6 @@ import { type Transaction } from "./db";
 type MyServices = { tx?: Transaction };
 
 export const myWorkflow = workflow<Input, Output, MyServices>(
-  {},
   async (ctx, input) => {
     if (ctx.services.tx) {
       await ctx.services.tx.insert(/* ... */);

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -23,7 +23,6 @@ type Output = {
 };
 
 export const myWorkflow = workflow<Input, Output>(
-  {},
   async (ctx, input): Promise<Output> => {
     const { session, page, logger } = ctx;
 
@@ -39,8 +38,7 @@ export const myWorkflow = workflow<Input, Output>(
 Key points:
 
 - The named export (e.g., `myWorkflow`) is what you pass as the second arg to `npx libretto run ./file.ts myWorkflow`
-- `workflow(metadata, handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
-- `metadata` is currently an object and is typically `{}` in generated files.
+- `workflow(handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
 - `ctx` provides `session`, `page`, `logger`, and `services` (generic, default `{}`)
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
 - If the site requires a saved login session, pass `--auth-profile <domain>` to the CLI (created via `npx libretto save <domain>`)

--- a/evals/references/broken-selector/usa-gov-broken-selector.mjs
+++ b/evals/references/broken-selector/usa-gov-broken-selector.mjs
@@ -1,6 +1,6 @@
 import { workflow } from "libretto";
 
-export const extractUsaGovTopic = workflow({}, async ({ page }, input) => {
+export const extractUsaGovTopic = workflow(async ({ page }, input) => {
   const query =
     typeof input?.query === "string" && input.query.trim().length > 0
       ? input.query.trim()

--- a/evals/references/network-conversion/weather-alerts-dom.mjs
+++ b/evals/references/network-conversion/weather-alerts-dom.mjs
@@ -1,6 +1,6 @@
 import { workflow } from "libretto";
 
-export const collectWeatherAlertsFromDom = workflow({}, async ({ page }, input) => {
+export const collectWeatherAlertsFromDom = workflow(async ({ page }, input) => {
   const requestedState =
     typeof input?.state === "string" && input.state.trim().length > 0
       ? input.state.trim().toUpperCase()

--- a/skills/libretto/references/code-generation-rules.md
+++ b/skills/libretto/references/code-generation-rules.md
@@ -57,7 +57,6 @@ import { type Transaction } from "./db";
 type MyServices = { tx?: Transaction };
 
 export const myWorkflow = workflow<Input, Output, MyServices>(
-  {},
   async (ctx, input) => {
     if (ctx.services.tx) {
       await ctx.services.tx.insert(/* ... */);

--- a/skills/libretto/references/code-generation-rules.md
+++ b/skills/libretto/references/code-generation-rules.md
@@ -23,7 +23,6 @@ type Output = {
 };
 
 export const myWorkflow = workflow<Input, Output>(
-  {},
   async (ctx, input): Promise<Output> => {
     const { session, page, logger } = ctx;
 
@@ -39,8 +38,7 @@ export const myWorkflow = workflow<Input, Output>(
 Key points:
 
 - The named export (e.g., `myWorkflow`) is what you pass as the second arg to `npx libretto run ./file.ts myWorkflow`
-- `workflow(metadata, handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
-- `metadata` is currently an object and is typically `{}` in generated files.
+- `workflow(handler)` returns a branded workflow object with a `.run(ctx, input)` method. The CLI expects that contract.
 - `ctx` provides `session`, `page`, `logger`, and `services` (generic, default `{}`)
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
 - If the site requires a saved login session, pass `--auth-profile <domain>` to the CLI (created via `npx libretto save <domain>`)

--- a/src/cli/workers/run-integration-runtime.ts
+++ b/src/cli/workers/run-integration-runtime.ts
@@ -28,7 +28,6 @@ import type { RunIntegrationWorkerRequest } from "./run-integration-worker-proto
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
 type LoadedLibrettoWorkflow = {
-  metadata: {};
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
 
@@ -116,9 +115,7 @@ function isLoadedLibrettoWorkflow(
   const candidate = value as Record<PropertyKey, unknown>;
   return (
     candidate[LIBRETTO_WORKFLOW_BRAND] === true &&
-    typeof candidate.run === "function" &&
-    !!candidate.metadata &&
-    typeof candidate.metadata === "object"
+    typeof candidate.run === "function"
   );
 }
 
@@ -192,7 +189,6 @@ async function loadWorkflowExport(
         '  import { workflow } from "libretto";',
         "",
         `  export const ${exportName} = workflow<InputType, OutputType>(`,
-        "    {},",
         "    async (ctx, input) => {",
         "      // ctx.session  — libretto session name",
         "      // ctx.page     — Playwright Page instance",

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,6 @@ export {
   LibrettoWorkflow,
   LIBRETTO_WORKFLOW_BRAND,
   workflow,
-  type LibrettoWorkflowMetadata,
   type LibrettoWorkflowContext,
   type LibrettoWorkflowHandler,
 } from "./shared/workflow/workflow.js";

--- a/src/shared/workflow/workflow.ts
+++ b/src/shared/workflow/workflow.ts
@@ -3,8 +3,6 @@ import type { MinimalLogger } from "../logger/logger.js";
 
 export const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
-export type LibrettoWorkflowMetadata = {};
-
 export type LibrettoWorkflowContext<S = {}> = {
   session: string;
   page: Page;
@@ -20,14 +18,9 @@ export type LibrettoWorkflowHandler<
 
 export class LibrettoWorkflow<Input = unknown, Output = unknown, S = {}> {
   public readonly [LIBRETTO_WORKFLOW_BRAND] = true;
-  public readonly metadata: LibrettoWorkflowMetadata;
   private readonly handler: LibrettoWorkflowHandler<Input, Output, S>;
 
-  constructor(
-    metadata: LibrettoWorkflowMetadata,
-    handler: LibrettoWorkflowHandler<Input, Output, S>,
-  ) {
-    this.metadata = metadata;
+  constructor(handler: LibrettoWorkflowHandler<Input, Output, S>) {
     this.handler = handler;
   }
 
@@ -37,8 +30,7 @@ export class LibrettoWorkflow<Input = unknown, Output = unknown, S = {}> {
 }
 
 export function workflow<Input = unknown, Output = unknown, S = {}>(
-  metadata: LibrettoWorkflowMetadata,
   handler: LibrettoWorkflowHandler<Input, Output, S>,
 ): LibrettoWorkflow<Input, Output, S> {
-  return new LibrettoWorkflow(metadata, handler);
+  return new LibrettoWorkflow(handler);
 }

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -339,7 +339,7 @@ export async function main() {
       `
 import message from "@/message";
 
-export const main = workflow({}, async () => {
+export const main = workflow(async () => {
   console.log(message);
 });
 `,
@@ -385,7 +385,6 @@ const brand = Symbol.for("libretto.workflow");
 
 export const main = {
   [brand]: true,
-  metadata: {},
   async run() {
     return "ok";
   },
@@ -409,12 +408,9 @@ export const main = {
     await writeWorkflow(
       "integration.ts",
       `
-export const main = workflow(
-  {},
-  async () => {
-    return "ok";
-  },
-);
+export const main = workflow(async () => {
+  return "ok";
+});
 `,
     );
 
@@ -438,7 +434,7 @@ export const main = workflow(
     await writeWorkflow(
       "integration.ts",
       `
-export const main = workflow({}, async () => "ok");
+export const main = workflow(async () => "ok");
 `,
     );
 
@@ -459,7 +455,7 @@ export const main = workflow({}, async () => "ok");
     const integrationFilePath = await writeWorkflow(
       "integration-pause.mjs",
       `
-export const main = workflow({}, async (ctx) => {
+export const main = workflow(async (ctx) => {
   console.log("WORKFLOW_BEFORE_PAUSE");
   await pause(ctx.session);
   console.log("WORKFLOW_AFTER_PAUSE");
@@ -484,7 +480,7 @@ export const main = workflow({}, async (ctx) => {
     const integrationFilePath = await writeWorkflow(
       "integration-pause-missing-session.mjs",
       `
-export const main = workflow({}, async () => {
+export const main = workflow(async () => {
   await pause("");
 });
 `,
@@ -508,7 +504,7 @@ export const main = workflow({}, async () => {
     const integrationFilePath = await writeWorkflow(
       "integration-complete.mjs",
       `
-export const main = workflow({}, async () => {
+export const main = workflow(async () => {
   console.log("WORKFLOW_COMPLETES");
 });
 `,
@@ -530,7 +526,7 @@ export const main = workflow({}, async () => {
     const integrationFilePath = await writeWorkflow(
       "integration-selector-error-debug.mjs",
       `
-export const main = workflow({}, async (ctx) => {
+export const main = workflow(async (ctx) => {
   await ctx.page.goto("https://example.com");
   await ctx.page.locator("[").click();
 });

--- a/test/multi-session.spec.ts
+++ b/test/multi-session.spec.ts
@@ -65,7 +65,7 @@ describe("multi-session CLI behavior", () => {
     const integrationFilePath = await writeWorkflow(
       "integration-auto-session.mjs",
       `
-export const main = workflow({}, async () => {
+export const main = workflow(async () => {
   console.log("AUTO_SESSION_RUN_OK");
 });
 `,


### PR DESCRIPTION
## Summary

Remove the unused `metadata` parameter from the `workflow()` function and `LibrettoWorkflow` class. The metadata was always an empty object `{}` and served no purpose.

## Changes

- Remove `LibrettoWorkflowMetadata` type and `metadata` property from `workflow.ts`
- Remove `metadata` from `LoadedLibrettoWorkflow` type and runtime validation
- Update error message example to omit metadata parameter
- Remove metadata type export from `index.ts`
- Update all test files to use `workflow(handler)` instead of `workflow({}, handler)`
- Update `code-generation-rules.md` skill reference

## API change

Before:
```ts
export const main = workflow({}, async (ctx, input) => { ... });
```

After:
```ts
export const main = workflow(async (ctx, input) => { ... });
```
