### PR TITLE
chore: record libretto v0.5.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- record the `package.json` bump to `0.5.2`
- align git history with the manual npm publish of `libretto@0.5.2`

## Verification
- `npm publish --access public`
- `npm view libretto version` -> `0.5.2`

## Notes
- `libretto@0.5.2` was published manually from this checkout before opening this PR
- the existing LinkedIn snapshot e2e failures on `main` were not fixed in this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
