### PR TITLE
[NTN-209] Make exec stdin explicit via '-'

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -83,8 +83,7 @@ npx libretto snapshot \
 
 - Use `exec` for focused inspection and short-lived interaction experiments.
 - Use `exec` to validate selectors, inspect data, or prototype a step before you encode it in the workflow file.
-- Pass code as one argument (usually quoted). Unquoted multi-token code is rejected.
-- Use `exec -` only when you intentionally want to read code from stdin.
+- Use `exec -` to run multi-line scripts from stdin, especially when the code is too long or complex for a command line argument.
 - Available globals: `page`, `context`, `browser`, `state`, `fetch`, `Buffer`.
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -83,6 +83,8 @@ npx libretto snapshot \
 
 - Use `exec` for focused inspection and short-lived interaction experiments.
 - Use `exec` to validate selectors, inspect data, or prototype a step before you encode it in the workflow file.
+- Pass code as one argument (usually quoted). Unquoted multi-token code is rejected.
+- Use `exec -` only when you intentionally want to read code from stdin.
 - Available globals: `page`, `context`, `browser`, `state`, `fetch`, `Buffer`.
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
@@ -91,6 +93,7 @@ npx libretto snapshot \
 npx libretto exec "return await page.url()"
 npx libretto exec "return await page.locator('button').count()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+echo "return await page.url()" | npx libretto exec - --session debug-example
 ```
 
 ### `pages`

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -83,8 +83,7 @@ npx libretto snapshot \
 
 - Use `exec` for focused inspection and short-lived interaction experiments.
 - Use `exec` to validate selectors, inspect data, or prototype a step before you encode it in the workflow file.
-- Pass code as one argument (usually quoted). Unquoted multi-token code is rejected.
-- Use `exec -` only when you intentionally want to read code from stdin.
+- Use `exec -` to run multi-line scripts from stdin, especially when the code is too long or complex for a command line argument.
 - Available globals: `page`, `context`, `browser`, `state`, `fetch`, `Buffer`.
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -83,6 +83,8 @@ npx libretto snapshot \
 
 - Use `exec` for focused inspection and short-lived interaction experiments.
 - Use `exec` to validate selectors, inspect data, or prototype a step before you encode it in the workflow file.
+- Pass code as one argument (usually quoted). Unquoted multi-token code is rejected.
+- Use `exec -` only when you intentionally want to read code from stdin.
 - Available globals: `page`, `context`, `browser`, `state`, `fetch`, `Buffer`.
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
@@ -91,6 +93,7 @@ npx libretto snapshot \
 npx libretto exec "return await page.url()"
 npx libretto exec "return await page.locator('button').count()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+echo "return await page.url()" | npx libretto exec - --session debug-example
 ```
 
 ### `pages`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ You can also use Libretto directly from the command line. All commands accept `-
 npx libretto init                          # interactive; run yourself, not through an agent
 npx libretto open <url>                    # launch browser and open a URL (headed by default)
 npx libretto snapshot --objective "..." --context "..."  # capture PNG + HTML and analyze with an LLM
-npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page
+npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page (single quoted argument)
+echo "<code>" | npx libretto exec -        # intentionally read Playwright TypeScript from stdin
 npx libretto run <file> <export>           # run an exported workflow from a file
 npx libretto resume                        # resume a paused workflow
 npx libretto network                       # view captured network requests

--- a/skills/libretto/SKILL.md
+++ b/skills/libretto/SKILL.md
@@ -83,6 +83,7 @@ npx libretto snapshot \
 
 - Use `exec` for focused inspection and short-lived interaction experiments.
 - Use `exec` to validate selectors, inspect data, or prototype a step before you encode it in the workflow file.
+- Use `exec -` to run multi-line scripts from stdin, especially when the code is too long or complex for a command line argument.
 - Available globals: `page`, `context`, `browser`, `state`, `fetch`, `Buffer`.
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
@@ -91,6 +92,7 @@ npx libretto snapshot \
 npx libretto exec "return await page.url()"
 npx libretto exec "return await page.locator('button').count()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+echo "return await page.url()" | npx libretto exec - --session debug-example
 ```
 
 ### `pages`

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -659,10 +659,20 @@ async function runIntegrationFromFile(
 function readStdinSync(): string | null {
   if (process.stdin.isTTY) return null;
   try {
-    return readFileSync("/dev/stdin", "utf8");
+    const content = readFileSync("/dev/stdin", "utf8");
+    return content.trim().length > 0 ? content : null;
   } catch {
     return null;
   }
+}
+
+/** Eagerly read stdin once at parse time so the refinement can validate. */
+let _cachedStdin: string | null | undefined;
+function getStdinCode(): string | null {
+  if (_cachedStdin === undefined) {
+    _cachedStdin = readStdinSync();
+  }
+  return _cachedStdin;
 }
 
 export const execInput = SimpleCLI.input({
@@ -679,7 +689,10 @@ export const execInput = SimpleCLI.input({
     }),
     page: pageOption(),
   },
-});
+}).refine(
+  (input) => input.codeParts.length > 0 || getStdinCode() !== null,
+  `Usage: libretto exec <code> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec [--session <name>] [--visualize]`,
+);
 
 export const execCommand = SimpleCLI.command({
   description: "Execute Playwright TypeScript code",
@@ -687,18 +700,8 @@ export const execCommand = SimpleCLI.command({
   .input(execInput)
   .use(withRequiredSession())
   .handle(async ({ input, ctx }) => {
-    let code: string;
-    if (input.codeParts.length > 0) {
-      code = input.codeParts.join(" ");
-    } else {
-      const stdinCode = readStdinSync();
-      if (!stdinCode || stdinCode.trim().length === 0) {
-        throw new Error(
-          `Usage: libretto exec <code> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec [--session <name>] [--visualize]`,
-        );
-      }
-      code = stdinCode;
-    }
+    const code =
+      input.codeParts.length > 0 ? input.codeParts.join(" ") : getStdinCode()!;
     await runExec(code, ctx.session, ctx.logger, input.visualize, input.page);
   });
 

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -657,9 +657,9 @@ async function runIntegrationFromFile(
 }
 
 function readStdinSync(): string | null {
-  if (process.stdin.isTTY) return null;
+  if (process.stdin.isTTY === true) return null;
   try {
-    const content = readFileSync("/dev/stdin", "utf8");
+    const content = readFileSync(0, "utf8");
     return content.trim().length > 0 ? content : null;
   } catch {
     return null;

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -666,20 +666,10 @@ function readStdinSync(): string | null {
   }
 }
 
-/** Eagerly read stdin once at parse time so the refinement can validate. */
-let _cachedStdin: string | null | undefined;
-function getStdinCode(): string | null {
-  if (_cachedStdin === undefined) {
-    _cachedStdin = readStdinSync();
-  }
-  return _cachedStdin;
-}
-
 export const execInput = SimpleCLI.input({
   positionals: [
-    SimpleCLI.positional("codeParts", z.array(z.string()).default([]), {
+    SimpleCLI.positional("code", z.string().optional(), {
       help: "Playwright TypeScript code to execute",
-      variadic: true,
     }),
   ],
   named: {
@@ -690,8 +680,8 @@ export const execInput = SimpleCLI.input({
     page: pageOption(),
   },
 }).refine(
-  (input) => input.codeParts.length > 0 || getStdinCode() !== null,
-  `Usage: libretto exec <code> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec [--session <name>] [--visualize]`,
+  (input) => input.code !== undefined,
+  `Usage: libretto exec <code|-> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec - [--session <name>] [--visualize]`,
 );
 
 export const execCommand = SimpleCLI.command({
@@ -700,9 +690,20 @@ export const execCommand = SimpleCLI.command({
   .input(execInput)
   .use(withRequiredSession())
   .handle(async ({ input, ctx }) => {
-    const code =
-      input.codeParts.length > 0 ? input.codeParts.join(" ") : getStdinCode()!;
-    await runExec(code, ctx.session, ctx.logger, input.visualize, input.page);
+    const code = input.code!;
+    const codeFromArgsOrStdin = code === "-" ? readStdinSync() : code;
+    if (codeFromArgsOrStdin === null) {
+      throw new Error(
+        "Missing stdin input for `exec -`. Pipe Playwright code into stdin.",
+      );
+    }
+    await runExec(
+      codeFromArgsOrStdin,
+      ctx.session,
+      ctx.logger,
+      input.visualize,
+      input.page,
+    );
   });
 
 const runUsage = `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--no-visualize] [--viewport WxH]`;

--- a/src/cli/commands/execution.ts
+++ b/src/cli/commands/execution.ts
@@ -656,6 +656,15 @@ async function runIntegrationFromFile(
   console.log("Integration completed.");
 }
 
+function readStdinSync(): string | null {
+  if (process.stdin.isTTY) return null;
+  try {
+    return readFileSync("/dev/stdin", "utf8");
+  } catch {
+    return null;
+  }
+}
+
 export const execInput = SimpleCLI.input({
   positionals: [
     SimpleCLI.positional("codeParts", z.array(z.string()).default([]), {
@@ -670,10 +679,7 @@ export const execInput = SimpleCLI.input({
     }),
     page: pageOption(),
   },
-}).refine(
-  (input) => input.codeParts.length > 0,
-  `Usage: libretto exec <code> [--session <name>] [--visualize]`,
-);
+});
 
 export const execCommand = SimpleCLI.command({
   description: "Execute Playwright TypeScript code",
@@ -681,13 +687,19 @@ export const execCommand = SimpleCLI.command({
   .input(execInput)
   .use(withRequiredSession())
   .handle(async ({ input, ctx }) => {
-    await runExec(
-      input.codeParts.join(" "),
-      ctx.session,
-      ctx.logger,
-      input.visualize,
-      input.page,
-    );
+    let code: string;
+    if (input.codeParts.length > 0) {
+      code = input.codeParts.join(" ");
+    } else {
+      const stdinCode = readStdinSync();
+      if (!stdinCode || stdinCode.trim().length === 0) {
+        throw new Error(
+          `Usage: libretto exec <code> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec [--session <name>] [--visualize]`,
+        );
+      }
+      code = stdinCode;
+    }
+    await runExec(code, ctx.session, ctx.logger, input.visualize, input.page);
   });
 
 const runUsage = `Usage: libretto run <integrationFile> <integrationExport> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--no-visualize] [--viewport WxH]`;

--- a/src/cli/framework/simple-cli.ts
+++ b/src/cli/framework/simple-cli.ts
@@ -579,6 +579,11 @@ export class SimpleCLIApp {
         break;
       }
 
+      if (arg === "-") {
+        positionals.push(arg);
+        continue;
+      }
+
       if (arg.startsWith("--")) {
         const [rawName, inlineValue] = splitNamedArg(arg.slice(2));
         const namedEntry = namedSpecs.get(rawName);

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -209,7 +209,7 @@ describe("basic CLI subprocess behavior", () => {
   test("fails exec with missing code usage error", async ({ librettoCli }) => {
     const result = await librettoCli("exec --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto exec <code> [--session <name>] [--visualize]",
+      "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
     );
   });
 
@@ -224,6 +224,14 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).not.toContain(
       `Missing required --session for "exec".`,
     );
+  });
+
+  test("exec with hyphen requires stdin input", async ({ librettoCli }) => {
+    const session = "exec-stdin-requires-input";
+    await librettoCli(`open https://example.com --headless --session ${session}`);
+
+    const result = await librettoCli(`exec - --session ${session}`);
+    expect(result.stderr).toContain("Missing stdin input for `exec -`.");
   });
 
   test("fails run when integration file does not exist", async ({

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -234,6 +234,21 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toContain("Missing stdin input for `exec -`.");
   });
 
+  test("exec with hyphen executes code piped through stdin", async ({
+    librettoCli,
+  }) => {
+    const session = "exec-stdin-with-input";
+    await librettoCli(`open https://example.com --headless --session ${session}`);
+
+    const result = await librettoCli(
+      `exec - --session ${session}`,
+      undefined,
+      "return 1;",
+    );
+    expect(result.stdout).toContain("1");
+    expect(result.stderr).toBe("");
+  });
+
   test("fails run when integration file does not exist", async ({
     librettoCli,
     evaluate,

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -289,7 +289,7 @@ const EVALUATE_RULES: readonly EvaluateRule[] = [
     check: (actual) =>
       requireIncludes(
         actual,
-        "Usage: libretto exec <code> [--session <name>] [--visualize]",
+        "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
       ),
   },
   {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -35,6 +35,7 @@ type CliFixtures = {
   librettoCli: (
     command: string,
     env?: Record<string, string>,
+    stdinText?: string,
   ) => Promise<SpawnResult>;
   evaluate: (actual: string) => EvaluateMatcher;
   writeWorkflow: (
@@ -132,9 +133,10 @@ async function execProcess(
   args: string[],
   cwd: string,
   env?: Record<string, string>,
+  stdinText?: string,
 ): Promise<SpawnResult> {
   return await new Promise<SpawnResult>((resolveResult, reject) => {
-    execFile(
+    const child = execFile(
       command,
       args,
       {
@@ -167,6 +169,10 @@ async function execProcess(
         });
       },
     );
+
+    if (stdinText !== undefined) {
+      child.stdin?.end(stdinText);
+    }
   });
 }
 
@@ -627,14 +633,21 @@ export const test = base.extend<CliFixtures>({
 
   librettoCli: async ({ workspaceDir }, use) => {
     ensureBuilt();
-    await use(async (command: string, env?: Record<string, string>) => {
-      return await execProcess(
-        process.execPath,
-        [cliEntry, ...parseCommandArgs(command)],
-        workspaceDir,
-        env,
-      );
-    });
+    await use(
+      async (
+        command: string,
+        env?: Record<string, string>,
+        stdinText?: string,
+      ) => {
+        return await execProcess(
+          process.execPath,
+          [cliEntry, ...parseCommandArgs(command)],
+          workspaceDir,
+          env,
+          stdinText,
+        );
+      },
+    );
   },
 
   evaluate: async ({}, use) => {

--- a/test/multi-session.spec.ts
+++ b/test/multi-session.spec.ts
@@ -94,17 +94,11 @@ export const main = workflow(async () => {
     expect(result.stderr).toContain("Missing required option --session.");
   });
 
-  test("exec accepts unquoted multi-token code", async ({
-    librettoCli,
-    evaluate,
-  }) => {
+  test("exec rejects unquoted multi-token code", async ({ librettoCli }) => {
     const result = await librettoCli(
       "exec await page.title() --session test-session",
     );
-    await evaluate(result.stderr).toMatch(
-      'Explains that session "test-session" does not exist, no active sessions are available, and suggests opening a session with libretto open <url> --session test-session.',
-    );
-    expect(result.stderr).not.toContain("Unexpected arguments for exec.");
+    expect(result.stderr).toContain("Unexpected arguments for exec.");
   });
 
   test("close --all works without --session", async ({ librettoCli }) => {


### PR DESCRIPTION
## Summary
- Make `exec` accept a single positional code argument instead of variadic tokens.
- Make stdin usage explicit: `exec -` reads code from stdin, and stdin is no longer used as an automatic fallback.
- Treat a lone `-` as a positional token in `SimpleCLI` so `exec -` works.
- Update tests and docs to reflect the new behavior.

## Usage

```bash
# Inline code (single argument)
libretto exec "return await page.url()" --session foo

# Explicit stdin mode
echo "return await page.url()" | libretto exec - --session foo
```

## Validation
- `pnpm type-check`
- `pnpm test -- test/simple-cli-framework.spec.ts test/basic.spec.ts test/multi-session.spec.ts`
