### PR TITLE
docs: generate synced libretto READMEs and mirrors

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.2"
+  version: "0.5.2"
 ---
 
 ## How Libretto Works

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.2"
+  version: "0.5.2"
 ---
 
 ## How Libretto Works

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -27,8 +27,8 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Check skill mirror parity
-        run: pnpm --filter libretto check:skills
+      - name: Check mirror parity
+        run: pnpm check:mirrors
 
       - name: Configure gcloud secret access for evaluator
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ pnpm test
 Targeted (most common during development):
 
 ```bash
+pnpm sync:mirrors
+pnpm check:mirrors
 pnpm --filter libretto type-check
 pnpm --filter libretto test -- test/basic.spec.ts
 pnpm --filter libretto test -- test/multi-page.spec.ts
@@ -40,5 +42,6 @@ pnpm --filter libretto cli help
 
 ## Skill Documentation Source of Truth
 
+- Edit `packages/libretto/README.template.md` directly for README changes, then run `pnpm sync:mirrors`.
 - Edit `packages/libretto/skills/libretto/SKILL.md` directly.
 - `packages/libretto/skills/libretto` is the source of truth for Libretto skill files.

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ pnpm test
 
 Source layout:
 
-- `src/cli/` — CLI commands
-- `src/runtime/` — browser runtime (network, recovery, downloads, extraction)
-- `src/shared/` — shared utilities (config, LLM client, logging, state)
-- `test/` — test files (`*.spec.ts`)
-- `skills/libretto/` — source of truth for the Libretto skill; mirrors are synced on `pnpm i`
+- `packages/libretto/src/cli/` — CLI commands
+- `packages/libretto/src/runtime/` — browser runtime (network, recovery, downloads, extraction)
+- `packages/libretto/src/shared/` — shared utilities (config, LLM client, logging, state)
+- `packages/libretto/test/` — test files (`*.spec.ts`)
+- `packages/libretto/skills/libretto/` — source of truth for the Libretto skill; mirrors are synced on `pnpm i`
 
 To check that skill mirrors are in sync without fixing them, run `pnpm check:skills`. To release, run `pnpm prepare-release`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,157 @@
+# Libretto
+
+[![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![GitHub Discussions](https://img.shields.io/github/discussions/saffron-health/libretto)](https://github.com/saffron-health/libretto/discussions)
+
+Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to:
+
+- Inspect live pages with minimal context overhead
+- Capture network traffic to reverse-engineer site APIs
+- Record user actions and replay them as automation scripts
+- Debug broken workflows interactively against the real site
+
+We at [Saffron Health](https://saffron.health) built Libretto to help us maintain our browser integrations to common healthcare software. We're open-sourcing it so other teams have an easier time doing the same thing.
+
+https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
+
+## Installation
+
+```bash
+npm install libretto
+
+# Install skill, download Chromium if not already installed, configure snapshot analysis
+npx libretto init
+
+# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto init` sets this up the first time.
+npx libretto ai configure <openai | anthropic | gemini | vertex>
+```
+
+## Use cases
+
+Libretto is designed to be used as a skill through your coding agent. Here are some example prompts:
+
+### One-shot script generation
+
+> Use the Libretto skill. Go on LinkedIn and scrape the first 10 posts for content, who posted it, the number of reactions, the first 25 comments, and the first 25 reposts.
+
+Your coding agent will open a window for you to log into LinkedIn, and then automatically start exploring.
+
+### Interactive script building
+
+> I'm gonna show you a workflow in the eclinicalworks EHR to get a patient's primary insurance ID. Use libretto skill to turn it into a playwright script that takes patient name and dob as input to get back the insurance ID. URL is ...
+
+Libretto can read your actions you perform in the browser, so you can perform a workflow, then ask it to use your actions to rebuild the workflow.
+
+### Convert browser automation to network requests
+
+> We have a browser script at ./integration.ts that automates going to Hacker News and getting the first 10 posts. Convert it to direct network scripts instead. Use the Libretto skill.
+
+Libretto can read network requests from the browser, which it can use to reverse engineer the API and create a script that directly calls those requests. Directly making API calls is faster, and more reliable, than UI automation. You can also ask Libretto to conduct a security analysis which analyzes the requests for common security cookies, so you can understand whether a network request approach will be safe.
+
+### Fix broken integrations
+
+> We have a browser script at ./integration.ts that is supposed to go to Availity and perform an eligibility check for a patient. But I'm getting a broken selector error when I run it. Fix it. Use the Libretto skill.
+
+Agents can use Libretto to reproduce the failure, pause the workflow at any point, inspect the live page, and fix issues, all autonomously.
+
+### CLI usage
+
+You can also use Libretto directly from the command line. All commands accept `--session <name>` to target a specific session.
+
+```bash
+npx libretto init                          # interactive; run yourself, not through an agent
+npx libretto open <url>                    # launch browser and open a URL (headed by default)
+npx libretto snapshot --objective "..." --context "..."  # capture PNG + HTML and analyze with an LLM
+npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page (single quoted argument)
+echo "<code>" | npx libretto exec -        # intentionally read Playwright TypeScript from stdin
+npx libretto run <file> <workflowName>     # run an exported workflow from a file
+npx libretto resume                        # resume a paused workflow
+npx libretto network                       # view captured network requests
+npx libretto actions                       # view captured user/agent actions
+npx libretto pages                         # list open pages in the session
+npx libretto save <domain>                 # save browser session (cookies, localStorage) for reuse
+npx libretto close                         # close the browser
+npx libretto ai configure <provider>       # configure snapshot analysis model
+```
+
+## Configuration
+
+All Libretto state lives in a `.libretto/` directory at your project root. Configuration is stored in `.libretto/config.json`.
+
+### Config file
+
+`.libretto/config.json` controls snapshot analysis and viewport settings:
+
+```json
+{
+  "version": 1,
+  "ai": {
+    "model": "openai/gpt-5.4",
+    "updatedAt": "2026-01-01T00:00:00.000Z"
+  },
+  "viewport": { "width": 1280, "height": 800 }
+}
+```
+
+The `ai` field configures which model Libretto uses for snapshot analysis — extracting selectors, identifying interactive elements, or diagnosing why a step failed. This keeps heavy visual context out of your coding agent's context window. Snapshot analysis is required.
+
+The easiest way to set the model is through the CLI:
+
+```bash
+npx libretto ai configure <openai | anthropic | gemini | vertex>
+```
+
+Provider credentials are read from environment variables or a `.env` file at your project root: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`, or `GOOGLE_CLOUD_PROJECT` for Vertex.
+
+The `viewport` field sets the default browser viewport size. Both fields are optional.
+
+### Sessions
+
+Each Libretto session gets its own directory under `.libretto/sessions/<name>/` containing runtime state. Sessions are git-ignored.
+
+- `state.json` — session metadata (debug port, PID, status)
+- `logs.jsonl` — structured session logs
+- `network.jsonl` — captured network requests
+- `actions.jsonl` — recorded user actions
+- `snapshots/` — screenshot PNGs and HTML snapshots
+
+### Profiles
+
+Profiles save browser sessions (cookies, localStorage) so you can reuse authenticated state across runs. They are stored in `.libretto/profiles/<domain>.json`, created via `npx libretto save <domain>`. Profiles are machine-local and git-ignored.
+
+## Community
+
+Have a question, idea, or want to share what you've built? Join the conversation on [GitHub Discussions](https://github.com/saffron-health/libretto/discussions).
+
+- **[Q&A](https://github.com/saffron-health/libretto/discussions/categories/q-a)** — Ask questions and get help
+- **[Ideas](https://github.com/saffron-health/libretto/discussions/categories/ideas)** — Suggest new features or improvements
+- **[Show and tell](https://github.com/saffron-health/libretto/discussions/categories/show-and-tell)** — Share your workflows and automations
+- **[General](https://github.com/saffron-health/libretto/discussions/categories/general)** — Chat about anything Libretto-related
+
+Found a bug? Please [open an issue](https://github.com/saffron-health/libretto/issues/new).
+
+## Authors
+
+Maintained by the team at [Saffron Health](https://saffron.health).
+
+## Development
+
+For local development in this repository:
+
+```bash
+pnpm i
+pnpm build
+pnpm type-check
+pnpm test
+```
+
+Source layout:
+
+- `src/cli/` — CLI commands
+- `src/runtime/` — browser runtime (network, recovery, downloads, extraction)
+- `src/shared/` — shared utilities (config, LLM client, logging, state)
+- `test/` — test files (`*.spec.ts`)
+- `skills/libretto/` — source of truth for the Libretto skill; mirrors are synced on `pnpm i`
+
+To check that skill mirrors are in sync without fixing them, run `pnpm check:skills`. To release, run `pnpm prepare-release`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "turbo run build",
     "website:build": "pnpm --dir ./apps/website build",
+    "sync:mirrors": "node packages/dev-tools/scripts/sync-mirrors.mjs",
+    "check:mirrors": "node packages/dev-tools/scripts/check-mirrors-sync.mjs",
     "type-check": "turbo run type-check",
     "test": "turbo run test",
     "prepare-release": "bash ./scripts/prepare-release.sh",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "sync:mirrors": "node scripts/sync-mirrors.mjs",
+    "check:mirrors": "node scripts/check-mirrors-sync.mjs"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/dev-tools/scripts/check-mirrors-sync.mjs
+++ b/packages/dev-tools/scripts/check-mirrors-sync.mjs
@@ -3,23 +3,23 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { compareSkillDirs, SKILL_DIRS } from "./skills-libretto.mjs";
+import { MIRRORS, compareMirrors } from "./mirrors-libretto.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..", "..", "..");
-const result = compareSkillDirs(repoRoot);
+const result = compareMirrors(repoRoot);
 
 if (result.ok) {
   console.log(
-    `libretto: verified identical skill mirrors across ${SKILL_DIRS.join(", ")}`,
+    `libretto: verified mirror parity for ${MIRRORS.map((mirror) => mirror.name).join(", ")}`,
   );
   process.exit(0);
 }
 
-console.error("libretto: skill directories must be identical:");
+console.error("libretto: mirrors must be in sync:");
 for (const issue of result.issues) {
   console.error(`- ${issue}`);
 }
 console.error("");
-console.error("Run `pnpm i` to resync the mirrors in this repository.");
+console.error("Run `pnpm sync:mirrors` to resync generated files and mirrors.");
 process.exit(1);

--- a/packages/dev-tools/scripts/mirrors-libretto.mjs
+++ b/packages/dev-tools/scripts/mirrors-libretto.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { SKILL_DIRS } from "../../libretto/scripts/skills-libretto.mjs";
+
+const README_TEMPLATE_PATH = "packages/libretto/README.template.md";
+const README_GENERATED_HEADER =
+  "<!-- Generated from packages/libretto/README.template.md by `pnpm sync:mirrors`. Do not edit directly. -->";
+const PACKAGE_JSON_PATH = "packages/libretto/package.json";
+const SKILL_SOURCE_PATH = "packages/libretto/skills/libretto/SKILL.md";
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   kind: "directory",
+ *   source: string,
+ *   targets: string[],
+ * }} DirectoryMirror
+ */
+
+/**
+ * @typedef {{
+ *   path: string,
+ *   render: (source: string) => string,
+ * }} FileMirrorTarget
+ */
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   kind: "file",
+ *   source: string,
+ *   targets: FileMirrorTarget[],
+ * }} FileMirror
+ */
+
+/** @type {(DirectoryMirror | FileMirror)[]} */
+export const MIRRORS = [
+  {
+    name: "skills",
+    kind: "directory",
+    source: SKILL_DIRS[0],
+    targets: SKILL_DIRS.slice(1),
+  },
+  {
+    name: "readmes",
+    kind: "file",
+    source: README_TEMPLATE_PATH,
+    targets: [
+      {
+        path: "packages/libretto/README.md",
+        render: (source) => renderReadme(source, ""),
+      },
+      {
+        path: "README.md",
+        render: (source) => renderReadme(source, "packages/libretto/"),
+      },
+    ],
+  },
+];
+
+function walkFiles(dir, baseDir = dir) {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, baseDir));
+      continue;
+    }
+    if (entry.isFile()) files.push(relative(baseDir, fullPath));
+  }
+
+  return files;
+}
+
+function normalizeText(content) {
+  const normalized = content.replace(/\r\n/g, "\n");
+  return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
+}
+
+function getFrontmatterBlock(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  return {
+    fullMatch: match[0],
+    body: match[1],
+    start: match.index,
+  };
+}
+
+function updateFrontmatterBody(frontmatterBody, updateLine) {
+  const lines = frontmatterBody.split("\n");
+  let inMetadata = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!inMetadata) {
+      if (line.trim() === "metadata:") {
+        inMetadata = true;
+      }
+      continue;
+    }
+
+    if (/^\S/.test(line)) break;
+
+    const updatedLine = updateLine(line);
+    if (updatedLine) {
+      lines[index] = updatedLine;
+      return lines.join("\n");
+    }
+  }
+
+  return null;
+}
+
+function findMetadataVersion(frontmatterBody) {
+  const lines = frontmatterBody.split("\n");
+  let inMetadata = false;
+
+  for (const line of lines) {
+    if (!inMetadata) {
+      if (line.trim() === "metadata:") {
+        inMetadata = true;
+      }
+      continue;
+    }
+
+    if (/^\S/.test(line)) break;
+
+    const match = line.match(/^\s*version:\s*"?([^"\n]+)"?\s*$/);
+    if (match) return match[1].trim();
+  }
+
+  return null;
+}
+
+function renderTemplate(template, variables) {
+  let rendered = template;
+  for (const [key, value] of Object.entries(variables)) {
+    rendered = rendered.replaceAll(`{{${key}}}`, value);
+  }
+
+  const unreplacedTokens = rendered.match(/{{[A-Z0-9_]+}}/g);
+  if (unreplacedTokens?.length) {
+    throw new Error(
+      `unreplaced template variables: ${[...new Set(unreplacedTokens)].join(", ")}`,
+    );
+  }
+
+  return rendered;
+}
+
+function renderReadme(source, librettoPathPrefix) {
+  const body = renderTemplate(source, {
+    LIBRETTO_PATH_PREFIX: librettoPathPrefix,
+  });
+  return normalizeText(`${README_GENERATED_HEADER}\n\n${body}`);
+}
+
+export function getLibrettoSkillVersion(skillSource) {
+  const frontmatter = getFrontmatterBlock(skillSource);
+  if (!frontmatter) return null;
+  return findMetadataVersion(frontmatter.body);
+}
+
+export function updateLibrettoSkillVersion(skillSource, version) {
+  const frontmatter = getFrontmatterBlock(skillSource);
+  if (!frontmatter) {
+    throw new Error(`missing frontmatter in ${SKILL_SOURCE_PATH}`);
+  }
+
+  const updatedFrontmatterBody = updateFrontmatterBody(frontmatter.body, (line) => {
+    const match = line.match(/^(\s*)version:\s*"?([^"\n]+)"?\s*$/);
+    if (!match) return null;
+    return `${match[1]}version: "${version}"`;
+  });
+
+  if (!updatedFrontmatterBody) {
+    throw new Error(`could not find metadata.version in ${SKILL_SOURCE_PATH}`);
+  }
+
+  return `${skillSource.slice(0, frontmatter.start)}---\n${updatedFrontmatterBody}\n---${skillSource.slice(frontmatter.start + frontmatter.fullMatch.length)}`;
+}
+
+export function setLibrettoSkillVersion(repoRoot, version) {
+  const skillPath = resolve(repoRoot, SKILL_SOURCE_PATH);
+  const currentContent = readFileSync(skillPath, "utf8");
+  writeFileSync(skillPath, updateLibrettoSkillVersion(currentContent, version), "utf8");
+}
+
+function syncDirectoryMirror(sourceDir, destDir) {
+  rmSync(destDir, { recursive: true, force: true });
+  mkdirSync(destDir, { recursive: true });
+  cpSync(sourceDir, destDir, { recursive: true });
+}
+
+function compareDirectoryMirror(mirror, repoRoot, issues) {
+  const sourceDir = resolve(repoRoot, mirror.source);
+  if (!existsSync(sourceDir)) {
+    issues.push(`${mirror.name}: missing source directory: ${mirror.source}`);
+    return;
+  }
+
+  const expectedFiles = walkFiles(sourceDir);
+  const expectedFileSet = new Set(expectedFiles);
+
+  for (const target of mirror.targets) {
+    const targetDir = resolve(repoRoot, target);
+    if (!existsSync(targetDir)) {
+      issues.push(`${mirror.name}: missing directory: ${target}`);
+      continue;
+    }
+
+    const actualFiles = walkFiles(targetDir);
+    const actualFileSet = new Set(actualFiles);
+
+    for (const file of expectedFiles) {
+      if (!actualFileSet.has(file)) {
+        issues.push(`${mirror.name}: ${target} is missing file: ${file}`);
+      }
+    }
+
+    for (const file of actualFiles) {
+      if (!expectedFileSet.has(file)) {
+        issues.push(`${mirror.name}: ${target} has unexpected file: ${file}`);
+      }
+    }
+
+    for (const file of expectedFiles) {
+      const sourceFilePath = join(sourceDir, file);
+      const targetFilePath = join(targetDir, file);
+      if (!existsSync(targetFilePath)) continue;
+
+      const expectedContent = readFileSync(sourceFilePath);
+      const actualContent = readFileSync(targetFilePath);
+      if (!expectedContent.equals(actualContent)) {
+        issues.push(`${mirror.name}: ${target} differs from ${mirror.source}: ${file}`);
+      }
+    }
+  }
+}
+
+function compareFileMirror(mirror, repoRoot, issues) {
+  const sourcePath = resolve(repoRoot, mirror.source);
+  if (!existsSync(sourcePath)) {
+    issues.push(`${mirror.name}: missing source file: ${mirror.source}`);
+    return;
+  }
+
+  const source = readFileSync(sourcePath, "utf8");
+  for (const target of mirror.targets) {
+    const targetPath = resolve(repoRoot, target.path);
+    if (!existsSync(targetPath)) {
+      issues.push(`${mirror.name}: missing file: ${target.path}`);
+      continue;
+    }
+
+    const expectedContent = target.render(source);
+    const actualContent = normalizeText(readFileSync(targetPath, "utf8"));
+    if (expectedContent !== actualContent) {
+      issues.push(`${mirror.name}: ${target.path} differs from ${mirror.source}`);
+    }
+  }
+}
+
+function getSkillVersionIssue(repoRoot) {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(repoRoot, PACKAGE_JSON_PATH), "utf8"),
+  );
+  const skillSource = readFileSync(resolve(repoRoot, SKILL_SOURCE_PATH), "utf8");
+  const skillVersion = getLibrettoSkillVersion(skillSource);
+
+  if (!skillVersion) {
+    return `validation: could not find metadata.version in ${SKILL_SOURCE_PATH}`;
+  }
+
+  if (skillVersion !== packageJson.version) {
+    return `validation: ${SKILL_SOURCE_PATH} metadata.version (${skillVersion}) must match ${PACKAGE_JSON_PATH} version (${packageJson.version})`;
+  }
+
+  return null;
+}
+
+export function compareMirrors(repoRoot) {
+  const issues = [];
+
+  for (const mirror of MIRRORS) {
+    if (mirror.kind === "directory") {
+      compareDirectoryMirror(mirror, repoRoot, issues);
+      continue;
+    }
+
+    compareFileMirror(mirror, repoRoot, issues);
+  }
+
+  const skillVersionIssue = getSkillVersionIssue(repoRoot);
+  if (skillVersionIssue) issues.push(skillVersionIssue);
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+export function syncMirrors(repoRoot) {
+  for (const mirror of MIRRORS) {
+    if (mirror.kind === "directory") {
+      const sourceDir = resolve(repoRoot, mirror.source);
+      if (!existsSync(sourceDir)) {
+        throw new Error(`missing source directory: ${mirror.source}`);
+      }
+
+      for (const target of mirror.targets) {
+        syncDirectoryMirror(sourceDir, resolve(repoRoot, target));
+      }
+      continue;
+    }
+
+    const sourcePath = resolve(repoRoot, mirror.source);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`missing source file: ${mirror.source}`);
+    }
+
+    const source = readFileSync(sourcePath, "utf8");
+    for (const target of mirror.targets) {
+      const targetPath = resolve(repoRoot, target.path);
+      mkdirSync(dirname(targetPath), { recursive: true });
+      writeFileSync(targetPath, target.render(source), "utf8");
+    }
+  }
+
+  const result = compareMirrors(repoRoot);
+  if (!result.ok) {
+    throw new Error(result.issues.join("\n"));
+  }
+}

--- a/packages/dev-tools/scripts/set-libretto-skill-version.mjs
+++ b/packages/dev-tools/scripts/set-libretto-skill-version.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setLibrettoSkillVersion } from "./mirrors-libretto.mjs";
+
+const nextVersion = process.argv[2]?.trim();
+if (!nextVersion) {
+  console.error("Usage: node packages/dev-tools/scripts/set-libretto-skill-version.mjs <version>");
+  process.exit(1);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..", "..");
+
+setLibrettoSkillVersion(repoRoot, nextVersion);

--- a/packages/dev-tools/scripts/sync-mirrors.mjs
+++ b/packages/dev-tools/scripts/sync-mirrors.mjs
@@ -3,10 +3,12 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SKILL_DIRS, syncRepoSkills } from "./skills-libretto.mjs";
+import { MIRRORS, syncMirrors } from "./mirrors-libretto.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..", "..", "..");
 
-syncRepoSkills(repoRoot);
-console.log(`libretto: synced skill mirrors across ${SKILL_DIRS.join(", ")}`);
+syncMirrors(repoRoot);
+console.log(
+  `libretto: synced mirrors for ${MIRRORS.map((mirror) => mirror.name).join(", ")}`,
+);

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -1,3 +1,5 @@
+<!-- Generated from packages/libretto/README.template.md by `pnpm sync:mirrors`. Do not edit directly. -->
+
 # Libretto
 
 [![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
@@ -152,6 +154,9 @@ Source layout:
 - `src/runtime/` — browser runtime (network, recovery, downloads, extraction)
 - `src/shared/` — shared utilities (config, LLM client, logging, state)
 - `test/` — test files (`*.spec.ts`)
-- `skills/libretto/` — source of truth for the Libretto skill; mirrors are synced on `pnpm i`
+- `README.template.md` — source of truth for the repo and package READMEs
+- `skills/libretto/` — source of truth for the Libretto skill
 
-To check that skill mirrors are in sync without fixing them, run `pnpm check:skills`. To release, run `pnpm prepare-release`.
+Run `pnpm sync:mirrors` after editing `README.template.md` or anything under `skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
+
+To check that generated READMEs, skill mirrors, and skill version metadata are in sync without fixing them, run `pnpm check:mirrors`. To release, run `pnpm prepare-release`.

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -1,5 +1,3 @@
-<!-- Generated from packages/libretto/README.template.md by `pnpm sync:mirrors`. Do not edit directly. -->
-
 # Libretto
 
 [![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
@@ -150,13 +148,13 @@ pnpm test
 
 Source layout:
 
-- `packages/libretto/src/cli/` — CLI commands
-- `packages/libretto/src/runtime/` — browser runtime (network, recovery, downloads, extraction)
-- `packages/libretto/src/shared/` — shared utilities (config, LLM client, logging, state)
-- `packages/libretto/test/` — test files (`*.spec.ts`)
-- `packages/libretto/README.template.md` — source of truth for the repo and package READMEs
-- `packages/libretto/skills/libretto/` — source of truth for the Libretto skill
+- `{{LIBRETTO_PATH_PREFIX}}src/cli/` — CLI commands
+- `{{LIBRETTO_PATH_PREFIX}}src/runtime/` — browser runtime (network, recovery, downloads, extraction)
+- `{{LIBRETTO_PATH_PREFIX}}src/shared/` — shared utilities (config, LLM client, logging, state)
+- `{{LIBRETTO_PATH_PREFIX}}test/` — test files (`*.spec.ts`)
+- `{{LIBRETTO_PATH_PREFIX}}README.template.md` — source of truth for the repo and package READMEs
+- `{{LIBRETTO_PATH_PREFIX}}skills/libretto/` — source of truth for the Libretto skill
 
-Run `pnpm sync:mirrors` after editing `packages/libretto/README.template.md` or anything under `packages/libretto/skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
+Run `pnpm sync:mirrors` after editing `{{LIBRETTO_PATH_PREFIX}}README.template.md` or anything under `{{LIBRETTO_PATH_PREFIX}}skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
 
 To check that generated READMEs, skill mirrors, and skill version metadata are in sync without fixing them, run `pnpm check:mirrors`. To release, run `pnpm prepare-release`.

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -31,8 +31,10 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.mjs",
-    "sync-skills": "node scripts/sync-skills.mjs",
-    "check:skills": "node scripts/check-skills-sync.mjs",
+    "sync:mirrors": "node ../dev-tools/scripts/sync-mirrors.mjs",
+    "check:mirrors": "node ../dev-tools/scripts/check-mirrors-sync.mjs",
+    "sync-skills": "pnpm run sync:mirrors",
+    "check:skills": "pnpm run check:mirrors",
     "build": "tsup --config tsup.config.ts",
     "type-check": "tsc --noEmit",
     "test": "pnpm run build && vitest run",

--- a/packages/libretto/scripts/skills-libretto.mjs
+++ b/packages/libretto/scripts/skills-libretto.mjs
@@ -1,14 +1,6 @@
 #!/usr/bin/env node
 
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-} from "node:fs";
-import { relative, resolve, join } from "node:path";
+import { cpSync, mkdirSync, rmSync } from "node:fs";
 
 export const SKILL_DIRS = [
   "packages/libretto/skills/libretto",
@@ -16,88 +8,8 @@ export const SKILL_DIRS = [
   ".claude/skills/libretto",
 ];
 
-function walkFiles(dir, baseDir = dir) {
-  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
-  const files = [];
-
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...walkFiles(fullPath, baseDir));
-      continue;
-    }
-    if (entry.isFile()) files.push(relative(baseDir, fullPath));
-  }
-
-  return files;
-}
-
 export function syncSkillDir(sourceDir, destDir) {
   rmSync(destDir, { recursive: true, force: true });
   mkdirSync(destDir, { recursive: true });
   cpSync(sourceDir, destDir, { recursive: true });
-}
-
-export function syncRepoSkills(repoRoot) {
-  const sourceDir = resolve(repoRoot, SKILL_DIRS[0]);
-  for (const dir of SKILL_DIRS.slice(1)) {
-    syncSkillDir(sourceDir, resolve(repoRoot, dir));
-  }
-}
-
-export function compareSkillDirs(repoRoot) {
-  const roots = SKILL_DIRS.map((dir) => ({
-    label: dir,
-    absPath: resolve(repoRoot, dir),
-  }));
-  const missing = roots.filter(({ absPath }) => !existsSync(absPath));
-  const mismatches = [];
-
-  if (missing.length > 0) {
-    return {
-      ok: false,
-      issues: missing.map(({ label }) => `missing directory: ${label}`),
-    };
-  }
-
-  const expectedFiles = walkFiles(roots[0].absPath);
-  const expectedFileSet = new Set(expectedFiles);
-
-  for (const root of roots.slice(1)) {
-    const actualFiles = walkFiles(root.absPath);
-    const actualFileSet = new Set(actualFiles);
-
-    for (const file of expectedFiles) {
-      if (!actualFileSet.has(file)) {
-        mismatches.push(`${root.label} is missing file: ${file}`);
-      }
-    }
-
-    for (const file of actualFiles) {
-      if (!expectedFileSet.has(file)) {
-        mismatches.push(`${root.label} has unexpected file: ${file}`);
-      }
-    }
-  }
-
-  for (const file of expectedFiles) {
-    const expectedContent = readFileSync(join(roots[0].absPath, file));
-    for (const root of roots.slice(1)) {
-      const targetPath = join(root.absPath, file);
-      if (!existsSync(targetPath)) continue;
-      const actualContent = readFileSync(targetPath);
-      if (!expectedContent.equals(actualContent)) {
-        mismatches.push(
-          `${root.label} differs from ${roots[0].label}: ${file}`,
-        );
-      }
-    }
-  }
-
-  return {
-    ok: mismatches.length === 0,
-    issues: mismatches,
-  };
 }

--- a/packages/libretto/scripts/skills-libretto.mjs
+++ b/packages/libretto/scripts/skills-libretto.mjs
@@ -41,7 +41,7 @@ export function syncSkillDir(sourceDir, destDir) {
 }
 
 export function syncRepoSkills(repoRoot) {
-  const sourceDir = resolve(repoRoot, "skills/libretto");
+  const sourceDir = resolve(repoRoot, SKILL_DIRS[0]);
   for (const dir of SKILL_DIRS.slice(1)) {
     syncSkillDir(sourceDir, resolve(repoRoot, dir));
   }

--- a/packages/libretto/skills/AGENTS.md
+++ b/packages/libretto/skills/AGENTS.md
@@ -6,6 +6,6 @@
 
 ## Syncing
 
-- Run `pnpm sync-skills` after changing anything under `skills/libretto`.
-- Run `pnpm check:skills` to verify that `skills/libretto`, `.agents/skills/libretto`, and `.claude/skills/libretto` are identical.
-- `pnpm i` also resyncs the mirrors through `postinstall`, but use `pnpm sync-skills` for local doc edits so you do not need a full install step.
+- Run `pnpm sync:mirrors` after changing anything under `skills/libretto`.
+- Run `pnpm check:mirrors` to verify that generated READMEs, skill mirrors, and skill version metadata are in sync.
+- `pnpm i` also resyncs the skill mirrors through `postinstall`, but use `pnpm sync:mirrors` for local doc edits because `postinstall` does not regenerate the READMEs.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.4.2"
+  version: "0.5.2"
 ---
 
 ## How Libretto Works

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -13,6 +13,7 @@ EOF
 bump="${1:-patch}"
 package_json_path="packages/libretto/package.json"
 package_dir="packages/libretto"
+skill_path="packages/libretto/skills/libretto/SKILL.md"
 
 case "$bump" in
   patch|minor|major)
@@ -75,13 +76,19 @@ if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; th
   exit 1
 fi
 
+git checkout -b "$branch_name"
+
 (
   cd "$package_dir"
   npm version "$next_version" --no-git-tag-version >/dev/null
 )
 
-git checkout -b "$branch_name"
-git add "$package_json_path"
+node packages/dev-tools/scripts/set-libretto-skill-version.mjs "$next_version"
+
+pnpm sync:mirrors
+pnpm check:mirrors
+
+git add "$package_json_path" "$skill_path" README.md packages/libretto/README.md .agents/skills/libretto .claude/skills/libretto
 git commit -m "release: v${next_version}"
 git push -u origin "$branch_name"
 


### PR DESCRIPTION
## Summary
- add a generated root `README.md` so GitHub shows Libretto docs at the repository root
- introduce `packages/libretto/README.template.md` as the README source of truth and generate both the root and package READMEs from it
- replace the skill-only sync scripts with generic mirror tooling in `packages/dev-tools`, add mirror parity checks to CI, and verify the skill metadata version matches `packages/libretto/package.json`
- update release prep to bump the skill version and resync mirrors automatically

## Testing
- `pnpm check:mirrors`
- `pnpm --filter libretto check:mirrors`
- `bash -n scripts/prepare-release.sh`
