### PR TITLE
Update glimpse-changes skill to latest upstream

### DIFF
--- a/.agents/skills/glimpse-changes/SKILL.md
+++ b/.agents/skills/glimpse-changes/SKILL.md
@@ -3,58 +3,74 @@ name: glimpse-changes
 description: Create a visual explanation of the current session diff as a single HTML page and show it in a native Glimpse window. Use when the user wants a visual walkthrough of local code changes instead of a plain text diff.
 metadata:
   author: tanishqkancharla
-  version: "1.2.0"
+  version: "1.4.0"
 ---
 
 # Glimpse Changes
 
-Use this skill when the user wants a visual explanation of the changes made in the current session.
+Render a Markdown document in a native Glimpse window with syntax-highlighted code and rich diff rendering.
 
-## Workflow
+## Usage
 
-1. Inspect the current session changes with `git status --short`, `git diff --stat`, `git diff --cached --stat`, and focused `git diff --unified=5 -- <files>` calls.
-2. Write a Markdown explanation of the diff, usually in `/tmp/session-diff-report.md`.
-3. Run `npx glimpse-changes` to render and open the Glimpse window.
-
-## Page Content
-
-Include:
-
-- A short title and summary of the session.
-- File-level sections that explain what changed and why it matters.
-- Command diffs using `!\`git diff -- path/to/file\`` to show changes inline.
-- Short representative snippets instead of full patches. Diff hunks don't need to be full files.
-- Order sections and hunks in the sequence that best explains the changes, not necessarily file order.
-- Risks, follow-up work, or open questions when they are relevant.
-
-## CLI
-
-The CLI accepts either a single inline Markdown argument or stdin:
+Pipe markdown or pass it as an argument:
 
 ```bash
-npx glimpse-changes "# Session diff\n\n- Summary"
-
-cat /tmp/session-diff-report.md | npx glimpse-changes
+cat report.md | npx glimpse-changes
+npx glimpse-changes "# Title\n\nContent"
 ```
 
-The CLI detaches the Glimpse window into a background process and exits immediately.
+The CLI opens a Glimpse window and exits immediately.
 
-## Rendering
+## Diff blocks
 
-- The renderer opens the page in Glimpse automatically with the `glimpseui` package.
-- The renderer always uses Diffs.com's `@pierre/diffs` browser module for fenced `diff` blocks.
-- The renderer defaults to split layout for fenced `diff` blocks.
-- Fenced `diff` blocks are rendered with `@pierre/diffs` from Diffs.com.
-- Diff blocks are capped to about `60%` of the viewport and scroll inside the page when they exceed that size.
-- Prefer command diffs (`!\`git diff ...\``) over pasting raw diff content into fenced blocks.
-- Command diffs execute at render time and always reflect the current state of the working tree.
-- Command diffs **must** start with `git diff`; any other command will be rejected.
-- Command diff output **must** contain valid unified diff hunks (with `diff --git` headers or `@@ ... @@` hunk headers); otherwise the renderer will throw an error.
-- Fenced `diff` blocks with literal patch content are still supported as a fallback.
+**Command diffs** — executed at render time, must start with `git diff`:
 
-## Rules
+```
+!`git diff -- path/to/file`
+```
 
-- Do not use `pnpm cli` or `libretto open` for this workflow.
-- Prefer `npx glimpse-changes` for display and Git for diff inspection.
-- If the diff is large, summarize repeated edits and show only the most informative snippets.
-- The CLI exits immediately after launching the Glimpse window in the background.
+**Full unified diffs** — paste standard `git diff` output in a `diff` fenced block:
+
+````
+```diff
+diff --git a/foo.txt b/foo.txt
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,3 +1,3 @@
+ context
+-old
++new
+```
+````
+
+**Inline diffs** — bare `+`/`-`/` ` prefixed lines in a `diff` fenced block:
+
+````
+```diff
+-removed line
++added line
+ context line
+```
+````
+
+Every non-empty line must start with `+`, `-`, or a space. Invalid lines cause an error.
+
+For added-file snippets, you can start with `+++ path/to/file.ext` and keep the remaining lines prefixed with `+`. The renderer will synthesize a proper new-file diff so the filename and syntax highlighting are preserved.
+
+## Code blocks
+
+Fenced code blocks with a language tag get syntax highlighting via `@pierre/diffs`:
+
+````
+```js
+const x = 1;
+```
+````
+
+## Typical workflow
+
+1. Inspect changes with `git diff`, `git status`, etc.
+2. Write a markdown explanation of the changes.
+3. Pipe it to `npx glimpse-changes`.
+
+Prefer command diffs (`!`git diff ...``) over pasting raw diff content — they always reflect the current working tree.

--- a/packages/libretto/skills-lock.json
+++ b/packages/libretto/skills-lock.json
@@ -4,7 +4,7 @@
     "glimpse-changes": {
       "source": "tanishqkancharla/glimpse-changes",
       "sourceType": "github",
-      "computedHash": "3719b3bd3db6a0ceea265d892920dc09e9e8e36405889d9baabec86fa2e03bfe"
+      "computedHash": "40e0a6fda116923f63e498de86440e0501569650a47e0b024e70dc6c7e8ca2a8"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the project `glimpse-changes` skill mirror to the latest upstream `1.4.0` content
- refresh `packages/libretto/skills-lock.json` to the new upstream computed hash
- keep the repo's installed skill documentation aligned with the latest published skill behavior

## Testing
- not run (skill/documentation and lockfile update only)
