### PR TITLE
ci: add timeout to opencode review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- add a 20 minute timeout to the OpenCode review workflow job
- prevent review runs from hanging indefinitely and consuming CI capacity
