### PR TITLE
Add file:// support to the open command

### DIFF
--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -65,6 +65,10 @@ function tryParseAbsoluteUrl(url: string): URL | null {
 }
 
 function isLikelyHostWithPort(parsedUrl: URL, rawUrl: string): boolean {
+  // `new URL("localhost:3000")` parses successfully, but treats `localhost:`
+  // as a custom scheme instead of a bare host with port. Detect that shape so
+  // CLI shorthand like `libretto open localhost:3000` still normalizes to
+  // `https://localhost:3000/`.
   const remainder = rawUrl.slice(parsedUrl.protocol.length);
   if (remainder.length === 0) return false;
 

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -65,7 +65,7 @@ export function normalizeUrl(url: string): URL {
       parsedUrl.protocol !== "file:"
     ) {
       throw new Error(
-        `Unsupported URL protocol for open: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
+        `Unsupported URL protocol: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
       );
     }
     return parsedUrl;

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -56,21 +56,53 @@ async function pickFreePort(): Promise<number> {
   });
 }
 
+function tryParseAbsoluteUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function isLikelyHostWithPort(parsedUrl: URL, rawUrl: string): boolean {
+  const remainder = rawUrl.slice(parsedUrl.protocol.length);
+  if (remainder.length === 0) return false;
+
+  let index = 0;
+  while (index < remainder.length) {
+    const charCode = remainder.charCodeAt(index);
+    if (charCode < 48 || charCode > 57) break;
+    index += 1;
+  }
+
+  if (index === 0) return false;
+  if (index === remainder.length) return true;
+
+  const nextChar = remainder[index];
+  return nextChar === "/" || nextChar === "?" || nextChar === "#";
+}
+
 export function normalizeUrl(url: string): URL {
-  if (url.includes("://")) {
-    const parsedUrl = new URL(url);
-    if (
-      parsedUrl.protocol !== "http:" &&
-      parsedUrl.protocol !== "https:" &&
-      parsedUrl.protocol !== "file:"
-    ) {
-      throw new Error(
-        `Unsupported URL protocol: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
-      );
-    }
+  const parsedUrl = tryParseAbsoluteUrl(url);
+  if (!parsedUrl) {
+    return new URL(`https://${url}`);
+  }
+
+  if (
+    parsedUrl.protocol === "http:" ||
+    parsedUrl.protocol === "https:" ||
+    parsedUrl.protocol === "file:"
+  ) {
     return parsedUrl;
   }
-  return new URL(`https://${url}`);
+
+  if (isLikelyHostWithPort(parsedUrl, url)) {
+    return new URL(`https://${url}`);
+  }
+
+  throw new Error(
+    `Unsupported URL protocol: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
+  );
 }
 
 export function normalizeDomain(url: URL): string {

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -56,20 +56,25 @@ async function pickFreePort(): Promise<number> {
   });
 }
 
-export function normalizeUrl(url: string): string {
-  if (!/^https?:\/\//i.test(url)) {
-    return `https://${url}`;
+export function normalizeUrl(url: string): URL {
+  if (url.includes("://")) {
+    const parsedUrl = new URL(url);
+    if (
+      parsedUrl.protocol !== "http:" &&
+      parsedUrl.protocol !== "https:" &&
+      parsedUrl.protocol !== "file:"
+    ) {
+      throw new Error(
+        `Unsupported URL protocol for open: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
+      );
+    }
+    return parsedUrl;
   }
-  return url;
+  return new URL(`https://${url}`);
 }
 
-export function normalizeDomain(url: string): string {
-  try {
-    const u = new URL(normalizeUrl(url));
-    return u.hostname.replace(/^www\./, "");
-  } catch {
-    return url.replace(/^www\./, "");
-  }
+export function normalizeDomain(url: URL): string {
+  return url.hostname.replace(/^www\./, "");
 }
 
 export function getProfilePath(domain: string): string {
@@ -359,7 +364,8 @@ export async function runOpen(
   logger: LoggerApi,
   options?: { viewport?: { width: number; height: number } },
 ): Promise<void> {
-  const url = normalizeUrl(rawUrl);
+  const parsedUrl = normalizeUrl(rawUrl);
+  const url = parsedUrl.href;
   const viewport = resolveViewport(options?.viewport, logger);
   const windowPosition = headed ? resolveWindowPosition(logger) : undefined;
   logger.info("open-start", { url, headed, session, viewport, windowPosition });
@@ -371,9 +377,11 @@ export async function runOpen(
   const actionsLogPath = getSessionActionsLogPath(session);
 
   const browserMode = headed ? "headed" : "headless";
-  const domain = normalizeDomain(url);
-  const profilePath = getProfilePath(domain);
-  const useProfile = hasProfile(domain);
+  const supportsSavedProfile =
+    parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  const domain = supportsSavedProfile ? normalizeDomain(parsedUrl) : undefined;
+  const profilePath = domain ? getProfilePath(domain) : undefined;
+  const useProfile = domain ? hasProfile(domain) : false;
 
   logger.info("open-launching", {
     url,
@@ -390,7 +398,7 @@ export async function runOpen(
   }
   console.log(`Launching ${browserMode} browser (session: ${session})...`);
 
-  const escapedProfilePath = profilePath
+  const escapedProfilePath = (profilePath ?? "")
     .replace(/\\/g, "\\\\")
     .replace(/'/g, "\\'");
   const escapedUrl = url.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
@@ -671,7 +679,7 @@ export async function runSave(
   try {
     await new Promise((r) => setTimeout(r, 500));
 
-    const domain = normalizeDomain(urlOrDomain);
+    const domain = normalizeDomain(normalizeUrl(urlOrDomain));
     const profilePath = getProfilePath(domain);
 
     const cdpSession = await context.newCDPSession(page);

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -398,12 +398,11 @@ export async function runOpen(
   }
   console.log(`Launching ${browserMode} browser (session: ${session})...`);
 
-  const escapedProfilePath = (profilePath ?? "")
-    .replace(/\\/g, "\\\\")
-    .replace(/'/g, "\\'");
   const escapedUrl = url.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
   const storageStateCode = useProfile
-    ? `storageState: '${escapedProfilePath}',`
+    ? `storageState: '${profilePath!
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'")}',`
     : "";
 
   const escapedLogPath = runLogPath.replace(/\\/g, "\\\\").replace(/'/g, "\\'");

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -14,7 +14,11 @@ import {
 } from "../../index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { parseSessionStateContent } from "../../shared/state/index.js";
-import { getProfilePath, normalizeDomain } from "../core/browser.js";
+import {
+  getProfilePath,
+  normalizeDomain,
+  normalizeUrl,
+} from "../core/browser.js";
 import {
   getSessionActionsLogPath,
   getSessionDir,
@@ -110,7 +114,7 @@ async function waitForFailureSessionRelease(args: {
 }
 
 function resolveLocalAuthProfilePath(domain: string): string {
-  return getProfilePath(normalizeDomain(domain));
+  return getProfilePath(normalizeDomain(normalizeUrl(domain)));
 }
 
 function getMissingLocalAuthProfileError(args: {
@@ -118,7 +122,7 @@ function getMissingLocalAuthProfileError(args: {
   profilePath: string;
   session: string;
 }): string {
-  const normalizedDomain = normalizeDomain(args.domain);
+  const normalizedDomain = normalizeDomain(normalizeUrl(args.domain));
   return [
     `Local auth profile not found for domain "${normalizedDomain}".`,
     `Expected profile file: ${args.profilePath}`,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
 
@@ -164,6 +165,42 @@ describe("basic CLI subprocess behavior", () => {
       "Usage: libretto open <url> [--headless] [--viewport WxH] [--session <name>]",
     );
   });
+
+  test("opens file URLs", async ({ librettoCli, workspacePath }) => {
+    const htmlPath = workspacePath("fixtures", "local-file.html");
+    await mkdir(workspacePath("fixtures"), { recursive: true });
+    await mkdir(workspacePath(".libretto", "profiles"), { recursive: true });
+    await writeFile(
+      htmlPath,
+      `<!doctype html><html><head><title>Local File Title</title></head><body><h1>Local File Body</h1></body></html>`,
+      "utf8",
+    );
+    await writeFile(
+      workspacePath(".libretto", "profiles", "local-file.json"),
+      "{ definitely-not-valid-json}",
+      "utf8",
+    );
+
+    const fileUrl = pathToFileURL(htmlPath).href;
+    const session = "file-url-open";
+
+    const opened = await librettoCli(
+      `open "${fileUrl}" --headless --session ${session}`,
+    );
+    expect(opened.stderr).toBe("");
+    expect(opened.stdout).toContain(`Browser open (headless): ${fileUrl}`);
+    expect(opened.stdout).not.toContain("Loading saved profile");
+
+    const title = await librettoCli(
+      `exec "return await page.title()" --session ${session}`,
+    );
+    expect(title.stderr).toBe("");
+    expect(title.stdout).toContain("Local File Title");
+
+    const closed = await librettoCli(`close --session ${session}`);
+    expect(closed.stderr).toBe("");
+    expect(closed.stdout).toContain(`Browser closed (session: ${session}).`);
+  }, 45_000);
 
   test("fails open with actionable error when browser child spawn fails", async ({
     librettoCli,

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -12,6 +12,12 @@ describe("browser URL normalization", () => {
     );
   });
 
+  test("treats bare hosts with embedded redirect URLs as bare hosts", () => {
+    expect(normalizeUrl("example.com?redirect=https://idp.com").href).toBe(
+      "https://example.com/?redirect=https://idp.com",
+    );
+  });
+
   test("preserves explicit https URLs", () => {
     expect(normalizeUrl("https://example.com").href).toBe(
       "https://example.com/",

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
+
+describe("browser URL normalization", () => {
+  test("adds https to bare hostnames", () => {
+    expect(normalizeUrl("example.com").href).toBe("https://example.com/");
+  });
+
+  test("adds https to bare hosts with ports", () => {
+    expect(normalizeUrl("localhost:3000").href).toBe(
+      "https://localhost:3000/",
+    );
+  });
+
+  test("preserves explicit https URLs", () => {
+    expect(normalizeUrl("https://example.com").href).toBe(
+      "https://example.com/",
+    );
+  });
+
+  test("preserves file URLs", () => {
+    expect(normalizeUrl("file:///tmp/example.html").href).toBe(
+      "file:///tmp/example.html",
+    );
+  });
+
+  test("normalizes www hostnames from parsed URLs", () => {
+    expect(normalizeDomain(normalizeUrl("https://www.example.com/path"))).toBe(
+      "example.com",
+    );
+  });
+});

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -31,6 +31,7 @@ function extractBundledImplementation(indexSource: string): string {
 }
 
 const require = createRequire(import.meta.url);
+const librettoPackageVersion = require("../package.json").version as string;
 
 describe("createHostedDeployPackage", () => {
   const cleanups: Array<() => void> = [];
@@ -209,7 +210,7 @@ describe("createHostedDeployPackage", () => {
     const implementation = extractBundledImplementation(bundle);
 
     expect(deployManifest.dependencies).toEqual({
-      libretto: "0.5.3",
+      libretto: librettoPackageVersion,
       lodash: "^4.17.21",
     });
     expect(bundle).toContain('export const testWorkflow = createWorkflowProxy("testWorkflow");');


### PR DESCRIPTION
## Summary
- allow `libretto open` to accept `file://` URLs in addition to HTTP(S) targets
- parse open targets into `URL` objects so profile handling can key off the parsed protocol cleanly
- add regression coverage for `file://` opens and URL normalization helpers
- make the deploy artifact test read the current Libretto package version instead of a stale hardcoded version

## Testing
- pnpm --filter libretto type-check
- pnpm --filter libretto test -- test/browser.spec.ts test/basic.spec.ts
