### PR TITLE
ci: pass GH_TOKEN to changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
           version="$(node -p "require('./packages/libretto/package.json').version")"
           echo "package_name=${package_name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
       - name: Check publish state
         id: state
@@ -117,8 +116,6 @@ jobs:
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.version.outputs.tag }}
       npm_exists: ${{ steps.state.outputs.npm_exists }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,34 +39,26 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
-      - name: Check release state
+      - name: Check publish state
         id: state
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          release_exists=false
           npm_exists=false
-
-          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            release_exists=true
-          fi
 
           if npm view "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             npm_exists=true
           fi
 
-          echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
           echo "npm_exists=${npm_exists}" >> "$GITHUB_OUTPUT"
 
       - name: Skip already published version
-        if: steps.state.outputs.release_exists == 'true' && steps.state.outputs.npm_exists == 'true'
+        if: steps.state.outputs.npm_exists == 'true'
         run: |
-          echo "Version ${{ steps.version.outputs.version }} is already published to npm and GitHub."
+          echo "Version ${{ steps.version.outputs.version }} is already published to npm."
 
       - name: Configure gcloud secret access for evaluator
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.npm_exists != 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -107,7 +99,7 @@ jobs:
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Restore evaluator cache
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.npm_exists != 'true'
         uses: actions/cache@v4
         with:
           path: temp/libretto-cli-evaluate-cache
@@ -116,28 +108,27 @@ jobs:
             libretto-evaluate-cache-${{ runner.os }}-
 
       - name: Install dependencies
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.npm_exists != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Verify release build
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.npm_exists != 'true'
         run: |
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
-      release_exists: ${{ steps.state.outputs.release_exists }}
       npm_exists: ${{ steps.state.outputs.npm_exists }}
 
   release:
     needs: verify
-    if: needs.verify.outputs.release_exists != 'true' || needs.verify.outputs.npm_exists != 'true'
+    if: needs.verify.outputs.npm_exists != 'true'
     runs-on: ubuntu-latest
     environment:
       name: release
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - name: Checkout
@@ -161,27 +152,5 @@ jobs:
         run: pnpm --filter libretto build
 
       - name: Publish to npm with trusted publishing
-        if: needs.verify.outputs.npm_exists != 'true'
         working-directory: packages/libretto
         run: npm publish --access public
-
-      - name: Generate changelog
-        if: needs.verify.outputs.release_exists != 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        working-directory: packages/libretto
-        run: pnpm generate-changelog "${{ needs.verify.outputs.tag }}" > "$RUNNER_TEMP/changelog.md"
-
-      - name: Create GitHub release
-        if: needs.verify.outputs.release_exists != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/${{ needs.verify.outputs.tag }}" >/dev/null 2>&1; then
-            gh release create "${{ needs.verify.outputs.tag }}" --notes-file "$RUNNER_TEMP/changelog.md"
-          else
-            gh release create "${{ needs.verify.outputs.tag }}" \
-              --target "${GITHUB_SHA}" \
-              --notes-file "$RUNNER_TEMP/changelog.md"
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,27 +37,36 @@ jobs:
           version="$(node -p "require('./packages/libretto/package.json').version")"
           echo "package_name=${package_name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
-      - name: Check publish state
+      - name: Check release state
         id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          release_exists=false
           npm_exists=false
+
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            release_exists=true
+          fi
 
           if npm view "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
             npm_exists=true
           fi
 
+          echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
           echo "npm_exists=${npm_exists}" >> "$GITHUB_OUTPUT"
 
       - name: Skip already published version
-        if: steps.state.outputs.npm_exists == 'true'
+        if: steps.state.outputs.release_exists == 'true' && steps.state.outputs.npm_exists == 'true'
         run: |
-          echo "Version ${{ steps.version.outputs.version }} is already published to npm."
+          echo "Version ${{ steps.version.outputs.version }} is already published to npm and GitHub."
 
       - name: Configure gcloud secret access for evaluator
-        if: steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -98,7 +107,7 @@ jobs:
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Restore evaluator cache
-        if: steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         uses: actions/cache@v4
         with:
           path: temp/libretto-cli-evaluate-cache
@@ -107,25 +116,28 @@ jobs:
             libretto-evaluate-cache-${{ runner.os }}-
 
       - name: Install dependencies
-        if: steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Verify release build
-        if: steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: |
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      release_exists: ${{ steps.state.outputs.release_exists }}
       npm_exists: ${{ steps.state.outputs.npm_exists }}
 
   release:
     needs: verify
-    if: needs.verify.outputs.npm_exists != 'true'
+    if: needs.verify.outputs.release_exists != 'true' || needs.verify.outputs.npm_exists != 'true'
     runs-on: ubuntu-latest
     environment:
       name: release
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout
@@ -149,5 +161,28 @@ jobs:
         run: pnpm --filter libretto build
 
       - name: Publish to npm with trusted publishing
+        if: needs.verify.outputs.npm_exists != 'true'
         working-directory: packages/libretto
         run: npm publish --access public
+
+      - name: Generate changelog
+        if: needs.verify.outputs.release_exists != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        working-directory: packages/libretto
+        run: pnpm generate-changelog "${{ needs.verify.outputs.tag }}" > "$RUNNER_TEMP/changelog.md"
+
+      - name: Create GitHub release
+        if: needs.verify.outputs.release_exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ needs.verify.outputs.tag }}" >/dev/null 2>&1; then
+            gh release create "${{ needs.verify.outputs.tag }}" --notes-file "$RUNNER_TEMP/changelog.md"
+          else
+            gh release create "${{ needs.verify.outputs.tag }}" \
+              --target "${GITHUB_SHA}" \
+              --notes-file "$RUNNER_TEMP/changelog.md"
+          fi


### PR DESCRIPTION
## Summary
- pass `GH_TOKEN` into the `Generate changelog` workflow step
- keep the existing release workflow behavior unchanged otherwise
- fix the GitHub Actions auth failure when `generate-changelog.ts` shells out to `gh`

## Testing
- not run (workflow-only change)
