### PR TITLE
[NTN-264] Remove postinstall, rename init to setup, create create-libretto package

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 ## Setup
 
-- Use `npx libretto init` for first-time workspace setup (sets up config file and snapshot command).
+- Use `npx libretto setup` for first-time workspace setup (sets up config file and snapshot command).
 - If credentials are already available, `npx libretto ai configure openai|anthropic|gemini|vertex` is usually enough.
 
 ## Working Rules

--- a/.agents/skills/libretto/references/configuration-file-reference.md
+++ b/.agents/skills/libretto/references/configuration-file-reference.md
@@ -41,7 +41,7 @@ Example:
 ## Common Commands
 
 ```bash
-npx libretto init
+npx libretto setup
 npx libretto ai configure openai
 npx libretto open https://app.example.com --viewport 1440x900
 npx libretto run ./integration.ts main --viewport 1440x900

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 ## Setup
 
-- Use `npx libretto init` for first-time workspace setup (sets up config file and snapshot command).
+- Use `npx libretto setup` for first-time workspace setup (sets up config file and snapshot command).
 - If credentials are already available, `npx libretto ai configure openai|anthropic|gemini|vertex` is usually enough.
 
 ## Working Rules

--- a/.claude/skills/libretto/references/configuration-file-reference.md
+++ b/.claude/skills/libretto/references/configuration-file-reference.md
@@ -41,7 +41,7 @@ Example:
 ## Common Commands
 
 ```bash
-npx libretto init
+npx libretto setup
 npx libretto ai configure openai
 npx libretto open https://app.example.com --viewport 1440x900
 npx libretto run ./integration.ts main --viewport 1440x900

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -81,5 +81,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
       - name: Run tests
         run: pnpm test

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
 npm install libretto
 
 # Install skill, download Chromium if not already installed, configure snapshot analysis
-npx libretto init
+npx libretto setup
 
-# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto init` sets this up the first time.
+# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto setup` sets this up the first time.
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
@@ -62,7 +62,7 @@ Agents can use Libretto to reproduce the failure, pause the workflow at any poin
 You can also use Libretto directly from the command line. All commands accept `--session <name>` to target a specific session.
 
 ```bash
-npx libretto init                          # interactive; run yourself, not through an agent
+npx libretto setup                         # interactive; run yourself, not through an agent
 npx libretto open <url>                    # launch browser and open a URL (headed by default)
 npx libretto snapshot --objective "..." --context "..."  # capture PNG + HTML and analyze with an LLM
 npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page (single quoted argument)

--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
+const version = pkg.version;
+
+console.log(`Setting up Libretto v${version}...\n`);
+
+// Install the version-locked libretto package
+try {
+  console.log(`Installing libretto@${version}...`);
+  execSync(`npm install libretto@${version}`, { stdio: "inherit" });
+} catch (error) {
+  console.error(`\nFailed to install libretto@${version}.`);
+  process.exit(1);
+}
+
+// Run libretto setup
+try {
+  console.log(`\nRunning libretto setup...\n`);
+  execSync(`npx libretto setup`, { stdio: "inherit" });
+} catch (error) {
+  console.error(`\nFailed to run libretto setup.`);
+  process.exit(1);
+}

--- a/packages/create-libretto/package.json
+++ b/packages/create-libretto/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "create-libretto",
+  "version": "0.5.4",
+  "description": "Create and set up a Libretto project",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/saffron-health/libretto"
+  },
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "create-libretto": "./index.mjs"
+  },
+  "files": [
+    "index.mjs"
+  ]
+}

--- a/packages/dev-tools/scripts/mirrors-libretto.mjs
+++ b/packages/dev-tools/scripts/mirrors-libretto.mjs
@@ -17,6 +17,8 @@ const README_TEMPLATE_PATH = "packages/libretto/README.template.md";
 const README_GENERATED_HEADER =
   "<!-- Generated from packages/libretto/README.template.md by `pnpm sync:mirrors`. Do not edit directly. -->";
 const PACKAGE_JSON_PATH = "packages/libretto/package.json";
+const CREATE_LIBRETTO_PACKAGE_JSON_PATH =
+  "packages/create-libretto/package.json";
 const SKILL_SOURCE_PATH = "packages/libretto/skills/libretto/SKILL.md";
 
 /**
@@ -184,11 +186,14 @@ export function updateLibrettoSkillVersion(skillSource, version) {
     throw new Error(`missing frontmatter in ${SKILL_SOURCE_PATH}`);
   }
 
-  const updatedFrontmatterBody = updateFrontmatterBody(frontmatter.body, (line) => {
-    const match = line.match(/^(\s*)version:\s*"?([^"\n]+)"?\s*$/);
-    if (!match) return null;
-    return `${match[1]}version: "${version}"`;
-  });
+  const updatedFrontmatterBody = updateFrontmatterBody(
+    frontmatter.body,
+    (line) => {
+      const match = line.match(/^(\s*)version:\s*"?([^"\n]+)"?\s*$/);
+      if (!match) return null;
+      return `${match[1]}version: "${version}"`;
+    },
+  );
 
   if (!updatedFrontmatterBody) {
     throw new Error(`could not find metadata.version in ${SKILL_SOURCE_PATH}`);
@@ -200,7 +205,11 @@ export function updateLibrettoSkillVersion(skillSource, version) {
 export function setLibrettoSkillVersion(repoRoot, version) {
   const skillPath = resolve(repoRoot, SKILL_SOURCE_PATH);
   const currentContent = readFileSync(skillPath, "utf8");
-  writeFileSync(skillPath, updateLibrettoSkillVersion(currentContent, version), "utf8");
+  writeFileSync(
+    skillPath,
+    updateLibrettoSkillVersion(currentContent, version),
+    "utf8",
+  );
 }
 
 function syncDirectoryMirror(sourceDir, destDir) {
@@ -249,7 +258,9 @@ function compareDirectoryMirror(mirror, repoRoot, issues) {
       const expectedContent = readFileSync(sourceFilePath);
       const actualContent = readFileSync(targetFilePath);
       if (!expectedContent.equals(actualContent)) {
-        issues.push(`${mirror.name}: ${target} differs from ${mirror.source}: ${file}`);
+        issues.push(
+          `${mirror.name}: ${target} differs from ${mirror.source}: ${file}`,
+        );
       }
     }
   }
@@ -273,7 +284,9 @@ function compareFileMirror(mirror, repoRoot, issues) {
     const expectedContent = target.render(source);
     const actualContent = normalizeText(readFileSync(targetPath, "utf8"));
     if (expectedContent !== actualContent) {
-      issues.push(`${mirror.name}: ${target.path} differs from ${mirror.source}`);
+      issues.push(
+        `${mirror.name}: ${target.path} differs from ${mirror.source}`,
+      );
     }
   }
 }
@@ -282,7 +295,10 @@ function getSkillVersionIssue(repoRoot) {
   const packageJson = JSON.parse(
     readFileSync(resolve(repoRoot, PACKAGE_JSON_PATH), "utf8"),
   );
-  const skillSource = readFileSync(resolve(repoRoot, SKILL_SOURCE_PATH), "utf8");
+  const skillSource = readFileSync(
+    resolve(repoRoot, SKILL_SOURCE_PATH),
+    "utf8",
+  );
   const skillVersion = getLibrettoSkillVersion(skillSource);
 
   if (!skillVersion) {
@@ -294,6 +310,51 @@ function getSkillVersionIssue(repoRoot) {
   }
 
   return null;
+}
+
+function getCreateLibrettoVersionIssue(repoRoot) {
+  const librettoJson = JSON.parse(
+    readFileSync(resolve(repoRoot, PACKAGE_JSON_PATH), "utf8"),
+  );
+  const createLibrettoPath = resolve(
+    repoRoot,
+    CREATE_LIBRETTO_PACKAGE_JSON_PATH,
+  );
+  if (!existsSync(createLibrettoPath)) {
+    return `validation: missing ${CREATE_LIBRETTO_PACKAGE_JSON_PATH}`;
+  }
+  const createLibrettoJson = JSON.parse(
+    readFileSync(createLibrettoPath, "utf8"),
+  );
+
+  if (createLibrettoJson.version !== librettoJson.version) {
+    return `validation: ${CREATE_LIBRETTO_PACKAGE_JSON_PATH} version (${createLibrettoJson.version}) must match ${PACKAGE_JSON_PATH} version (${librettoJson.version})`;
+  }
+
+  return null;
+}
+
+export function syncCreateLibrettoVersion(repoRoot) {
+  const librettoJson = JSON.parse(
+    readFileSync(resolve(repoRoot, PACKAGE_JSON_PATH), "utf8"),
+  );
+  const createLibrettoPath = resolve(
+    repoRoot,
+    CREATE_LIBRETTO_PACKAGE_JSON_PATH,
+  );
+  if (!existsSync(createLibrettoPath)) return;
+  const createLibrettoJson = JSON.parse(
+    readFileSync(createLibrettoPath, "utf8"),
+  );
+
+  if (createLibrettoJson.version !== librettoJson.version) {
+    createLibrettoJson.version = librettoJson.version;
+    writeFileSync(
+      createLibrettoPath,
+      JSON.stringify(createLibrettoJson, null, 2) + "\n",
+      "utf8",
+    );
+  }
 }
 
 export function compareMirrors(repoRoot) {
@@ -310,6 +371,9 @@ export function compareMirrors(repoRoot) {
 
   const skillVersionIssue = getSkillVersionIssue(repoRoot);
   if (skillVersionIssue) issues.push(skillVersionIssue);
+
+  const createLibrettoIssue = getCreateLibrettoVersionIssue(repoRoot);
+  if (createLibrettoIssue) issues.push(createLibrettoIssue);
 
   return {
     ok: issues.length === 0,
@@ -343,6 +407,8 @@ export function syncMirrors(repoRoot) {
       writeFileSync(targetPath, target.render(source), "utf8");
     }
   }
+
+  syncCreateLibrettoVersion(repoRoot);
 
   const result = compareMirrors(repoRoot);
   if (!result.ok) {

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -23,9 +23,9 @@ https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
 npm install libretto
 
 # Install skill, download Chromium if not already installed, configure snapshot analysis
-npx libretto init
+npx libretto setup
 
-# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto init` sets this up the first time.
+# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto setup` sets this up the first time.
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
@@ -62,7 +62,7 @@ Agents can use Libretto to reproduce the failure, pause the workflow at any poin
 You can also use Libretto directly from the command line. All commands accept `--session <name>` to target a specific session.
 
 ```bash
-npx libretto init                          # interactive; run yourself, not through an agent
+npx libretto setup                         # interactive; run yourself, not through an agent
 npx libretto open <url>                    # launch browser and open a URL (headed by default)
 npx libretto snapshot --objective "..." --context "..."  # capture PNG + HTML and analyze with an LLM
 npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page (single quoted argument)

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -21,9 +21,9 @@ https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
 npm install libretto
 
 # Install skill, download Chromium if not already installed, configure snapshot analysis
-npx libretto init
+npx libretto setup
 
-# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto init` sets this up the first time.
+# Configure or change the snapshot analysis model (see Configuration section below). `npx libretto setup` sets this up the first time.
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
@@ -60,7 +60,7 @@ Agents can use Libretto to reproduce the failure, pause the workflow at any poin
 You can also use Libretto directly from the command line. All commands accept `--session <name>` to target a specific session.
 
 ```bash
-npx libretto init                          # interactive; run yourself, not through an agent
+npx libretto setup                         # interactive; run yourself, not through an agent
 npx libretto open <url>                    # launch browser and open a URL (headed by default)
 npx libretto snapshot --objective "..." --context "..."  # capture PNG + HTML and analyze with an LLM
 npx libretto exec "<code>"                 # execute Playwright TypeScript against the open page (single quoted argument)

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -30,7 +30,6 @@
     }
   },
   "scripts": {
-    "postinstall": "node scripts/postinstall.mjs",
     "sync:mirrors": "node ../dev-tools/scripts/sync-mirrors.mjs",
     "check:mirrors": "node ../dev-tools/scripts/check-mirrors-sync.mjs",
     "sync-skills": "pnpm run sync:mirrors",

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 
 ## Setup
 
-- Use `npx libretto init` for first-time workspace setup (sets up config file and snapshot command).
+- Use `npx libretto setup` for first-time workspace setup (sets up config file and snapshot command).
 - If credentials are already available, `npx libretto ai configure openai|anthropic|gemini|vertex` is usually enough.
 
 ## Working Rules

--- a/packages/libretto/skills/libretto/references/configuration-file-reference.md
+++ b/packages/libretto/skills/libretto/references/configuration-file-reference.md
@@ -41,7 +41,7 @@ Example:
 ## Common Commands
 
 ```bash
-npx libretto init
+npx libretto setup
 npx libretto ai configure openai
 npx libretto open https://app.example.com --viewport 1440x900
 npx libretto run ./integration.ts main --viewport 1440x900

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -12,7 +12,7 @@ import { spawnSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readAiConfig } from "../core/ai-config.js";
-import { REPO_ROOT } from "../core/context.js";
+import { ensureLibrettoSetup, REPO_ROOT } from "../core/context.js";
 import {
   loadSnapshotEnv,
   resolveSnapshotApiModel,
@@ -119,7 +119,7 @@ function printSnapshotApiStatus(): void {
     "    Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
   );
   console.log(
-    "    Run `npx libretto init` interactively to set up credentials.",
+    "    Run `npx libretto setup` interactively to set up credentials.",
   );
 }
 
@@ -161,7 +161,7 @@ async function runInteractiveApiSetup(): Promise<void> {
 
     if (answer.toLowerCase() === "s" || !answer) {
       console.log(
-        "\n  Skipped. You can set up API credentials later by rerunning `npx libretto init`.",
+        "\n  Skipped. You can set up API credentials later by rerunning `npx libretto setup`.",
       );
       console.log("  Or add credentials directly to your .env file:");
       console.log("    OPENAI_API_KEY=...");
@@ -295,7 +295,7 @@ function copySkills(): void {
   }
 }
 
-export const initInput = SimpleCLI.input({
+export const setupInput = SimpleCLI.input({
   positionals: [],
   named: {
     skipBrowsers: SimpleCLI.flag({
@@ -305,12 +305,13 @@ export const initInput = SimpleCLI.input({
   },
 });
 
-export const initCommand = SimpleCLI.command({
-  description: "Initialize libretto in the current project",
+export const setupCommand = SimpleCLI.command({
+  description: "Set up libretto in the current project",
 })
-  .input(initInput)
+  .input(setupInput)
   .handle(async ({ input }) => {
-    console.log("Initializing libretto...\n");
+    console.log("Setting up libretto...\n");
+    ensureLibrettoSetup();
 
     if (!input.skipBrowsers) {
       installBrowsers();
@@ -325,7 +326,14 @@ export const initCommand = SimpleCLI.command({
     } else {
       loadSnapshotEnv();
       printSnapshotApiStatus();
+      const config = safeReadAiConfig();
+      const selection = resolveSnapshotApiModel(config);
+      if (!selection || !hasProviderCredentials(selection.provider)) {
+        console.log(
+          "\nIf you're an agent, request the user to run `npx libretto setup`.",
+        );
+      }
     }
 
-    console.log("\n✓ libretto init complete");
+    console.log("\n✓ libretto setup complete");
   });

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -86,7 +86,7 @@ function printInvalidAiConfigWarning(): void {
   }
 }
 
-function printSnapshotApiStatus(): void {
+function printSnapshotApiStatus(): boolean {
   const config = safeReadAiConfig();
   const selection = resolveSnapshotApiModel(config);
   const envPath = join(REPO_ROOT, ".env");
@@ -104,7 +104,7 @@ function printSnapshotApiStatus(): void {
       "    Snapshot objectives will use the API analyzer by default.",
     );
     console.log("    No further action required.");
-    return;
+    return true;
   }
 
   console.log("  ✗ No snapshot API credentials detected.");
@@ -121,6 +121,7 @@ function printSnapshotApiStatus(): void {
   console.log(
     "    Run `npx libretto setup` interactively to set up credentials.",
   );
+  return false;
 }
 
 async function runInteractiveApiSetup(): Promise<void> {
@@ -325,10 +326,8 @@ export const setupCommand = SimpleCLI.command({
       await runInteractiveApiSetup();
     } else {
       loadSnapshotEnv();
-      printSnapshotApiStatus();
-      const config = safeReadAiConfig();
-      const selection = resolveSnapshotApiModel(config);
-      if (!selection || !hasProviderCredentials(selection.provider)) {
+      const ready = printSnapshotApiStatus();
+      if (!ready) {
         console.log(
           "\nIf you're an agent, request the user to run `npx libretto setup`.",
         );

--- a/packages/libretto/src/cli/core/snapshot-api-config.ts
+++ b/packages/libretto/src/cli/core/snapshot-api-config.ts
@@ -67,7 +67,7 @@ function noSnapshotApiConfiguredMessage(): string {
   return [
     "Failed to analyze snapshot because no snapshot analyzer is configured.",
     `Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with \`${defaultModelCommandLine()}\`.`,
-    "For more info, run `npx libretto init`.",
+    "For more info, run `npx libretto setup`.",
   ].join(" ");
 }
 
@@ -81,7 +81,7 @@ function missingProviderSnapshotMessage(
   return [
     `Failed to analyze snapshot because ${selection.provider} is configured${configuredSource}, but ${providerMissingCredentialSummary(selection.provider)}.`,
     providerSetupSentence(selection.provider),
-    "For more info, run `npx libretto init`.",
+    "For more info, run `npx libretto setup`.",
   ].join(" ");
 }
 

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -2,7 +2,7 @@ import { aiCommands } from "./commands/ai.js";
 import { browserCommands } from "./commands/browser.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
-import { initCommand } from "./commands/init.js";
+import { setupCommand } from "./commands/setup.js";
 import { logCommands } from "./commands/logs.js";
 import { snapshotCommand } from "./commands/snapshot.js";
 import { SimpleCLI } from "./framework/simple-cli.js";
@@ -13,7 +13,7 @@ export const cliRoutes = {
   ...executionCommands,
   ...logCommands,
   ai: aiCommands,
-  init: initCommand,
+  setup: setupCommand,
   snapshot: snapshotCommand,
 };
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -42,10 +42,10 @@ function expectMissingSessionError(output: string, session: string): void {
 }
 
 describe("basic CLI subprocess behavior", () => {
-  test("init explains snapshot API env setup when no credentials are configured", async ({
+  test("setup explains snapshot API env setup when no credentials are configured", async ({
     librettoCli,
   }) => {
-    const result = await librettoCli("init --skip-browsers", {
+    const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
       ANTHROPIC_API_KEY: "",
@@ -62,10 +62,10 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("GEMINI_API_KEY=...");
   });
 
-  test("init reports when snapshot API credentials are already ready", async ({
+  test("setup reports when snapshot API credentials are already ready", async ({
     librettoCli,
   }) => {
-    const result = await librettoCli("init --skip-browsers", {
+    const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "test-openai-key",
     });
@@ -75,7 +75,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("No further action required.");
   });
 
-  test("init copies skill files without confirmation when agent dirs exist", async ({
+  test("setup copies skill files without confirmation when agent dirs exist", async ({
     librettoCli,
     workspacePath,
   }) => {
@@ -89,7 +89,7 @@ describe("basic CLI subprocess behavior", () => {
       "utf8",
     );
 
-    const result = await librettoCli("init --skip-browsers", {
+    const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
       ANTHROPIC_API_KEY: "",
@@ -151,7 +151,9 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("help experimental");
     expect(result.stdout).toContain("Experimental commands");
-    expect(result.stdout).toContain("Usage: libretto experimental <subcommand>");
+    expect(result.stdout).toContain(
+      "Usage: libretto experimental <subcommand>",
+    );
     expect(result.stdout).toContain("deploy");
     expect(result.stderr).toBe("");
   });
@@ -279,7 +281,9 @@ describe("basic CLI subprocess behavior", () => {
 
   test("exec with hyphen requires stdin input", async ({ librettoCli }) => {
     const session = "exec-stdin-requires-input";
-    await librettoCli(`open https://example.com --headless --session ${session}`);
+    await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
 
     const result = await librettoCli(`exec - --session ${session}`);
     expect(result.stderr).toContain("Missing stdin input for `exec -`.");
@@ -289,7 +293,9 @@ describe("basic CLI subprocess behavior", () => {
     librettoCli,
   }) => {
     const session = "exec-stdin-with-input";
-    await librettoCli(`open https://example.com --headless --session ${session}`);
+    await librettoCli(
+      `open https://example.com --headless --session ${session}`,
+    );
 
     const result = await librettoCli(
       `exec - --session ${session}`,
@@ -485,7 +491,7 @@ export const main = workflow("main", async () => {
         "missing-playwright-browsers",
       ),
     });
-    expect(result.stderr).not.toContain("Workflow \"main\" not found");
+    expect(result.stderr).not.toContain('Workflow "main" not found');
   });
 
   test("accepts workflow exported via workflows manifest", async ({
@@ -512,7 +518,7 @@ export const workflows = {
         "missing-playwright-browsers",
       ),
     });
-    expect(result.stderr).not.toContain("Workflow \"main\" not found");
+    expect(result.stderr).not.toContain('Workflow "main" not found');
   });
 
   test("accepts workflow exported directly from workflows binding", async ({
@@ -535,7 +541,7 @@ export const workflows = workflow("main", async () => {
         "missing-playwright-browsers",
       ),
     });
-    expect(result.stderr).not.toContain("Workflow \"main\" not found");
+    expect(result.stderr).not.toContain('Workflow "main" not found');
   });
 
   test("fails run when local auth profile is declared but missing", async ({

--- a/packages/libretto/test/snapshot-api-config.spec.ts
+++ b/packages/libretto/test/snapshot-api-config.spec.ts
@@ -123,7 +123,7 @@ describe("snapshot API model resolution", () => {
     clearProviderEnv();
 
     expect(() => resolveSnapshotApiModelOrThrow(null)).toThrowError(
-      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex`. For more info, run `npx libretto init`.",
+      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, or GOOGLE_CLOUD_PROJECT to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex`. For more info, run `npx libretto setup`.",
     );
   });
 
@@ -134,7 +134,7 @@ describe("snapshot API model resolution", () => {
     expect(() =>
       resolveSnapshotApiModelOrThrow(makeConfig("openai/gpt-5.4")),
     ).toThrowError(
-      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto init\`.`,
+      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto setup\`.`,
     );
   });
 });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -45,9 +45,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
-  test("configures, shows, and clears AI config", async ({
-    librettoCli,
-  }) => {
+  test("configures, shows, and clears AI config", async ({ librettoCli }) => {
     const configure = await librettoCli("ai configure openai");
     expect(configure.stdout).toContain("AI config saved.");
     expect(configure.stdout).toContain("Model: openai/gpt-5.4");
@@ -138,7 +136,7 @@ describe("state-driven CLI subprocess behavior", () => {
       "Failed to analyze snapshot because no snapshot analyzer is configured.",
     );
     expect(snapshot.stderr).toContain(
-      "For more info, run `npx libretto init`.",
+      "For more info, run `npx libretto setup`.",
     );
     expect(
       existsSync(workspacePath(".libretto", "sessions", session, "snapshots")),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/libretto
 
+  packages/create-libretto: {}
+
   packages/dev-tools:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

Removes the `postinstall` script from libretto, renames the `init` CLI command to `setup`, and creates a new `create-libretto` package so users can run `npm init libretto@latest`.

## Changes

### `npx libretto setup` (replaces `npx libretto init`)
- Renamed CLI command from `init` to `setup`
- Calls `ensureLibrettoSetup()` to explicitly initialize the `.libretto/` directory (config, sessions, profiles, `.gitignore`)
- Non-TTY mode now prints an agent hint when snapshot API credentials are missing: `"If you're an agent, request the user to run 'npx libretto setup'."`

### Removed `postinstall`
- Removed `"postinstall": "node scripts/postinstall.mjs"` from `packages/libretto/package.json`
- Browser installation and skill copying are now handled by `npx libretto setup`

### New `create-libretto` package
- `npm init libretto@latest` installs the version-locked `libretto` package and runs `npx libretto setup`
- Version is kept in sync with `libretto` via the mirror system (`pnpm sync:mirrors` / `pnpm check:mirrors`)

### Mirror system update
- Added `create-libretto` version validation to `compareMirrors()` — catches drift in CI
- Added `syncCreateLibrettoVersion()` — auto-fixes version on `pnpm sync:mirrors`

### CI workflow update
- Added explicit `npx playwright install chromium` step to `.github/workflows/cli-tests.yml` since `postinstall` no longer handles it

### Reference updates
- All `npx libretto init` → `npx libretto setup` across READMEs, SKILL.md, configuration docs, and test expectations

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
