### PR TITLE
Fix: wt close lands shell in deleted directory

### DIFF
--- a/.bin/wt
+++ b/.bin/wt
@@ -262,8 +262,10 @@ cmd_close() {
     local branch
     branch=$(git rev-parse --abbrev-ref HEAD)
 
-    # Move back to the main repo root
-    cd "$ROOT_DIR"
+    # Move back to the main repo root (not the worktree root, which is about to be deleted)
+    local main_root
+    main_root=$(git -C "$wt_path" worktree list --porcelain | head -1 | sed 's/^worktree //')
+    cd "$main_root"
 
     # Remove the worktree
     local remove_args=("worktree" "remove")


### PR DESCRIPTION
## Summary

`wt close` was leaving the terminal in a deleted directory (showing as `.` in the prompt).

## Root Cause

`ROOT_DIR` was computed as `$SCRIPT_DIR/..` — but since `.bin/wt` lives inside the worktree, this resolved to the worktree's own root. So `cd "$ROOT_DIR"` stayed in the worktree directory, which then got deleted by `git worktree remove`. The subsequent `exec "$SHELL"` spawned a shell in a deleted directory.

## Fix

Instead of using the script-relative `ROOT_DIR`, derive the main repo root from `git worktree list --porcelain` (the first entry is always the main worktree). This ensures the shell lands in the real repo root after closing a worktree.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
