### PR TITLE
docs: update setup command references

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ Source layout:
 - `packages/libretto/README.template.md` — source of truth for the repo and package READMEs
 - `packages/libretto/skills/libretto/` — source of truth for the Libretto skill
 
-Run `pnpm sync:mirrors` after editing `packages/libretto/README.template.md` or anything under `packages/libretto/skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
+Run `pnpm sync:mirrors` after editing `packages/libretto/README.template.md` or anything under `packages/libretto/skills/libretto/`.
 
 To check that generated READMEs, skill mirrors, and skill version metadata are in sync without fixing them, run `pnpm check:mirrors`. To release, run `pnpm prepare-release`.

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { CheckIcon, CopyIcon } from "../icons";
 
 const COMMAND_1 = "npm i libretto";
-const COMMAND_2 = "npx libretto init";
-const COPY_COMMAND = "npm i libretto && npx libretto init";
+const COMMAND_2 = "npx libretto setup";
+const COPY_COMMAND = "npm i libretto && npx libretto setup";
 
 export function InstallSnippet() {
   const [copied, setCopied] = useState(false);

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -157,6 +157,6 @@ Source layout:
 - `README.template.md` — source of truth for the repo and package READMEs
 - `skills/libretto/` — source of truth for the Libretto skill
 
-Run `pnpm sync:mirrors` after editing `README.template.md` or anything under `skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
+Run `pnpm sync:mirrors` after editing `README.template.md` or anything under `skills/libretto/`.
 
 To check that generated READMEs, skill mirrors, and skill version metadata are in sync without fixing them, run `pnpm check:mirrors`. To release, run `pnpm prepare-release`.

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -155,6 +155,6 @@ Source layout:
 - `{{LIBRETTO_PATH_PREFIX}}README.template.md` — source of truth for the repo and package READMEs
 - `{{LIBRETTO_PATH_PREFIX}}skills/libretto/` — source of truth for the Libretto skill
 
-Run `pnpm sync:mirrors` after editing `{{LIBRETTO_PATH_PREFIX}}README.template.md` or anything under `{{LIBRETTO_PATH_PREFIX}}skills/libretto/`. `pnpm i` also resyncs the skill mirrors through `postinstall`.
+Run `pnpm sync:mirrors` after editing `{{LIBRETTO_PATH_PREFIX}}README.template.md` or anything under `{{LIBRETTO_PATH_PREFIX}}skills/libretto/`.
 
 To check that generated READMEs, skill mirrors, and skill version metadata are in sync without fixing them, run `pnpm check:mirrors`. To release, run `pnpm prepare-release`.

--- a/packages/libretto/skills/AGENTS.md
+++ b/packages/libretto/skills/AGENTS.md
@@ -8,4 +8,3 @@
 
 - Run `pnpm sync:mirrors` after changing anything under `skills/libretto`.
 - Run `pnpm check:mirrors` to verify that generated READMEs, skill mirrors, and skill version metadata are in sync.
-- `pnpm i` also resyncs the skill mirrors through `postinstall`, but use `pnpm sync:mirrors` for local doc edits because `postinstall` does not regenerate the READMEs.


### PR DESCRIPTION
## Summary
- update the website install snippet to use `npx libretto setup`
- remove outdated `postinstall` mirror-sync guidance from the libretto README template and skills docs
- regenerate the mirrored README files with `pnpm sync:mirrors`

## Testing
- `pnpm sync:mirrors`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
