### PR TITLE
chore: upgrade pnpm and set minimumReleaseAge to 10080

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -145,8 +143,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=false
+minimumReleaseAge=4320

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 enable-pre-post-scripts=false
-minimumReleaseAge=4320

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
 # Enable corepack for pnpm
-RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libretto-monorepo",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.58",
     "@ai-sdk/google": "^3.0.51",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Developer tooling for the libretto monorepo",
   "type": "module",
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.33.0",
   "bin": {
     "wt": "./dist/wt.js"
   },

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/saffron-health/libretto"
   },
   "type": "module",
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
   - "benchmarks"
   - "evals"
   - "packages/*"
+
+minimumReleaseAge: 4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ packages:
   - "evals"
   - "packages/*"
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 10800

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ packages:
   - "evals"
   - "packages/*"
 
-minimumReleaseAge: 10800
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- upgrade pnpm to 10.33.0 so `minimumReleaseAge` is supported
- configure `minimumReleaseAge: 10080` in the root `pnpm-workspace.yaml`
- update version-pinned package metadata and Docker setup to match
- update GitHub workflows to use the repo `packageManager` pnpm version

## Testing
- verified `corepack pnpm --version` returns `10.33.0`
- verified `corepack pnpm config get minimumReleaseAge` returns `10080`