### PR TITLE
[NTN-281] Warn on outdated skills for open, run, and connect

### DIFF
--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -12,6 +12,7 @@ import {
   assertSessionAvailableForStart,
   validateSessionName,
 } from "../core/session.js";
+import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   sessionOption,
@@ -72,6 +73,7 @@ export const openCommand = SimpleCLI.command({
   .input(openInput)
   .use(withAutoSession())
   .handle(async ({ input, ctx }) => {
+    warnIfInstalledSkillOutOfDate();
     assertSessionAvailableForStart(ctx.session, ctx.logger);
     const headed = input.headed || !input.headless;
     const viewport = parseViewportArg(input.viewport);
@@ -98,6 +100,7 @@ export const connectCommand = SimpleCLI.command({
   .input(connectInput)
   .use(withAutoSession())
   .handle(async ({ input, ctx }) => {
+    warnIfInstalledSkillOutOfDate();
     await runConnectWithLogger(input.cdpUrl!, ctx.session, ctx.logger);
   });
 

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -19,6 +19,7 @@ import {
   setSessionStatus,
   type SessionState,
 } from "../core/session.js";
+import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import {
   readActionLog,
   readNetworkLog,
@@ -784,6 +785,7 @@ export const runCommand = SimpleCLI.command({
   .input(runInput)
   .use(withAutoSession())
   .handle(async ({ input, ctx }) => {
+    warnIfInstalledSkillOutOfDate();
     await stopExistingFailedRunSession(ctx.session, ctx.logger);
     assertSessionAvailableForStart(ctx.session, ctx.logger);
 

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { REPO_ROOT } from "./context.js";
+
+type PackageManifest = {
+  version?: string;
+};
+
+const INSTALLED_SKILL_PATHS = [
+  [".agents", "skills", "libretto", "SKILL.md"],
+  [".claude", "skills", "libretto", "SKILL.md"],
+] as const;
+
+let cachedCliVersion: string | null = null;
+
+function readCurrentCliVersion(): string {
+  if (cachedCliVersion) {
+    return cachedCliVersion;
+  }
+
+  const packageJsonPath = fileURLToPath(
+    new URL("../../../package.json", import.meta.url),
+  );
+  const manifest = JSON.parse(
+    readFileSync(packageJsonPath, "utf8"),
+  ) as PackageManifest;
+
+  if (!manifest.version) {
+    throw new Error(
+      `Unable to determine current libretto version from ${packageJsonPath}.`,
+    );
+  }
+
+  cachedCliVersion = manifest.version;
+  return cachedCliVersion;
+}
+
+function readInstalledSkillVersion(skillPath: string): string | null {
+  if (!existsSync(skillPath)) {
+    return null;
+  }
+
+  const contents = readFileSync(skillPath, "utf8");
+  const frontmatterMatch = contents.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch) {
+    return null;
+  }
+
+  const metadataBlock = frontmatterMatch[1].match(
+    /^metadata:\s*\r?\n((?:[ \t]+.*(?:\r?\n|$))*)/m,
+  )?.[1];
+  if (!metadataBlock) {
+    return null;
+  }
+
+  const versionMatch = metadataBlock.match(
+    /^[ \t]+version:\s*["']?([^"'\r\n]+)["']?\s*$/m,
+  );
+  return versionMatch?.[1]?.trim() ?? null;
+}
+
+function findInstalledSkillVersionMismatch(): {
+  installedVersion: string;
+  cliVersion: string;
+} | null {
+  const cliVersion = readCurrentCliVersion();
+
+  for (const relativePathParts of INSTALLED_SKILL_PATHS) {
+    const skillPath = join(REPO_ROOT, ...relativePathParts);
+    const installedVersion = readInstalledSkillVersion(skillPath);
+    if (installedVersion && installedVersion !== cliVersion) {
+      return { installedVersion, cliVersion };
+    }
+  }
+
+  return null;
+}
+
+export function warnIfInstalledSkillOutOfDate(): void {
+  try {
+    const mismatch = findInstalledSkillVersionMismatch();
+    if (!mismatch) {
+      return;
+    }
+
+    console.error(
+      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`,
+    );
+  } catch {
+    // Never block command execution on a best-effort skill version check.
+  }
+}

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from "node:url";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
 
+const packageJsonUrl = new URL("../package.json", import.meta.url);
+
 function extractReturnedSessionId(output: string): string | null {
   const patterns = [
     /\(session:\s*([a-zA-Z0-9._-]+)\)/i,
@@ -39,6 +41,40 @@ function expectMissingSessionError(output: string, session: string): void {
   expect(output).toContain("No active sessions.");
   expect(output).toContain("Start one with:");
   expect(output).toContain(`libretto open <url> --session ${session}`);
+}
+
+async function readCliVersion(): Promise<string> {
+  const manifest = JSON.parse(await readFile(packageJsonUrl, "utf8")) as {
+    version: string;
+  };
+  return manifest.version;
+}
+
+async function seedInstalledSkillVersion(
+  workspacePath: (...parts: string[]) => string,
+  rootDir: ".agents" | ".claude",
+  version: string,
+): Promise<void> {
+  await mkdir(workspacePath(rootDir, "skills", "libretto"), {
+    recursive: true,
+  });
+  await writeFile(
+    workspacePath(rootDir, "skills", "libretto", "SKILL.md"),
+    `---
+name: libretto
+metadata:
+  version: "${version}"
+---
+`,
+    "utf8",
+  );
+}
+
+function expectedSkillVersionWarning(
+  skillVersion: string,
+  cliVersion: string,
+): string {
+  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`;
 }
 
 describe("basic CLI subprocess behavior", () => {
@@ -237,6 +273,23 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toContain("Check logs:");
   });
 
+  test("warns on open when the installed skill version is out of date", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedInstalledSkillVersion(workspacePath, ".agents", "0.0.0");
+
+    const result = await librettoCli("open https://example.com", {
+      PATH: "/definitely-not-real",
+    });
+
+    expect(result.stderr).toContain(
+      expectedSkillVersionWarning("0.0.0", cliVersion),
+    );
+    expect(result.stderr).toContain("Failed to launch browser child process:");
+  });
+
   test("defaults sessioned browser commands to the default session", async ({
     librettoCli,
   }) => {
@@ -312,6 +365,49 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("run ./integration.ts main");
     expect(result.stderr).toContain("Integration file does not exist:");
     expect(result.stderr).toContain("integration.ts");
+  });
+
+  test("warns on run when the installed skill version is out of date", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedInstalledSkillVersion(workspacePath, ".claude", "0.0.0");
+
+    const result = await librettoCli("run ./integration.ts main");
+
+    expect(result.stderr).toContain(
+      expectedSkillVersionWarning("0.0.0", cliVersion),
+    );
+    expect(result.stderr).toContain("Integration file does not exist:");
+  });
+
+  test("warns on connect when the installed skill version is out of date", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedInstalledSkillVersion(workspacePath, ".agents", "0.0.0");
+
+    const result = await librettoCli("connect not-a-url --session mismatch");
+
+    expect(result.stderr).toContain(
+      expectedSkillVersionWarning("0.0.0", cliVersion),
+    );
+    expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
+  });
+
+  test("does not warn when the installed skill version matches the CLI", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedInstalledSkillVersion(workspacePath, ".agents", cliVersion);
+
+    const result = await librettoCli("connect not-a-url --session matching");
+
+    expect(result.stderr).not.toContain("Warning: Your agent skill (");
+    expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
   test("fails run with invalid JSON in --params", async ({ librettoCli }) => {

--- a/packages/libretto/vitest.config.ts
+++ b/packages/libretto/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     testTimeout: 30_000,
     pool: "forks",
     isolate: true,
-    fileParallelism: false,
-    maxWorkers: 1,
+    fileParallelism: true,
+    maxWorkers: 4,
   },
 });


### PR DESCRIPTION
## Summary
- warn before `open`, `run`, and `connect` when the installed Libretto skill version in `.agents` or `.claude` does not match the CLI package version
- add CLI coverage for mismatch and match cases so the warning text stays stable
- enable 4-worker Vitest file parallelism to speed up multi-file test runs during local development

## Validation
- `pnpm --filter libretto type-check`
- `cd packages/libretto && pnpm exec vitest run test/basic.spec.ts test/stateful.spec.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
