### PR TITLE
docs: add website docs experience and polish TOC navigation

### DIFF
--- a/apps/website/docs/index.html
+++ b/apps/website/docs/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="/favicon.ico"
+      sizes="16x16 32x32 48x48 256x256"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Libretto Docs</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,7 +21,8 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "safe-mdx": "^1.3.9",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "wouter": "^3.9.0"
   },
   "devDependencies": {
     "@ai-sdk/google-vertex": "^4.0.95",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -13,15 +13,20 @@
     "knip": "knip --cache --files --exports"
   },
   "dependencies": {
+    "@orama/orama": "^3.1.18",
     "@tailwindcss/vite": "^4.2.2",
     "classnames": "^2.5.1",
     "motion": "^12.38.0",
+    "prismjs": "^1.30.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "safe-mdx": "^1.3.9",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@ai-sdk/google-vertex": "^4.0.95",
+    "@types/mdast": "^4.0.4",
+    "@types/prismjs": "^1.26.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/website/public/icons/file-text.svg
+++ b/apps/website/public/icons/file-text.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9.25H13.75V5"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 15.25H14.25"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 12.25H14.25"/>
+</svg>

--- a/apps/website/public/icons/file-text.svg
+++ b/apps/website/public/icons/file-text.svg
@@ -1,6 +1,0 @@
-<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"/>
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 9.25H13.75V5"/>
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 15.25H14.25"/>
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 12.25H14.25"/>
-</svg>

--- a/apps/website/public/icons/information.svg
+++ b/apps/website/public/icons/information.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 13V15"/>
+  <circle cx="12" cy="9" r="1" fill="currentColor"/>
+  <circle cx="12" cy="12" r="7.25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>

--- a/apps/website/public/icons/information.svg
+++ b/apps/website/public/icons/information.svg
@@ -1,5 +1,0 @@
-<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 13V15"/>
-  <circle cx="12" cy="9" r="1" fill="currentColor"/>
-  <circle cx="12" cy="12" r="7.25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
-</svg>

--- a/apps/website/public/icons/warning-triangle.svg
+++ b/apps/website/public/icons/warning-triangle.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.9522 16.3536L10.2152 5.85658C10.9531 4.38481 13.0539 4.3852 13.7913 5.85723L19.0495 16.3543C19.7156 17.6841 18.7487 19.25 17.2613 19.25H6.74007C5.25234 19.25 4.2854 17.6835 4.9522 16.3536Z"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10V12"/>
+  <circle cx="12" cy="16" r="1" fill="currentColor"/>
+</svg>

--- a/apps/website/public/icons/warning-triangle.svg
+++ b/apps/website/public/icons/warning-triangle.svg
@@ -1,5 +1,0 @@
-<svg width="24" height="24" fill="none" viewBox="0 0 24 24">
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.9522 16.3536L10.2152 5.85658C10.9531 4.38481 13.0539 4.3852 13.7913 5.85723L19.0495 16.3543C19.7156 17.6841 18.7487 19.25 17.2613 19.25H6.74007C5.25234 19.25 4.2854 17.6835 4.9522 16.3536Z"/>
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10V12"/>
-  <circle cx="12" cy="16" r="1" fill="currentColor"/>
-</svg>

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,25 +1,22 @@
 import { Suspense, lazy } from "react";
+import { useLocation } from "wouter";
 import { HomePage } from "./HomePage";
+import { normalizeDocsPath } from "./docs/content";
 
 const DocsPage = lazy(() =>
   import("./docs/DocsPage").then((module) => ({ default: module.DocsPage })),
 );
 
-function normalizePath(pathname: string): string {
-  if (pathname === "/") {
-    return pathname;
-  }
-
-  return pathname.replace(/\/+$/, "");
-}
-
 export function App() {
-  const pathname = normalizePath(window.location.pathname);
+  const [href] = useLocation();
+  const pathname = normalizeDocsPath(
+    new URL(href, window.location.origin).pathname,
+  );
 
-  if (pathname === "/docs" || pathname === "/docs/index.html") {
+  if (pathname === "/docs" || pathname === "/docs/index.html" || pathname.startsWith("/docs/")) {
     return (
       <Suspense fallback={null}>
-        <DocsPage />
+        <DocsPage pathname={pathname} />
       </Suspense>
     );
   }

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,187 +1,28 @@
-import { useEffect, useRef, useState } from "react";
-import { CanvasAsciiIcosahedron } from "./components/CanvasAsciiIcosahedron";
-import { Button } from "./components/Button";
-import { Text } from "./components/Text";
-import { TerminalDemo } from "./components/TerminalDemo";
-import { InstallSnippet } from "./components/InstallSnippet";
-import { GitHubStarIcon } from "./icons";
-import {
-  OrchestrationContainer,
-  AnimationTarget,
-} from "./components/AnimationOrchestration";
-import { AnimatedTitle } from "./components/AnimatedTitle";
+import { Suspense, lazy } from "react";
+import { HomePage } from "./HomePage";
 
-const REPO_URL = "https://github.com/saffron-health/libretto";
-const DISCUSSIONS_URL = `${REPO_URL}/discussions`;
-const RELEASES_URL = `${REPO_URL}/releases`;
+const DocsPage = lazy(() =>
+  import("./docs/DocsPage").then((module) => ({ default: module.DocsPage })),
+);
 
-function useGitHubStars(repo: string) {
-  const [stars, setStars] = useState<number | null>(null);
-  useEffect(() => {
-    fetch(`https://api.github.com/repos/${repo}`)
-      .then((r) => r.json())
-      .then((data) => {
-        if (typeof data.stargazers_count === "number") {
-          setStars(data.stargazers_count);
-        }
-      })
-      .catch(() => {});
-  }, [repo]);
-  return stars;
-}
-
-function formatStars(count: number): string {
-  if (count >= 1000) {
-    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+function normalizePath(pathname: string): string {
+  if (pathname === "/") {
+    return pathname;
   }
-  return String(count);
-}
 
-function Navbar() {
-  const stars = useGitHubStars("saffron-health/libretto");
-
-  return (
-    <nav
-      data-animate={AnimationTarget.Navbar}
-      style={{ opacity: 0 }}
-      className="px-8 pt-6"
-    >
-      <div className="relative mx-auto flex max-w-[800px] items-center justify-between">
-        <div className="flex items-center gap-10">
-          <a href="/" className="no-underline">
-            <Text size="xl" style="serif" className="text-ink font-[200]">
-              Libretto
-            </Text>
-          </a>
-          <div className="absolute left-1/2 -translate-x-1/2 flex gap-7">
-            <a
-              href={DISCUSSIONS_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="no-underline"
-            >
-              <Text size="sm" className="font-medium text-ink">
-                Forum
-              </Text>
-            </a>
-            <a
-              href={RELEASES_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="no-underline"
-            >
-              <Text size="sm" className="font-medium text-ink">
-                Changelog
-              </Text>
-            </a>
-          </div>
-        </div>
-        <div className="flex items-center gap-4">
-          <a
-            href={REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 text-ink/70 hover:text-ink transition-colors"
-          >
-            <GitHubStarIcon width={15} height={15} />
-            {stars !== null && (
-              <span className="text-sm font-medium">{formatStars(stars)}</span>
-            )}
-          </a>
-          <Button
-            href={REPO_URL}
-            size="sm"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="rounded-full bg-ink border-ink px-5 py-2.5 text-cream hover:bg-ink/90 no-underline"
-          >
-            Go to docs
-          </Button>
-        </div>
-      </div>
-    </nav>
-  );
-}
-
-function Hero() {
-  const sectionRef = useRef<HTMLElement>(null);
-
-  return (
-    <section
-      ref={sectionRef}
-      className="relative px-8 pt-24 pb-16 overflow-hidden"
-    >
-      {/* Interactive ASCII icosahedron background */}
-      <div
-        data-animate={AnimationTarget.Icosahedron}
-        style={{ opacity: 0 }}
-        className="pointer-events-none absolute inset-0 flex items-center justify-center -translate-y-24 select-none"
-      >
-        <CanvasAsciiIcosahedron
-          className="h-[1600px] w-[1600px] max-h-[180vw] max-w-[180vw] text-ink"
-          showAnnotations={false}
-          objectScale={1.2}
-        />
-      </div>
-      <div className="relative mx-auto max-w-[1200px]">
-        <Text
-          as="h1"
-          size="5xl"
-          style="serif"
-          className="mb-8 max-w-[800px] text-center tracking-[-0.03em] text-ink [text-wrap:balance] mx-auto"
-        >
-          <AnimatedTitle
-            className="grain"
-            style={{
-              fontWeight: 300,
-              fontSize: "clamp(48px, 6vw, 72px)",
-              lineHeight: 1.1,
-            }}
-          >
-            The AI Toolkit for Building Robust Web Integrations
-          </AnimatedTitle>
-        </Text>
-        <Text
-          as="p"
-          size="lg"
-          data-animate={AnimationTarget.Content}
-          htmlStyle={{ opacity: 0 }}
-          className="mb-8 max-w-[560px] mx-auto text-center leading-relaxed text-muted"
-        >
-          An agent skill and token-efficient CLI that inspects live pages,
-          reverse-engineers network requests, and ships production-ready
-          integration workflows.
-        </Text>
-        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
-          <InstallSnippet />
-        </div>
-        <div
-          data-animate={AnimationTarget.Content}
-          style={{ opacity: 0 }}
-          className="flex items-center justify-center gap-6 mb-16"
-        >
-          <Button
-            href={REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="rounded-full bg-ink border-ink px-7 py-3 text-cream hover:bg-ink/90 no-underline"
-          >
-            Go to docs
-          </Button>
-        </div>
-        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
-          <TerminalDemo />
-        </div>
-      </div>
-    </section>
-  );
+  return pathname.replace(/\/+$/, "");
 }
 
 export function App() {
-  return (
-    <OrchestrationContainer className="min-h-screen bg-cream text-ink">
-      <Navbar />
-      <Hero />
-    </OrchestrationContainer>
-  );
+  const pathname = normalizePath(window.location.pathname);
+
+  if (pathname === "/docs" || pathname === "/docs/index.html") {
+    return (
+      <Suspense fallback={null}>
+        <DocsPage />
+      </Suspense>
+    );
+  }
+
+  return <HomePage />;
 }

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -11,6 +11,7 @@ import {
 } from "./components/AnimationOrchestration";
 import { AnimatedTitle } from "./components/AnimatedTitle";
 import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "./site";
+import { AppLink } from "./routing";
 
 function useGitHubStars(repo: string) {
   const [stars, setStars] = useState<number | null>(null);
@@ -48,11 +49,11 @@ function Navbar() {
     >
       <div className="relative mx-auto flex max-w-[800px] items-center justify-between">
         <div className="flex items-center gap-10">
-          <a href="/" className="no-underline">
+          <AppLink href="/" className="no-underline">
             <Text size="xl" style="serif" className="text-ink font-[200]">
               Libretto
             </Text>
-          </a>
+          </AppLink>
           <div className="absolute left-1/2 flex -translate-x-1/2 gap-7">
             <a
               href={DISCUSSIONS_URL}
@@ -91,7 +92,6 @@ function Navbar() {
           <Button
             href="/docs/"
             size="sm"
-            className="rounded-full border-ink bg-ink px-5 py-2.5 text-cream no-underline hover:bg-ink/90"
           >
             Go to docs
           </Button>
@@ -159,7 +159,6 @@ function Hero() {
         >
           <Button
             href="/docs/"
-            className="rounded-full border-ink bg-ink px-7 py-3 text-cream no-underline hover:bg-ink/90"
           >
             Go to docs
           </Button>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from "react";
+import { CanvasAsciiIcosahedron } from "./components/CanvasAsciiIcosahedron";
+import { Button } from "./components/Button";
+import { Text } from "./components/Text";
+import { TerminalDemo } from "./components/TerminalDemo";
+import { InstallSnippet } from "./components/InstallSnippet";
+import { GitHubStarIcon } from "./icons";
+import {
+  OrchestrationContainer,
+  AnimationTarget,
+} from "./components/AnimationOrchestration";
+import { AnimatedTitle } from "./components/AnimatedTitle";
+import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "./site";
+
+function useGitHubStars(repo: string) {
+  const [stars, setStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetch(`https://api.github.com/repos/${repo}`)
+      .then((response) => response.json())
+      .then((data) => {
+        if (typeof data.stargazers_count === "number") {
+          setStars(data.stargazers_count);
+        }
+      })
+      .catch(() => {});
+  }, [repo]);
+
+  return stars;
+}
+
+function formatStars(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+
+  return String(count);
+}
+
+function Navbar() {
+  const stars = useGitHubStars("saffron-health/libretto");
+
+  return (
+    <nav
+      data-animate={AnimationTarget.Navbar}
+      style={{ opacity: 0 }}
+      className="px-8 pt-6"
+    >
+      <div className="relative mx-auto flex max-w-[800px] items-center justify-between">
+        <div className="flex items-center gap-10">
+          <a href="/" className="no-underline">
+            <Text size="xl" style="serif" className="text-ink font-[200]">
+              Libretto
+            </Text>
+          </a>
+          <div className="absolute left-1/2 flex -translate-x-1/2 gap-7">
+            <a
+              href={DISCUSSIONS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline"
+            >
+              <Text size="sm" className="font-medium text-ink">
+                Forum
+              </Text>
+            </a>
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-underline"
+            >
+              <Text size="sm" className="font-medium text-ink">
+                Changelog
+              </Text>
+            </a>
+          </div>
+        </div>
+        <div className="flex items-center gap-4">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-ink/70 transition-colors hover:text-ink"
+          >
+            <GitHubStarIcon width={15} height={15} />
+            {stars !== null && (
+              <span className="text-sm font-medium">{formatStars(stars)}</span>
+            )}
+          </a>
+          <Button
+            href="/docs/"
+            size="sm"
+            className="rounded-full border-ink bg-ink px-5 py-2.5 text-cream no-underline hover:bg-ink/90"
+          >
+            Go to docs
+          </Button>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function Hero() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative overflow-hidden px-8 pt-24 pb-16"
+    >
+      <div
+        data-animate={AnimationTarget.Icosahedron}
+        style={{ opacity: 0 }}
+        className="pointer-events-none absolute inset-0 flex -translate-y-24 items-center justify-center select-none"
+      >
+        <CanvasAsciiIcosahedron
+          className="h-[1600px] w-[1600px] max-h-[180vw] max-w-[180vw] text-ink"
+          showAnnotations={false}
+          objectScale={1.2}
+        />
+      </div>
+      <div className="relative mx-auto max-w-[1200px]">
+        <Text
+          as="h1"
+          size="5xl"
+          style="serif"
+          className="mx-auto mb-8 max-w-[800px] text-center tracking-[-0.03em] text-ink [text-wrap:balance]"
+        >
+          <AnimatedTitle
+            className="grain"
+            style={{
+              fontWeight: 300,
+              fontSize: "clamp(48px, 6vw, 72px)",
+              lineHeight: 1.1,
+            }}
+          >
+            The AI Toolkit for Building Robust Web Integrations
+          </AnimatedTitle>
+        </Text>
+        <Text
+          as="p"
+          size="lg"
+          data-animate={AnimationTarget.Content}
+          htmlStyle={{ opacity: 0 }}
+          className="mx-auto mb-8 max-w-[560px] text-center leading-relaxed text-muted"
+        >
+          An agent skill and token-efficient CLI that inspects live pages,
+          reverse-engineers network requests, and ships production-ready
+          integration workflows.
+        </Text>
+        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
+          <InstallSnippet />
+        </div>
+        <div
+          data-animate={AnimationTarget.Content}
+          style={{ opacity: 0 }}
+          className="mb-16 flex items-center justify-center gap-6"
+        >
+          <Button
+            href="/docs/"
+            className="rounded-full border-ink bg-ink px-7 py-3 text-cream no-underline hover:bg-ink/90"
+          >
+            Go to docs
+          </Button>
+        </div>
+        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
+          <TerminalDemo />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function HomePage() {
+  return (
+    <OrchestrationContainer className="min-h-screen bg-cream text-ink">
+      <Navbar />
+      <Hero />
+    </OrchestrationContainer>
+  );
+}

--- a/apps/website/src/components/Button.tsx
+++ b/apps/website/src/components/Button.tsx
@@ -1,13 +1,14 @@
 import type * as React from "react";
+import { AppLink } from "../routing";
 
 type ButtonSize = "default" | "sm";
 
 const base =
-  "inline-flex shrink-0 cursor-pointer items-center justify-center whitespace-nowrap rounded-lg border font-medium outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64";
+  "libretto-button inline-flex shrink-0 cursor-pointer items-center justify-center whitespace-nowrap text-center no-underline outline-none disabled:pointer-events-none disabled:opacity-64";
 
 const sizeClasses: Record<ButtonSize, string> = {
-  default: "h-9 px-[calc(--spacing(3)-1px)] sm:h-8",
-  sm: "h-8 gap-1.5 px-[calc(--spacing(2.5)-1px)] sm:h-7",
+  default: "libretto-button--default",
+  sm: "libretto-button--sm",
 };
 
 type ButtonAsButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -33,9 +34,15 @@ export function Button({
 
   if (typeof props.href === "string") {
     const anchorProps = props as ButtonAsAnchorProps;
-    return <a className={classes} {...anchorProps} />;
+    return <AppLink className={classes} {...anchorProps} />;
   }
 
   const buttonProps = props as ButtonAsButtonProps;
-  return <button className={classes} type={buttonProps.type ?? "button"} {...buttonProps} />;
+  return (
+    <button
+      {...buttonProps}
+      className={classes}
+      type={buttonProps.type ?? "button"}
+    />
+  );
 }

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -2,15 +2,13 @@ import classnames from "classnames";
 import { useState } from "react";
 import { CheckIcon, CopyIcon } from "../icons";
 
-const COMMAND_1 = "npm i libretto";
-const COMMAND_2 = "npx libretto setup";
-const COPY_COMMAND = "npm i libretto && npx libretto setup";
+const COMMAND = "npm init libretto@latest";
 
 export function InstallSnippet() {
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {
-    void navigator.clipboard.writeText(COPY_COMMAND);
+    void navigator.clipboard.writeText(COMMAND);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }
@@ -42,15 +40,9 @@ export function InstallSnippet() {
             </div>
           </div>
         </button>
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center">
-            <span className="select-none text-ink/20 w-4">$</span>
-            <span className="pl-2">{COMMAND_1}</span>
-          </div>
-          <div className="flex items-center">
-            <span className="select-none text-ink/20 w-4">$</span>
-            <span className="pl-2">{COMMAND_2}</span>
-          </div>
+        <div className="flex items-center">
+          <span className="select-none text-ink/20 w-4">$</span>
+          <span className="pl-2">{COMMAND}</span>
         </div>
       </div>
     </div>

--- a/apps/website/src/components/Text.tsx
+++ b/apps/website/src/components/Text.tsx
@@ -18,6 +18,7 @@ interface TextProps {
   size?: Size;
   style?: "serif" | "sans";
   as?: keyof JSX.IntrinsicElements;
+  id?: string;
   className?: string;
   children: React.ReactNode;
   htmlStyle?: React.CSSProperties;

--- a/apps/website/src/docs/DocsPage.tsx
+++ b/apps/website/src/docs/DocsPage.tsx
@@ -146,21 +146,6 @@ type MdastSection = {
 
 type MdxFlowElement = Extract<RootContent, { type: "mdxJsxFlowElement" }>;
 
-function getSectionHref(
-  section: MdastSection,
-  headingIds: WeakMap<Heading, string>,
-): string | null {
-  const heading = section.contentNodes.find((node): node is Heading => {
-    return node.type === "heading" && (node as Heading).depth === 2;
-  });
-
-  if (!heading) {
-    return null;
-  }
-
-  return `#${headingIds.get(heading) ?? slugify(extractText(heading.children))}`;
-}
-
 function buildHeadingIdMap(roots: Root[]): WeakMap<Heading, string> {
   const counts = new Map<string, number>();
   const headingIds = new WeakMap<Heading, string>();
@@ -576,15 +561,6 @@ export function DocsPage({ pathname }: { pathname?: string }) {
     return createMdxComponents(resolveDocsHref);
   }, [resolveDocsHref]);
 
-  const currentGroupMdast: Root = {
-    type: "root",
-    children: parsedCurrentGroup.pages.flatMap((page) => {
-      return page.mdast.children;
-    }),
-  };
-  const contentChildren = currentGroupMdast.children.filter((node) => !isHeroNode(node));
-  const contentMdast: Root = { type: "root", children: contentChildren };
-
   const tocItems = flattenTocTree({
     roots: buildDocsTocTree({
       groups: parsedDocsGroups,
@@ -592,17 +568,6 @@ export function DocsPage({ pathname }: { pathname?: string }) {
       currentGroupId: parsedCurrentGroup.id,
     }),
   });
-  const mdastSections = groupBySections(contentMdast);
-  const sectionByHref = new Map(
-    mdastSections
-      .map((section) => {
-        const href = getSectionHref(section, currentGroupHeadingIds);
-        return href ? ([href, section] as const) : null;
-      })
-      .filter(
-        (entry): entry is readonly [string, MdastSection] => entry !== null,
-      ),
-  );
 
   const sections: EditorialSection[] = [
     {
@@ -614,46 +579,41 @@ export function DocsPage({ pathname }: { pathname?: string }) {
         </div>
       ),
     },
-    ...parsedCurrentGroup.pages.map((page) => {
-      const firstPageHeading = page.mdast.children.find(
-        (node): node is Heading => {
-          return node.type === "heading";
-        },
-      );
+    ...parsedCurrentGroup.pages.flatMap((page) => {
+      const contentMdast: Root = {
+        type: "root",
+        children: page.mdast.children.filter((node) => !isHeroNode(node)),
+      };
+      const pageSections = groupBySections(contentMdast);
 
-      if (!firstPageHeading) {
-        throw new Error(`Missing top-level heading for docs page ${page.id}`);
+      if (pageSections.length === 0) {
+        throw new Error(`Missing docs sections for page ${page.id}`);
       }
 
-      const pageHref = `#${currentGroupHeadingIds.get(firstPageHeading) ?? slugify(extractText(firstPageHeading.children))}`;
-      const section = sectionByHref.get(pageHref);
+      return pageSections.map((section) => {
+        const aside =
+          section.asideNodes.length > 0 ? (
+            <RenderNodes
+              nodes={section.asideNodes}
+              markdown={currentGroupMarkdown}
+              components={mdxComponents}
+              headingIds={currentGroupHeadingIds}
+            />
+          ) : undefined;
 
-      if (!section) {
-        throw new Error(`Missing docs page section for ${pageHref}`);
-      }
-
-      const aside =
-        section.asideNodes.length > 0 ? (
-          <RenderNodes
-            nodes={section.asideNodes}
-            markdown={currentGroupMarkdown}
-            components={mdxComponents}
-            headingIds={currentGroupHeadingIds}
-          />
-        ) : undefined;
-
-      return {
-        content: (
-          <RenderNodes
-            nodes={section.contentNodes}
-            markdown={currentGroupMarkdown}
-            components={mdxComponents}
-            headingIds={currentGroupHeadingIds}
-          />
-        ),
-        aside,
-        fullWidth: section.fullWidth,
-      } satisfies EditorialSection;
+        return {
+          content: (
+            <RenderNodes
+              nodes={section.contentNodes}
+              markdown={currentGroupMarkdown}
+              components={mdxComponents}
+              headingIds={currentGroupHeadingIds}
+            />
+          ),
+          aside,
+          fullWidth: section.fullWidth,
+        } satisfies EditorialSection;
+      });
     }),
   ];
 

--- a/apps/website/src/docs/DocsPage.tsx
+++ b/apps/website/src/docs/DocsPage.tsx
@@ -1,13 +1,10 @@
-import { Fragment, type ReactNode } from "react";
+import { Fragment, type ReactNode, useEffect, useMemo } from "react";
 import type { Heading, Image, Root, RootContent } from "mdast";
 import { SafeMdxRenderer, type MyRootContent } from "safe-mdx";
 import { mdxParse } from "safe-mdx/parse";
 import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "../site";
 import {
   A,
-  Aside,
-  Accordion,
-  AccordionGroup,
   Bleed,
   Blockquote,
   Caption,
@@ -53,7 +50,11 @@ import {
   slugify,
 } from "./components/toc-tree";
 import "./styles/docs.css";
-import { docsManifest, docsMdxContent } from "./content";
+import {
+  docsManifest,
+  getDefaultDocsGroup,
+  getDocsGroupByPath,
+} from "./content";
 
 const tabItems = [
   { label: "Docs", href: "/docs/" },
@@ -62,11 +63,11 @@ const tabItems = [
   { label: "Changelog", href: RELEASES_URL },
 ] satisfies TabItem[];
 
-function isAsideNode(node: RootContent): boolean {
+function isSidebarCalloutNode(node: RootContent): boolean {
   return (
     node.type === "mdxJsxFlowElement" &&
     "name" in node &&
-    (node as { name?: string }).name === "Aside"
+    ["Note", "Tip", "Warning"].includes((node as { name?: string }).name ?? "")
   );
 }
 
@@ -86,11 +87,64 @@ function isHeroNode(node: RootContent): boolean {
   );
 }
 
+function hoistStepAsideCallouts(node: RootContent): {
+  node: RootContent;
+  asideNodes: RootContent[];
+} {
+  if (node.type !== "mdxJsxFlowElement") {
+    return { node, asideNodes: [] };
+  }
+
+  const element = node as MdxFlowElement;
+  const children = element.children;
+
+  if (element.name === "Step") {
+    const asideNodes = children.filter((child) => isSidebarCalloutNode(child));
+
+    if (asideNodes.length === 0) {
+      return { node, asideNodes: [] };
+    }
+
+    return {
+      node: {
+        ...element,
+        children: children.filter(
+          (child) => !isSidebarCalloutNode(child),
+        ) as typeof children,
+      },
+      asideNodes,
+    };
+  }
+
+  let changed = false;
+  const asideNodes: RootContent[] = [];
+  const nextChildren = children.map((child) => {
+    const result = hoistStepAsideCallouts(child);
+    changed ||= result.node !== child;
+    asideNodes.push(...result.asideNodes);
+    return result.node;
+  }) as typeof children;
+
+  if (!changed && asideNodes.length === 0) {
+    return { node, asideNodes: [] };
+  }
+
+  return {
+    node: {
+      ...element,
+      children: nextChildren,
+    },
+    asideNodes,
+  };
+}
+
 type MdastSection = {
   contentNodes: RootContent[];
   asideNodes: RootContent[];
   fullWidth?: boolean;
 };
+
+type MdxFlowElement = Extract<RootContent, { type: "mdxJsxFlowElement" }>;
 
 function getSectionHref(
   section: MdastSection,
@@ -156,10 +210,12 @@ function groupBySections(root: Root): MdastSection[] {
         fullWidth: true,
       });
       current = { contentNodes: [], asideNodes: [] };
-    } else if (isAsideNode(node)) {
+    } else if (isSidebarCalloutNode(node)) {
       current.asideNodes.push(node);
     } else {
-      current.contentNodes.push(node);
+      const { node: normalizedNode, asideNodes } = hoistStepAsideCallouts(node);
+      current.contentNodes.push(normalizedNode);
+      current.asideNodes.push(...asideNodes);
     }
   }
 
@@ -182,18 +238,56 @@ const parsedDocsGroups = docsManifest.map((group) => {
   };
 });
 
-const pageMdasts = parsedDocsGroups.flatMap((group) => {
-  return group.pages.map((page) => {
-    return page.mdast;
-  });
-});
-
-const mdast: Root = {
-  type: "root",
-  children: pageMdasts.flatMap((pageMdast) => {
-    return pageMdast.children;
+const headingIdsByGroup = new Map(
+  parsedDocsGroups.map((group) => {
+    return [
+      group.id,
+      buildHeadingIdMap(
+        group.pages.map((page) => {
+          return page.mdast;
+        }),
+      ),
+    ] as const;
   }),
-};
+);
+
+function addHeadingTarget(
+  lookup: Map<string, string[]>,
+  id: string,
+  target: string,
+) {
+  const existing = lookup.get(id);
+  if (existing) {
+    existing.push(target);
+    return;
+  }
+
+  lookup.set(id, [target]);
+}
+
+const headingHrefLookup = (() => {
+  const lookup = new Map<string, string[]>();
+
+  for (const group of parsedDocsGroups) {
+    addHeadingTarget(lookup, group.id, group.path);
+    const groupHeadingIds = headingIdsByGroup.get(group.id);
+
+    for (const page of group.pages) {
+      for (const node of page.mdast.children) {
+        if (node.type !== "heading") {
+          continue;
+        }
+
+        const heading = node as Heading;
+        const id =
+          groupHeadingIds?.get(heading) ?? slugify(extractText(heading.children));
+        addHeadingTarget(lookup, id, `${group.path}#${id}`);
+      }
+    }
+  }
+
+  return lookup;
+})();
 
 function PlainImage({
   src,
@@ -223,48 +317,125 @@ function PlainImage({
   return <img src={src} alt={alt} className={className} />;
 }
 
-const mdxComponents = {
-  p: P,
-  a: A,
-  code: Code,
-  ul: List,
-  ol: OL,
-  li: Li,
-  Caption,
-  ComparisonTable,
-  PixelatedImage: PlainImage,
-  Bleed,
-  Aside,
-  FullWidth,
-  Note,
-  Tip,
-  Warning,
-  Steps,
-  Step,
-  CardGroup,
-  Card,
-  Columns,
-  Tabs,
-  Tab,
-  CodeGroup,
-  ParamField,
-  ResponseField,
-  AccordionGroup,
-  Accordion,
-  Expandable,
-  blockquote: Blockquote,
-  table: Table,
-  thead: THead,
-  tbody: TBody,
-  tr: TR,
-  th: TH,
-  td: TD,
-  hr: () => (
-    <div className="docs-divider">
-      <div className="docs-divider-line" />
-    </div>
-  ),
-};
+function createMdxComponents(resolveHref: (href: string) => string) {
+  return {
+    p: P,
+    a: ({ href, children }: { href: string; children: ReactNode }) => {
+      return <A href={resolveHref(href)}>{children}</A>;
+    },
+    code: Code,
+    ul: List,
+    ol: OL,
+    li: Li,
+    Caption,
+    ComparisonTable,
+    PixelatedImage: PlainImage,
+    Bleed,
+    FullWidth,
+    Note,
+    Tip,
+    Warning,
+    Steps,
+    Step,
+    CardGroup,
+    Card: ({
+      title,
+      href,
+      children,
+    }: {
+      title: string;
+      href: string;
+      children: ReactNode;
+    }) => {
+      return (
+        <Card title={title} href={resolveHref(href)}>
+          {children}
+        </Card>
+      );
+    },
+    Columns,
+    Tabs,
+    Tab,
+    CodeGroup,
+    ParamField,
+    ResponseField,
+    Expandable,
+    blockquote: Blockquote,
+    table: Table,
+    thead: THead,
+    tbody: TBody,
+    tr: TR,
+    th: TH,
+    td: TD,
+    hr: () => (
+      <div className="docs-divider">
+        <div className="docs-divider-line" />
+      </div>
+    ),
+  };
+}
+
+function stripMetaValue(raw: string): string {
+  const unwrappedBraces = raw.replace(/^\{(.+)\}$/, "$1");
+
+  if (
+    (unwrappedBraces.startsWith('"') && unwrappedBraces.endsWith('"')) ||
+    (unwrappedBraces.startsWith("'") && unwrappedBraces.endsWith("'"))
+  ) {
+    return unwrappedBraces.slice(1, -1);
+  }
+
+  return unwrappedBraces;
+}
+
+function parseBooleanMetaValue(raw: string): boolean | undefined {
+  const value = stripMetaValue(raw).trim();
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  return undefined;
+}
+
+function parseCodeBlockMeta(meta?: string): {
+  title?: string;
+  showLineNumbers?: boolean;
+} {
+  if (!meta?.trim()) {
+    return {};
+  }
+
+  const tokens = meta.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? [];
+  let title: string | undefined;
+  let showLineNumbers: boolean | undefined;
+
+  for (const token of tokens) {
+    const equalsIndex = token.indexOf("=");
+
+    if (equalsIndex === -1) {
+      title ??= stripMetaValue(token);
+      continue;
+    }
+
+    const key = token.slice(0, equalsIndex);
+    const value = token.slice(equalsIndex + 1);
+
+    if (key === "title") {
+      title = stripMetaValue(value);
+    }
+
+    if (key === "showLineNumbers") {
+      showLineNumbers = parseBooleanMetaValue(value);
+    }
+  }
+
+  return { title, showLineNumbers };
+}
 
 function renderNode(
   node: MyRootContent,
@@ -295,17 +466,14 @@ function renderNode(
     const codeNode = node as { lang?: string; value: string; meta?: string };
     const lang = codeNode.lang || "bash";
     const isDiagram = lang === "diagram";
-    const title = codeNode.meta
-      ?.trim()
-      .split(/\s+/)
-      .find((part) => !part.includes("=") && !part.includes("{"));
+    const { title, showLineNumbers } = parseCodeBlockMeta(codeNode.meta);
 
     return (
       <CodeBlock
         lang={lang}
         title={title}
         lineHeight={isDiagram ? "1.3" : "1.85"}
-        showLineNumbers={!isDiagram}
+        showLineNumbers={isDiagram ? false : showLineNumbers}
       >
         {codeNode.value}
       </CodeBlock>
@@ -317,36 +485,114 @@ function renderNode(
 
 function RenderNodes({
   nodes,
+  markdown,
+  components,
   headingIds,
 }: {
   nodes: RootContent[];
+  markdown: string;
+  components: ReturnType<typeof createMdxComponents>;
   headingIds: WeakMap<Heading, string>;
 }) {
   const syntheticRoot: Root = { type: "root", children: nodes };
 
   return (
     <SafeMdxRenderer
-      markdown={docsMdxContent}
+      markdown={markdown}
       mdast={syntheticRoot as MyRootContent}
-      components={mdxComponents}
+      components={components}
       renderNode={(node, transform) => renderNode(node, transform, headingIds)}
     />
   );
 }
 
-export function DocsPage() {
-  const contentChildren = mdast.children.filter((node) => !isHeroNode(node));
+export function DocsPage({ pathname }: { pathname?: string }) {
+  const currentGroup =
+    getDocsGroupByPath(pathname ?? window.location.pathname) ??
+    getDefaultDocsGroup();
+  const parsedCurrentGroup =
+    parsedDocsGroups.find((group) => {
+      return group.id === currentGroup.id;
+    }) ?? parsedDocsGroups[0];
+  const currentGroupHeadingIds = headingIdsByGroup.get(parsedCurrentGroup.id);
+
+  if (!currentGroupHeadingIds) {
+    throw new Error(`Missing heading ids for docs group ${parsedCurrentGroup.id}`);
+  }
+
+  const currentGroupMarkdown = parsedCurrentGroup.pages
+    .map((page) => {
+      return page.content;
+    })
+    .join("\n\n");
+  const currentGroupAnchorIds = new Set<string>([parsedCurrentGroup.id]);
+
+  for (const page of parsedCurrentGroup.pages) {
+    for (const node of page.mdast.children) {
+      if (node.type !== "heading") {
+        continue;
+      }
+
+      const heading = node as Heading;
+      currentGroupAnchorIds.add(
+        currentGroupHeadingIds.get(heading) ??
+          slugify(extractText(heading.children)),
+      );
+    }
+  }
+
+  const resolveDocsHref = useMemo(() => {
+    return (href: string) => {
+      if (/^(https?:)?\/\//.test(href)) {
+        return href;
+      }
+
+      const anchor = href.startsWith("/docs/#")
+        ? href.slice("/docs/#".length)
+        : href.startsWith("#")
+          ? href.slice(1)
+          : null;
+
+      if (anchor) {
+        if (currentGroupAnchorIds.has(anchor)) {
+          return `#${anchor}`;
+        }
+
+        const targets = headingHrefLookup.get(anchor);
+        if (targets && targets.length > 0) {
+          return targets[0];
+        }
+      }
+
+      return href;
+    };
+  }, [currentGroupAnchorIds]);
+
+  const mdxComponents = useMemo(() => {
+    return createMdxComponents(resolveDocsHref);
+  }, [resolveDocsHref]);
+
+  const currentGroupMdast: Root = {
+    type: "root",
+    children: parsedCurrentGroup.pages.flatMap((page) => {
+      return page.mdast.children;
+    }),
+  };
+  const contentChildren = currentGroupMdast.children.filter((node) => !isHeroNode(node));
   const contentMdast: Root = { type: "root", children: contentChildren };
-  const headingIds = buildHeadingIdMap(pageMdasts);
 
   const tocItems = flattenTocTree({
-    roots: buildDocsTocTree({ groups: parsedDocsGroups, headingIds }),
+    roots: buildDocsTocTree({
+      groups: parsedDocsGroups,
+      headingIdsByGroup,
+      currentGroupId: parsedCurrentGroup.id,
+    }),
   });
   const mdastSections = groupBySections(contentMdast);
   const sectionByHref = new Map(
     mdastSections
       .map((section) => {
-        const href = getSectionHref(section, headingIds);
+        const href = getSectionHref(section, currentGroupHeadingIds);
         return href ? ([href, section] as const) : null;
       })
       .filter(
@@ -354,18 +600,17 @@ export function DocsPage() {
       ),
   );
 
-  const sections: EditorialSection[] = parsedDocsGroups.flatMap((group) => {
-    const groupHeadingSection: EditorialSection = {
+  const sections: EditorialSection[] = [
+    {
       content: (
         <div className="docs-group-heading-section">
-          <SectionHeading id={group.id} level={1}>
-            {group.label}
+          <SectionHeading id={parsedCurrentGroup.id} level={1}>
+            {parsedCurrentGroup.label}
           </SectionHeading>
         </div>
       ),
-    };
-
-    const groupSections = group.pages.map((page) => {
+    },
+    ...parsedCurrentGroup.pages.map((page) => {
       const firstPageHeading = page.mdast.children.find(
         (node): node is Heading => {
           return node.type === "heading";
@@ -376,7 +621,7 @@ export function DocsPage() {
         throw new Error(`Missing top-level heading for docs page ${page.id}`);
       }
 
-      const pageHref = `#${headingIds.get(firstPageHeading) ?? slugify(extractText(firstPageHeading.children))}`;
+      const pageHref = `#${currentGroupHeadingIds.get(firstPageHeading) ?? slugify(extractText(firstPageHeading.children))}`;
       const section = sectionByHref.get(pageHref);
 
       if (!section) {
@@ -385,20 +630,43 @@ export function DocsPage() {
 
       const aside =
         section.asideNodes.length > 0 ? (
-          <RenderNodes nodes={section.asideNodes} headingIds={headingIds} />
+          <RenderNodes
+            nodes={section.asideNodes}
+            markdown={currentGroupMarkdown}
+            components={mdxComponents}
+            headingIds={currentGroupHeadingIds}
+          />
         ) : undefined;
 
       return {
         content: (
-          <RenderNodes nodes={section.contentNodes} headingIds={headingIds} />
+          <RenderNodes
+            nodes={section.contentNodes}
+            markdown={currentGroupMarkdown}
+            components={mdxComponents}
+            headingIds={currentGroupHeadingIds}
+          />
         ),
         aside,
         fullWidth: section.fullWidth,
       } satisfies EditorialSection;
-    });
+    }),
+  ];
 
-    return [groupHeadingSection, ...groupSections];
-  });
+  useEffect(() => {
+    if (!window.location.hash) {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+      return;
+    }
+
+    const targetId = window.location.hash.replace(/^#/, "");
+    const scrollToTarget = () => {
+      const target = document.getElementById(targetId);
+      target?.scrollIntoView({ block: "start" });
+    };
+
+    window.requestAnimationFrame(scrollToTarget);
+  }, [parsedCurrentGroup.id, pathname]);
 
   return (
     <div className="docs-root">

--- a/apps/website/src/docs/DocsPage.tsx
+++ b/apps/website/src/docs/DocsPage.tsx
@@ -163,7 +163,7 @@ function buildHeadingIdMap(roots: Root[]): WeakMap<Heading, string> {
 
       headingIds.set(
         heading,
-        nextCount === 0 ? base : `${base}-${nextCount + 1}`,
+        nextCount === 0 ? base : `${base}-${nextCount}`,
       );
     }
   }

--- a/apps/website/src/docs/DocsPage.tsx
+++ b/apps/website/src/docs/DocsPage.tsx
@@ -1,0 +1,413 @@
+import { Fragment, type ReactNode } from "react";
+import type { Heading, Image, Root, RootContent } from "mdast";
+import { SafeMdxRenderer, type MyRootContent } from "safe-mdx";
+import { mdxParse } from "safe-mdx/parse";
+import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "../site";
+import {
+  A,
+  Aside,
+  Accordion,
+  AccordionGroup,
+  Bleed,
+  Blockquote,
+  Caption,
+  Card,
+  CardGroup,
+  Code,
+  CodeBlock,
+  CodeGroup,
+  ComparisonTable,
+  Columns,
+  EditorialPage,
+  Expandable,
+  Note,
+  FullWidth,
+  Li,
+  List,
+  ParamField,
+  OL,
+  P,
+  PixelatedImage,
+  ResponseField,
+  SectionHeading,
+  Step,
+  Steps,
+  Tab,
+  Tabs,
+  Table,
+  TBody,
+  TD,
+  TH,
+  THead,
+  TR,
+  Tip,
+  type EditorialSection,
+  type HeadingLevel,
+  type TabItem,
+  Warning,
+} from "./components/markdown";
+import {
+  buildDocsTocTree,
+  extractText,
+  flattenTocTree,
+  slugify,
+} from "./components/toc-tree";
+import "./styles/docs.css";
+import { docsManifest, docsMdxContent } from "./content";
+
+const tabItems = [
+  { label: "Docs", href: "/docs/" },
+  { label: "GitHub", href: REPO_URL },
+  { label: "Forum", href: DISCUSSIONS_URL },
+  { label: "Changelog", href: RELEASES_URL },
+] satisfies TabItem[];
+
+function isAsideNode(node: RootContent): boolean {
+  return (
+    node.type === "mdxJsxFlowElement" &&
+    "name" in node &&
+    (node as { name?: string }).name === "Aside"
+  );
+}
+
+function isFullWidthNode(node: RootContent): boolean {
+  return (
+    node.type === "mdxJsxFlowElement" &&
+    "name" in node &&
+    (node as { name?: string }).name === "FullWidth"
+  );
+}
+
+function isHeroNode(node: RootContent): boolean {
+  return (
+    node.type === "mdxJsxFlowElement" &&
+    "name" in node &&
+    (node as { name?: string }).name === "Hero"
+  );
+}
+
+type MdastSection = {
+  contentNodes: RootContent[];
+  asideNodes: RootContent[];
+  fullWidth?: boolean;
+};
+
+function getSectionHref(
+  section: MdastSection,
+  headingIds: WeakMap<Heading, string>,
+): string | null {
+  const heading = section.contentNodes.find((node): node is Heading => {
+    return node.type === "heading" && (node as Heading).depth === 2;
+  });
+
+  if (!heading) {
+    return null;
+  }
+
+  return `#${headingIds.get(heading) ?? slugify(extractText(heading.children))}`;
+}
+
+function buildHeadingIdMap(roots: Root[]): WeakMap<Heading, string> {
+  const counts = new Map<string, number>();
+  const headingIds = new WeakMap<Heading, string>();
+
+  for (const root of roots) {
+    for (const node of root.children) {
+      if (node.type !== "heading") {
+        continue;
+      }
+
+      const heading = node as Heading;
+      const base = slugify(extractText(heading.children));
+      const nextCount = counts.get(base) ?? 0;
+      counts.set(base, nextCount + 1);
+
+      headingIds.set(
+        heading,
+        nextCount === 0 ? base : `${base}-${nextCount + 1}`,
+      );
+    }
+  }
+
+  return headingIds;
+}
+
+function groupBySections(root: Root): MdastSection[] {
+  const sections: MdastSection[] = [];
+  let current: MdastSection = { contentNodes: [], asideNodes: [] };
+
+  for (const node of root.children) {
+    if (node.type === "heading" && (node as Heading).depth === 2) {
+      if (current.contentNodes.length > 0 || current.asideNodes.length > 0) {
+        sections.push(current);
+      }
+      current = { contentNodes: [node], asideNodes: [] };
+    } else if (isFullWidthNode(node)) {
+      if (current.contentNodes.length > 0 || current.asideNodes.length > 0) {
+        sections.push(current);
+      }
+      const children =
+        "children" in node
+          ? (node as { children: RootContent[] }).children
+          : [];
+      sections.push({
+        contentNodes: children,
+        asideNodes: [],
+        fullWidth: true,
+      });
+      current = { contentNodes: [], asideNodes: [] };
+    } else if (isAsideNode(node)) {
+      current.asideNodes.push(node);
+    } else {
+      current.contentNodes.push(node);
+    }
+  }
+
+  if (current.contentNodes.length > 0 || current.asideNodes.length > 0) {
+    sections.push(current);
+  }
+
+  return sections;
+}
+
+const parsedDocsGroups = docsManifest.map((group) => {
+  return {
+    ...group,
+    pages: group.pages.map((page) => {
+      return {
+        ...page,
+        mdast: mdxParse(page.content) as Root,
+      };
+    }),
+  };
+});
+
+const pageMdasts = parsedDocsGroups.flatMap((group) => {
+  return group.pages.map((page) => {
+    return page.mdast;
+  });
+});
+
+const mdast: Root = {
+  type: "root",
+  children: pageMdasts.flatMap((pageMdast) => {
+    return pageMdast.children;
+  }),
+};
+
+function PlainImage({
+  src,
+  alt,
+  width,
+  height,
+  className,
+}: {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  className?: string;
+}) {
+  if (width && height) {
+    return (
+      <PixelatedImage
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        className={className ?? ""}
+      />
+    );
+  }
+
+  return <img src={src} alt={alt} className={className} />;
+}
+
+const mdxComponents = {
+  p: P,
+  a: A,
+  code: Code,
+  ul: List,
+  ol: OL,
+  li: Li,
+  Caption,
+  ComparisonTable,
+  PixelatedImage: PlainImage,
+  Bleed,
+  Aside,
+  FullWidth,
+  Note,
+  Tip,
+  Warning,
+  Steps,
+  Step,
+  CardGroup,
+  Card,
+  Columns,
+  Tabs,
+  Tab,
+  CodeGroup,
+  ParamField,
+  ResponseField,
+  AccordionGroup,
+  Accordion,
+  Expandable,
+  blockquote: Blockquote,
+  table: Table,
+  thead: THead,
+  tbody: TBody,
+  tr: TR,
+  th: TH,
+  td: TD,
+  hr: () => (
+    <div className="docs-divider">
+      <div className="docs-divider-line" />
+    </div>
+  ),
+};
+
+function renderNode(
+  node: MyRootContent,
+  transform: (candidate: MyRootContent) => ReactNode,
+  headingIds: WeakMap<Heading, string>,
+): ReactNode | undefined {
+  if (node.type === "image") {
+    const imageNode = node as Image;
+    return <PlainImage src={imageNode.url} alt={imageNode.alt || ""} />;
+  }
+
+  if (node.type === "heading") {
+    const heading = node as Heading;
+    const id =
+      headingIds.get(heading) ?? slugify(extractText(heading.children));
+    const level = Math.min(Math.max(heading.depth, 1), 3) as HeadingLevel;
+
+    return (
+      <SectionHeading key={id} id={id} level={level}>
+        {heading.children.map((child, index) => (
+          <Fragment key={index}>{transform(child as MyRootContent)}</Fragment>
+        ))}
+      </SectionHeading>
+    );
+  }
+
+  if (node.type === "code") {
+    const codeNode = node as { lang?: string; value: string; meta?: string };
+    const lang = codeNode.lang || "bash";
+    const isDiagram = lang === "diagram";
+    const title = codeNode.meta
+      ?.trim()
+      .split(/\s+/)
+      .find((part) => !part.includes("=") && !part.includes("{"));
+
+    return (
+      <CodeBlock
+        lang={lang}
+        title={title}
+        lineHeight={isDiagram ? "1.3" : "1.85"}
+        showLineNumbers={!isDiagram}
+      >
+        {codeNode.value}
+      </CodeBlock>
+    );
+  }
+
+  return undefined;
+}
+
+function RenderNodes({
+  nodes,
+  headingIds,
+}: {
+  nodes: RootContent[];
+  headingIds: WeakMap<Heading, string>;
+}) {
+  const syntheticRoot: Root = { type: "root", children: nodes };
+
+  return (
+    <SafeMdxRenderer
+      markdown={docsMdxContent}
+      mdast={syntheticRoot as MyRootContent}
+      components={mdxComponents}
+      renderNode={(node, transform) => renderNode(node, transform, headingIds)}
+    />
+  );
+}
+
+export function DocsPage() {
+  const contentChildren = mdast.children.filter((node) => !isHeroNode(node));
+  const contentMdast: Root = { type: "root", children: contentChildren };
+  const headingIds = buildHeadingIdMap(pageMdasts);
+
+  const tocItems = flattenTocTree({
+    roots: buildDocsTocTree({ groups: parsedDocsGroups, headingIds }),
+  });
+  const mdastSections = groupBySections(contentMdast);
+  const sectionByHref = new Map(
+    mdastSections
+      .map((section) => {
+        const href = getSectionHref(section, headingIds);
+        return href ? ([href, section] as const) : null;
+      })
+      .filter(
+        (entry): entry is readonly [string, MdastSection] => entry !== null,
+      ),
+  );
+
+  const sections: EditorialSection[] = parsedDocsGroups.flatMap((group) => {
+    const groupHeadingSection: EditorialSection = {
+      content: (
+        <div className="docs-group-heading-section">
+          <SectionHeading id={group.id} level={1}>
+            {group.label}
+          </SectionHeading>
+        </div>
+      ),
+    };
+
+    const groupSections = group.pages.map((page) => {
+      const firstPageHeading = page.mdast.children.find(
+        (node): node is Heading => {
+          return node.type === "heading";
+        },
+      );
+
+      if (!firstPageHeading) {
+        throw new Error(`Missing top-level heading for docs page ${page.id}`);
+      }
+
+      const pageHref = `#${headingIds.get(firstPageHeading) ?? slugify(extractText(firstPageHeading.children))}`;
+      const section = sectionByHref.get(pageHref);
+
+      if (!section) {
+        throw new Error(`Missing docs page section for ${pageHref}`);
+      }
+
+      const aside =
+        section.asideNodes.length > 0 ? (
+          <RenderNodes nodes={section.asideNodes} headingIds={headingIds} />
+        ) : undefined;
+
+      return {
+        content: (
+          <RenderNodes nodes={section.contentNodes} headingIds={headingIds} />
+        ),
+        aside,
+        fullWidth: section.fullWidth,
+      } satisfies EditorialSection;
+    });
+
+    return [groupHeadingSection, ...groupSections];
+  });
+
+  return (
+    <div className="docs-root">
+      <EditorialPage
+        toc={tocItems}
+        tabs={tabItems}
+        activeTab="/docs/"
+        sections={sections}
+      />
+    </div>
+  );
+}

--- a/apps/website/src/docs/DocsPage.tsx
+++ b/apps/website/src/docs/DocsPage.tsx
@@ -525,21 +525,25 @@ export function DocsPage({ pathname }: { pathname?: string }) {
       return page.content;
     })
     .join("\n\n");
-  const currentGroupAnchorIds = new Set<string>([parsedCurrentGroup.id]);
+  const currentGroupAnchorIds = useMemo(() => {
+    const ids = new Set<string>([parsedCurrentGroup.id]);
 
-  for (const page of parsedCurrentGroup.pages) {
-    for (const node of page.mdast.children) {
-      if (node.type !== "heading") {
-        continue;
+    for (const page of parsedCurrentGroup.pages) {
+      for (const node of page.mdast.children) {
+        if (node.type !== "heading") {
+          continue;
+        }
+
+        const heading = node as Heading;
+        ids.add(
+          currentGroupHeadingIds.get(heading) ??
+            slugify(extractText(heading.children)),
+        );
       }
-
-      const heading = node as Heading;
-      currentGroupAnchorIds.add(
-        currentGroupHeadingIds.get(heading) ??
-          slugify(extractText(heading.children)),
-      );
     }
-  }
+
+    return ids;
+  }, [parsedCurrentGroup, currentGroupHeadingIds]);
 
   const resolveDocsHref = useMemo(() => {
     return (href: string) => {

--- a/apps/website/src/docs/components/markdown.tsx
+++ b/apps/website/src/docs/components/markdown.tsx
@@ -2309,9 +2309,6 @@ export function EditorialPage({
           <>
             {/* Section-based layout: each section is a subgrid row with
                 content in column 3 and optional aside in column 5 (sticky). */}
-            <div className="contents lg:grid lg:grid-cols-subgrid lg:col-[2/-1]">
-              <div className="slot-main flex flex-col gap-5 lg:col-[1] lg:overflow-visible text-(length:--type-body-size)"></div>
-            </div>
             {sections.map((section, i) => {
               if (section.fullWidth) {
                 return (

--- a/apps/website/src/docs/components/markdown.tsx
+++ b/apps/website/src/docs/components/markdown.tsx
@@ -100,16 +100,23 @@ function normalizeDocsPathname(pathname: string): string {
   return pathname.replace(/\/+$/, "");
 }
 
-function getHrefPathname(href: string, fallbackPathname: string): string {
-  if (href.startsWith("#")) {
-    return fallbackPathname;
+function resolveHrefUrl(href: string): URL | null {
+  if (typeof window === "undefined") {
+    return null;
   }
 
   try {
-    return normalizeDocsPathname(new URL(href, window.location.origin).pathname);
+    return new URL(href, window.location.href);
   } catch {
-    return fallbackPathname;
+    return null;
   }
+}
+
+function getHrefPathname(href: string, fallbackPathname: string): string {
+  const resolvedUrl = resolveHrefUrl(href);
+  return resolvedUrl
+    ? normalizeDocsPathname(resolvedUrl.pathname)
+    : fallbackPathname;
 }
 
 function isPlainAnchorNavigationClick(
@@ -387,6 +394,32 @@ function useActiveTocId({ fallbackId }: { fallbackId: string }) {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
+function useCurrentHash() {
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const handleHistoryNavigation = () => {
+      onStoreChange();
+    };
+
+    window.addEventListener("hashchange", handleHistoryNavigation);
+    window.addEventListener("popstate", handleHistoryNavigation);
+
+    return () => {
+      window.removeEventListener("hashchange", handleHistoryNavigation);
+      window.removeEventListener("popstate", handleHistoryNavigation);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => {
+    return window.location.hash;
+  }, []);
+
+  const getServerSnapshot = useCallback(() => {
+    return "";
+  }, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
 function TocLink({
   item,
   isActive,
@@ -539,6 +572,7 @@ export function TableOfContents({
   });
   const fallbackId = getTargetIdFromHref(firstNavigableItem?.href ?? "");
   const activeHeadingId = useActiveTocId({ fallbackId });
+  const currentHash = useCurrentHash();
   const [pendingNavigation, setPendingNavigation] =
     useState<PendingNavigation | null>(null);
 
@@ -575,9 +609,14 @@ export function TableOfContents({
       getHrefPathname(item.href, currentPathname) === currentPathname
     );
   });
+  const hashedItemId =
+    preferredItemIdByHref.get(currentHash) ??
+    preferredItemIdByHref.get(`${currentPathname}${currentHash}`) ??
+    null;
   const activeItemId =
     preferredItemIdByHref.get(`#${activeHeadingId}`) ??
     preferredItemIdByHref.get(`${currentPathname}#${activeHeadingId}`) ??
+    hashedItemId ??
     activeGroupItem?.id ??
     firstNavigableItem?.id ??
     items[0]?.id ??
@@ -721,11 +760,13 @@ export function TableOfContents({
 
   const navigateToItem = useCallback(
     (item: FlatTocItem, link?: HTMLAnchorElement | null) => {
-      const itemUrl = new URL(item.href, window.location.origin);
-      const itemPathname = normalizeDocsPathname(itemUrl.pathname);
+      const itemUrl = resolveHrefUrl(item.href);
+      const itemPathname = itemUrl
+        ? normalizeDocsPathname(itemUrl.pathname)
+        : currentPathname;
 
       if (itemPathname !== currentPathname) {
-        if (!isAppOwnedPathname(itemPathname)) {
+        if (!itemUrl || !isAppOwnedPathname(itemPathname)) {
           return false;
         }
 

--- a/apps/website/src/docs/components/markdown.tsx
+++ b/apps/website/src/docs/components/markdown.tsx
@@ -8,6 +8,9 @@
  */
 
 import {
+  Children,
+  Fragment,
+  isValidElement,
   useCallback,
   useEffect,
   useMemo,
@@ -16,6 +19,8 @@ import {
   useSyncExternalStore,
   useTransition,
 } from "react";
+import { useLocation } from "wouter";
+import { AppLink, isAppOwnedPathname } from "../../routing";
 import { createTocDb, searchToc, type SearchState } from "./search";
 import type {
   TocNodeType,
@@ -26,9 +31,12 @@ import type {
 
 export type { TocNodeType, VisualLevel, TocTreeNode, FlatTocItem };
 import Prism from "prismjs";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-typescript";
 import "prismjs/components/prism-jsx";
 import "prismjs/components/prism-tsx";
 import "prismjs/components/prism-bash";
+import "prismjs/components/prism-json";
 
 /* Custom "diagram" language for ASCII/Unicode box-drawing diagrams.
    Tokenizes box-drawing chars as neutral structure, text as highlighted labels. */
@@ -45,8 +53,36 @@ Prism.languages.diagram = {
    ========================================================================= */
 
 const WEIGHT = { regular: 400, prose: 475, heading: 560, bold: 700 } as const;
-const ACTIVE_SECTION_PROBE_OFFSET = 60;
+const ACTIVE_SECTION_VISIBILITY_PX = 60;
+const NAVIGATION_SETTLE_TOLERANCE_PX = 4;
+const NAVIGATION_IDLE_MS = 120;
 type ManualExpansionMode = "open" | "closed";
+
+const CODE_LANGUAGE_ALIASES: Record<string, string> = {
+  bash: "bash",
+  javascript: "javascript",
+  js: "javascript",
+  json: "json",
+  jsonc: "json",
+  shell: "bash",
+  sh: "bash",
+  text: "text",
+  plaintext: "text",
+  ts: "typescript",
+  tsx: "tsx",
+  txt: "text",
+  typescript: "typescript",
+  jsx: "jsx",
+  zsh: "bash",
+};
+
+function normalizeCodeLanguage(lang?: string): string | undefined {
+  if (!lang) {
+    return undefined;
+  }
+
+  return CODE_LANGUAGE_ALIASES[lang.toLowerCase()] ?? lang.toLowerCase();
+}
 
 function getHrefFragment(href: string): string {
   return href.includes("#") ? href.slice(href.indexOf("#")) : href;
@@ -54,6 +90,26 @@ function getHrefFragment(href: string): string {
 
 function getTargetIdFromHref(href: string): string {
   return getHrefFragment(href).replace(/^#/, "");
+}
+
+function normalizeDocsPathname(pathname: string): string {
+  if (pathname === "/") {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/, "");
+}
+
+function getHrefPathname(href: string, fallbackPathname: string): string {
+  if (href.startsWith("#")) {
+    return fallbackPathname;
+  }
+
+  try {
+    return normalizeDocsPathname(new URL(href, window.location.origin).pathname);
+  } catch {
+    return fallbackPathname;
+  }
 }
 
 function isPlainAnchorNavigationClick(
@@ -134,6 +190,7 @@ const headingTagByLevel: Record<HeadingLevel, "h1" | "h2" | "h3"> = {
 type PendingNavigation = {
   itemId: string;
   targetId: string;
+  startedAt: number;
 };
 
 function getHeaderHeight(): number {
@@ -160,14 +217,65 @@ function isNavigationInterruptKey(event: KeyboardEvent): boolean {
 
 /* flattenTocTree and helpers moved to toc-tree.ts (server-safe, no 'use client'). */
 
-/** Single useSyncExternalStore that handles both initial hash and scroll-based
- *  active heading tracking. Server snapshot returns fallbackId to avoid
- *  hydration mismatch. Hash is read inside subscribe (not during render) to
- *  keep render pure. All callbacks are stable via useCallback. */
+type TocSectionBounds = {
+  id: string;
+  top: number;
+  bottom: number;
+  visibleHeight: number;
+};
+
+function getTocSectionBounds(headings: HTMLElement[]) {
+  const documentBottom = document.documentElement.scrollHeight;
+
+  return headings.map((heading, index): TocSectionBounds => {
+    const top = window.scrollY + heading.getBoundingClientRect().top;
+    const nextHeading = headings[index + 1];
+    const bottom = nextHeading
+      ? window.scrollY + nextHeading.getBoundingClientRect().top
+      : documentBottom;
+
+    return {
+      id: heading.id,
+      top,
+      bottom,
+      visibleHeight: 0,
+    };
+  });
+}
+
+function getVisibleSectionBounds({
+  sections,
+  viewportTop,
+  viewportBottom,
+}: {
+  sections: TocSectionBounds[];
+  viewportTop: number;
+  viewportBottom: number;
+}) {
+  return sections.map((section) => {
+    const visibleTop = Math.max(section.top, viewportTop);
+    const visibleBottom = Math.min(section.bottom, viewportBottom);
+
+    return {
+      ...section,
+      visibleHeight: Math.max(0, visibleBottom - visibleTop),
+    };
+  });
+}
+
+/** Scroll-derived TOC selection.
+ *
+ * Rules:
+ * - At the top of the docs, the first section is selected.
+ * - During manual scrolling, select the last section in document order with at
+ *   least 60px visible beneath the sticky header.
+ * - If no section reaches the 60px threshold (rare edge cases like tiny final
+ *   sections), fall back to the last partially visible section, then the last
+ *   section above the viewport.
+ *
+ * Server snapshot returns fallbackId to avoid hydration mismatch. */
 function useActiveTocId({ fallbackId }: { fallbackId: string }) {
   const activeRef = useRef(fallbackId);
-  const lastScrollYRef = useRef(0);
-  const scrollDirectionRef = useRef<"up" | "down">("down");
 
   const subscribe = useCallback((onStoreChange: () => void) => {
     const emit = (next: string) => {
@@ -178,19 +286,15 @@ function useActiveTocId({ fallbackId }: { fallbackId: string }) {
       onStoreChange();
     };
 
-    // Read hash on first subscribe to fix flash on initial paint
-    const hash = window.location.hash.replace(/^#/, "");
-    if (hash) {
-      emit(hash);
-    }
-
-    const headings = Array.from(
-      document.querySelectorAll<HTMLElement>('[data-toc-heading="true"][id]'),
-    );
     let rafId = 0;
-    lastScrollYRef.current = window.scrollY;
 
     const computeActive = () => {
+      const headings = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '[data-toc-heading="true"][id]',
+        ),
+      );
+
       if (headings.length === 0) {
         return;
       }
@@ -199,27 +303,20 @@ function useActiveTocId({ fallbackId }: { fallbackId: string }) {
       const viewportTop = window.scrollY + safeHeaderHeight;
       const viewportBottom = window.scrollY + window.innerHeight;
 
-      const sections = headings.map((heading, index) => {
-        const top = window.scrollY + heading.getBoundingClientRect().top;
-        const nextHeading = headings[index + 1];
-        const bottom = nextHeading
-          ? window.scrollY + nextHeading.getBoundingClientRect().top
-          : document.documentElement.scrollHeight;
-        const anchor = top + ACTIVE_SECTION_PROBE_OFFSET;
-
-        return { id: heading.id, top, bottom, anchor };
+      const sections = getVisibleSectionBounds({
+        sections: getTocSectionBounds(headings),
+        viewportTop,
+        viewportBottom,
       });
-
       const firstSection = sections[0];
-      if (firstSection && viewportTop <= firstSection.anchor) {
+
+      if (firstSection && viewportTop <= firstSection.top) {
         emit(firstSection.id);
         return;
       }
 
       const visibleSections = sections.filter((section) => {
-        return (
-          section.anchor >= viewportTop && section.anchor <= viewportBottom
-        );
+        return section.visibleHeight >= ACTIVE_SECTION_VISIBILITY_PX;
       });
 
       if (visibleSections.length > 0) {
@@ -227,30 +324,20 @@ function useActiveTocId({ fallbackId }: { fallbackId: string }) {
         return;
       }
 
-      if (scrollDirectionRef.current === "up") {
-        const nextVisibleFromBottom = sections.find((section) => {
-          return section.anchor > viewportBottom;
-        });
+      const partiallyVisibleSections = sections.filter((section) => {
+        return section.visibleHeight > 0;
+      });
 
-        if (nextVisibleFromBottom) {
-          emit(nextVisibleFromBottom.id);
-          return;
-        }
-
-        emit(sections[sections.length - 1].id);
+      if (partiallyVisibleSections.length > 0) {
+        emit(partiallyVisibleSections[partiallyVisibleSections.length - 1].id);
         return;
       }
 
       const passedSections = sections.filter((section) => {
-        return section.anchor < viewportTop;
+        return section.top <= viewportTop;
       });
 
-      if (passedSections.length > 0) {
-        emit(passedSections[passedSections.length - 1].id);
-        return;
-      }
-
-      emit(sections[0].id);
+      emit(passedSections[passedSections.length - 1]?.id ?? firstSection.id);
     };
 
     const scheduleCompute = () => {
@@ -265,23 +352,10 @@ function useActiveTocId({ fallbackId }: { fallbackId: string }) {
     };
 
     const handleScroll = () => {
-      const nextScrollY = window.scrollY;
-
-      if (nextScrollY > lastScrollYRef.current) {
-        scrollDirectionRef.current = "down";
-      } else if (nextScrollY < lastScrollYRef.current) {
-        scrollDirectionRef.current = "up";
-      }
-
-      lastScrollYRef.current = nextScrollY;
       scheduleCompute();
     };
 
     const handleHistoryNavigation = () => {
-      const nextHash = window.location.hash.replace(/^#/, "");
-      if (nextHash) {
-        emit(nextHash);
-      }
       scheduleCompute();
     };
 
@@ -328,7 +402,7 @@ function TocLink({
   isActive: boolean;
   chevron?: { expanded: boolean; lockedOpen?: boolean };
   onToggle?: () => void;
-  onNavigate?: (item: FlatTocItem, link: HTMLAnchorElement) => void;
+  onNavigate?: (item: FlatTocItem, link: HTMLAnchorElement) => boolean;
   /** Search: dim non-matching items to opacity 0.3 */
   dimmed?: boolean;
   /** Search: item matched the query */
@@ -374,8 +448,10 @@ function TocLink({
         if (!onNavigate || !isPlainAnchorNavigationClick(e)) {
           return;
         }
-        e.preventDefault();
-        onNavigate(item, e.currentTarget);
+        const handled = onNavigate(item, e.currentTarget);
+        if (handled) {
+          e.preventDefault();
+        }
       }}
       onMouseEnter={(e) => {
         if (!effectiveActive && !dimmed) {
@@ -450,8 +526,16 @@ export function TableOfContents({
   items: FlatTocItem[];
   logo?: string;
 }) {
+  const [, navigate] = useLocation();
+  const currentPathname =
+    typeof window === "undefined"
+      ? "/docs"
+      : normalizeDocsPathname(window.location.pathname);
   const firstNavigableItem = items.find((item) => {
-    return item.href.startsWith("#");
+    return (
+      getHrefPathname(item.href, currentPathname) === currentPathname &&
+      item.href.includes("#")
+    );
   });
   const fallbackId = getTargetIdFromHref(firstNavigableItem?.href ?? "");
   const activeHeadingId = useActiveTocId({ fallbackId });
@@ -485,12 +569,25 @@ export function TableOfContents({
     return next;
   }, [items]);
 
+  const activeGroupItem = items.find((item) => {
+    return (
+      item.type === "group" &&
+      getHrefPathname(item.href, currentPathname) === currentPathname
+    );
+  });
   const activeItemId =
     preferredItemIdByHref.get(`#${activeHeadingId}`) ??
+    preferredItemIdByHref.get(`${currentPathname}#${activeHeadingId}`) ??
+    activeGroupItem?.id ??
     firstNavigableItem?.id ??
     items[0]?.id ??
     null;
   const selectedItemId = pendingNavigation?.itemId ?? activeItemId;
+  const activeHeadingIdRef = useRef(activeHeadingId);
+
+  useEffect(() => {
+    activeHeadingIdRef.current = activeHeadingId;
+  }, [activeHeadingId]);
 
   const defaultExpandedIds = useMemo(() => {
     return new Set(
@@ -549,11 +646,6 @@ export function TableOfContents({
       return;
     }
 
-    if (activeHeadingId === pendingNavigation.targetId) {
-      setPendingNavigation(null);
-      return;
-    }
-
     const target = document.getElementById(pendingNavigation.targetId);
     if (!target) {
       setPendingNavigation(null);
@@ -561,6 +653,8 @@ export function TableOfContents({
     }
 
     let rafId = 0;
+    let lastScrollY = window.scrollY;
+    let lastScrollChangeAt = pendingNavigation.startedAt;
 
     const clearPendingNavigation = () => {
       setPendingNavigation((current) => {
@@ -581,10 +675,22 @@ export function TableOfContents({
     };
 
     const checkTargetPosition = () => {
+      const nextScrollY = window.scrollY;
+      if (Math.abs(nextScrollY - lastScrollY) > 0.5) {
+        lastScrollY = nextScrollY;
+        lastScrollChangeAt = performance.now();
+      }
+
       const distanceFromViewportTop =
         target.getBoundingClientRect().top - getHeaderHeight();
+      const targetAligned =
+        Math.abs(distanceFromViewportTop) <= NAVIGATION_SETTLE_TOLERANCE_PX;
+      const targetSelected =
+        activeHeadingIdRef.current === pendingNavigation.targetId;
+      const navigationSettled =
+        performance.now() - lastScrollChangeAt >= NAVIGATION_IDLE_MS;
 
-      if (Math.abs(distanceFromViewportTop) <= 4) {
+      if ((targetAligned || targetSelected) && navigationSettled) {
         clearPendingNavigation();
         return;
       }
@@ -597,7 +703,7 @@ export function TableOfContents({
     window.addEventListener("touchstart", handleUserInterrupt, {
       passive: true,
     });
-    window.addEventListener("mousedown", handleUserInterrupt);
+    window.addEventListener("pointerdown", handleUserInterrupt);
     window.addEventListener("popstate", handleUserInterrupt);
     window.addEventListener("keydown", handleKeyDown);
 
@@ -607,22 +713,38 @@ export function TableOfContents({
       }
       window.removeEventListener("wheel", handleUserInterrupt);
       window.removeEventListener("touchstart", handleUserInterrupt);
-      window.removeEventListener("mousedown", handleUserInterrupt);
+      window.removeEventListener("pointerdown", handleUserInterrupt);
       window.removeEventListener("popstate", handleUserInterrupt);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [activeHeadingId, pendingNavigation]);
+  }, [pendingNavigation]);
 
   const navigateToItem = useCallback(
     (item: FlatTocItem, link?: HTMLAnchorElement | null) => {
+      const itemUrl = new URL(item.href, window.location.origin);
+      const itemPathname = normalizeDocsPathname(itemUrl.pathname);
+
+      if (itemPathname !== currentPathname) {
+        if (!isAppOwnedPathname(itemPathname)) {
+          return false;
+        }
+
+        navigate(`${itemUrl.pathname}${itemUrl.search}${itemUrl.hash}`);
+        return true;
+      }
+
       const targetId = getTargetIdFromHref(item.href);
       const target = targetId ? document.getElementById(targetId) : null;
 
       if (!targetId || !target) {
-        return;
+        return false;
       }
 
-      setPendingNavigation({ itemId: item.id, targetId });
+      setPendingNavigation({
+        itemId: item.id,
+        targetId,
+        startedAt: performance.now(),
+      });
 
       const nextHash = `#${targetId}`;
       const nextUrl = `${window.location.pathname}${window.location.search}${nextHash}`;
@@ -634,8 +756,9 @@ export function TableOfContents({
 
       link?.focus();
       target.scrollIntoView({ block: "start" });
+      return true;
     },
-    [],
+    [currentPathname, navigate],
   );
 
   const toggle = useCallback(
@@ -758,7 +881,16 @@ export function TableOfContents({
         const itemId = focusable[highlightedIndex];
         const item = itemId ? itemById.get(itemId) : undefined;
         if (item) {
-          navigateToItem(item);
+          const handled = navigateToItem(item);
+          if (!handled) {
+            const itemPathname = getHrefPathname(item.href, currentPathname);
+
+            if (isAppOwnedPathname(itemPathname)) {
+              navigate(item.href);
+            } else {
+              window.location.assign(item.href);
+            }
+          }
           handleQueryChange("");
           searchInputRef.current?.blur();
         }
@@ -769,7 +901,9 @@ export function TableOfContents({
       highlightedIndex,
       handleQueryChange,
       itemById,
+      navigate,
       navigateToItem,
+      currentPathname,
     ],
   );
 
@@ -911,7 +1045,7 @@ export function TableOfContents({
 
 export function BackButton() {
   return (
-    <a
+    <AppLink
       href="/"
       className="docs-back-button fixed top-5 right-5 z-[100000] flex h-10 w-10 items-center justify-center rounded-full no-underline"
     >
@@ -924,7 +1058,7 @@ export function BackButton() {
           strokeLinejoin="round"
         />
       </svg>
-    </a>
+    </AppLink>
   );
 }
 
@@ -954,11 +1088,11 @@ export function SectionHeading({
         scrollMarginTop: "var(--header-height)",
       }}
     >
-      <span
-        className={level === 1 ? "docs-section-heading-text-nowrap" : undefined}
-      >
-        {children}
-      </span>
+      {level === 1 ? (
+        <span className="docs-section-heading-text-nowrap">{children}</span>
+      ) : (
+        children
+      )}
       {level === 1 ? <span className="docs-section-heading-rule" /> : null}
     </Tag>
   );
@@ -994,13 +1128,13 @@ export function A({
   const isExternal = /^(https?:)?\/\//.test(href);
 
   return (
-    <a
+    <AppLink
       href={href}
       {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       className="docs-link"
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 
@@ -1095,10 +1229,99 @@ function Callout({
   children: React.ReactNode;
 }) {
   return (
-    <div className={`docs-callout docs-callout-${tone}`}>
-      <div className="docs-callout-label">{label}</div>
+    <div
+      className={`docs-callout docs-callout-${tone}`}
+      data-callout-tone={tone}
+    >
+      <div className="docs-callout-header">
+        <div className="docs-callout-icon-wrap" aria-hidden="true">
+          <CalloutIcon tone={tone} />
+        </div>
+        <div className="docs-callout-label">{label}</div>
+      </div>
       <div className="docs-callout-body">{children}</div>
     </div>
+  );
+}
+
+function CalloutIcon({ tone }: { tone: "note" | "tip" | "warning" }) {
+  if (tone === "note") {
+    return (
+      <svg className="docs-callout-icon" viewBox="0 0 24 24" fill="none">
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"
+        />
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M18 9.25H13.75V5"
+        />
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M9.75 15.25H14.25"
+        />
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M9.75 12.25H14.25"
+        />
+      </svg>
+    );
+  }
+
+  if (tone === "tip") {
+    return (
+      <svg className="docs-callout-icon" viewBox="0 0 24 24" fill="none">
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M12 13V15"
+        />
+        <circle cx="12" cy="9" r="1" fill="currentColor" />
+        <circle
+          cx="12"
+          cy="12"
+          r="7.25"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg className="docs-callout-icon" viewBox="0 0 24 24" fill="none">
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+        d="M4.9522 16.3536L10.2152 5.85658C10.9531 4.38481 13.0539 4.3852 13.7913 5.85723L19.0495 16.3543C19.7156 17.6841 18.7487 19.25 17.2613 19.25H6.74007C5.25234 19.25 4.2854 17.6835 4.9522 16.3536Z"
+      />
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M12 10V12"
+      />
+      <circle cx="12" cy="16" r="1" fill="currentColor" />
+    </svg>
   );
 }
 
@@ -1126,6 +1349,83 @@ export function Warning({ children }: { children: React.ReactNode }) {
   );
 }
 
+function partitionCalloutChildren(children: React.ReactNode) {
+  const flattenChildren = (nodes: React.ReactNode): React.ReactNode[] => {
+    return Children.toArray(nodes).flatMap((child) => {
+      if (isValidElement(child) && child.type === Fragment) {
+        return flattenChildren(
+          (child.props as { children?: React.ReactNode }).children,
+        );
+      }
+
+      return [child];
+    });
+  };
+
+  const isCalloutElement = (child: React.ReactNode) => {
+    if (!isValidElement(child)) {
+      return false;
+    }
+
+    if (child.type === Note || child.type === Tip || child.type === Warning) {
+      return true;
+    }
+
+    const props = child.props as {
+      [key: string]: unknown;
+      className?: string;
+    };
+    const tone = props["data-callout-tone"];
+    const className = props.className;
+    return (
+      typeof tone === "string" ||
+      (typeof className === "string" && className.includes("docs-callout"))
+    );
+  };
+
+  const childNodes = flattenChildren(children).filter((child) => {
+    return !(typeof child === "string" && child.trim().length === 0);
+  });
+  const asideChildren = childNodes.filter((child) => {
+    return isCalloutElement(child);
+  });
+  const bodyChildren = childNodes.filter((child) => {
+    return !asideChildren.includes(child);
+  });
+
+  return {
+    bodyChildren,
+    asideChildren,
+  };
+}
+
+function CalloutAsideLayout({
+  children,
+  bodyClassName,
+  asideClassName,
+}: {
+  children: React.ReactNode;
+  bodyClassName?: string;
+  asideClassName?: string;
+}) {
+  const { bodyChildren, asideChildren } = partitionCalloutChildren(children);
+
+  return (
+    <div
+      className={`docs-callout-aside-layout ${asideChildren.length > 0 ? "docs-callout-aside-layout-with-aside" : ""}`.trim()}
+    >
+      <div className={bodyClassName ?? "docs-callout-aside-main"}>
+        {bodyChildren}
+      </div>
+      {asideChildren.length > 0 ? (
+        <aside className={asideClassName ?? "docs-callout-aside-rail"}>
+          {asideChildren}
+        </aside>
+      ) : null}
+    </div>
+  );
+}
+
 export function Steps({ children }: { children: React.ReactNode }) {
   return <div className="docs-steps">{children}</div>;
 }
@@ -1142,7 +1442,7 @@ export function Step({
       <div className="docs-step-badge" aria-hidden="true" />
       <div className="docs-step-content">
         <h4 className="docs-step-title">{title}</h4>
-        <div className="docs-step-body">{children}</div>
+        <div className="docs-step-body docs-step-main">{children}</div>
       </div>
     </section>
   );
@@ -1195,17 +1495,61 @@ export function Card({
   children: React.ReactNode;
   icon?: string;
 }) {
-  const isExternal = /^(https?:)?\/\//.test(href);
+  return (
+    <CardLinkSurface title={title} href={href} className="docs-card">
+      <div className="docs-card-body">{children}</div>
+    </CardLinkSurface>
+  );
+}
+
+function CardLinkSurface({
+  title,
+  href,
+  className,
+  titleClassName = "docs-card-title",
+  children,
+}: {
+  title: string;
+  href?: string;
+  className: string;
+  titleClassName?: string;
+  children: React.ReactNode;
+}) {
+  const isExternal = href ? /^(https?:)?\/\//.test(href) : false;
+  const surface = (
+    <>
+      <div className="docs-card-link-icon" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path
+            d="M4.083 9.917 9.917 4.083M5.25 4.083h4.667V8.75"
+            stroke="currentColor"
+            strokeWidth="1.35"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <h4 className={titleClassName}>{title}</h4>
+      {children}
+    </>
+  );
+
+  if (!href) {
+    return (
+      <section className={`${className} docs-card-link-surface`.trim()}>
+        {surface}
+      </section>
+    );
+  }
 
   return (
-    <a
+    <AppLink
       href={href}
       {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-      className="docs-card no-underline"
+      className={`${className} docs-card-link-surface no-underline`.trim()}
     >
-      <div className="docs-card-title">{title}</div>
-      <div className="docs-card-body">{children}</div>
-    </a>
+      {surface}
+    </AppLink>
   );
 }
 
@@ -1221,10 +1565,20 @@ export function Tab({
   children: React.ReactNode;
 }) {
   return (
-    <section className="docs-tab-panel">
-      <h4 className="docs-tab-title">{title}</h4>
-      <div className="docs-tab-body">{children}</div>
-    </section>
+    <CardLinkSurface
+      title={title}
+      className="docs-tab-panel"
+      titleClassName="docs-tab-title"
+    >
+      <div className="docs-tab-body">
+        <CalloutAsideLayout
+          bodyClassName="docs-tab-main"
+          asideClassName="docs-tab-aside"
+        >
+          {children}
+        </CalloutAsideLayout>
+      </div>
+    </CardLinkSurface>
   );
 }
 
@@ -1293,25 +1647,6 @@ export function ResponseField({
   );
 }
 
-export function AccordionGroup({ children }: { children: React.ReactNode }) {
-  return <div className="docs-accordion-group">{children}</div>;
-}
-
-export function Accordion({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="docs-accordion">
-      <h4 className="docs-accordion-title">{title}</h4>
-      <div className="docs-accordion-body">{children}</div>
-    </section>
-  );
-}
-
 export function Expandable({
   title,
   children,
@@ -1322,7 +1657,14 @@ export function Expandable({
   return (
     <section className="docs-expandable">
       <h5 className="docs-expandable-title">{title}</h5>
-      <div className="docs-expandable-body">{children}</div>
+      <div className="docs-expandable-body">
+        <CalloutAsideLayout
+          bodyClassName="docs-expandable-main"
+          asideClassName="docs-expandable-aside"
+        >
+          {children}
+        </CalloutAsideLayout>
+      </div>
     </section>
   );
 }
@@ -1336,7 +1678,7 @@ export function CodeBlock({
   lang = "jsx",
   title,
   lineHeight = "1.85",
-  showLineNumbers = true,
+  showLineNumbers: _showLineNumbers,
 }: {
   children: string;
   lang?: string;
@@ -1344,22 +1686,28 @@ export function CodeBlock({
   lineHeight?: string;
   showLineNumbers?: boolean;
 }) {
-  const lines = children.split("\n");
-
   /* Use Prism.highlight() to get highlighted HTML as a string. Works on both
      server and client (no DOM dependency), avoiding hydration mismatch issues
      that occur with useEffect + highlightElement. */
+  const prismLang = normalizeCodeLanguage(lang);
+
   const highlightedHtml = useMemo(() => {
-    const grammar = lang ? Prism.languages[lang] : undefined;
+    if (!prismLang || prismLang === "text") {
+      return undefined;
+    }
+
+    const grammar = Prism.languages[prismLang];
     if (!grammar) {
       return undefined;
     }
-    return Prism.highlight(children, grammar, lang);
-  }, [children, lang]);
+    return Prism.highlight(children, grammar, prismLang);
+  }, [children, prismLang]);
+
+  const codeClassName = `docs-code-content ${prismLang ? `language-${prismLang}` : ""}`.trim();
 
   return (
-    <figure className="m-0 bleed">
-      <div className="relative">
+    <figure className="m-0">
+      <div className="docs-code-frame relative">
         {title && <div className="docs-code-title">{title}</div>}
         <pre className="docs-code-pre overflow-x-auto">
           <div
@@ -1371,20 +1719,6 @@ export function CodeBlock({
               } as React.CSSProperties
             }
           >
-            {showLineNumbers && (
-              <span
-                className="docs-code-line-numbers select-none shrink-0"
-                aria-hidden="true"
-              >
-                {lines.map((_, i) => {
-                  return (
-                    <span key={i} className="block">
-                      {i + 1}
-                    </span>
-                  );
-                })}
-              </span>
-            )}
             {highlightedHtml ? (
               <code
                 style={
@@ -1393,12 +1727,12 @@ export function CodeBlock({
                       lineHeight,
                   } as React.CSSProperties
                 }
-                className={`docs-code-content ${lang ? `language-${lang}` : ""}`.trim()}
+                className={codeClassName}
                 dangerouslySetInnerHTML={{ __html: highlightedHtml }}
               />
             ) : (
               <code
-                className={`docs-code-content ${lang ? `language-${lang}` : ""}`.trim()}
+                className={codeClassName}
                 style={
                   {
                     ["--docs-code-line-height" as "--docs-code-line-height"]:
@@ -1730,19 +2064,6 @@ export type TabItem = {
   href: string;
 };
 
-/* =========================================================================
-   Aside — MDX component for right-sidebar content.
-   On desktop, extracted from content flow and rendered in grid column 5
-   via SectionRow. On mobile, renders inline as a styled callout.
-   ========================================================================= */
-
-/** Aside is a marker component for MDX. On desktop, its children are extracted
- *  by the section grouping logic and rendered in the right sidebar slot.
- *  On mobile, SectionRow renders it inline. The component itself is a pass-through. */
-export function Aside({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
-}
-
 /** FullWidth is a marker component for MDX. Its children become a section that
  *  spans both the content and aside columns in the grid layout. */
 export function FullWidth({ children }: { children: React.ReactNode }) {
@@ -1767,7 +2088,7 @@ export function SectionRow({
         {content}
       </div>
       {aside && (
-        <div className="docs-section-aside flex flex-col gap-3 my-2 p-3 rounded-(--border-radius-md) border border-(--border-subtle) text-(length:--type-toc-size) leading-[1.5] text-(color:--text-tree-label) lg:col-[2] lg:sticky lg:top-(--sticky-top) lg:self-start lg:max-h-[calc(100vh-var(--header-height))] lg:overflow-y-auto lg:my-[4px]">
+        <div className="docs-section-aside lg:col-[2] lg:sticky lg:top-(--sticky-top) lg:self-start lg:max-h-[calc(100vh-var(--header-height))] lg:overflow-y-auto">
           {aside}
         </div>
       )}
@@ -1794,9 +2115,12 @@ export function SidebarBanner({
   return (
     <div className="docs-sidebar-banner">
       {text}
-      <a href={buttonHref} className="docs-sidebar-banner-button no-underline">
+      <AppLink
+        href={buttonHref}
+        className="docs-sidebar-banner-button no-underline"
+      >
         {buttonLabel}
-      </a>
+      </AppLink>
       {imageUrl && (
         <img
           src={imageUrl}
@@ -1813,14 +2137,14 @@ export function SidebarBanner({
 function TabLink({ tab, isActive }: { tab: TabItem; isActive: boolean }) {
   const isExternal = tab.href.startsWith("http");
   return (
-    <a
+    <AppLink
       href={tab.href}
       {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       className={`docs-tab-link slot-tab no-underline text-(length:--type-toc-size) font-[475] [font-family:var(--font-primary)] ${isActive ? "docs-tab-link-active" : ""}`}
     >
       {tab.label}
       <div data-tab-indicator className="docs-tab-indicator" />
-    </a>
+    </AppLink>
   );
 }
 
@@ -1881,7 +2205,7 @@ export function EditorialPage({
         <div className="slot-navbar">
           {/* Top row: logo + right links */}
           <div className="mx-auto flex items-center justify-between px-(--mobile-padding) py-(--header-padding-y) lg:max-w-(--grid-max-width) lg:px-0">
-            <a href="/" className="slot-logo no-underline flex items-center">
+            <AppLink href="/" className="slot-logo no-underline flex items-center">
               {logo ? (
                 <div
                   role="img"
@@ -1904,7 +2228,7 @@ export function EditorialPage({
                   Libretto
                 </span>
               )}
-            </a>
+            </AppLink>
             <div className="flex items-center gap-4">
               {/* Icon links */}
               {headerLinks && headerLinks.length > 0 && (

--- a/apps/website/src/docs/components/markdown.tsx
+++ b/apps/website/src/docs/components/markdown.tsx
@@ -554,10 +554,8 @@ function TocLink({
 
 export function TableOfContents({
   items,
-  logo: _logo,
 }: {
   items: FlatTocItem[];
-  logo?: string;
 }) {
   const [, navigate] = useLocation();
   const currentPathname =
@@ -2217,7 +2215,6 @@ export type EditorialSection = {
 
 export function EditorialPage({
   toc,
-  logo,
   tabs,
   activeTab,
   showHeader = true,
@@ -2227,7 +2224,6 @@ export function EditorialPage({
   sections,
 }: {
   toc: FlatTocItem[];
-  logo?: string;
   tabs?: TabItem[];
   activeTab?: string;
   showHeader?: boolean;
@@ -2247,28 +2243,9 @@ export function EditorialPage({
           {/* Top row: logo + right links */}
           <div className="mx-auto flex items-center justify-between px-(--mobile-padding) py-(--header-padding-y) lg:max-w-(--grid-max-width) lg:px-0">
             <AppLink href="/" className="slot-logo no-underline flex items-center">
-              {logo ? (
-                <div
-                  role="img"
-                  aria-label="playwriter"
-                  style={{
-                    height: "var(--logo-height)",
-                    /* aspect ratio from SVG viewBox: 730/201 ≈ 3.63 */
-                    aspectRatio: "730 / 201",
-                    backgroundColor: "var(--logo-color)",
-                    maskImage: `url(${logo})`,
-                    maskSize: "contain",
-                    maskRepeat: "no-repeat",
-                    WebkitMaskImage: `url(${logo})`,
-                    WebkitMaskSize: "contain",
-                    WebkitMaskRepeat: "no-repeat",
-                  }}
-                />
-              ) : (
-                <span className="text-[18px] font-[300] [font-family:var(--font-secondary)] tracking-[-0.02em]">
-                  Libretto
-                </span>
-              )}
+              <span className="text-[18px] font-[300] [font-family:var(--font-secondary)] tracking-[-0.02em]">
+                Libretto
+              </span>
             </AppLink>
             <div className="flex items-center gap-4">
               {/* Icon links */}
@@ -2324,7 +2301,7 @@ export function EditorialPage({
                 : "100vh",
             }}
           >
-            <TableOfContents items={toc} logo={logo} />
+            <TableOfContents items={toc} />
           </div>
         </div>
 

--- a/apps/website/src/docs/components/markdown.tsx
+++ b/apps/website/src/docs/components/markdown.tsx
@@ -1,0 +1,2013 @@
+"use client";
+/*
+ * Editorial markdown components.
+ *
+ * All components use CSS variables from globals.css (no prefix).
+ * Conflicting names with shadcn: --brand-primary, --brand-secondary,
+ * --link-accent, --page-border.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+} from "react";
+import { createTocDb, searchToc, type SearchState } from "./search";
+import type {
+  TocNodeType,
+  VisualLevel,
+  TocTreeNode,
+  FlatTocItem,
+} from "./toc-tree";
+
+export type { TocNodeType, VisualLevel, TocTreeNode, FlatTocItem };
+import Prism from "prismjs";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-bash";
+
+/* Custom "diagram" language for ASCII/Unicode box-drawing diagrams.
+   Tokenizes box-drawing chars as neutral structure, text as highlighted labels. */
+Prism.languages.diagram = {
+  "box-drawing": /[┌┐└┘├┤┬┴┼─│═║╔╗╚╝╠╣╦╩╬╭╮╯╰┊┈╌┄╶╴╵╷]+/,
+  "line-char": /[-_|<>]+/,
+  label: /[^\s┌┐└┘├┤┬┴┼─│═║╔╗╚╝╠╣╦╩╬╭╮╯╰┊┈╌┄╶╴╵╷\-_|<>]+/,
+};
+
+/* =========================================================================
+   Typography primitives — reduced set after merging near-identical values.
+   4 weights (regular/prose/heading/bold), 2 line-heights (heading/prose).
+   Mirrors CSS variables in globals.css. Used in inline styles for type safety.
+   ========================================================================= */
+
+const WEIGHT = { regular: 400, prose: 475, heading: 560, bold: 700 } as const;
+const ACTIVE_SECTION_PROBE_OFFSET = 60;
+type ManualExpansionMode = "open" | "closed";
+
+function getHrefFragment(href: string): string {
+  return href.includes("#") ? href.slice(href.indexOf("#")) : href;
+}
+
+function getTargetIdFromHref(href: string): string {
+  return getHrefFragment(href).replace(/^#/, "");
+}
+
+function isPlainAnchorNavigationClick(
+  event: React.MouseEvent<HTMLAnchorElement>,
+) {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
+function ChevronIcon({
+  expanded,
+  style,
+}: {
+  expanded: boolean;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <span
+      style={{
+        flexShrink: 0,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "12px",
+        height: "12px",
+        cursor: "pointer",
+        ...style,
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        width="12"
+        height="12"
+        style={{
+          transition: "transform 0.15s ease",
+          transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+        }}
+      >
+        <path
+          d="M6 4l4 4-4 4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </span>
+  );
+}
+
+/* =========================================================================
+   TOC sidebar (fixed left)
+   ========================================================================= */
+
+export type HeadingLevel = 1 | 2 | 3;
+
+/* Multi-page TOC tree types. Pages are root nodes that contain headings or
+   nested sub-pages. The recursive tree is flattened to FlatTocItem[] before
+   rendering, clamping visual depth to 4 levels (0-3) so the sidebar never
+   gets too wide regardless of page nesting depth. */
+
+/* TocNodeType, VisualLevel, TocTreeNode, FlatTocItem — defined in toc-tree.ts,
+   re-exported above for backward compatibility. */
+
+const headingTagByLevel: Record<HeadingLevel, "h1" | "h2" | "h3"> = {
+  1: "h1",
+  2: "h2",
+  3: "h3",
+};
+
+type PendingNavigation = {
+  itemId: string;
+  targetId: string;
+};
+
+function getHeaderHeight(): number {
+  const root = document.querySelector<HTMLElement>(".docs-root");
+  const headerHeight = root
+    ? Number.parseFloat(
+        getComputedStyle(root).getPropertyValue("--header-height"),
+      )
+    : 0;
+  return Number.isFinite(headerHeight) ? headerHeight : 0;
+}
+
+function isNavigationInterruptKey(event: KeyboardEvent): boolean {
+  return [
+    "ArrowUp",
+    "ArrowDown",
+    "PageUp",
+    "PageDown",
+    "Home",
+    "End",
+    " ",
+  ].includes(event.key);
+}
+
+/* flattenTocTree and helpers moved to toc-tree.ts (server-safe, no 'use client'). */
+
+/** Single useSyncExternalStore that handles both initial hash and scroll-based
+ *  active heading tracking. Server snapshot returns fallbackId to avoid
+ *  hydration mismatch. Hash is read inside subscribe (not during render) to
+ *  keep render pure. All callbacks are stable via useCallback. */
+function useActiveTocId({ fallbackId }: { fallbackId: string }) {
+  const activeRef = useRef(fallbackId);
+  const lastScrollYRef = useRef(0);
+  const scrollDirectionRef = useRef<"up" | "down">("down");
+
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const emit = (next: string) => {
+      if (activeRef.current === next) {
+        return;
+      }
+      activeRef.current = next;
+      onStoreChange();
+    };
+
+    // Read hash on first subscribe to fix flash on initial paint
+    const hash = window.location.hash.replace(/^#/, "");
+    if (hash) {
+      emit(hash);
+    }
+
+    const headings = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-toc-heading="true"][id]'),
+    );
+    let rafId = 0;
+    lastScrollYRef.current = window.scrollY;
+
+    const computeActive = () => {
+      if (headings.length === 0) {
+        return;
+      }
+
+      const safeHeaderHeight = getHeaderHeight();
+      const viewportTop = window.scrollY + safeHeaderHeight;
+      const viewportBottom = window.scrollY + window.innerHeight;
+
+      const sections = headings.map((heading, index) => {
+        const top = window.scrollY + heading.getBoundingClientRect().top;
+        const nextHeading = headings[index + 1];
+        const bottom = nextHeading
+          ? window.scrollY + nextHeading.getBoundingClientRect().top
+          : document.documentElement.scrollHeight;
+        const anchor = top + ACTIVE_SECTION_PROBE_OFFSET;
+
+        return { id: heading.id, top, bottom, anchor };
+      });
+
+      const firstSection = sections[0];
+      if (firstSection && viewportTop <= firstSection.anchor) {
+        emit(firstSection.id);
+        return;
+      }
+
+      const visibleSections = sections.filter((section) => {
+        return (
+          section.anchor >= viewportTop && section.anchor <= viewportBottom
+        );
+      });
+
+      if (visibleSections.length > 0) {
+        emit(visibleSections[visibleSections.length - 1].id);
+        return;
+      }
+
+      if (scrollDirectionRef.current === "up") {
+        const nextVisibleFromBottom = sections.find((section) => {
+          return section.anchor > viewportBottom;
+        });
+
+        if (nextVisibleFromBottom) {
+          emit(nextVisibleFromBottom.id);
+          return;
+        }
+
+        emit(sections[sections.length - 1].id);
+        return;
+      }
+
+      const passedSections = sections.filter((section) => {
+        return section.anchor < viewportTop;
+      });
+
+      if (passedSections.length > 0) {
+        emit(passedSections[passedSections.length - 1].id);
+        return;
+      }
+
+      emit(sections[0].id);
+    };
+
+    const scheduleCompute = () => {
+      if (rafId !== 0) {
+        return;
+      }
+
+      rafId = window.requestAnimationFrame(() => {
+        rafId = 0;
+        computeActive();
+      });
+    };
+
+    const handleScroll = () => {
+      const nextScrollY = window.scrollY;
+
+      if (nextScrollY > lastScrollYRef.current) {
+        scrollDirectionRef.current = "down";
+      } else if (nextScrollY < lastScrollYRef.current) {
+        scrollDirectionRef.current = "up";
+      }
+
+      lastScrollYRef.current = nextScrollY;
+      scheduleCompute();
+    };
+
+    const handleHistoryNavigation = () => {
+      const nextHash = window.location.hash.replace(/^#/, "");
+      if (nextHash) {
+        emit(nextHash);
+      }
+      scheduleCompute();
+    };
+
+    computeActive();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", scheduleCompute);
+    window.addEventListener("hashchange", handleHistoryNavigation);
+    window.addEventListener("popstate", handleHistoryNavigation);
+
+    return () => {
+      if (rafId !== 0) {
+        window.cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", scheduleCompute);
+      window.removeEventListener("hashchange", handleHistoryNavigation);
+      window.removeEventListener("popstate", handleHistoryNavigation);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => {
+    return activeRef.current;
+  }, []);
+
+  const getServerSnapshot = useCallback(() => {
+    return fallbackId;
+  }, [fallbackId]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+function TocLink({
+  item,
+  isActive,
+  chevron,
+  onToggle,
+  onNavigate,
+  dimmed,
+  isMatched,
+  isHighlighted,
+  linkRef,
+}: {
+  item: FlatTocItem;
+  isActive: boolean;
+  chevron?: { expanded: boolean; lockedOpen?: boolean };
+  onToggle?: () => void;
+  onNavigate?: (item: FlatTocItem, link: HTMLAnchorElement) => void;
+  /** Search: dim non-matching items to opacity 0.3 */
+  dimmed?: boolean;
+  /** Search: item matched the query */
+  isMatched?: boolean;
+  /** Search: arrow-key highlighted item */
+  isHighlighted?: boolean;
+  linkRef?: React.Ref<HTMLAnchorElement>;
+}) {
+  const effectiveActive = isActive && !dimmed;
+  const defaultColor = effectiveActive
+    ? "var(--text-primary)"
+    : dimmed
+      ? "var(--text-tertiary)"
+      : "var(--text-secondary)";
+  const defaultPrefixColor = effectiveActive
+    ? "var(--text-secondary)"
+    : "var(--text-tertiary)";
+  const defaultChevronColor = chevron?.lockedOpen
+    ? "var(--text-primary)"
+    : defaultPrefixColor;
+  const bg = isHighlighted
+    ? "var(--border-subtle)"
+    : effectiveActive
+      ? "var(--border-subtle)"
+      : "transparent";
+  const fontWeight = isMatched ? 450 : WEIGHT.regular;
+  return (
+    <a
+      ref={linkRef}
+      href={item.href}
+      className="docs-toc-link block no-underline"
+      aria-current={effectiveActive ? "location" : undefined}
+      tabIndex={dimmed ? -1 : 0}
+      style={
+        {
+          ["--toc-link-color" as "--toc-link-color"]: defaultColor,
+          ["--toc-link-bg" as "--toc-link-bg"]: bg,
+          ["--toc-link-opacity" as "--toc-link-opacity"]: dimmed ? 0.22 : 1,
+          ["--toc-link-font-weight" as "--toc-link-font-weight"]: fontWeight,
+        } as React.CSSProperties
+      }
+      onClick={(e) => {
+        if (!onNavigate || !isPlainAnchorNavigationClick(e)) {
+          return;
+        }
+        e.preventDefault();
+        onNavigate(item, e.currentTarget);
+      }}
+      onMouseEnter={(e) => {
+        if (!effectiveActive && !dimmed) {
+          e.currentTarget.style.setProperty(
+            "--toc-link-color",
+            "var(--text-primary)",
+          );
+          e.currentTarget.style.setProperty(
+            "--toc-link-bg",
+            "var(--border-subtle)",
+          );
+          const chevronEl = e.currentTarget.querySelector<HTMLElement>(
+            '[data-toc-chevron="true"]',
+          );
+          chevronEl?.style.setProperty(
+            "--toc-prefix-color",
+            "var(--text-primary)",
+          );
+        }
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.setProperty("--toc-link-color", defaultColor);
+        e.currentTarget.style.setProperty("--toc-link-bg", bg);
+        const chevronEl = e.currentTarget.querySelector<HTMLElement>(
+          '[data-toc-chevron="true"]',
+        );
+        chevronEl?.style.setProperty("--toc-prefix-color", defaultChevronColor);
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="docs-toc-link-prefix"
+        style={
+          {
+            ["--toc-prefix-color" as "--toc-prefix-color"]: defaultPrefixColor,
+          } as React.CSSProperties
+        }
+      >
+        {item.prefix}
+      </span>
+      <span className="docs-toc-link-label">{item.label}</span>
+      {chevron && (
+        <span
+          data-toc-chevron="true"
+          className="docs-toc-chevron"
+          style={
+            {
+              ["--toc-prefix-color" as "--toc-prefix-color"]:
+                defaultChevronColor,
+            } as React.CSSProperties
+          }
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggle?.();
+          }}
+        >
+          <ChevronIcon
+            expanded={chevron.expanded}
+            style={{ marginLeft: "4px" }}
+          />
+        </span>
+      )}
+    </a>
+  );
+}
+
+export function TableOfContents({
+  items,
+  logo: _logo,
+}: {
+  items: FlatTocItem[];
+  logo?: string;
+}) {
+  const firstNavigableItem = items.find((item) => {
+    return item.href.startsWith("#");
+  });
+  const fallbackId = getTargetIdFromHref(firstNavigableItem?.href ?? "");
+  const activeHeadingId = useActiveTocId({ fallbackId });
+  const [pendingNavigation, setPendingNavigation] =
+    useState<PendingNavigation | null>(null);
+
+  const expandableIds = useMemo(() => {
+    return new Set(
+      items
+        .map((i) => {
+          return i.parentId;
+        })
+        .filter(Boolean) as string[],
+    );
+  }, [items]);
+
+  /* Lookup map for walking the parent chain */
+  const itemById = useMemo(() => {
+    return new Map(
+      items.map((i) => {
+        return [i.id, i] as const;
+      }),
+    );
+  }, [items]);
+
+  const preferredItemIdByHref = useMemo(() => {
+    const next = new Map<string, string>();
+    for (const item of items) {
+      next.set(item.href, item.id);
+    }
+    return next;
+  }, [items]);
+
+  const activeItemId =
+    preferredItemIdByHref.get(`#${activeHeadingId}`) ??
+    firstNavigableItem?.id ??
+    items[0]?.id ??
+    null;
+  const selectedItemId = pendingNavigation?.itemId ?? activeItemId;
+
+  const defaultExpandedIds = useMemo(() => {
+    return new Set(
+      items
+        .filter((item) => {
+          return item.type === "group";
+        })
+        .map((item) => {
+          return item.id;
+        }),
+    );
+  }, [items]);
+
+  const passiveExpandedIds = useMemo(() => {
+    const next = new Set(defaultExpandedIds);
+    if (!selectedItemId) {
+      return next;
+    }
+
+    if (expandableIds.has(selectedItemId)) {
+      next.add(selectedItemId);
+    }
+
+    let current = itemById.get(selectedItemId);
+    while (current?.parentId) {
+      next.add(current.parentId);
+      current = itemById.get(current.parentId);
+    }
+
+    return next;
+  }, [selectedItemId, expandableIds, itemById, defaultExpandedIds]);
+
+  const [manualExpansion, setManualExpansion] = useState<
+    Map<string, ManualExpansionMode>
+  >(() => {
+    return new Map();
+  });
+
+  useEffect(() => {
+    setManualExpansion((prev) => {
+      let next: Map<string, ManualExpansionMode> | null = null;
+
+      for (const [id, mode] of prev) {
+        if (mode === "closed" && !passiveExpandedIds.has(id)) {
+          next ??= new Map(prev);
+          next.delete(id);
+        }
+      }
+
+      return next ?? prev;
+    });
+  }, [passiveExpandedIds]);
+
+  useEffect(() => {
+    if (!pendingNavigation) {
+      return;
+    }
+
+    if (activeHeadingId === pendingNavigation.targetId) {
+      setPendingNavigation(null);
+      return;
+    }
+
+    const target = document.getElementById(pendingNavigation.targetId);
+    if (!target) {
+      setPendingNavigation(null);
+      return;
+    }
+
+    let rafId = 0;
+
+    const clearPendingNavigation = () => {
+      setPendingNavigation((current) => {
+        return current?.targetId === pendingNavigation.targetId
+          ? null
+          : current;
+      });
+    };
+
+    const handleUserInterrupt = () => {
+      clearPendingNavigation();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isNavigationInterruptKey(event)) {
+        handleUserInterrupt();
+      }
+    };
+
+    const checkTargetPosition = () => {
+      const distanceFromViewportTop =
+        target.getBoundingClientRect().top - getHeaderHeight();
+
+      if (Math.abs(distanceFromViewportTop) <= 4) {
+        clearPendingNavigation();
+        return;
+      }
+
+      rafId = window.requestAnimationFrame(checkTargetPosition);
+    };
+
+    rafId = window.requestAnimationFrame(checkTargetPosition);
+    window.addEventListener("wheel", handleUserInterrupt, { passive: true });
+    window.addEventListener("touchstart", handleUserInterrupt, {
+      passive: true,
+    });
+    window.addEventListener("mousedown", handleUserInterrupt);
+    window.addEventListener("popstate", handleUserInterrupt);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      if (rafId !== 0) {
+        window.cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener("wheel", handleUserInterrupt);
+      window.removeEventListener("touchstart", handleUserInterrupt);
+      window.removeEventListener("mousedown", handleUserInterrupt);
+      window.removeEventListener("popstate", handleUserInterrupt);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeHeadingId, pendingNavigation]);
+
+  const navigateToItem = useCallback(
+    (item: FlatTocItem, link?: HTMLAnchorElement | null) => {
+      const targetId = getTargetIdFromHref(item.href);
+      const target = targetId ? document.getElementById(targetId) : null;
+
+      if (!targetId || !target) {
+        return;
+      }
+
+      setPendingNavigation({ itemId: item.id, targetId });
+
+      const nextHash = `#${targetId}`;
+      const nextUrl = `${window.location.pathname}${window.location.search}${nextHash}`;
+      if (window.location.hash === nextHash) {
+        window.history.replaceState(window.history.state, "", nextUrl);
+      } else {
+        window.history.pushState(window.history.state, "", nextUrl);
+      }
+
+      link?.focus();
+      target.scrollIntoView({ block: "start" });
+    },
+    [],
+  );
+
+  const toggle = useCallback(
+    (id: string) => {
+      setManualExpansion((prev) => {
+        const next = new Map(prev);
+        const override = next.get(id);
+        const isExpanded =
+          override === "open"
+            ? true
+            : override === "closed"
+              ? false
+              : passiveExpandedIds.has(id);
+
+        if (!isExpanded) {
+          next.set(id, "open");
+          return next;
+        }
+
+        if (passiveExpandedIds.has(id)) {
+          next.set(id, "closed");
+        } else {
+          next.delete(id);
+        }
+
+        return next;
+      });
+    },
+    [passiveExpandedIds],
+  );
+
+  // --- Search state ---
+  // useTransition makes typing non-blocking: setQuery is urgent (input stays
+  // responsive), while the TOC re-render from setSearchState is deferred and
+  // interruptible — new keystrokes cancel in-progress renders automatically.
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const highlightedRef = useRef<HTMLAnchorElement>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // Build Orama search DB once
+  const db = useMemo(() => {
+    return createTocDb({ items });
+  }, [items]);
+
+  const [searchState, setSearchState] = useState<SearchState>({
+    matchedIds: null,
+    expandOverrideIds: null,
+    dimmedIds: null,
+    focusableIds: null,
+  });
+
+  const handleQueryChange = useCallback(
+    (value: string) => {
+      setQuery(value);
+      startTransition(() => {
+        const state = searchToc({ db, query: value, items });
+        setSearchState(state);
+        setHighlightedIndex(0);
+      });
+    },
+    [db, items],
+  );
+
+  // Scroll highlighted item into view (only when search is active)
+  useEffect(() => {
+    if (!searchState.focusableIds) {
+      return;
+    }
+    highlightedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex, searchState.focusableIds]);
+
+  // Global / hotkey to focus search input
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const tag = (e.target as HTMLElement).tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          (e.target as HTMLElement).isContentEditable
+        ) {
+          return;
+        }
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleQueryChange("");
+        searchInputRef.current?.blur();
+        return;
+      }
+      const focusable = searchState.focusableIds;
+      if (!focusable || focusable.length === 0) {
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setHighlightedIndex((prev) => {
+          return Math.min(prev + 1, focusable.length - 1);
+        });
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setHighlightedIndex((prev) => {
+          return Math.max(prev - 1, 0);
+        });
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const itemId = focusable[highlightedIndex];
+        const item = itemId ? itemById.get(itemId) : undefined;
+        if (item) {
+          navigateToItem(item);
+          handleQueryChange("");
+          searchInputRef.current?.blur();
+        }
+      }
+    },
+    [
+      searchState.focusableIds,
+      highlightedIndex,
+      handleQueryChange,
+      itemById,
+      navigateToItem,
+    ],
+  );
+
+  const isSearchActive = searchState.matchedIds !== null;
+
+  /* Merge search expand overrides into the expanded set so matched items
+     inside collapsed branches become visible during search. */
+  const effectiveExpandedIds = useMemo(() => {
+    const next = new Set(defaultExpandedIds);
+
+    for (const id of passiveExpandedIds) {
+      next.add(id);
+    }
+
+    for (const [id, mode] of manualExpansion) {
+      if (mode === "open") {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+    }
+
+    if (isSearchActive && searchState.expandOverrideIds) {
+      for (const id of searchState.expandOverrideIds) {
+        next.add(id);
+      }
+    }
+
+    return next;
+  }, [
+    defaultExpandedIds,
+    passiveExpandedIds,
+    manualExpansion,
+    isSearchActive,
+    searchState.expandOverrideIds,
+  ]);
+
+  /* Compute visible items: an item is visible if all its ancestors are
+     effectively expanded. Since items are in document order, parents
+     always come before children so a single forward pass works. */
+  const visibleItems = useMemo(() => {
+    const visible = new Set<string>();
+    return items.filter((item) => {
+      if (item.parentId === null) {
+        visible.add(item.id);
+        return true;
+      }
+      if (
+        effectiveExpandedIds.has(item.parentId) &&
+        visible.has(item.parentId)
+      ) {
+        visible.add(item.id);
+        return true;
+      }
+      return false;
+    });
+  }, [items, effectiveExpandedIds]);
+
+  return (
+    <aside className="docs-toc">
+      {/* Search input with / hotkey badge — stays pinned at top */}
+      <div className="docs-toc-search">
+        <input
+          ref={searchInputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            handleQueryChange(e.target.value);
+          }}
+          onKeyDown={handleSearchKeyDown}
+          placeholder="Search..."
+          className="docs-toc-search-input"
+          style={{ opacity: isPending ? 0.5 : 1 }}
+          onFocus={(e) => {
+            e.currentTarget.style.borderColor = "var(--text-tertiary)";
+          }}
+          onBlur={(e) => {
+            e.currentTarget.style.borderColor = "var(--page-border)";
+          }}
+        />
+        {/* Hotkey badge — hidden when input has text */}
+        {!query && (
+          <span aria-hidden="true" className="docs-toc-hotkey">
+            /
+          </span>
+        )}
+      </div>
+
+      <nav aria-label="Table of contents" className="docs-toc-nav">
+        {visibleItems.map((item, i) => {
+          const isExpandable =
+            item.type !== "group" && expandableIds.has(item.id);
+          const isExpanded = effectiveExpandedIds.has(item.id);
+          const isLockedOpen = manualExpansion.get(item.id) === "open";
+          const isDimmed =
+            isSearchActive && searchState.dimmedIds?.has(item.id);
+          const isMatched =
+            isSearchActive && Boolean(searchState.matchedIds?.has(item.id));
+          const highlightedId = isSearchActive
+            ? searchState.focusableIds?.[highlightedIndex]
+            : undefined;
+          const isHighlighted = highlightedId === item.id;
+          const marginTop =
+            i === 0 ? undefined : item.visualLevel === 0 ? "7px" : "1px";
+          return (
+            <div key={item.id} style={marginTop ? { marginTop } : undefined}>
+              <TocLink
+                item={item}
+                isActive={item.id === selectedItemId}
+                chevron={
+                  isExpandable
+                    ? { expanded: isExpanded, lockedOpen: isLockedOpen }
+                    : undefined
+                }
+                onToggle={
+                  isExpandable
+                    ? () => {
+                        toggle(item.id);
+                      }
+                    : undefined
+                }
+                onNavigate={navigateToItem}
+                dimmed={isDimmed || false}
+                isMatched={isMatched}
+                isHighlighted={isHighlighted}
+                linkRef={isHighlighted ? highlightedRef : undefined}
+              />
+            </div>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+/* =========================================================================
+   Back button (fixed top-right)
+   ========================================================================= */
+
+export function BackButton() {
+  return (
+    <a
+      href="/"
+      className="docs-back-button fixed top-5 right-5 z-[100000] flex h-10 w-10 items-center justify-center rounded-full no-underline"
+    >
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <path
+          d="M12.25 7H1.75M1.75 7L6.125 2.625M1.75 7L6.125 11.375"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </a>
+  );
+}
+
+/* =========================================================================
+   Typography
+   ========================================================================= */
+
+export function SectionHeading({
+  id,
+  level = 1,
+  children,
+}: {
+  id: string;
+  level?: HeadingLevel;
+  children: React.ReactNode;
+}) {
+  level ||= 1;
+  const Tag = headingTagByLevel[level] || "h4";
+
+  return (
+    <Tag
+      id={id}
+      data-toc-heading="true"
+      data-toc-level={level}
+      className={`docs-section-heading docs-section-heading-${level}`}
+      style={{
+        scrollMarginTop: "var(--header-height)",
+      }}
+    >
+      <span
+        className={level === 1 ? "docs-section-heading-text-nowrap" : undefined}
+      >
+        {children}
+      </span>
+      {level === 1 ? <span className="docs-section-heading-rule" /> : null}
+    </Tag>
+  );
+}
+
+export function P({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={`editorial-prose docs-prose-p ${className}`}>{children}</p>
+  );
+}
+
+export function Caption({ children }: { children: React.ReactNode }) {
+  return <p className="docs-caption">{children}</p>;
+}
+
+export function Blockquote({ children }: { children: React.ReactNode }) {
+  return <blockquote className="docs-blockquote">{children}</blockquote>;
+}
+
+export function A({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const isExternal = /^(https?:)?\/\//.test(href);
+
+  return (
+    <a
+      href={href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className="docs-link"
+    >
+      {children}
+    </a>
+  );
+}
+
+export function Code({ children }: { children: React.ReactNode }) {
+  return <code className="inline-code">{children}</code>;
+}
+
+/* =========================================================================
+   Layout
+   ========================================================================= */
+
+export function Bleed({ children }: { children: React.ReactNode }) {
+  return <div className="docs-bleed">{children}</div>;
+}
+
+export function Divider() {
+  return (
+    <div className="docs-divider">
+      <div className="docs-divider-line" />
+    </div>
+  );
+}
+
+export function Section({
+  id,
+  title,
+  level = 1,
+  children,
+}: {
+  id: string;
+  title: string;
+  level?: HeadingLevel;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <SectionHeading id={id} level={level}>
+        {title}
+      </SectionHeading>
+      {children}
+    </>
+  );
+}
+
+export function OL({ children }: { children: React.ReactNode }) {
+  return <ol className="docs-list docs-list-ordered m-0 pl-5">{children}</ol>;
+}
+
+export function List({ children }: { children: React.ReactNode }) {
+  return <ul className="docs-list docs-list-unordered m-0 pl-5">{children}</ul>;
+}
+
+export function Li({ children }: { children: React.ReactNode }) {
+  return <li className="docs-list-item">{children}</li>;
+}
+
+export function Table({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="docs-table-wrap">
+      <table className="docs-table">{children}</table>
+    </div>
+  );
+}
+
+export function THead({ children }: { children: React.ReactNode }) {
+  return <thead>{children}</thead>;
+}
+
+export function TBody({ children }: { children: React.ReactNode }) {
+  return <tbody>{children}</tbody>;
+}
+
+export function TR({ children }: { children: React.ReactNode }) {
+  return <tr>{children}</tr>;
+}
+
+export function TH({ children }: { children: React.ReactNode }) {
+  return <th className="docs-table-header">{children}</th>;
+}
+
+export function TD({ children }: { children: React.ReactNode }) {
+  return <td className="docs-table-cell">{children}</td>;
+}
+
+function Callout({
+  tone,
+  label,
+  children,
+}: {
+  tone: "note" | "tip" | "warning";
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`docs-callout docs-callout-${tone}`}>
+      <div className="docs-callout-label">{label}</div>
+      <div className="docs-callout-body">{children}</div>
+    </div>
+  );
+}
+
+export function Note({ children }: { children: React.ReactNode }) {
+  return (
+    <Callout tone="note" label="Note">
+      {children}
+    </Callout>
+  );
+}
+
+export function Tip({ children }: { children: React.ReactNode }) {
+  return (
+    <Callout tone="tip" label="Tip">
+      {children}
+    </Callout>
+  );
+}
+
+export function Warning({ children }: { children: React.ReactNode }) {
+  return (
+    <Callout tone="warning" label="Warning">
+      {children}
+    </Callout>
+  );
+}
+
+export function Steps({ children }: { children: React.ReactNode }) {
+  return <div className="docs-steps">{children}</div>;
+}
+
+export function Step({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="docs-step">
+      <div className="docs-step-badge" aria-hidden="true" />
+      <div className="docs-step-content">
+        <h4 className="docs-step-title">{title}</h4>
+        <div className="docs-step-body">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+export function CardGroup({
+  cols = 2,
+  children,
+}: {
+  cols?: number | string;
+  children: React.ReactNode;
+}) {
+  const parsed =
+    typeof cols === "number" ? cols : Number.parseInt(String(cols), 10);
+  const columns = Number.isFinite(parsed)
+    ? Math.min(Math.max(parsed, 1), 3)
+    : 2;
+
+  return (
+    <div
+      className="docs-card-grid"
+      style={
+        {
+          ["--docs-card-columns" as "--docs-card-columns"]: String(columns),
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Columns({
+  cols = 2,
+  children,
+}: {
+  cols?: number | string;
+  children: React.ReactNode;
+}) {
+  return <CardGroup cols={cols}>{children}</CardGroup>;
+}
+
+export function Card({
+  title,
+  href,
+  children,
+}: {
+  title: string;
+  href: string;
+  children: React.ReactNode;
+  icon?: string;
+}) {
+  const isExternal = /^(https?:)?\/\//.test(href);
+
+  return (
+    <a
+      href={href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className="docs-card no-underline"
+    >
+      <div className="docs-card-title">{title}</div>
+      <div className="docs-card-body">{children}</div>
+    </a>
+  );
+}
+
+export function Tabs({ children }: { children: React.ReactNode }) {
+  return <div className="docs-tabs">{children}</div>;
+}
+
+export function Tab({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="docs-tab-panel">
+      <h4 className="docs-tab-title">{title}</h4>
+      <div className="docs-tab-body">{children}</div>
+    </section>
+  );
+}
+
+export function CodeGroup({ children }: { children: React.ReactNode }) {
+  return <div className="docs-code-group">{children}</div>;
+}
+
+function FieldRow({
+  label,
+  type,
+  required,
+  children,
+}: {
+  label: string;
+  type?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="docs-field">
+      <div className="docs-field-header">
+        <code className="docs-field-name">{label}</code>
+        {type ? <code className="docs-field-type">{type}</code> : null}
+        {required ? (
+          <span className="docs-field-required">required</span>
+        ) : null}
+      </div>
+      <div className="docs-field-body">{children}</div>
+    </div>
+  );
+}
+
+export function ParamField({
+  path,
+  type,
+  required,
+  children,
+}: {
+  path?: string;
+  type?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <FieldRow label={path ?? "parameter"} type={type} required={required}>
+      {children}
+    </FieldRow>
+  );
+}
+
+export function ResponseField({
+  name,
+  type,
+  required,
+  children,
+}: {
+  name?: string;
+  type?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <FieldRow label={name ?? "response"} type={type} required={required}>
+      {children}
+    </FieldRow>
+  );
+}
+
+export function AccordionGroup({ children }: { children: React.ReactNode }) {
+  return <div className="docs-accordion-group">{children}</div>;
+}
+
+export function Accordion({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="docs-accordion">
+      <h4 className="docs-accordion-title">{title}</h4>
+      <div className="docs-accordion-body">{children}</div>
+    </section>
+  );
+}
+
+export function Expandable({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="docs-expandable">
+      <h5 className="docs-expandable-title">{title}</h5>
+      <div className="docs-expandable-body">{children}</div>
+    </section>
+  );
+}
+
+/* =========================================================================
+   Code block with Prism syntax highlighting and line numbers
+   ========================================================================= */
+
+export function CodeBlock({
+  children,
+  lang = "jsx",
+  title,
+  lineHeight = "1.85",
+  showLineNumbers = true,
+}: {
+  children: string;
+  lang?: string;
+  title?: string;
+  lineHeight?: string;
+  showLineNumbers?: boolean;
+}) {
+  const lines = children.split("\n");
+
+  /* Use Prism.highlight() to get highlighted HTML as a string. Works on both
+     server and client (no DOM dependency), avoiding hydration mismatch issues
+     that occur with useEffect + highlightElement. */
+  const highlightedHtml = useMemo(() => {
+    const grammar = lang ? Prism.languages[lang] : undefined;
+    if (!grammar) {
+      return undefined;
+    }
+    return Prism.highlight(children, grammar, lang);
+  }, [children, lang]);
+
+  return (
+    <figure className="m-0 bleed">
+      <div className="relative">
+        {title && <div className="docs-code-title">{title}</div>}
+        <pre className="docs-code-pre overflow-x-auto">
+          <div
+            className="docs-code-body flex"
+            style={
+              {
+                ["--docs-code-line-height" as "--docs-code-line-height"]:
+                  lineHeight,
+              } as React.CSSProperties
+            }
+          >
+            {showLineNumbers && (
+              <span
+                className="docs-code-line-numbers select-none shrink-0"
+                aria-hidden="true"
+              >
+                {lines.map((_, i) => {
+                  return (
+                    <span key={i} className="block">
+                      {i + 1}
+                    </span>
+                  );
+                })}
+              </span>
+            )}
+            {highlightedHtml ? (
+              <code
+                style={
+                  {
+                    ["--docs-code-line-height" as "--docs-code-line-height"]:
+                      lineHeight,
+                  } as React.CSSProperties
+                }
+                className={`docs-code-content ${lang ? `language-${lang}` : ""}`.trim()}
+                dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              />
+            ) : (
+              <code
+                className={`docs-code-content ${lang ? `language-${lang}` : ""}`.trim()}
+                style={
+                  {
+                    ["--docs-code-line-height" as "--docs-code-line-height"]:
+                      lineHeight,
+                  } as React.CSSProperties
+                }
+              >
+                {children}
+              </code>
+            )}
+          </div>
+        </pre>
+      </div>
+    </figure>
+  );
+}
+
+/* =========================================================================
+   Pixelated placeholder image
+   Uses a tiny pre-generated image with CSS image-rendering: pixelated
+   (nearest-neighbor / point sampling in GPU terms) for a crisp mosaic
+   effect. The real image fades in on top once loaded — no flash because
+   the placeholder stays underneath and the real image starts at opacity 0.
+   ========================================================================= */
+
+export function PixelatedImage({
+  src,
+  placeholder,
+  alt,
+  width,
+  height,
+  className = "",
+  style,
+}: {
+  src: string;
+  /**
+   * Base64 data URI of the tiny pixelated placeholder image (~2–4KB PNG).
+   * Injected automatically by the server-side mdast image processor
+   * (website/src/lib/image-cache.ts) — no need to pass manually in MDX.
+   * The processor reads each image from public/, generates a 64px-wide
+   * placeholder with sharp, and caches it as JSON in .cache/images/.
+   */
+  placeholder?: string;
+  alt: string;
+  width: number;
+  height: number;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const [loaded, setLoaded] = useState(false);
+
+  // Handles both the normal onLoad event and the case where the image is
+  // already cached (img.complete is true before React mounts the handler).
+  const imgRef = useCallback((img: HTMLImageElement | null) => {
+    if (img?.complete && img.naturalWidth > 0) {
+      setLoaded(true);
+    }
+  }, []);
+
+  return (
+    <div
+      className={`docs-media-frame ${className}`.trim()}
+      style={{
+        position: "relative",
+        width: "100%",
+        maxWidth: `min(${width}px, 100%)`,
+        aspectRatio: `${width} / ${height}`,
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {/* Placeholder: tiny image rendered with nearest-neighbor sampling */}
+      {placeholder && (
+        <img
+          src={placeholder}
+          alt=""
+          aria-hidden
+          width={width}
+          height={height}
+          className="docs-media-placeholder"
+        />
+      )}
+      {/* Real image: starts invisible, fades in over the placeholder */}
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        onLoad={() => {
+          setLoaded(true);
+        }}
+        className="docs-media-image"
+        style={{ opacity: !placeholder || loaded ? 1 : 0 }}
+      />
+    </div>
+  );
+}
+
+/* =========================================================================
+   Lazy video with pixelated poster placeholder
+   Same visual pattern as PixelatedImage but for <video> elements.
+   Poster layers (pixelated → real) show through the transparent video element.
+   Video uses native loading="lazy" + preload="none" so zero bytes are
+   downloaded until the element is near the viewport and the user clicks play.
+   No custom IntersectionObserver needed — all native HTML attributes.
+   ========================================================================= */
+
+export function LazyVideo({
+  src,
+  poster,
+  placeholderPoster,
+  width,
+  height,
+  type = "video/mp4",
+  className = "",
+  style,
+}: {
+  src: string;
+  poster: string;
+  /**
+   * URL of the tiny pixelated poster placeholder. Use a static import so Vite
+   * inlines it as a base64 data URI (all placeholders are < 4KB, well under
+   * Vite's default assetsInlineLimit of 4096 bytes). This makes the
+   * placeholder available synchronously on first render with zero HTTP
+   * requests. Do NOT use dynamic imports or public/ paths — dynamic imports
+   * add a microtask delay, and public/ files bypass Vite's asset pipeline.
+   *
+   * @example
+   * ```tsx
+   * import placeholderPoster from "../assets/placeholders/placeholder-demo-poster.png";
+   * <LazyVideo placeholderPoster={placeholderPoster} poster="/demo-poster.png" ... />
+   * ```
+   */
+  placeholderPoster: string;
+  width: number;
+  height: number;
+  type?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const [posterLoaded, setPosterLoaded] = useState(false);
+
+  // Handles cached poster images (same pattern as PixelatedImage)
+  const posterRef = useCallback((img: HTMLImageElement | null) => {
+    if (img?.complete && img.naturalWidth > 0) {
+      setPosterLoaded(true);
+    }
+  }, []);
+
+  return (
+    <div
+      className={`docs-media-frame ${className}`.trim()}
+      style={{
+        position: "relative",
+        width: "100%",
+        maxWidth: `${width}px`,
+        aspectRatio: `${width} / ${height}`,
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {/* Pixelated poster placeholder: loads instantly (~500 bytes) */}
+      <img
+        src={placeholderPoster}
+        alt=""
+        aria-hidden
+        width={width}
+        height={height}
+        className="docs-media-placeholder"
+      />
+      {/* Real poster: fades in over the pixelated placeholder */}
+      <img
+        ref={posterRef}
+        src={poster}
+        alt=""
+        aria-hidden
+        width={width}
+        height={height}
+        onLoad={() => {
+          setPosterLoaded(true);
+        }}
+        className="docs-media-poster"
+        style={{ opacity: posterLoaded ? 1 : 0 }}
+      />
+      {/* Video: transparent until playing, native lazy + no preload.
+          Controls float on top of poster layers. No poster attr needed
+          because the img layers handle the visual placeholder.
+          loading="lazy" is a newer HTML attr not yet in React's TS types. */}
+      <video
+        controls
+        preload="none"
+        {...({
+          loading: "lazy",
+        } as React.VideoHTMLAttributes<HTMLVideoElement>)}
+        width={width}
+        height={height}
+        className="docs-media-video"
+      >
+        <source src={src} type={type} />
+      </video>
+    </div>
+  );
+}
+
+/* =========================================================================
+   Chart placeholder (dark box with animated line)
+   ========================================================================= */
+
+export function ChartPlaceholder({
+  height = 200,
+  label,
+}: {
+  height?: number;
+  label?: string;
+}) {
+  return (
+    <div className="bleed">
+      <div
+        className="docs-chart-placeholder w-full overflow-hidden relative"
+        style={{ height: `${height}px` }}
+      >
+        <svg
+          viewBox="0 0 550 200"
+          className="absolute inset-0 w-full h-full"
+          preserveAspectRatio="none"
+        >
+          <defs>
+            <linearGradient id="chartFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.3" />
+              <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M0,140 C30,135 60,120 90,125 C120,130 150,100 180,95 C210,90 240,110 270,105 C300,100 330,80 360,85 C390,90 420,70 450,65 C480,60 510,75 550,60"
+            fill="none"
+            stroke="#3b82f6"
+            strokeWidth="2"
+          />
+          <path
+            d="M0,140 C30,135 60,120 90,125 C120,130 150,100 180,95 C210,90 240,110 270,105 C300,100 330,80 360,85 C390,90 420,70 450,65 C480,60 510,75 550,60 L550,200 L0,200 Z"
+            fill="url(#chartFill)"
+          />
+          <circle cx="550" cy="60" r="4" fill="#3b82f6">
+            <animate
+              attributeName="r"
+              values="4;6;4"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+            <animate
+              attributeName="opacity"
+              values="1;0.6;1"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </circle>
+        </svg>
+        {label && (
+          <div className="docs-chart-label absolute top-3 right-3 rounded px-2 py-1 text-xs">
+            {label}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* =========================================================================
+   Comparison table
+   ========================================================================= */
+
+export function ComparisonTable({
+  title,
+  headers,
+  rows,
+}: {
+  title?: string;
+  headers: [string, string, string];
+  rows: Array<[string, string, string]>;
+}) {
+  return (
+    <div className="docs-comparison-table-wrap w-full max-w-full overflow-x-auto">
+      {title && <div className="docs-comparison-table-title">{title}</div>}
+      <table className="docs-comparison-table w-full">
+        <thead>
+          <tr>
+            {headers.map((header) => {
+              return (
+                <th
+                  key={header}
+                  className="docs-comparison-table-header text-left"
+                >
+                  {header}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(([feature, them, us]) => {
+            return (
+              <tr key={feature}>
+                <td className="docs-comparison-table-cell docs-comparison-table-cell-code docs-comparison-table-cell-nowrap">
+                  {feature}
+                </td>
+                <td className="docs-comparison-table-cell docs-comparison-table-cell-code docs-comparison-table-cell-nowrap">
+                  {them}
+                </td>
+                <td className="docs-comparison-table-cell docs-comparison-table-cell-code">
+                  {us}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* =========================================================================
+   Tab bar — Mintlify/Notion-style top navigation tabs
+   Active tab has 1.5px bottom indicator + faux bold via text-shadow.
+   ========================================================================= */
+
+export type TabItem = {
+  label: string;
+  href: string;
+};
+
+/* =========================================================================
+   Aside — MDX component for right-sidebar content.
+   On desktop, extracted from content flow and rendered in grid column 5
+   via SectionRow. On mobile, renders inline as a styled callout.
+   ========================================================================= */
+
+/** Aside is a marker component for MDX. On desktop, its children are extracted
+ *  by the section grouping logic and rendered in the right sidebar slot.
+ *  On mobile, SectionRow renders it inline. The component itself is a pass-through. */
+export function Aside({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+/** FullWidth is a marker component for MDX. Its children become a section that
+ *  spans both the content and aside columns in the grid layout. */
+export function FullWidth({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+/* =========================================================================
+   SectionRow — renders one content section as a grid row.
+   Content goes in column 3, aside in column 5 (sticky).
+   ========================================================================= */
+
+export function SectionRow({
+  content,
+  aside,
+}: {
+  content: React.ReactNode;
+  aside?: React.ReactNode;
+}) {
+  return (
+    <div className="contents lg:grid lg:grid-cols-subgrid lg:col-[2/-1]">
+      <div className="slot-main flex flex-col gap-5 lg:col-[1] lg:overflow-visible text-(length:--type-body-size)">
+        {content}
+      </div>
+      {aside && (
+        <div className="docs-section-aside flex flex-col gap-3 my-2 p-3 rounded-(--border-radius-md) border border-(--border-subtle) text-(length:--type-toc-size) leading-[1.5] text-(color:--text-tree-label) lg:col-[2] lg:sticky lg:top-(--sticky-top) lg:self-start lg:max-h-[calc(100vh-var(--header-height))] lg:overflow-y-auto lg:my-[4px]">
+          {aside}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* =========================================================================
+   Sidebar banner — Seline-style CTA card for the right gutter.
+   Tinted background, short text, full-width button, optional corner image.
+   ========================================================================= */
+
+export function SidebarBanner({
+  text,
+  buttonLabel,
+  buttonHref,
+  imageUrl,
+}: {
+  text: React.ReactNode;
+  buttonLabel: string;
+  buttonHref: string;
+  imageUrl?: string;
+}) {
+  return (
+    <div className="docs-sidebar-banner">
+      {text}
+      <a href={buttonHref} className="docs-sidebar-banner-button no-underline">
+        {buttonLabel}
+      </a>
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt=""
+          width={144}
+          height={144}
+          className="docs-sidebar-banner-image"
+        />
+      )}
+    </div>
+  );
+}
+
+function TabLink({ tab, isActive }: { tab: TabItem; isActive: boolean }) {
+  const isExternal = tab.href.startsWith("http");
+  return (
+    <a
+      href={tab.href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className={`docs-tab-link slot-tab no-underline text-(length:--type-toc-size) font-[475] [font-family:var(--font-primary)] ${isActive ? "docs-tab-link-active" : ""}`}
+    >
+      {tab.label}
+      <div data-tab-indicator className="docs-tab-indicator" />
+    </a>
+  );
+}
+
+/* =========================================================================
+   Page shell — CSS grid layout with named areas.
+
+   Desktop (lg+):
+     "tabs    tabs   ."
+     "toc     content ."
+
+   Mobile:
+     "tabs"
+     "content"
+
+   The grid centers the content column. The TOC column is sticky.
+   ========================================================================= */
+
+export type HeaderLink = {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+};
+
+export type EditorialSection = {
+  content: React.ReactNode;
+  aside?: React.ReactNode;
+  fullWidth?: boolean;
+};
+
+export function EditorialPage({
+  toc,
+  logo,
+  tabs,
+  activeTab,
+  showHeader = true,
+  sidebar,
+  headerLinks,
+  children,
+  sections,
+}: {
+  toc: FlatTocItem[];
+  logo?: string;
+  tabs?: TabItem[];
+  activeTab?: string;
+  showHeader?: boolean;
+  sidebar?: React.ReactNode;
+  headerLinks?: HeaderLink[];
+  children?: React.ReactNode;
+  /** When provided, renders section rows with aside support instead of flat children */
+  sections?: EditorialSection[];
+}) {
+  const hasTabBar = showHeader && tabs && tabs.length > 0;
+
+  return (
+    <div className="slot-page flex flex-col min-h-screen bg-(--bg) text-(color:--text-primary) [font-family:var(--font-primary)] antialiased [text-rendering:optimizeLegibility]">
+      {/* Header + Tab bar: full-width, sticky at top */}
+      {showHeader && (
+        <div className="slot-navbar">
+          {/* Top row: logo + right links */}
+          <div className="mx-auto flex items-center justify-between px-(--mobile-padding) py-(--header-padding-y) lg:max-w-(--grid-max-width) lg:px-0">
+            <a href="/" className="slot-logo no-underline flex items-center">
+              {logo ? (
+                <div
+                  role="img"
+                  aria-label="playwriter"
+                  style={{
+                    height: "var(--logo-height)",
+                    /* aspect ratio from SVG viewBox: 730/201 ≈ 3.63 */
+                    aspectRatio: "730 / 201",
+                    backgroundColor: "var(--logo-color)",
+                    maskImage: `url(${logo})`,
+                    maskSize: "contain",
+                    maskRepeat: "no-repeat",
+                    WebkitMaskImage: `url(${logo})`,
+                    WebkitMaskSize: "contain",
+                    WebkitMaskRepeat: "no-repeat",
+                  }}
+                />
+              ) : (
+                <span className="text-[18px] font-[300] [font-family:var(--font-secondary)] tracking-[-0.02em]">
+                  Libretto
+                </span>
+              )}
+            </a>
+            <div className="flex items-center gap-4">
+              {/* Icon links */}
+              {headerLinks && headerLinks.length > 0 && (
+                <div className="flex items-center gap-3">
+                  {headerLinks.map((link) => {
+                    return (
+                      <a
+                        key={link.href}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={link.label}
+                        className="no-underline flex items-center text-(color:--text-secondary) transition-colors duration-150 hover:text-(color:--text-primary)"
+                      >
+                        {link.icon}
+                      </a>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Tab row */}
+          {hasTabBar && (
+            <div className="slot-tabbar">
+              <div className="mx-auto flex h-(--tab-bar-height) max-w-full items-stretch gap-6 overflow-x-auto px-(--mobile-padding) lg:max-w-(--grid-max-width) lg:px-0">
+                {tabs.map((tab) => {
+                  return (
+                    <TabLink
+                      key={tab.href}
+                      tab={tab}
+                      isActive={tab.href === (activeTab ?? tabs[0].href)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 max-w-full mx-auto px-(--mobile-padding) lg:grid-cols-[var(--grid-toc-width)_var(--grid-content-width)_var(--grid-sidebar-width)] lg:gap-x-(--grid-gap) lg:max-w-(--grid-max-width) lg:px-0">
+        {/* TOC sidebar: sticky within its grid cell */}
+        <div className="slot-sidebar-left">
+          <div
+            className="docs-sidebar-sticky"
+            style={{
+              top: hasTabBar ? "var(--sticky-top)" : "0px",
+              maxHeight: hasTabBar
+                ? "calc(100vh - var(--sticky-top))"
+                : "100vh",
+            }}
+          >
+            <TableOfContents items={toc} logo={logo} />
+          </div>
+        </div>
+
+        {sections ? (
+          <>
+            {/* Section-based layout: each section is a subgrid row with
+                content in column 3 and optional aside in column 5 (sticky). */}
+            <div className="contents lg:grid lg:grid-cols-subgrid lg:col-[2/-1]">
+              <div className="slot-main flex flex-col gap-5 lg:col-[1] lg:overflow-visible text-(length:--type-body-size)"></div>
+            </div>
+            {sections.map((section, i) => {
+              if (section.fullWidth) {
+                return (
+                  <div
+                    key={i}
+                    className="lg:col-[2/-1] text-(length:--type-body-size) my-5"
+                  >
+                    <div className="flex flex-col gap-5">{section.content}</div>
+                  </div>
+                );
+              }
+              return (
+                <SectionRow
+                  key={i}
+                  content={section.content}
+                  aside={section.aside}
+                />
+              );
+            })}
+          </>
+        ) : (
+          <>
+            {/* Flat layout: single article column + optional static sidebar */}
+            <div className="slot-main pb-24 lg:col-[2] text-(length:--type-body-size)">
+              <article className="flex flex-col gap-[20px]">{children}</article>
+            </div>
+
+            <div className="slot-sidebar-right">
+              <div
+                className="docs-sidebar-right-sticky"
+                style={{ top: hasTabBar ? "var(--sticky-top)" : "12px" }}
+              >
+                {sidebar}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/docs/components/search.ts
+++ b/apps/website/src/docs/components/search.ts
@@ -1,0 +1,107 @@
+/*
+ * TOC search powered by Orama — full-text, typo-tolerant, in-memory.
+ * Reference: https://www.mintlify.com/oramasearch/orama/quickstart.md
+ *
+ * Operates directly on FlatTocItem[] — no intermediate SearchEntry type.
+ * Each flat item already carries parentId for deriving which groups to
+ * expand and which items to dim. Scales to thousands
+ * of entries — Orama searches in ~20us, derive pass is O(n).
+ */
+
+import { create, insertMultiple, search, type AnyOrama } from '@orama/orama'
+import type { FlatTocItem } from './markdown'
+
+const tocSchema = {
+  id: 'string',
+  title: 'string',
+  href: 'string',
+} as const
+
+/** Create and populate an Orama DB from flat TOC items. Synchronous. */
+export function createTocDb({ items }: { items: FlatTocItem[] }): AnyOrama {
+  const db = create({ schema: tocSchema })
+  /* insertMultiple is sync with default components. We cast away the union
+     return type since we know no async components are configured. */
+  insertMultiple(db, items.map((item) => {
+    return { id: item.id, title: item.label, href: item.href }
+  })) as string[]
+  return db
+}
+
+export type SearchState = {
+  /** Set of item ids that matched the query. null = no active search. */
+  matchedIds: Set<string> | null
+  /** Set of parent ids to force-expand. null = no override. */
+  expandOverrideIds: Set<string> | null
+  /** Set of item ids to dim (opacity 0.3). null = no dimming. */
+  dimmedIds: Set<string> | null
+  /** Ordered list of item ids focusable via arrow keys. null = all focusable. */
+  focusableIds: string[] | null
+}
+
+const emptySearchState: SearchState = {
+  matchedIds: null,
+  expandOverrideIds: null,
+  dimmedIds: null,
+  focusableIds: null,
+}
+
+/** Search the TOC DB. Returns null matchedIds when query is empty (show all).
+ *  Walks up the parentId chain to expand all ancestors of matched items. */
+export function searchToc({ db, query, items }: {
+  db: AnyOrama
+  query: string
+  items: FlatTocItem[]
+}): SearchState {
+  const trimmed = query.trim()
+  if (!trimmed) {
+    return emptySearchState
+  }
+
+  const results = search(db, {
+    term: trimmed,
+    properties: ['title'],
+    tolerance: 1,
+    limit: items.length,
+  }) as { hits: Array<{ id: string; score: number; document: { id: string; title: string; href: string } }> }
+
+  if (results.hits.length === 0) {
+    return {
+      matchedIds: new Set(),
+      expandOverrideIds: new Set(),
+      dimmedIds: new Set(items.map((i) => { return i.id })),
+      focusableIds: [],
+    }
+  }
+
+  const itemById = new Map(items.map((i) => { return [i.id, i] as const }))
+
+  const matchedIds = new Set(results.hits.map((hit) => { return hit.document.id }))
+  const expandOverrideIds = new Set<string>()
+
+  for (const item of items) {
+    if (matchedIds.has(item.id)) {
+      /* Walk up the parent chain to expand all ancestors */
+      let current: FlatTocItem | undefined = item
+      while (current?.parentId) {
+        expandOverrideIds.add(current.parentId)
+        current = itemById.get(current.parentId)
+      }
+      /* If the matched item itself has children, expand it too */
+      expandOverrideIds.add(item.id)
+    }
+  }
+
+  const dimmedIds = new Set(
+    items
+      .filter((i) => { return !matchedIds.has(i.id) })
+      .map((i) => { return i.id }),
+  )
+
+  /* Focusable in document order — only matched items */
+  const focusableIds = items
+    .filter((i) => { return matchedIds.has(i.id) })
+    .map((i) => { return i.id })
+
+  return { matchedIds, expandOverrideIds, dimmedIds, focusableIds }
+}

--- a/apps/website/src/docs/components/toc-tree.ts
+++ b/apps/website/src/docs/components/toc-tree.ts
@@ -36,6 +36,7 @@ export type TocManifestPage = {
 export type TocManifestGroup = {
   id: string;
   label: string;
+  path: string;
   pages: TocManifestPage[];
 };
 
@@ -90,18 +91,19 @@ function getHeadings(mdast: Root, headingIds?: WeakMap<Heading, string>): Headin
 export function generateTocTree(
   mdast: Root,
   headingIds?: WeakMap<Heading, string>,
-  options?: { idPrefix?: string },
+  options?: { idPrefix?: string; hrefPrefix?: string },
 ): TocTreeNode[] {
   const headings = getHeadings(mdast, headingIds);
   const result: TocTreeNode[] = [];
   const stack: { node: TocTreeNode; depth: number }[] = [];
   const idPrefix = options?.idPrefix ?? "heading:";
+  const hrefPrefix = options?.hrefPrefix ?? "";
 
   for (const heading of headings) {
     const node: TocTreeNode = {
       id: `${idPrefix}${heading.id}`,
       label: heading.label,
-      href: heading.href,
+      href: `${hrefPrefix}${heading.href}`,
       type: `h${heading.depth}` as TocNodeType,
       children: [],
     };
@@ -140,32 +142,41 @@ function withoutFirstHeading(mdast: Root): Root {
 
 export function buildDocsTocTree({
   groups,
-  headingIds,
+  headingIdsByGroup,
+  currentGroupId,
 }: {
   groups: TocManifestGroup[];
-  headingIds: WeakMap<Heading, string>;
+  headingIdsByGroup: Map<string, WeakMap<Heading, string>>;
+  currentGroupId: string;
 }): TocTreeNode[] {
   return groups.map((group) => {
+    const groupHeadingIds = headingIdsByGroup.get(group.id);
     const pageNodes = group.pages.map((page) => {
-      const pageHeadings = getHeadings(page.mdast, headingIds);
+      const pageHeadings = getHeadings(page.mdast, groupHeadingIds);
       const firstHeading = pageHeadings[0];
-      const href = firstHeading?.href ?? "#";
+      const href =
+        group.id === currentGroupId
+          ? firstHeading?.href ?? group.path
+          : `${group.path}${firstHeading?.href ?? ""}`;
 
       return {
         id: page.id,
         label: page.label,
         href,
         type: "page" as const,
-        children: generateTocTree(withoutFirstHeading(page.mdast), headingIds, {
-          idPrefix: `${page.id}:`,
-        }),
+        children:
+          group.id === currentGroupId
+            ? generateTocTree(withoutFirstHeading(page.mdast), groupHeadingIds, {
+                idPrefix: `${page.id}:`,
+              })
+            : [],
       };
     });
 
     return {
       id: group.id,
       label: group.label,
-      href: `#${group.id}`,
+      href: group.path,
       type: "group" as const,
       children: pageNodes,
     };

--- a/apps/website/src/docs/components/toc-tree.ts
+++ b/apps/website/src/docs/components/toc-tree.ts
@@ -1,0 +1,282 @@
+/**
+ * Pure functions for building and flattening TocTreeNode[] from docs manifest
+ * groups/pages and mdast headings.
+ * Server-safe — no 'use client', no hooks, no browser APIs.
+ */
+
+import type { Heading, PhrasingContent, Root, RootContent } from "mdast";
+
+export type TocNodeType = "group" | "page" | `h${1 | 2 | 3 | 4 | 5 | 6}`;
+export type VisualLevel = 0 | 1 | 2 | 3;
+
+export type TocTreeNode = {
+  id: string;
+  label: string;
+  href: string;
+  type: TocNodeType;
+  children: TocTreeNode[];
+};
+
+export type FlatTocItem = {
+  id: string;
+  label: string;
+  href: string;
+  type: TocNodeType;
+  visualLevel: VisualLevel;
+  prefix: string;
+  parentId: string | null;
+};
+
+export type TocManifestPage = {
+  id: string;
+  label: string;
+  mdast: Root;
+};
+
+export type TocManifestGroup = {
+  id: string;
+  label: string;
+  pages: TocManifestPage[];
+};
+
+type HeadingDescriptor = {
+  id: string;
+  label: string;
+  href: string;
+  depth: number;
+};
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
+
+export function extractText(children: PhrasingContent[]): string {
+  return children
+    .map((child) => {
+      if ("value" in child && typeof child.value === "string") {
+        return child.value;
+      }
+      if ("children" in child) {
+        return extractText(child.children as PhrasingContent[]);
+      }
+      return "";
+    })
+    .join("");
+}
+
+function getHeadings(mdast: Root, headingIds?: WeakMap<Heading, string>): HeadingDescriptor[] {
+  return mdast.children
+    .filter((node): node is Heading => {
+      return node.type === "heading";
+    })
+    .map((heading) => {
+      const label = extractText(heading.children);
+      const id = headingIds?.get(heading) ?? slugify(label);
+
+      return {
+        id,
+        label,
+        href: `#${id}`,
+        depth: heading.depth,
+      };
+    });
+}
+
+export function generateTocTree(
+  mdast: Root,
+  headingIds?: WeakMap<Heading, string>,
+  options?: { idPrefix?: string },
+): TocTreeNode[] {
+  const headings = getHeadings(mdast, headingIds);
+  const result: TocTreeNode[] = [];
+  const stack: { node: TocTreeNode; depth: number }[] = [];
+  const idPrefix = options?.idPrefix ?? "heading:";
+
+  for (const heading of headings) {
+    const node: TocTreeNode = {
+      id: `${idPrefix}${heading.id}`,
+      label: heading.label,
+      href: heading.href,
+      type: `h${heading.depth}` as TocNodeType,
+      children: [],
+    };
+
+    while (stack.length > 0 && stack[stack.length - 1].depth >= heading.depth) {
+      stack.pop();
+    }
+
+    if (stack.length === 0) {
+      result.push(node);
+    } else {
+      stack[stack.length - 1].node.children.push(node);
+    }
+
+    stack.push({ node, depth: heading.depth });
+  }
+
+  return result;
+}
+
+function withoutFirstHeading(mdast: Root): Root {
+  let removedFirstHeading = false;
+
+  return {
+    type: "root",
+    children: mdast.children.filter((node): node is RootContent => {
+      if (!removedFirstHeading && node.type === "heading") {
+        removedFirstHeading = true;
+        return false;
+      }
+
+      return true;
+    }),
+  };
+}
+
+export function buildDocsTocTree({
+  groups,
+  headingIds,
+}: {
+  groups: TocManifestGroup[];
+  headingIds: WeakMap<Heading, string>;
+}): TocTreeNode[] {
+  return groups.map((group) => {
+    const pageNodes = group.pages.map((page) => {
+      const pageHeadings = getHeadings(page.mdast, headingIds);
+      const firstHeading = pageHeadings[0];
+      const href = firstHeading?.href ?? "#";
+
+      return {
+        id: page.id,
+        label: page.label,
+        href,
+        type: "page" as const,
+        children: generateTocTree(withoutFirstHeading(page.mdast), headingIds, {
+          idPrefix: `${page.id}:`,
+        }),
+      };
+    });
+
+    return {
+      id: group.id,
+      label: group.label,
+      href: `#${group.id}`,
+      type: "group" as const,
+      children: pageNodes,
+    };
+  });
+}
+
+function headingDepthFromType(type: TocNodeType): number | null {
+  if (!type.startsWith("h")) {
+    return null;
+  }
+
+  return Number.parseInt(type.slice(1), 10);
+}
+
+function hasNextSiblingAtLevel({
+  items,
+  index,
+  level,
+}: {
+  items: FlatTocItem[];
+  index: number;
+  level: VisualLevel;
+}): boolean {
+  for (let i = index + 1; i < items.length; i++) {
+    if (items[i].visualLevel < level) {
+      return false;
+    }
+    if (items[i].visualLevel === level) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function addPrefixes({ items }: { items: FlatTocItem[] }) {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const isLast = !hasNextSiblingAtLevel({
+      items,
+      index: i,
+      level: item.visualLevel,
+    });
+
+    if (item.visualLevel === 0) {
+      item.prefix = "";
+      continue;
+    }
+
+    item.prefix = `${"  ".repeat(Math.max(0, item.visualLevel - 1))}${isLast ? "└─ " : "├─ "}`;
+  }
+}
+
+export function flattenTocTree({ roots }: { roots: TocTreeNode[] }): FlatTocItem[] {
+  const result: FlatTocItem[] = [];
+
+  function walk({
+    nodes,
+    parentId,
+    parentVisualLevel,
+    parentHeadingDepth,
+  }: {
+    nodes: TocTreeNode[];
+    parentId: string | null;
+    parentVisualLevel: number;
+    parentHeadingDepth: number | null;
+  }) {
+    for (const node of nodes) {
+      let nextVisualLevel = parentVisualLevel;
+      let nextHeadingDepth = parentHeadingDepth;
+
+      if (node.type === "group") {
+        nextVisualLevel = parentId === null ? 0 : parentVisualLevel + 1;
+        nextHeadingDepth = null;
+      } else if (node.type === "page") {
+        nextVisualLevel = parentVisualLevel + 1;
+        nextHeadingDepth = 2;
+      } else {
+        const nodeHeadingDepth = headingDepthFromType(node.type) ?? 2;
+        const depthDelta = nextHeadingDepth === null ? 1 : Math.max(1, nodeHeadingDepth - nextHeadingDepth);
+
+        nextVisualLevel = parentVisualLevel + depthDelta;
+        nextHeadingDepth = nodeHeadingDepth;
+      }
+
+      result.push({
+        id: node.id,
+        label: node.label,
+        href: node.href,
+        type: node.type,
+        visualLevel: Math.min(nextVisualLevel, 3) as VisualLevel,
+        prefix: "",
+        parentId,
+      });
+
+      walk({
+        nodes: node.children,
+        parentId: node.id,
+        parentVisualLevel: nextVisualLevel,
+        parentHeadingDepth: nextHeadingDepth,
+      });
+    }
+  }
+
+  walk({
+    nodes: roots,
+    parentId: null,
+    parentVisualLevel: 0,
+    parentHeadingDepth: null,
+  });
+
+  addPrefixes({ items: result });
+  return result;
+}

--- a/apps/website/src/docs/content/index.ts
+++ b/apps/website/src/docs/content/index.ts
@@ -1,4 +1,5 @@
 import introduction from "./pages/introduction.mdx?raw";
+import uiKit from "./pages/ui-kit.mdx?raw";
 import quickstart from "./pages/quickstart.mdx?raw";
 import configuration from "./pages/configuration.mdx?raw";
 import openAndConnect from "./pages/open-and-connect.mdx?raw";
@@ -23,13 +24,34 @@ export type DocsContentPage = {
 export type DocsContentGroup = {
   id: string;
   label: string;
+  path: string;
   pages: DocsContentPage[];
 };
 
+export const defaultDocsGroupId = "get-started";
+
+const isDocsDevBuild =
+  !import.meta.env.PROD ||
+  (typeof window !== "undefined" &&
+    ["localhost", "127.0.0.1"].includes(window.location.hostname));
+
+const devDocsManifest = isDocsDevBuild
+  ? [
+      {
+        id: "ui-kit",
+        label: "UI Kit",
+        path: "/docs/ui-kit",
+        pages: [{ id: "ui-kit-components", label: "Components", content: uiKit }],
+      },
+    ]
+  : [];
+
 export const docsManifest = [
+  ...devDocsManifest,
   {
     id: "get-started",
     label: "Get Started",
+    path: "/docs/get-started",
     pages: [
       { id: "introduction", label: "Introduction", content: introduction },
       { id: "quickstart", label: "Quick start", content: quickstart },
@@ -39,6 +61,7 @@ export const docsManifest = [
   {
     id: "cli-reference",
     label: "CLI Reference",
+    path: "/docs/cli-reference",
     pages: [
       {
         id: "open-and-connect",
@@ -67,6 +90,7 @@ export const docsManifest = [
   {
     id: "library-api",
     label: "Library API",
+    path: "/docs/library-api",
     pages: [
       { id: "workflow", label: "Workflow", content: workflow },
       { id: "extraction", label: "AI Extraction", content: extraction },
@@ -85,6 +109,34 @@ export const docsManifest = [
 export const docsPages = docsManifest.flatMap((group) => {
   return group.pages;
 });
+
+export function normalizeDocsPath(pathname: string): string {
+  if (pathname === "/" || pathname.length === 0) {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/, "");
+}
+
+export function getDefaultDocsGroup() {
+  return (
+    docsManifest.find((group) => {
+      return group.id === defaultDocsGroupId;
+    }) ?? docsManifest[0]
+  );
+}
+
+export function getDocsGroupByPath(pathname: string) {
+  const normalizedPath = normalizeDocsPath(pathname);
+
+  if (normalizedPath === "/docs" || normalizedPath === "/docs/index.html") {
+    return getDefaultDocsGroup();
+  }
+
+  return docsManifest.find((group) => {
+    return group.path === normalizedPath;
+  });
+}
 
 export const docsMdxContent = docsPages
   .map((page) => {

--- a/apps/website/src/docs/content/index.ts
+++ b/apps/website/src/docs/content/index.ts
@@ -2,18 +2,26 @@ import introduction from "./pages/introduction.mdx?raw";
 import uiKit from "./pages/ui-kit.mdx?raw";
 import quickstart from "./pages/quickstart.mdx?raw";
 import configuration from "./pages/configuration.mdx?raw";
+import automationApproaches from "./pages/automation-approaches.mdx?raw";
+import botDetection from "./pages/bot-detection.mdx?raw";
 import openAndConnect from "./pages/open-and-connect.mdx?raw";
+import sessionsAndProfiles from "./pages/sessions-and-profiles.mdx?raw";
 import snapshot from "./pages/snapshot.mdx?raw";
 import exec from "./pages/exec.mdx?raw";
 import networkAndActions from "./pages/network-and-actions.mdx?raw";
 import sessionManagement from "./pages/session-management.mdx?raw";
 import runAndResume from "./pages/run-and-resume.mdx?raw";
+import oneShotScriptGeneration from "./pages/one-shot-script-generation.mdx?raw";
+import interactiveScriptBuilding from "./pages/interactive-script-building.mdx?raw";
+import debuggingWorkflows from "./pages/debugging-workflows.mdx?raw";
+import convertToNetworkRequests from "./pages/convert-to-network-requests.mdx?raw";
 import workflow from "./pages/workflow.mdx?raw";
 import logging from "./pages/logging.mdx?raw";
 import instrumentation from "./pages/instrumentation.mdx?raw";
 import extraction from "./pages/extraction.mdx?raw";
 import network from "./pages/network.mdx?raw";
 import recovery from "./pages/recovery.mdx?raw";
+import openapiSpec from "./pages/openapi-spec.mdx?raw";
 
 export type DocsContentPage = {
   id: string;
@@ -28,7 +36,7 @@ export type DocsContentGroup = {
   pages: DocsContentPage[];
 };
 
-export const defaultDocsGroupId = "get-started";
+const defaultDocsGroupId = "get-started";
 
 const isDocsDevBuild =
   !import.meta.env.PROD ||
@@ -56,6 +64,12 @@ export const docsManifest = [
       { id: "introduction", label: "Introduction", content: introduction },
       { id: "quickstart", label: "Quick start", content: quickstart },
       { id: "configuration", label: "Configuration", content: configuration },
+      {
+        id: "automation-approaches",
+        label: "Automation approaches",
+        content: automationApproaches,
+      },
+      { id: "bot-detection", label: "Bot detection", content: botDetection },
     ],
   },
   {
@@ -67,6 +81,11 @@ export const docsManifest = [
         id: "open-and-connect",
         label: "open & connect",
         content: openAndConnect,
+      },
+      {
+        id: "sessions-and-profiles",
+        label: "sessions & profiles",
+        content: sessionsAndProfiles,
       },
       { id: "snapshot", label: "snapshot", content: snapshot },
       { id: "exec", label: "exec", content: exec },
@@ -88,6 +107,33 @@ export const docsManifest = [
     ],
   },
   {
+    id: "workflow-guides",
+    label: "Workflow Guides",
+    path: "/docs/workflow-guides",
+    pages: [
+      {
+        id: "one-shot-script-generation",
+        label: "One-shot script generation",
+        content: oneShotScriptGeneration,
+      },
+      {
+        id: "interactive-script-building",
+        label: "Interactive script building",
+        content: interactiveScriptBuilding,
+      },
+      {
+        id: "debugging-workflows",
+        label: "Debugging workflows",
+        content: debuggingWorkflows,
+      },
+      {
+        id: "convert-to-network-requests",
+        label: "Convert to network requests",
+        content: convertToNetworkRequests,
+      },
+    ],
+  },
+  {
     id: "library-api",
     label: "Library API",
     path: "/docs/library-api",
@@ -102,13 +148,10 @@ export const docsManifest = [
         content: instrumentation,
       },
       { id: "logging", label: "Logging", content: logging },
+      { id: "openapi-spec", label: "OpenAPI spec", content: openapiSpec },
     ],
   },
 ] satisfies DocsContentGroup[];
-
-export const docsPages = docsManifest.flatMap((group) => {
-  return group.pages;
-});
 
 export function normalizeDocsPath(pathname: string): string {
   if (pathname === "/" || pathname.length === 0) {
@@ -137,9 +180,3 @@ export function getDocsGroupByPath(pathname: string) {
     return group.path === normalizedPath;
   });
 }
-
-export const docsMdxContent = docsPages
-  .map((page) => {
-    return page.content;
-  })
-  .join("\n\n");

--- a/apps/website/src/docs/content/index.ts
+++ b/apps/website/src/docs/content/index.ts
@@ -1,0 +1,93 @@
+import introduction from "./pages/introduction.mdx?raw";
+import quickstart from "./pages/quickstart.mdx?raw";
+import configuration from "./pages/configuration.mdx?raw";
+import openAndConnect from "./pages/open-and-connect.mdx?raw";
+import snapshot from "./pages/snapshot.mdx?raw";
+import exec from "./pages/exec.mdx?raw";
+import networkAndActions from "./pages/network-and-actions.mdx?raw";
+import sessionManagement from "./pages/session-management.mdx?raw";
+import runAndResume from "./pages/run-and-resume.mdx?raw";
+import workflow from "./pages/workflow.mdx?raw";
+import logging from "./pages/logging.mdx?raw";
+import instrumentation from "./pages/instrumentation.mdx?raw";
+import extraction from "./pages/extraction.mdx?raw";
+import network from "./pages/network.mdx?raw";
+import recovery from "./pages/recovery.mdx?raw";
+
+export type DocsContentPage = {
+  id: string;
+  label: string;
+  content: string;
+};
+
+export type DocsContentGroup = {
+  id: string;
+  label: string;
+  pages: DocsContentPage[];
+};
+
+export const docsManifest = [
+  {
+    id: "get-started",
+    label: "Get Started",
+    pages: [
+      { id: "introduction", label: "Introduction", content: introduction },
+      { id: "quickstart", label: "Quick start", content: quickstart },
+      { id: "configuration", label: "Configuration", content: configuration },
+    ],
+  },
+  {
+    id: "cli-reference",
+    label: "CLI Reference",
+    pages: [
+      {
+        id: "open-and-connect",
+        label: "open & connect",
+        content: openAndConnect,
+      },
+      { id: "snapshot", label: "snapshot", content: snapshot },
+      { id: "exec", label: "exec", content: exec },
+      {
+        id: "run-and-resume",
+        label: "run & resume",
+        content: runAndResume,
+      },
+      {
+        id: "network-and-actions",
+        label: "network & actions",
+        content: networkAndActions,
+      },
+      {
+        id: "session-management",
+        label: "save, pages & close",
+        content: sessionManagement,
+      },
+    ],
+  },
+  {
+    id: "library-api",
+    label: "Library API",
+    pages: [
+      { id: "workflow", label: "Workflow", content: workflow },
+      { id: "extraction", label: "AI Extraction", content: extraction },
+      { id: "network", label: "Network", content: network },
+      { id: "recovery", label: "Recovery", content: recovery },
+      {
+        id: "instrumentation",
+        label: "Instrumentation",
+        content: instrumentation,
+      },
+      { id: "logging", label: "Logging", content: logging },
+    ],
+  },
+] satisfies DocsContentGroup[];
+
+export const docsPages = docsManifest.flatMap((group) => {
+  return group.pages;
+});
+
+export const docsMdxContent = docsPages
+  .map((page) => {
+    return page.content;
+  })
+  .join("\n\n");

--- a/apps/website/src/docs/content/pages/automation-approaches.mdx
+++ b/apps/website/src/docs/content/pages/automation-approaches.mdx
@@ -1,0 +1,261 @@
+## Automation approaches
+
+> Choose the right integration strategy: Playwright UI, passive interception, in-browser fetch, or direct HTTP.
+
+### Overview
+
+Libretto supports four distinct approaches to capturing data and automating web interactions. Each makes different trade-offs between detection risk, setup complexity, data quality, and control. Understanding the trade-offs helps you pick the right tool for your target site.
+
+| Approach                                     | Bot detection risk | Best for                                            |
+| -------------------------------------------- | ------------------ | --------------------------------------------------- |
+| Regular Playwright                           | Moderate           | Simple DOM extraction, server-rendered sites        |
+| Passive interception (`page.on('response')`) | Low                | SPAs that load data via API calls during navigation |
+| In-browser fetch (`pageRequest()`)           | Low to moderate    | Deep pagination, bulk queries without UI clicking   |
+| Direct HTTP from Node.js                     | Very high          | Public/documented APIs with no bot detection        |
+
+<Tip>
+  **Recommended hybrid:** Combine Regular Playwright for navigation with passive `page.on('response')` interception for data capture. This gives you browser-based reliability with structured API data quality at minimal detection risk.
+</Tip>
+
+***
+
+### Approach details
+
+<Tabs>
+  <Tab title="Regular Playwright">
+    Standard Playwright usage — navigate pages, click elements, fill forms, and read DOM content using selectors and `page.evaluate()`.
+
+    ```typescript  theme={null}
+    // Navigate and interact
+    await page.goto('https://example.com/search');
+    await page.fill('#query', 'search term');
+    await page.click('#submit');
+    await page.waitForSelector('.results');
+
+    // Extract data from the DOM
+    const results = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('.result-item')).map(el => ({
+        title: el.querySelector('h2')?.textContent,
+        price: el.querySelector('.price')?.textContent,
+      }));
+    });
+    ```
+
+    **Pros:**
+
+    * Simplest approach — uses Playwright as intended
+    * No need to understand the site's API structure
+    * Works with any site regardless of how data is rendered (server-side, client-side, or hybrid)
+    * Data extraction is visual/DOM-based, which maps naturally to what a user sees
+    * Easy to debug with `headless: false` and Playwright's trace viewer
+    * Integrates directly with Libretto's step-based workflow, recovery, and extraction features
+
+    **Cons:**
+
+    * Slower than API-based approaches — requires full page rendering
+    * Fragile against DOM changes — selectors break when the site updates its markup
+    * Harder to get structured data — you're scraping rendered HTML rather than clean API responses
+    * Cannot access data that isn't rendered in the DOM (e.g., API responses with fields the UI doesn't display)
+
+    **Bot detection risk: MODERATE**
+
+    Plain Playwright is detectable by browser fingerprinting (Layer 1). Sites with any enterprise bot protection will likely flag it. Sites without active detection won't notice.
+
+    <Note>
+      Use `playwright-extra` with the stealth plugin to patch common fingerprint leaks, or run Playwright with a persistent browser context that looks more like a real browser profile.
+    </Note>
+  </Tab>
+
+  <Tab title="Passive Interception">
+    Listen to network responses the browser naturally makes as you navigate. You don't make any extra requests — you just capture the data flowing through.
+
+    ```typescript  theme={null}
+    const capturedData: any[] = [];
+
+    page.on('response', async (response) => {
+      const url = response.url();
+      if (url.includes('/api/search/results')) {
+        const json = await response.json();
+        capturedData.push(json);
+      }
+    });
+
+    // Trigger the data load by interacting with the UI normally
+    await page.goto('https://example.com/search?q=term');
+    await page.waitForSelector('.results');
+    // capturedData now has the raw API response
+    ```
+
+    **Pros:**
+
+    * Zero additional bot detection risk from network requests — you're not making any extra calls. The requests that happen are the ones the site's own code triggers.
+    * Gets clean, structured API data (JSON) rather than scraped DOM content
+    * API responses often contain more data than the UI displays (hidden fields, IDs, metadata)
+    * Not fragile against DOM changes — the API contract tends to be more stable than CSS selectors
+    * Works with Playwright's existing page context — no additional setup
+
+    **Cons:**
+
+    * You only get data that the page naturally loads — you must trigger the right UI flow to cause the requests you need
+    * Still requires Playwright browser automation to drive the page, so you have the browser fingerprinting risk for the navigation itself
+    * Timing can be tricky — you must set up the listener before the navigation that triggers the request
+    * Responses may be paginated or partial — the site's UI might lazy-load data, requiring you to trigger scrolling or "load more" interactions
+    * If the site uses GraphQL or batched API calls, parsing the right data out of responses requires understanding the API structure
+    * Some responses may be encrypted or obfuscated by bot protection services
+
+    **Bot detection risk: LOW**
+
+    The network requests themselves carry zero additional risk since they originate from the site's own JavaScript. The only risk is from the browser automation layer needed to drive the UI. No extra fetch calls means no anomalous network patterns for API-level monitoring to flag.
+  </Tab>
+
+  <Tab title="In-Browser Fetch">
+    Execute fetch calls from within the browser page's JavaScript context. The requests originate from the browser process itself with all the right credentials and fingerprints. Libretto's `pageRequest()` function provides a typed wrapper for this pattern.
+
+    ```typescript  theme={null}
+    const data = await page.evaluate(async () => {
+      const res = await fetch('/api/search/results?q=term&page=2', {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+      return res.json();
+    });
+    ```
+
+    **Pros:**
+
+    * Requests come from the real browser — same TLS fingerprint, same cookies, same origin, same HTTP/2 settings. From the server's perspective, it looks identical to a request the site's own JS would make.
+    * Full control over which endpoints you call and with what parameters — no need to trigger UI flows
+    * Can call endpoints the UI doesn't naturally hit (e.g., fetch page 50 of results without clicking "next" 49 times)
+    * Gets clean, structured API data (JSON)
+    * Faster than driving the UI — skip page rendering and go straight to the data
+
+    **Cons:**
+
+    * Requires understanding the site's API — you need to know the endpoint URLs, required headers, authentication tokens, and request body format. This requires reverse-engineering the site's network traffic first.
+    * Vulnerable to fetch/XHR monkey-patching — if the site wraps `window.fetch`, your calls may be intercepted and flagged because the call stack won't match the site's expected code paths
+    * Still requires a Playwright browser to be running (for the execution context)
+    * API endpoints can change without notice
+    * Must handle authentication tokens and CSRF tokens that the site's own code normally manages
+
+    **Bot detection risk: LOW to MODERATE**
+
+    The network-level risk is very low — the requests are genuine browser requests. The risk comes from browser fingerprinting (same as regular Playwright), fetch/XHR monkey-patching detecting unexpected call stacks, and timing/pattern analysis if your requests don't match normal UI flow patterns.
+
+    <Note>
+      Most sites do not implement fetch call stack monitoring. This approach is effectively undetectable on the vast majority of sites. Only sites with enterprise-grade bot protection from services like PerimeterX or Shape Security are likely to catch this.
+    </Note>
+  </Tab>
+
+  <Tab title="Direct HTTP">
+    Make HTTP requests directly from Node.js using `fetch`, `axios`, `got`, or similar libraries. No browser involved.
+
+    ```typescript  theme={null}
+    import axios from 'axios';
+
+    const response = await axios.get('https://example.com/api/search/results', {
+      params: { q: 'term', page: 1 },
+      headers: {
+        'User-Agent': 'Mozilla/5.0 ...',
+        'Cookie': 'session=abc123; ...',
+      },
+    });
+    const data = response.data;
+    ```
+
+    **Pros:**
+
+    * Fastest approach — no browser overhead, no page rendering, minimal memory usage
+    * Simple code — just HTTP requests, no browser lifecycle management
+    * Easy to parallelize — make many concurrent requests without launching multiple browser instances
+    * Lowest resource consumption — suitable for high-volume data collection
+
+    **Cons:**
+
+    * No cookies unless manually managed — you must extract cookies from a browser session and replicate them, including HttpOnly cookies you can't access from JS
+    * No browser-specific headers — `sec-ch-ua`, `sec-fetch-*`, and other headers that browsers add automatically must be manually fabricated
+    * No JavaScript execution — if the site requires JS to set cookies, generate tokens, or solve challenges, you can't do it
+    * CSRF and auth tokens must be manually extracted and refreshed
+    * Breaks easily — API changes, new security headers, or updated bot protection will break requests with no fallback
+
+    <Warning>
+      **Bot detection risk: VERY HIGH.** This approach is detectable at nearly every layer. TLS fingerprinting alone will catch Node.js HTTP clients on any site with even basic bot protection — the TLS fingerprint is fundamentally different from any real browser, and this is one of the strongest detection signals. This approach only works reliably against sites with zero bot detection, or against documented public APIs that expect programmatic access.
+    </Warning>
+  </Tab>
+</Tabs>
+
+***
+
+### Comparison matrix
+
+| Criteria                           | Regular Playwright      | Passive interception         | In-browser fetch        | Direct HTTP             |
+| ---------------------------------- | ----------------------- | ---------------------------- | ----------------------- | ----------------------- |
+| **Bot detection risk**             | Moderate                | Low                          | Low–Moderate            | Very High               |
+| **Browser fingerprint risk**       | Yes                     | Yes                          | Yes                     | N/A (wrong fingerprint) |
+| **Network fingerprint risk**       | None (browser requests) | None (browser requests)      | None (browser requests) | Very High               |
+| **API monitoring risk**            | None                    | None                         | Low (fetch patching)    | N/A                     |
+| **Data quality**                   | DOM-dependent           | Structured JSON              | Structured JSON         | Structured JSON         |
+| **Setup complexity**               | Low                     | Medium                       | Medium–High             | Low–Medium              |
+| **API reverse-engineering needed** | No                      | Partial (identify endpoints) | Yes (full)              | Yes (full)              |
+| **Control over data fetching**     | Low                     | Low                          | High                    | High                    |
+| **Speed**                          | Slow                    | Medium                       | Medium–Fast             | Fast                    |
+| **Resource usage**                 | High                    | High                         | High                    | Low                     |
+| **Resilience to DOM changes**      | Low                     | High                         | High                    | High                    |
+| **Resilience to API changes**      | Medium                  | Low                          | Low                     | Low                     |
+
+***
+
+### Decision guide
+
+**Use Regular Playwright when:**
+
+* The data you need is visible in the DOM and straightforward to extract with selectors
+* The site doesn't have aggressive bot protection, or you're using stealth plugins
+* You want the simplest implementation that integrates with Libretto's recovery and extraction features
+* The data is rendered server-side and doesn't come from a separate API call
+
+**Use passive interception (`page.on('response')`) when:**
+
+* The site loads data via API calls during normal navigation (most modern SPAs)
+* You want structured JSON data without reverse-engineering the full API
+* Minimizing detection risk is important
+* You're already navigating through the UI and want to passively capture data along the way
+
+**Use in-browser fetch (`pageRequest()`) when:**
+
+* You need data from API endpoints that the UI doesn't naturally trigger (e.g., deep pagination, bulk exports)
+* You've verified the site doesn't monkey-patch `fetch` (or you can work around it)
+* You want maximum control over which data you fetch and when
+* You've already reverse-engineered the relevant API endpoints
+
+**Use Direct Node.js HTTP when:**
+
+* The target site has zero bot detection
+* Speed and resource efficiency are the primary concerns
+* You're hitting a public/documented API (not scraping a website)
+* You need to make thousands of concurrent requests
+
+***
+
+### Recommended hybrid
+
+<Tip>
+  For most browser automation workflows, combine Approach 1 and Approach 2: use Regular Playwright to navigate and interact with the site (handling popups, login flows, and anything requiring UI interaction with Libretto's recovery features), and passively intercept API responses with `page.on('response')` to capture structured data.
+
+  This gives you the reliability of browser-based navigation with the data quality of API responses, at minimal detection risk.
+</Tip>
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Bot detection" icon="shield" href="#bot-detection">
+    Understand how sites detect automation and which signals each approach exposes.
+  </Card>
+
+  <Card title="Sessions and profiles" icon="user" href="#sessions-and-profiles">
+    Manage named browser sessions and persist authenticated state across runs.
+  </Card>
+</Columns>

--- a/apps/website/src/docs/content/pages/bot-detection.mdx
+++ b/apps/website/src/docs/content/pages/bot-detection.mdx
@@ -8,89 +8,87 @@ Bot detection operates at multiple independent layers. A site doesn't need to im
 
 The five layers range from passive browser fingerprinting (which fires the moment your browser connects) to enterprise bot protection services that aggregate all signals and apply machine learning. Each layer has different mitigations.
 
-<AccordionGroup>
-  <Accordion title="Layer 1: Browser fingerprinting">
-    When a browser connects to a site, the site can inspect dozens of signals to determine if the browser is real or automated:
+#### Layer 1: Browser fingerprinting
 
-    * **`navigator.webdriver`**: Set to `true` in automated browsers. Detection scripts check this immediately. Playwright sets this by default.
-    * **Browser plugin and extension footprint**: Real browsers have plugins like PDF viewers, font lists, and media codecs. Automated browsers often have none. In headless mode, `navigator.plugins.length === 0` is a strong signal.
-    * **WebGL and Canvas fingerprinting**: The site renders invisible graphics and hashes the output. Headless browsers produce distinct rendering artifacts.
-    * **Screen and window dimensions**: Headless browsers often report unusual viewport sizes or have `window.outerWidth === 0`.
-    * **User-Agent consistency**: The User-Agent string must match actual browser behavior. Claiming to be Chrome 120 but having Firefox-like JS engine behavior is a red flag.
-    * **CDP detection**: Some sites detect whether a Chrome DevTools Protocol (CDP) session is attached, which is how Playwright controls the browser.
-    * **Headless-specific object detection**: Automated browsers are missing objects and properties that exist in real headed Chrome. Detection scripts check for a missing `chrome.runtime`, absent `Notification.permission` prompts, `navigator.permissions.query()` behaving differently, and `window.chrome` being undefined or incomplete. `navigator.languages` may also be empty or contain only `"en"` in headless mode.
-    * **Iframe and sandbox detection**: Some sites check if their code is running inside an iframe or sandboxed context by comparing `window.self !== window.top`, inspecting `window.frameElement`, or checking whether `document.hasFocus()` returns `false` (common in headless or background contexts) and whether `document.visibilityState` is `"visible"`.
+When a browser connects to a site, the site can inspect dozens of signals to determine if the browser is real or automated:
 
-    **Affected approaches:** All Playwright-based approaches (Regular Playwright, passive interception, in-browser fetch). Direct HTTP has a different problem — a completely wrong fingerprint.
-  </Accordion>
+* **`navigator.webdriver`**: Set to `true` in automated browsers. Detection scripts check this immediately. Playwright sets this by default.
+* **Browser plugin and extension footprint**: Real browsers have plugins like PDF viewers, font lists, and media codecs. Automated browsers often have none. In headless mode, `navigator.plugins.length === 0` is a strong signal.
+* **WebGL and Canvas fingerprinting**: The site renders invisible graphics and hashes the output. Headless browsers produce distinct rendering artifacts.
+* **Screen and window dimensions**: Headless browsers often report unusual viewport sizes or have `window.outerWidth === 0`.
+* **User-Agent consistency**: The User-Agent string must match actual browser behavior. Claiming to be Chrome 120 but having Firefox-like JS engine behavior is a red flag.
+* **CDP detection**: Some sites detect whether a Chrome DevTools Protocol (CDP) session is attached, which is how Playwright controls the browser.
+* **Headless-specific object detection**: Automated browsers are missing objects and properties that exist in real headed Chrome. Detection scripts check for a missing `chrome.runtime`, absent `Notification.permission` prompts, `navigator.permissions.query()` behaving differently, and `window.chrome` being undefined or incomplete. `navigator.languages` may also be empty or contain only `"en"` in headless mode.
+* **Iframe and sandbox detection**: Some sites check if their code is running inside an iframe or sandboxed context by comparing `window.self !== window.top`, inspecting `window.frameElement`, or checking whether `document.hasFocus()` returns `false` (common in headless or background contexts) and whether `document.visibilityState` is `"visible"`.
 
-  <Accordion title="Layer 2: Behavioral analysis">
-    Beyond the browser itself, detection systems analyze how the user behaves:
+**Affected approaches:** All Playwright-based approaches (Regular Playwright, passive interception, in-browser fetch). Direct HTTP has a different problem — a completely wrong fingerprint.
 
-    * **Mouse movement patterns**: Real users have natural mouse trajectories with acceleration curves. Automated clicks happen without preceding mouse movement.
-    * **Typing cadence**: Real typing has variable delays between keystrokes. `page.fill()` inserts text instantly. `page.type()` with default settings uses uniform delays.
-    * **Scroll behavior**: Real users scroll with momentum and variable speed. Programmatic scrolling is instant or perfectly uniform.
-    * **Navigation timing**: Real users take time to read content before clicking. Bots navigate instantly between actions.
-    * **Interaction sequence**: Clicking a submit button without first clicking or focusing the input fields is suspicious.
+#### Layer 2: Behavioral analysis
 
-    **Mitigation:** Add realistic delays between actions. Use `page.type()` with random inter-key delays instead of `page.fill()` for sensitive fields. Add scroll interactions before clicking. Never navigate faster than a human could read.
-  </Accordion>
+Beyond the browser itself, detection systems analyze how the user behaves:
 
-  <Accordion title="Layer 3: Network-level detection">
-    The network request itself carries signals independent of what the browser reports:
+* **Mouse movement patterns**: Real users have natural mouse trajectories with acceleration curves. Automated clicks happen without preceding mouse movement.
+* **Typing cadence**: Real typing has variable delays between keystrokes. `page.fill()` inserts text instantly. `page.type()` with default settings uses uniform delays.
+* **Scroll behavior**: Real users scroll with momentum and variable speed. Programmatic scrolling is instant or perfectly uniform.
+* **Navigation timing**: Real users take time to read content before clicking. Bots navigate instantly between actions.
+* **Interaction sequence**: Clicking a submit button without first clicking or focusing the input fields is suspicious.
 
-    * **TLS fingerprint (JA3/JA4)**: Every HTTP client has a unique TLS handshake fingerprint based on the cipher suites, extensions, and elliptic curves it offers. Node.js `fetch`/`axios` have a completely different TLS fingerprint than Chrome. This is one of the strongest detection signals and is very hard to fake from outside a browser.
-    * **HTTP/2 fingerprint**: The SETTINGS frame, WINDOW\_UPDATE behavior, and header ordering in HTTP/2 differ between browsers and HTTP libraries.
-    * **Header ordering and values**: Browsers send headers in a specific order — Chrome always sends `sec-ch-ua` headers, for example. Node.js HTTP clients send headers in a different order or omit browser-specific headers entirely.
-    * **Cookie state**: Requests from a real browser session carry the full cookie jar. External HTTP requests must manually replicate cookies and may miss HttpOnly cookies or cookies set by JavaScript.
-    * **Referer and Origin**: Browser requests automatically include the correct `Referer` and `Origin` headers based on navigation state. External requests must fabricate these.
+**Mitigation:** Add realistic delays between actions. Use `page.type()` with random inter-key delays instead of `page.fill()` for sensitive fields. Add scroll interactions before clicking. Never navigate faster than a human could read.
 
-    **Affected approaches:** Direct HTTP is maximally exposed here. Playwright-based requests (including in-browser fetch) use the real browser's TLS stack and header ordering, so they pass network-level checks.
-  </Accordion>
+#### Layer 3: Network-level detection
 
-  <Accordion title="Layer 4: API-level monitoring">
-    Some sophisticated sites monitor the behavior of their own frontend code at runtime:
+The network request itself carries signals independent of what the browser reports:
 
-    * **Fetch/XHR monkey-patching**: The site overrides `window.fetch` and/or `XMLHttpRequest.prototype.open` with wrapper functions that log every request, including its call stack. If a `fetch()` call originates from code that isn't part of the site's own bundle, it can be flagged.
+* **TLS fingerprint (JA3/JA4)**: Every HTTP client has a unique TLS handshake fingerprint based on the cipher suites, extensions, and elliptic curves it offers. Node.js `fetch`/`axios` have a completely different TLS fingerprint than Chrome. This is one of the strongest detection signals and is very hard to fake from outside a browser.
+* **HTTP/2 fingerprint**: The SETTINGS frame, WINDOW\_UPDATE behavior, and header ordering in HTTP/2 differ between browsers and HTTP libraries.
+* **Header ordering and values**: Browsers send headers in a specific order — Chrome always sends `sec-ch-ua` headers, for example. Node.js HTTP clients send headers in a different order or omit browser-specific headers entirely.
+* **Cookie state**: Requests from a real browser session carry the full cookie jar. External HTTP requests must manually replicate cookies and may miss HttpOnly cookies or cookies set by JavaScript.
+* **Referer and Origin**: Browser requests automatically include the correct `Referer` and `Origin` headers based on navigation state. External requests must fabricate these.
 
-    ```javascript  theme={null}
-    // What the site does (runs very early, before your code):
-    const _fetch = window.fetch;
-    window.fetch = function(...args) {
-      const stack = new Error().stack;
-      if (!isExpectedCallSite(stack)) {
-        reportAnomaly({ url: args[0], stack });
-      }
-      return _fetch.apply(this, args);
-    };
-    ```
+**Affected approaches:** Direct HTTP is maximally exposed here. Playwright-based requests (including in-browser fetch) use the real browser's TLS stack and header ordering, so they pass network-level checks.
 
-    * **Proxy-based interception**: Instead of replacing `fetch`, some sites use `Proxy` objects to wrap it. This is harder to detect because `fetch.toString()` still returns `"function fetch() { [native code] }"`.
-    * **Timing correlation**: The site knows which API calls its own code makes and when. If an endpoint is called at a time when the UI flow wouldn't trigger it, that's anomalous.
-    * **Request frequency and patterns**: The site's own code calls APIs in predictable patterns — pagination calls come in sequence, search calls follow debounce timings. Automation that deviates from these patterns can be flagged.
+#### Layer 4: API-level monitoring
 
-    **Affected approaches:** In-browser fetch (`pageRequest()`) is the primary target here. Passive interception (`page.on('response')`) is immune — it makes no additional fetch calls at all.
+Some sophisticated sites monitor the behavior of their own frontend code at runtime:
 
-    <Note>
-      Most sites do not implement Layer 4 monitoring. It is primarily found on sites with enterprise-grade bot protection from services like PerimeterX or Shape Security. Check for fetch patching before committing to an in-browser fetch approach.
-    </Note>
-  </Accordion>
+* **Fetch/XHR monkey-patching**: The site overrides `window.fetch` and/or `XMLHttpRequest.prototype.open` with wrapper functions that log every request, including its call stack. If a `fetch()` call originates from code that isn't part of the site's own bundle, it can be flagged.
 
-  <Accordion title="Layer 5: Enterprise bot protection services">
-    Many sites don't build their own detection — they use third-party services that combine all the layers above into a continuously updated product:
+```javascript  theme={null}
+// What the site does (runs very early, before your code):
+const _fetch = window.fetch;
+window.fetch = function(...args) {
+  const stack = new Error().stack;
+  if (!isExpectedCallSite(stack)) {
+    reportAnomaly({ url: args[0], stack });
+  }
+  return _fetch.apply(this, args);
+};
+```
 
-    | Service                       | Common indicators                                                             |
-    | ----------------------------- | ----------------------------------------------------------------------------- |
-    | **Akamai Bot Manager**        | Scripts from `*.akamaized.net`, `_abck` cookie, `sensor_data` payloads        |
-    | **PerimeterX (HUMAN)**        | Scripts loading from `*.perimeterx.net` or `*.px-cdn.net`, `_px` cookies      |
-    | **DataDome**                  | Scripts from `*.datadome.co`, `datadome` cookie, interstitial challenge pages |
-    | **Cloudflare Bot Management** | `cf_clearance` cookie, challenge pages with "Checking your browser" message   |
-    | **Shape Security (F5)**       | Obfuscated inline scripts that collect telemetry, `_imp_apg_r_` style cookies |
-    | **Kasada**                    | Scripts from `*.kasada.io`, `x-kpsdk-*` headers                               |
+* **Proxy-based interception**: Instead of replacing `fetch`, some sites use `Proxy` objects to wrap it. This is harder to detect because `fetch.toString()` still returns `"function fetch() { [native code] }"`.
+* **Timing correlation**: The site knows which API calls its own code makes and when. If an endpoint is called at a time when the UI flow wouldn't trigger it, that's anomalous.
+* **Request frequency and patterns**: The site's own code calls APIs in predictable patterns — pagination calls come in sequence, search calls follow debounce timings. Automation that deviates from these patterns can be flagged.
 
-    These services push updates frequently. An automation that works today may break next week with no changes on your end.
-  </Accordion>
-</AccordionGroup>
+**Affected approaches:** In-browser fetch (`pageRequest()`) is the primary target here. Passive interception (`page.on('response')`) is immune — it makes no additional fetch calls at all.
+
+<Note>
+  Most sites do not implement Layer 4 monitoring. It is primarily found on sites with enterprise-grade bot protection from services like PerimeterX or Shape Security. Check for fetch patching before committing to an in-browser fetch approach.
+</Note>
+
+#### Layer 5: Enterprise bot protection services
+
+Many sites don't build their own detection — they use third-party services that combine all the layers above into a continuously updated product:
+
+| Service                       | Common indicators                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------- |
+| **Akamai Bot Manager**        | Scripts from `*.akamaized.net`, `_abck` cookie, `sensor_data` payloads        |
+| **PerimeterX (HUMAN)**        | Scripts loading from `*.perimeterx.net` or `*.px-cdn.net`, `_px` cookies      |
+| **DataDome**                  | Scripts from `*.datadome.co`, `datadome` cookie, interstitial challenge pages |
+| **Cloudflare Bot Management** | `cf_clearance` cookie, challenge pages with "Checking your browser" message   |
+| **Shape Security (F5)**       | Obfuscated inline scripts that collect telemetry, `_imp_apg_r_` style cookies |
+| **Kasada**                    | Scripts from `*.kasada.io`, `x-kpsdk-*` headers                               |
+
+These services push updates frequently. An automation that works today may break next week with no changes on your end.
 
 ***
 

--- a/apps/website/src/docs/content/pages/bot-detection.mdx
+++ b/apps/website/src/docs/content/pages/bot-detection.mdx
@@ -1,0 +1,227 @@
+## Bot detection
+
+> Understand how sites detect automation and choose approaches that minimize detection risk.
+
+### Overview
+
+Bot detection operates at multiple independent layers. A site doesn't need to implement all of them — even one active layer can block your automation. Knowing which layers are present on your target site is the first step to choosing an approach that won't get flagged.
+
+The five layers range from passive browser fingerprinting (which fires the moment your browser connects) to enterprise bot protection services that aggregate all signals and apply machine learning. Each layer has different mitigations.
+
+<AccordionGroup>
+  <Accordion title="Layer 1: Browser fingerprinting">
+    When a browser connects to a site, the site can inspect dozens of signals to determine if the browser is real or automated:
+
+    * **`navigator.webdriver`**: Set to `true` in automated browsers. Detection scripts check this immediately. Playwright sets this by default.
+    * **Browser plugin and extension footprint**: Real browsers have plugins like PDF viewers, font lists, and media codecs. Automated browsers often have none. In headless mode, `navigator.plugins.length === 0` is a strong signal.
+    * **WebGL and Canvas fingerprinting**: The site renders invisible graphics and hashes the output. Headless browsers produce distinct rendering artifacts.
+    * **Screen and window dimensions**: Headless browsers often report unusual viewport sizes or have `window.outerWidth === 0`.
+    * **User-Agent consistency**: The User-Agent string must match actual browser behavior. Claiming to be Chrome 120 but having Firefox-like JS engine behavior is a red flag.
+    * **CDP detection**: Some sites detect whether a Chrome DevTools Protocol (CDP) session is attached, which is how Playwright controls the browser.
+    * **Headless-specific object detection**: Automated browsers are missing objects and properties that exist in real headed Chrome. Detection scripts check for a missing `chrome.runtime`, absent `Notification.permission` prompts, `navigator.permissions.query()` behaving differently, and `window.chrome` being undefined or incomplete. `navigator.languages` may also be empty or contain only `"en"` in headless mode.
+    * **Iframe and sandbox detection**: Some sites check if their code is running inside an iframe or sandboxed context by comparing `window.self !== window.top`, inspecting `window.frameElement`, or checking whether `document.hasFocus()` returns `false` (common in headless or background contexts) and whether `document.visibilityState` is `"visible"`.
+
+    **Affected approaches:** All Playwright-based approaches (Regular Playwright, passive interception, in-browser fetch). Direct HTTP has a different problem — a completely wrong fingerprint.
+  </Accordion>
+
+  <Accordion title="Layer 2: Behavioral analysis">
+    Beyond the browser itself, detection systems analyze how the user behaves:
+
+    * **Mouse movement patterns**: Real users have natural mouse trajectories with acceleration curves. Automated clicks happen without preceding mouse movement.
+    * **Typing cadence**: Real typing has variable delays between keystrokes. `page.fill()` inserts text instantly. `page.type()` with default settings uses uniform delays.
+    * **Scroll behavior**: Real users scroll with momentum and variable speed. Programmatic scrolling is instant or perfectly uniform.
+    * **Navigation timing**: Real users take time to read content before clicking. Bots navigate instantly between actions.
+    * **Interaction sequence**: Clicking a submit button without first clicking or focusing the input fields is suspicious.
+
+    **Mitigation:** Add realistic delays between actions. Use `page.type()` with random inter-key delays instead of `page.fill()` for sensitive fields. Add scroll interactions before clicking. Never navigate faster than a human could read.
+  </Accordion>
+
+  <Accordion title="Layer 3: Network-level detection">
+    The network request itself carries signals independent of what the browser reports:
+
+    * **TLS fingerprint (JA3/JA4)**: Every HTTP client has a unique TLS handshake fingerprint based on the cipher suites, extensions, and elliptic curves it offers. Node.js `fetch`/`axios` have a completely different TLS fingerprint than Chrome. This is one of the strongest detection signals and is very hard to fake from outside a browser.
+    * **HTTP/2 fingerprint**: The SETTINGS frame, WINDOW\_UPDATE behavior, and header ordering in HTTP/2 differ between browsers and HTTP libraries.
+    * **Header ordering and values**: Browsers send headers in a specific order — Chrome always sends `sec-ch-ua` headers, for example. Node.js HTTP clients send headers in a different order or omit browser-specific headers entirely.
+    * **Cookie state**: Requests from a real browser session carry the full cookie jar. External HTTP requests must manually replicate cookies and may miss HttpOnly cookies or cookies set by JavaScript.
+    * **Referer and Origin**: Browser requests automatically include the correct `Referer` and `Origin` headers based on navigation state. External requests must fabricate these.
+
+    **Affected approaches:** Direct HTTP is maximally exposed here. Playwright-based requests (including in-browser fetch) use the real browser's TLS stack and header ordering, so they pass network-level checks.
+  </Accordion>
+
+  <Accordion title="Layer 4: API-level monitoring">
+    Some sophisticated sites monitor the behavior of their own frontend code at runtime:
+
+    * **Fetch/XHR monkey-patching**: The site overrides `window.fetch` and/or `XMLHttpRequest.prototype.open` with wrapper functions that log every request, including its call stack. If a `fetch()` call originates from code that isn't part of the site's own bundle, it can be flagged.
+
+    ```javascript  theme={null}
+    // What the site does (runs very early, before your code):
+    const _fetch = window.fetch;
+    window.fetch = function(...args) {
+      const stack = new Error().stack;
+      if (!isExpectedCallSite(stack)) {
+        reportAnomaly({ url: args[0], stack });
+      }
+      return _fetch.apply(this, args);
+    };
+    ```
+
+    * **Proxy-based interception**: Instead of replacing `fetch`, some sites use `Proxy` objects to wrap it. This is harder to detect because `fetch.toString()` still returns `"function fetch() { [native code] }"`.
+    * **Timing correlation**: The site knows which API calls its own code makes and when. If an endpoint is called at a time when the UI flow wouldn't trigger it, that's anomalous.
+    * **Request frequency and patterns**: The site's own code calls APIs in predictable patterns — pagination calls come in sequence, search calls follow debounce timings. Automation that deviates from these patterns can be flagged.
+
+    **Affected approaches:** In-browser fetch (`pageRequest()`) is the primary target here. Passive interception (`page.on('response')`) is immune — it makes no additional fetch calls at all.
+
+    <Note>
+      Most sites do not implement Layer 4 monitoring. It is primarily found on sites with enterprise-grade bot protection from services like PerimeterX or Shape Security. Check for fetch patching before committing to an in-browser fetch approach.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Layer 5: Enterprise bot protection services">
+    Many sites don't build their own detection — they use third-party services that combine all the layers above into a continuously updated product:
+
+    | Service                       | Common indicators                                                             |
+    | ----------------------------- | ----------------------------------------------------------------------------- |
+    | **Akamai Bot Manager**        | Scripts from `*.akamaized.net`, `_abck` cookie, `sensor_data` payloads        |
+    | **PerimeterX (HUMAN)**        | Scripts loading from `*.perimeterx.net` or `*.px-cdn.net`, `_px` cookies      |
+    | **DataDome**                  | Scripts from `*.datadome.co`, `datadome` cookie, interstitial challenge pages |
+    | **Cloudflare Bot Management** | `cf_clearance` cookie, challenge pages with "Checking your browser" message   |
+    | **Shape Security (F5)**       | Obfuscated inline scripts that collect telemetry, `_imp_apg_r_` style cookies |
+    | **Kasada**                    | Scripts from `*.kasada.io`, `x-kpsdk-*` headers                               |
+
+    These services push updates frequently. An automation that works today may break next week with no changes on your end.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+### Identifying bot detection on your target site
+
+Before building your automation, audit the target site to understand what you're up against.
+
+<Steps>
+  <Step title="Check for enterprise bot protection">
+    Open the site in a normal browser with DevTools open on the Network tab:
+
+    1. Filter by JS in the Network tab. Look for domains associated with known bot protection services (listed in the table above).
+    2. In DevTools **Application > Cookies**, look for telltale cookies like `_abck`, `_px`, `datadome`, `cf_clearance`, etc.
+    3. Navigate around the site. If you see a "Checking your browser..." interstitial, the site uses active bot protection.
+    4. View source and look at the first `<script>` tags. Enterprise bot protection scripts are typically injected before any application code.
+  </Step>
+
+  <Step title="Check if fetch/XHR is patched">
+    Open the browser console and run:
+
+    ```javascript  theme={null}
+    // Check if fetch has been wrapped
+    window.fetch.toString()
+    // Native (safe):     "function fetch() { [native code] }"
+    // Patched (flagged): will show actual JavaScript source
+
+    // Check XMLHttpRequest
+    XMLHttpRequest.prototype.open.toString()
+    // Native: "function open() { [native code] }"
+
+    // Check for property descriptor tampering
+    Object.getOwnPropertyDescriptor(window, 'fetch')
+    // Native: { value: ƒ, writable: true, enumerable: true, configurable: true }
+    // Tampered: may have getters/setters or different configurability
+    ```
+
+    <Note>
+      If the site uses `Proxy` to wrap `fetch`, the `toString()` check will still return `"[native code]"`. To detect Proxy-based wrapping:
+
+      ```javascript  theme={null}
+      try {
+        const desc = Object.getOwnPropertyDescriptor(window, 'fetch');
+        console.log('configurable:', desc.configurable);
+        console.log('writable:', desc.writable);
+        console.log(window.fetch instanceof Function); // should be true
+        console.log(window.fetch.prototype); // native fetch has no prototype
+      } catch (e) {
+        console.log('fetch access is trapped');
+      }
+      ```
+    </Note>
+  </Step>
+
+  <Step title="Check for behavioral monitoring">
+    Look for signs that the site collects behavioral telemetry:
+
+    ```javascript  theme={null}
+    // Check if common event listeners are heavily registered
+    getEventListeners(document)
+    // In Chrome DevTools, this shows all listeners. An unusually large number
+    // of mousemove, keydown, scroll, and touchstart listeners suggests telemetry.
+
+    // Check for known telemetry globals
+    // PerimeterX:
+    typeof window._pxAppId !== 'undefined'
+    // Akamai:
+    typeof window.bmak !== 'undefined'
+    // DataDome:
+    typeof window.ddjskey !== 'undefined'
+    ```
+  </Step>
+
+  <Step title="Test with plain Playwright">
+    The simplest test: run a basic Playwright script against the site and observe what happens.
+
+    ```typescript  theme={null}
+    import { chromium } from 'playwright';
+    const browser = await chromium.launch({ headless: false });
+    const page = await browser.newPage();
+    await page.goto('https://target-site.com');
+    // If you get a challenge page, CAPTCHA, or block — bot detection is active.
+    ```
+
+    If plain Playwright gets blocked, the site has browser-level detection. If it works, the site likely has only basic or no detection.
+  </Step>
+</Steps>
+
+***
+
+### Infrastructure considerations
+
+Even with a well-fingerprinted browser, infrastructure-level signals can expose automation:
+
+**IP reputation and rate limiting**
+
+* Cloud provider IP ranges (AWS, GCP, Azure) are well-known and flagged by most bot protection services. Requests from these ranges face higher scrutiny or outright blocking regardless of browser fingerprint quality.
+* Even without bot detection, sites enforce per-IP request limits. Hitting the same site too frequently from one IP triggers throttling or temporary bans.
+* If your IP geolocates to one region but your browser reports a timezone and locale from another, that inconsistency is a signal.
+* Residential proxy services provide IP addresses from real ISPs, making requests appear to originate from normal households. Rotating proxies distribute requests across many IPs to avoid rate limits.
+
+**CAPTCHA and challenge handling**
+
+* **reCAPTCHA v2**: The checkbox or image-selection challenge. Can sometimes be bypassed in automated browsers if the risk score is low enough (it evaluates browser fingerprint and behavior first).
+* **reCAPTCHA v3**: Invisible — returns a score from 0.0 to 1.0 with no user interaction. A well-fingerprinted browser with natural behavior scores higher.
+* **hCaptcha**: Similar to reCAPTCHA v2. Cloudflare uses it as a fallback.
+* **Cloudflare Turnstile**: Non-interactive challenge that evaluates browser signals. Replaces traditional CAPTCHAs on many Cloudflare-protected sites.
+
+<Note>
+  If a CAPTCHA is triggered during automation, it usually means the browser fingerprint or behavior failed earlier checks. Fixing the root cause — better stealth, slower interaction patterns — is more effective than trying to solve CAPTCHAs programmatically.
+</Note>
+
+**Block manifestations**
+
+* **Soft blocks**: The site returns degraded results (fewer items, missing data, slower responses) without an explicit error. These are hard to detect — you may not realize you're getting incomplete data.
+* **Hard blocks**: HTTP 403, CAPTCHA pages, "Access Denied" responses, or redirects to a challenge page.
+* **Cookie consent and GDPR banners**: Not bot detection, but a common obstacle. These overlays block interactions with the underlying page and must be detected and dismissed before proceeding.
+
+**Anti-detection maintenance**
+
+Bot detection is adversarial — both sides are continuously updating. Enterprise bot protection services push updates frequently. Browser updates change fingerprints. Stealth patches need to keep pace with detection updates. Budget time for ongoing maintenance of any automation targeting a site with active bot protection.
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Automation approaches" icon="code" href="#automation-approaches">
+    Compare the four integration strategies and their detection risk profiles.
+  </Card>
+
+  <Card title="Sessions and profiles" icon="user" href="#sessions-and-profiles">
+    Manage named browser sessions and persist authenticated state across runs.
+  </Card>
+</Columns>

--- a/apps/website/src/docs/content/pages/configuration.mdx
+++ b/apps/website/src/docs/content/pages/configuration.mdx
@@ -112,45 +112,37 @@ npx libretto ai configure --clear
 
 Provider credentials are read from your shell environment or a `.env` file at the project root. Set the variable for your chosen provider:
 
-<CodeGroup>
-  ```bash OpenAI theme={null}
-  OPENAI_API_KEY=sk-...
-  ```
+```bash theme={null} showLineNumbers={false}
+# OpenAI
+OPENAI_API_KEY=sk-...
 
-  ```bash Anthropic theme={null}
-  ANTHROPIC_API_KEY=sk-ant-...
-  ```
+# Anthropic
+ANTHROPIC_API_KEY=sk-ant-...
 
-  ```bash Gemini theme={null}
-  # Either of these is accepted:
-  GEMINI_API_KEY=...
-  GOOGLE_GENERATIVE_AI_API_KEY=...
-  ```
+# Gemini
+# Either of these is accepted:
+GEMINI_API_KEY=...
+GOOGLE_GENERATIVE_AI_API_KEY=...
 
-  ```bash Vertex theme={null}
-  GOOGLE_CLOUD_PROJECT=my-gcp-project
-  ```
-</CodeGroup>
+# Vertex
+GOOGLE_CLOUD_PROJECT=my-gcp-project
+```
 
 You also need to install the matching Vercel AI SDK peer dependency:
 
-<CodeGroup>
-  ```bash OpenAI theme={null}
-  npm install @ai-sdk/openai
-  ```
+```bash theme={null} showLineNumbers={false}
+# OpenAI
+npm install @ai-sdk/openai
 
-  ```bash Anthropic theme={null}
-  npm install @ai-sdk/anthropic
-  ```
+# Anthropic
+npm install @ai-sdk/anthropic
 
-  ```bash Gemini theme={null}
-  npm install @ai-sdk/google
-  ```
+# Gemini
+npm install @ai-sdk/google
 
-  ```bash Vertex theme={null}
-  npm install @ai-sdk/google-vertex
-  ```
-</CodeGroup>
+# Vertex
+npm install @ai-sdk/google-vertex
+```
 
 All four peer dependencies are optional — install only the one you need.
 

--- a/apps/website/src/docs/content/pages/configuration.mdx
+++ b/apps/website/src/docs/content/pages/configuration.mdx
@@ -1,0 +1,231 @@
+## Configuration
+
+> Configure Libretto's AI model, viewport, and session settings.
+
+All Libretto state lives in a `.libretto/` directory at your project root. This page covers the config file, environment variables, sessions, and auth profiles.
+
+<Note>
+  Add `.libretto/` to your `.gitignore`. Libretto creates a `.libretto/.gitignore` that automatically ignores `sessions/` and `profiles/`, but the `config.json` file itself is not ignored. If you prefer to exclude the entire directory, add `.libretto/` to your root `.gitignore`.
+</Note>
+
+### Config file
+
+**Location:** `.libretto/config.json`
+
+The config file controls snapshot analysis and the default viewport. The easiest way to create or update it is through the CLI:
+
+```bash  theme={null}
+npx libretto ai configure <openai|anthropic|gemini|vertex>
+```
+
+You can also edit the file directly. The full schema is:
+
+```json  theme={null}
+{
+  "version": 1,
+  "ai": {
+    "model": "openai/gpt-5.4",
+    "updatedAt": "2026-01-01T00:00:00.000Z"
+  },
+  "viewport": { "width": 1280, "height": 800 }
+}
+```
+
+#### Fields
+
+<ParamField path="version" type="number" required>
+  Config schema version. Always `1`.
+</ParamField>
+
+<ParamField path="ai" type="object">
+  Configures the model used for `snapshot` analysis. Snapshot analysis is required — without it, `npx libretto snapshot` will fail.
+</ParamField>
+
+<ParamField path="ai.model" type="string">
+  A `provider/model-id` string, for example `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`, `google/gemini-3-flash-preview`, or `vertex/gemini-2.5-pro`. This is the model Libretto sends screenshot and HTML data to when you run `snapshot`.
+</ParamField>
+
+<ParamField path="ai.updatedAt" type="string">
+  ISO 8601 timestamp of the last time the AI config was written. Set automatically by `npx libretto ai configure`.
+</ParamField>
+
+<ParamField path="viewport" type="object">
+  Default viewport size used by `open` and `run` when you don't pass `--viewport`. Precedence: CLI `--viewport` flag > `config.json` > built-in default of `1366x768`.
+</ParamField>
+
+<ParamField path="viewport.width" type="number">
+  Viewport width in pixels. Must be a positive integer.
+</ParamField>
+
+<ParamField path="viewport.height" type="number">
+  Viewport height in pixels. Must be a positive integer.
+</ParamField>
+
+<ParamField path="windowPosition" type="object">
+  Optional. Sets the initial position of the headed browser window on screen. Has no effect in headless mode.
+</ParamField>
+
+<ParamField path="windowPosition.x" type="number">
+  Horizontal position in pixels from the left edge of the screen.
+</ParamField>
+
+<ParamField path="windowPosition.y" type="number">
+  Vertical position in pixels from the top of the screen.
+</ParamField>
+
+### AI provider setup
+
+To set your model, run:
+
+```bash  theme={null}
+npx libretto ai configure <provider>
+```
+
+Accepted provider shorthands and their default models:
+
+| Provider    | Default model                   |
+| ----------- | ------------------------------- |
+| `openai`    | `openai/gpt-5.4`                |
+| `anthropic` | `anthropic/claude-sonnet-4-6`   |
+| `gemini`    | `google/gemini-3-flash-preview` |
+| `vertex`    | `vertex/gemini-2.5-pro`         |
+
+You can also pass a full `provider/model-id` string to pin a specific version:
+
+```bash  theme={null}
+npx libretto ai configure openai/gpt-4o
+```
+
+To view the current configuration:
+
+```bash  theme={null}
+npx libretto ai configure
+```
+
+To clear it:
+
+```bash  theme={null}
+npx libretto ai configure --clear
+```
+
+#### Environment variables
+
+Provider credentials are read from your shell environment or a `.env` file at the project root. Set the variable for your chosen provider:
+
+<CodeGroup>
+  ```bash OpenAI theme={null}
+  OPENAI_API_KEY=sk-...
+  ```
+
+  ```bash Anthropic theme={null}
+  ANTHROPIC_API_KEY=sk-ant-...
+  ```
+
+  ```bash Gemini theme={null}
+  # Either of these is accepted:
+  GEMINI_API_KEY=...
+  GOOGLE_GENERATIVE_AI_API_KEY=...
+  ```
+
+  ```bash Vertex theme={null}
+  GOOGLE_CLOUD_PROJECT=my-gcp-project
+  ```
+</CodeGroup>
+
+You also need to install the matching Vercel AI SDK peer dependency:
+
+<CodeGroup>
+  ```bash OpenAI theme={null}
+  npm install @ai-sdk/openai
+  ```
+
+  ```bash Anthropic theme={null}
+  npm install @ai-sdk/anthropic
+  ```
+
+  ```bash Gemini theme={null}
+  npm install @ai-sdk/google
+  ```
+
+  ```bash Vertex theme={null}
+  npm install @ai-sdk/google-vertex
+  ```
+</CodeGroup>
+
+All four peer dependencies are optional — install only the one you need.
+
+### Sessions
+
+Each Libretto session gets its own directory under `.libretto/sessions/<name>/`. Sessions are created automatically when you run `npx libretto open` and are cleaned up with `npx libretto close`.
+
+**Session directory layout:**
+
+```
+.libretto/sessions/<name>/
+├── state.json      # Debug port, browser PID, session status
+├── logs.jsonl      # Structured CLI and runtime logs
+├── network.jsonl   # Captured HTTP requests and responses
+├── actions.jsonl   # Recorded user and agent actions
+└── snapshots/      # PNG screenshots and HTML captures
+    └── <run-id>/
+```
+
+#### Session files
+
+**`state.json`** — Metadata Libretto uses to reconnect to a running browser: the CDP debug port, the browser process PID, and the session status (`running`, `paused`, `exited`).
+
+**`logs.jsonl`** — Structured JSONL log of CLI events for the session. Useful for tracing what happened during a run.
+
+**`network.jsonl`** — One entry per HTTP request/response captured while the session was open. Each entry includes `ts`, `method`, `url`, `status`, `contentType`, and `responseBody`. Query with `jq`:
+
+```bash  theme={null}
+# Show all POST requests
+jq 'select(.method == "POST")' .libretto/sessions/my-session/network.jsonl
+```
+
+**`actions.jsonl`** — One entry per user or agent action. User entries include `bestSemanticSelector`, `nearbyText`, and coordinates. Agent entries include the Playwright locator and duration. Query with `jq`:
+
+```bash  theme={null}
+# Last 20 actions
+tail -n 20 .libretto/sessions/my-session/actions.jsonl | jq .
+```
+
+**`snapshots/`** — One subdirectory per `snapshot` run, containing the captured PNG and HTML file.
+
+Sessions are git-ignored by `.libretto/.gitignore`.
+
+### Profiles
+
+Profiles save browser session state — cookies, localStorage, and other persistent storage — so you can reuse authenticated state across runs without logging in again each time.
+
+**Location:** `.libretto/profiles/<domain>.json`
+
+#### Saving a profile
+
+1. Open the site in headed mode so you can log in manually:
+
+   ```bash  theme={null}
+   npx libretto open https://app.example.com --headed
+   ```
+
+2. Log in to the site in the browser window.
+
+3. Save the current session state as a profile:
+
+   ```bash  theme={null}
+   npx libretto save app.example.com
+   ```
+
+#### Using a profile
+
+Pass `--auth-profile <domain>` to `run`:
+
+```bash  theme={null}
+npx libretto run ./integration.ts main --auth-profile app.example.com
+```
+
+<Warning>
+  Sessions can expire. If a profile stops working, repeat the login and save flow to refresh it.
+</Warning>
+
+Profiles are machine-local and git-ignored. They are not safe to commit or share — they contain authentication tokens for live accounts.

--- a/apps/website/src/docs/content/pages/convert-to-network-requests.mdx
+++ b/apps/website/src/docs/content/pages/convert-to-network-requests.mdx
@@ -1,0 +1,204 @@
+## Convert to network requests
+
+> Convert browser automations to direct API calls for speed and reliability.
+
+Browser automation is reliable, but it's not always the fastest approach. When a site's internal API is accessible from within the browser context, calling those endpoints directly is faster and less fragile than driving the UI — no selectors to maintain, no page rendering to wait for, and no DOM changes to break your script.
+
+Libretto captures all network traffic during a browser session, so your agent can inspect exactly which API calls the site makes and convert a UI-based workflow to direct requests.
+
+### Example prompt
+
+> We have a browser script at ./integration.ts that automates going to Hacker News and getting the first 10 posts. Convert it to direct network scripts instead. Use the Libretto skill.
+
+The agent runs the existing script, examines the captured network log, identifies the API endpoints that return the data, and rewrites the integration to call them directly from within the browser context.
+
+### The process
+
+<Steps>
+  <Step title="Run the existing script and capture traffic">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headed
+    ```
+
+    Running the script with Libretto automatically captures all network requests and responses to `.libretto/sessions/<session>/network.jsonl`.
+  </Step>
+
+  <Step title="Examine the network log">
+    ```bash  theme={null}
+    npx libretto network
+    ```
+
+    The agent reviews the captured requests to find API calls that return the data you need:
+
+    ```bash  theme={null}
+    # Filter for JSON API responses
+    jq 'select(.contentType | test("application/json"))' \
+      .libretto/sessions/<session>/network.jsonl
+
+    # Find POST requests
+    jq 'select(.method == "POST")' \
+      .libretto/sessions/<session>/network.jsonl
+    ```
+  </Step>
+
+  <Step title="Run a site security review">
+    Before committing to a network-first approach, the agent checks whether direct API calls are safe on this site:
+
+    * Is there enterprise bot protection (Akamai, PerimeterX, Cloudflare)?
+    * Is `window.fetch` monkey-patched to inspect call stacks?
+    * Does the site do API-level monitoring?
+
+    This determines which network strategy to use.
+  </Step>
+
+  <Step title="Choose the right network approach">
+    <Tabs>
+      <Tab title="In-browser fetch">
+        Call endpoints from within the browser's JavaScript context. The requests share the browser's cookies, TLS fingerprint, and origin — they look identical to requests the site's own code would make.
+
+        ```typescript  theme={null}
+        // In your workflow file
+        const data = await page.evaluate(async () => {
+          const res = await fetch("/api/items?page=1");
+          return res.json();
+        });
+        ```
+
+        Use this when the site has no bot protection and `fetch` is not monkey-patched.
+      </Tab>
+
+      <Tab title="Passive interception">
+        Set up a `page.on('response', ...)` listener before navigating. The requests happen naturally as the site loads; you capture the responses without making any extra calls.
+
+        ```typescript  theme={null}
+        const capturedData: unknown[] = [];
+
+        page.on("response", async (response) => {
+          if (response.url().includes("/api/items")) {
+            capturedData.push(await response.json());
+          }
+        });
+
+        await page.goto("https://example.com");
+        await page.waitForSelector(".item-list");
+        ```
+
+        Use this when the site has bot protection or monkey-patches `fetch` — no extra requests means no anomalous call stack patterns to flag.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Rewrite the workflow">
+    The agent replaces the DOM-extraction logic with typed API client methods:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Post = {
+      id: number;
+      title: string;
+      url: string;
+      score: number;
+      by: string;
+    };
+
+    type Output = { posts: Post[] };
+
+    class HackerNewsClient {
+      constructor(private page: import("playwright").Page) {}
+
+      private async apiFetch(path: string): Promise<string> {
+        return await this.page.evaluate(
+          async ({ path }) => {
+            const res = await fetch(`https://hacker-news.firebaseio.com${path}`);
+            if (!res.ok) throw new Error(`${res.status} for ${path}`);
+            return res.text();
+          },
+          { path },
+        );
+      }
+
+      async getTopStoryIds(): Promise<number[]> {
+        const raw = await this.apiFetch("/v0/topstories.json");
+        return JSON.parse(raw);
+      }
+
+      async getItem(id: number): Promise<Post> {
+        const raw = await this.apiFetch(`/v0/item/${id}.json`);
+        return JSON.parse(raw);
+      }
+    }
+
+    export const topPosts = workflow<{}, Output>(async (ctx): Promise<Output> => {
+      const { page } = ctx;
+      await page.goto("https://news.ycombinator.com");
+
+      const client = new HackerNewsClient(page);
+      const ids = (await client.getTopStoryIds()).slice(0, 10);
+      const posts = await Promise.all(ids.map((id) => client.getItem(id)));
+
+      return { posts };
+    });
+    ```
+  </Step>
+
+  <Step title="Validate headless">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts topPosts --headless
+    ```
+
+    Confirm the output matches what the browser-based version returned.
+  </Step>
+</Steps>
+
+### When to use direct network calls
+
+The network approach is the default preference for new integrations. Use it when:
+
+* The site exposes a usable JSON API
+* You need to paginate deeply (fetching page 50 without clicking "next" 49 times)
+* You want data the UI doesn't display (hidden fields, metadata, IDs)
+* Speed and reliability matter more than DOM fidelity
+
+### When not to use the network approach
+
+<Warning>
+  Check the site's security posture before committing to a network-first strategy. Do not use direct `fetch()` calls if:
+
+  * The site has enterprise bot protection (Akamai, PerimeterX, Shape Security) **and** you've confirmed fetch is monkey-patched
+  * `window.fetch` is wrapped with call-stack inspection — your calls will be flagged because they don't originate from the site's own bundled code
+  * The site does API-level monitoring that correlates request timing to UI interactions
+
+  In these cases, use passive interception (`page.on('response', ...)`) instead. It captures the same data at zero additional detection risk because the requests come from the site's own code.
+</Warning>
+
+### Security analysis
+
+The Libretto skill includes a site-security review reference that guides your agent through checking for bot protection services, fetch interception, and challenge flows. The agent uses this to produce a **Site Assessment Summary** before choosing an integration strategy:
+
+```text  theme={null}
+## Site Assessment: https://example.com
+
+### Bot Detection Profile
+- Enterprise bot protection: None detected
+- Fetch/XHR interception: Native (not patched)
+- Challenge pages: None
+- Overall security posture: Low
+
+### Safe Approaches
+- page.evaluate(fetch(...)): Safe
+- page.on('response', ...): Viable
+- DOM extraction: Always available as fallback
+```
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="#one-shot-script-generation">
+    Start from scratch — give your agent a goal and let it build the workflow.
+  </Card>
+
+  <Card title="Debugging workflows" href="#debugging-workflows">
+    Reproduce failures and fix broken automations interactively.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/debugging-workflows.mdx
+++ b/apps/website/src/docs/content/pages/debugging-workflows.mdx
@@ -1,0 +1,167 @@
+## Debugging workflows
+
+> Reproduce failures, inspect live page state, and fix broken browser automations.
+
+When a Libretto workflow fails, the browser stays open at the exact point of failure. This is the key difference between debugging with Libretto and debugging with a generic test runner — you don't lose the state. Your agent can inspect the live page, test new selectors, and fix the issue before re-running to verify.
+
+### Example prompt
+
+> We have a browser script at ./integration.ts that is supposed to go to Availity and perform an eligibility check for a patient. But I'm getting a broken selector error when I run it. Fix it. Use the Libretto skill.
+
+The agent reproduces the failure, snapshots the broken state, finds the correct selector in the current DOM, patches the code, and re-runs to confirm.
+
+### The debugging workflow
+
+<Steps>
+  <Step title="Run the failing script">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --session debug-flow --headed
+    ```
+
+    Use `--headed` so you can watch the browser and see where it stops. Name the session something descriptive — you'll use it for all subsequent commands.
+  </Step>
+
+  <Step title="Browser stays open at the failure point">
+    When a workflow fails, Libretto keeps the browser open and returns control to the CLI. The agent sees the error message and knows to inspect the current page state before touching any code.
+  </Step>
+
+  <Step title="Snapshot the broken state">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session debug-flow \
+      --objective "Find the blocking error or broken selector target" \
+      --context "The workflow failed while trying to submit the eligibility form. I need to identify the element that can't be found."
+    ```
+
+    Snapshot captures the current screenshot and HTML, then uses LLM analysis to identify what's on the page, what's missing, and what the correct selectors should be. This keeps the heavy visual context out of your coding agent's context window.
+  </Step>
+
+  <Step title="Test selectors with exec">
+    Once the snapshot identifies candidate selectors, the agent validates them against the live page:
+
+    ```bash  theme={null}
+    npx libretto exec --session debug-flow \
+      "return await page.locator('[data-testid=\"member-id-input\"]').count()"
+    ```
+
+    If the count is `0`, the selector doesn't match. Try alternatives until you find one that returns `1`:
+
+    ```bash  theme={null}
+    npx libretto exec --session debug-flow \
+      "return await page.locator('input[name=\"memberId\"]').count()"
+    ```
+  </Step>
+
+  <Step title="Fix the code">
+    With the correct selector confirmed, the agent updates the workflow file. Read the code generation rules before editing production code — Playwright locator APIs, no `querySelectorAll` in `page.evaluate()`, type-safe output.
+  </Step>
+
+  <Step title="Re-run to verify">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless
+    ```
+
+    Switch to `--headless` for the verify loop — it's faster. If the run succeeds, confirm the actual returned output is correct. If it fails again, the browser stays open and you repeat from step 3.
+  </Step>
+</Steps>
+
+### Using `pause()` as a breakpoint
+
+If you need to stop a workflow at a specific point — not at failure, but at a known state you want to inspect — add a `pause()` call:
+
+```typescript  theme={null}
+import { workflow, pause } from "libretto";
+
+export const eligibilityCheck = workflow(async (ctx, input) => {
+  const { session, page } = ctx;
+
+  await page.goto("https://availity.com");
+  await page.locator("#memberSearch").fill(input.memberId);
+
+  // Pause here to inspect the page before submitting
+  await pause(session);
+
+  await page.locator("button[type='submit']").click();
+  // ...
+});
+```
+
+Run the workflow and it will halt at the `pause()` call with the browser open. Inspect, test selectors, then resume:
+
+```bash  theme={null}
+npx libretto resume --session debug-flow
+```
+
+`pause()` is a no-op when `NODE_ENV === "production"`, so you can leave it in during development and it won't affect production runs. Remove it once you're done debugging.
+
+### Reading logs for error context
+
+The session log at `.libretto/sessions/<session>/logs.jsonl` contains structured entries for every step the workflow took. Use `jq` to find the error:
+
+```bash  theme={null}
+# Find error entries
+jq 'select(.level == "error")' .libretto/sessions/debug-flow/logs.jsonl
+
+# See the last 20 log entries
+tail -n 20 .libretto/sessions/debug-flow/logs.jsonl | jq .
+```
+
+Libretto's instrumentation enriches timeout errors with element context — what was being waited for, its selector, and the page state at the time — so you're not left reading a raw timeout message.
+
+### Common errors
+
+**Broken selectors**
+
+The most common failure. A selector that worked last week no longer matches because the site updated its markup. Fix:
+
+1. Use `snapshot` to see the current DOM and identify the updated element
+2. Use `exec` to test new selectors against the live page
+3. Prefer stable selectors: `data-testid` attributes, ARIA roles, and visible label text over class names and positional selectors
+
+**Popups blocking the workflow**
+
+A modal, cookie banner, or session-expiry dialog appears unexpectedly and blocks interaction with the underlying page. Consider using `attemptWithRecovery()` from the Library API to handle known popup patterns:
+
+```typescript  theme={null}
+const result = await attemptWithRecovery(
+  ctx,
+  async () => {
+    await page.locator("#continueButton").click();
+  },
+  [
+    {
+      detect: async () =>
+        (await page.locator("#sessionExpiredModal").count()) > 0,
+      recover: async () => {
+        await page.locator("#sessionExpiredModal button").click();
+      },
+    },
+  ],
+);
+```
+
+**Timeout errors**
+
+A `waitForSelector` or locator action times out because the expected element never appeared. Check the snapshot to see what the page actually shows — it may be a loading spinner, an error state, or a redirect you didn't expect. The structured log entry will include which selector was being waited for.
+
+### Tips
+
+<Tip>
+  Use `--headless` for the fix/verify loop and `--headed` when you need to watch what's happening. Headed mode is slower but lets you see exactly what the browser is doing at each step. Switch back to headless once you've confirmed the visual behavior is correct.
+</Tip>
+
+<Tip>
+  Give your debug session a descriptive name with `--session`. If you run multiple debug sessions, names like `debug-eligibility-submit` are much easier to work with than the default session name.
+</Tip>
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="#one-shot-script-generation">
+    Build a new automation from scratch without any prior knowledge of the site.
+  </Card>
+
+  <Card title="Interactive script building" href="#interactive-script-building">
+    Show the workflow manually and let your agent turn it into reusable code.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/exec.mdx
+++ b/apps/website/src/docs/content/pages/exec.mdx
@@ -1,0 +1,142 @@
+## exec
+
+> Execute Playwright TypeScript code against the open browser page.
+
+The `exec` command runs TypeScript Playwright code against a live browser session. Use it to validate selectors, inspect page data, prototype individual steps, and experiment with interactions before encoding them in a workflow file.
+
+```bash  theme={null}
+npx libretto exec "return await page.url()"
+```
+
+### Usage
+
+<Tabs>
+  <Tab title="Single-line">
+    Pass the code as a quoted string argument:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.url()"
+    npx libretto exec "return await page.locator('button').count()"
+    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    ```
+  </Tab>
+
+  <Tab title="stdin (multi-line)">
+    Pipe code into `exec -` for complex or multi-line scripts:
+
+    ```bash  theme={null}
+    echo "return await page.url()" | npx libretto exec - --session debug-example
+    ```
+
+    ```bash  theme={null}
+    cat <<'EOF' | npx libretto exec - --session debug-example
+    const rows = await page.locator('table tbody tr').all();
+    const data = [];
+    for (const row of rows) {
+      const cells = await row.locator('td').allTextContents();
+      data.push(cells);
+    }
+    return data;
+    EOF
+    ```
+  </Tab>
+</Tabs>
+
+### Available globals
+
+Inside the code you pass to `exec`, these variables are available without any imports:
+
+| Global       | Type                      | Description                                 |
+| ------------ | ------------------------- | ------------------------------------------- |
+| `page`       | `Page`                    | The active Playwright page                  |
+| `context`    | `BrowserContext`          | The browser context for the session         |
+| `browser`    | `Browser`                 | The browser instance                        |
+| `state`      | `Record<string, unknown>` | A mutable object scoped to this `exec` call |
+| `fetch`      | `typeof fetch`            | The global fetch function                   |
+| `Buffer`     | `typeof Buffer`           | Node.js `Buffer`                            |
+| `networkLog` | `function`                | Read captured network log entries           |
+| `actionLog`  | `function`                | Read captured action log entries            |
+
+### Flags
+
+<ParamField path="code" type="string" required>
+  The Playwright TypeScript code to execute, passed as the first positional argument. Pass `-` to read from stdin.
+</ParamField>
+
+<ParamField path="--session" type="string" required>
+  The session to execute against.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Target a specific page ID within the session. Use `npx libretto pages --session <name>` to list page IDs when a popup or new tab is open.
+</ParamField>
+
+<ParamField path="--visualize" type="boolean">
+  Enable ghost cursor and highlight visualization. Shows a visible cursor trace and element highlights as Playwright interacts with the page.
+</ParamField>
+
+### Return values
+
+If the code returns a value, `exec` prints it to stdout:
+
+* Strings are printed as-is.
+* All other values are printed as pretty-printed JSON.
+* If the code returns nothing (`undefined`), `exec` prints `Executed successfully`.
+
+```bash  theme={null}
+npx libretto exec "return await page.title()"
+# My Page Title
+
+npx libretto exec "return await page.locator('li').count()"
+# 12
+```
+
+### Rules
+
+<Warning>
+  **Let failures throw.** Do not hide `exec` failures with `try/catch` or `.catch()`. Swallowed errors make debugging harder — surface them so you can see exactly what failed.
+</Warning>
+
+<Warning>
+  **Do not run multiple `exec` commands in parallel.** Each `exec` call drives the same browser page. Running them concurrently causes race conditions.
+</Warning>
+
+* Use `exec` for focused inspection and short-lived interaction experiments.
+* Use `exec -` (stdin) for complex multi-line scripts.
+* Validate a selector with `exec` before encoding it in a workflow file.
+* Use `exec` to prototype a single step, then move the working code into your `.ts` workflow file.
+
+### Examples
+
+```bash  theme={null}
+# Return the current URL
+npx libretto exec "return await page.url()"
+
+# Count how many buttons are on the page
+npx libretto exec "return await page.locator('button').count()"
+
+# Click a button
+npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+
+# Read a value from an input field
+npx libretto exec "return await page.locator('input[name=\"email\"]').inputValue()"
+
+# Run against a named session
+npx libretto exec --session debug-example "return await page.url()"
+
+# Run against a specific page in a session
+npx libretto exec --session debug-example --page <page-id> "return await page.url()"
+
+# Pipe from stdin (multi-line, named session)
+echo "return await page.url()" | npx libretto exec - --session debug-example
+```
+
+<CardGroup cols={2}>
+  <Card title="snapshot" icon="camera" href="#snapshot">
+    Use snapshot to identify selectors before running exec.
+  </Card>
+
+  <Card title="run & resume" icon="play" href="#run-resume">
+    Move validated exec code into a workflow file and run it end to end.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/extraction.mdx
+++ b/apps/website/src/docs/content/pages/extraction.mdx
@@ -1,0 +1,134 @@
+## AI Extraction
+
+> Extract structured data from pages using AI-powered analysis.
+
+`extractFromPage()` combines a screenshot with DOM content and sends both to an LLM to extract structured data matching a Zod schema. Because the visual analysis happens in a separate LLM call, it keeps your coding agent's context window free of raw HTML.
+
+### `extractFromPage()`
+
+```typescript  theme={null}
+async function extractFromPage<T extends z.ZodType>(
+  options: ExtractOptions<T>
+): Promise<z.infer<T>>
+```
+
+#### How it works
+
+* **With `selector`**: waits for the element to be visible, takes a screenshot of just that element, and reads its `innerHTML` (truncated at 30 000 characters).
+* **Without `selector`**: takes a full-page screenshot via CDP and reads the full page HTML (truncated at 50 000 characters).
+
+Both the screenshot and the DOM snippet are sent to the LLM together with your instruction. The response is parsed and validated against your Zod schema before being returned.
+
+#### `ExtractOptions<T>`
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to extract from.
+</ParamField>
+
+<ParamField path="instruction" type="string" required>
+  A natural-language description of what to extract. For example: `"Extract the first 5 search results"`.
+</ParamField>
+
+<ParamField path="schema" type="T extends z.ZodType" required>
+  A Zod schema that describes the shape of the data you want back. The return type of `extractFromPage` is `z.infer<T>`.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient" required>
+  An LLM client instance. Create one with [`createLLMClientFromModel()`](#createllmclientfrommodel). The backing model must support vision (multimodal) input because `extractFromPage` always sends a screenshot.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Defaults to a simple `console`-based logger when omitted.
+</ParamField>
+
+<ParamField path="selector" type="string">
+  Optional CSS selector. When provided, the screenshot and DOM capture are scoped to the matching element instead of the full page. Useful for large pages where you only care about one section.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { extractFromPage, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+const SearchResult = z.object({
+  title: z.string(),
+  url: z.string(),
+  snippet: z.string(),
+});
+
+const results = await extractFromPage({
+  page,
+  instruction: "Extract the first 5 search results",
+  schema: z.array(SearchResult),
+  llmClient,
+  // Optional: scope to a specific element
+  selector: ".search-results",
+});
+// results is typed as Array<{ title: string; url: string; snippet: string }>
+```
+
+<Tip>
+  Use `selector` to narrow extraction to a single widget or table when the full page HTML is large. Scoped extraction is faster and uses fewer tokens.
+</Tip>
+
+***
+
+### `createLLMClientFromModel()`
+
+Creates a Libretto `LLMClient` from a Vercel AI SDK `LanguageModel`. This is the standard way to supply an LLM client to `extractFromPage`, `attemptWithRecovery`, and `detectSubmissionError`.
+
+```typescript  theme={null}
+function createLLMClientFromModel(model: LanguageModel): LLMClient
+```
+
+<ParamField path="model" type="LanguageModel" required>
+  A Vercel AI SDK language model instance. Pass the result of calling a provider factory such as `openai("gpt-4o")`, `anthropic("claude-3-5-sonnet-20241022")`, or `google("gemini-1.5-pro")`.
+</ParamField>
+
+#### Supported providers
+
+Any provider that implements the Vercel AI SDK `LanguageModel` interface works. The most common ones:
+
+| Package                 | Example                                   |
+| ----------------------- | ----------------------------------------- |
+| `@ai-sdk/openai`        | `openai("gpt-4o")`                        |
+| `@ai-sdk/anthropic`     | `anthropic("claude-3-5-sonnet-20241022")` |
+| `@ai-sdk/google`        | `google("gemini-1.5-pro")`                |
+| `@ai-sdk/google-vertex` | `vertex("gemini-1.5-pro")`                |
+
+#### Example
+
+```typescript  theme={null}
+import { createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+```
+
+#### `LLMClient` interface
+
+You can also implement `LLMClient` directly if you want to use a provider that is not in the Vercel AI SDK:
+
+```typescript  theme={null}
+interface LLMClient {
+  generateObject<T extends z.ZodType>(opts: {
+    prompt: string;
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+
+  generateObjectFromMessages<T extends z.ZodType>(opts: {
+    messages: Message[];
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+}
+```
+
+<Note>
+  Implementations should throw on failure rather than returning sentinel values like `null` or `undefined`. Libretto relies on thrown exceptions to trigger retry and recovery logic.
+</Note>

--- a/apps/website/src/docs/content/pages/instrumentation.mdx
+++ b/apps/website/src/docs/content/pages/instrumentation.mdx
@@ -1,0 +1,274 @@
+## Instrumentation
+
+> Add ghost cursor visualization and error enrichment to Playwright pages.
+
+Instrumentation wraps Playwright's locator and page actions with two capabilities:
+
+* **Visualization** — before each action, a ghost cursor animates to the target element and the element is highlighted. After the action, the highlight clears.
+* **Error enrichment** — when a pointer action (`click`, `dblclick`, `hover`) times out, additional context is captured and attached to the error.
+
+### `instrumentPage()`
+
+Applies instrumentation to a `Page` in place and returns it typed as `InstrumentedPage`. The original page object is modified directly.
+
+```typescript  theme={null}
+async function instrumentPage(
+  page: Page,
+  options?: InstrumentationOptions
+): Promise<InstrumentedPage>
+```
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to instrument.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { instrumentPage } from "libretto";
+
+const instrumented = await instrumentPage(page, {
+  visualize: true,
+  highlightBeforeActionMs: 500,
+  logger,
+});
+
+// All subsequent locator actions show ghost cursor + element highlights
+await instrumented.locator("#submit").click();
+await instrumented.locator("#email").fill("user@example.com");
+```
+
+***
+
+### `installInstrumentation()`
+
+Same as `instrumentPage()` but returns `void` instead of the page. Useful when you don't need the typed return value, or when you want to instrument a page that was passed in from elsewhere.
+
+```typescript  theme={null}
+async function installInstrumentation(
+  page: Page,
+  options?: InstrumentationOptions
+): Promise<void>
+```
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to patch in place.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+<Note>
+  Calling `installInstrumentation()` (or `instrumentPage()`) on an already-instrumented page is a no-op. The check is based on the presence of `page.__librettoInstrumented`.
+</Note>
+
+***
+
+### `instrumentContext()`
+
+Instruments all current pages in a `BrowserContext` and automatically instruments any pages that open in the future. Useful when connecting to an existing browser via CDP, or when your workflow opens multiple tabs.
+
+```typescript  theme={null}
+async function instrumentContext(
+  context: BrowserContext,
+  options?: InstrumentationOptions
+): Promise<void>
+```
+
+<ParamField path="context" type="BrowserContext" required>
+  The Playwright `BrowserContext` to instrument.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { instrumentContext } from "libretto";
+
+await instrumentContext(browserContext, { visualize: true, logger });
+
+// All existing pages are now instrumented.
+// Any new page opened in this context will be instrumented automatically.
+const newPage = await browserContext.newPage();
+```
+
+***
+
+### `InstrumentationOptions`
+
+<ParamField path="visualize" type="boolean">
+  Enable ghost cursor animation and element highlight overlays. Defaults to `false`.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Navigation actions (`goto`, `reload`, `goBack`, `goForward`) are logged at `info` level when a logger is provided.
+</ParamField>
+
+<ParamField path="highlightBeforeActionMs" type="number">
+  How long (in milliseconds) to show the element highlight before performing the action. Defaults to `350`.
+</ParamField>
+
+<ParamField path="ghostCursor" type="GhostCursorOptions">
+  Options for the ghost cursor overlay.
+
+  <Expandable title="GhostCursorOptions">
+    <ParamField path="style" type="&#x22;minimal&#x22; | &#x22;dot&#x22; | &#x22;screenstudio&#x22;">
+      Visual style of the cursor. `"minimal"` is a small arrow SVG (default). `"dot"` is a filled circle. `"screenstudio"` is a glowing circle.
+    </ParamField>
+
+    <ParamField path="color" type="string">
+      CSS color for the cursor. Defaults to `"rgba(255, 70, 70, 0.9)"`.
+    </ParamField>
+
+    <ParamField path="size" type="number">
+      Cursor size in pixels. Defaults to `23`.
+    </ParamField>
+
+    <ParamField path="zIndex" type="number">
+      CSS `z-index` for the cursor overlay. Defaults to `2147483646`.
+    </ParamField>
+
+    <ParamField path="easing" type="string">
+      CSS easing function for cursor movement. Defaults to `"cubic-bezier(0.16, 1, 0.3, 1)"`.
+    </ParamField>
+
+    <ParamField path="minDurationMs" type="number">
+      Minimum movement duration in milliseconds. Defaults to `100`.
+    </ParamField>
+
+    <ParamField path="maxDurationMs" type="number">
+      Maximum movement duration in milliseconds. Defaults to `600`.
+    </ParamField>
+
+    <ParamField path="speedPxPerMs" type="number">
+      Cursor speed in pixels per millisecond used to calculate distance-based duration. Defaults to `1.5`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField path="highlight" type="HighlightOptions">
+  Options for the element highlight overlay.
+
+  <Expandable title="HighlightOptions">
+    <ParamField path="color" type="string">
+      CSS color for the highlight rectangle. Defaults to `"rgba(59, 130, 246, 0.25)"`.
+    </ParamField>
+
+    <ParamField path="zIndex" type="number">
+      CSS `z-index` for the highlight layer. Defaults to `2147483645`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+***
+
+### Standalone visualization functions
+
+You can use the ghost cursor and highlight primitives directly without going through `instrumentPage`.
+
+#### Ghost cursor
+
+##### `ensureGhostCursor(page, options?)`
+
+Injects the ghost cursor overlay into the page if it is not already present. Also installs a `page.addInitScript` so the cursor reappears after navigation.
+
+```typescript  theme={null}
+async function ensureGhostCursor(page: Page, options?: GhostCursorOptions): Promise<void>
+```
+
+##### `moveGhostCursor(page, target)`
+
+Animates the ghost cursor to a specific coordinate.
+
+```typescript  theme={null}
+async function moveGhostCursor(
+  page: Page,
+  target: { x: number; y: number; durationMs?: number }
+): Promise<void>
+```
+
+##### `ghostClick(page, target)`
+
+Animates a press-and-release visual feedback on the ghost cursor at the given coordinates.
+
+```typescript  theme={null}
+async function ghostClick(page: Page, target: { x: number; y: number }): Promise<void>
+```
+
+##### `hideGhostCursor(page)`
+
+Fades the ghost cursor out.
+
+```typescript  theme={null}
+async function hideGhostCursor(page: Page): Promise<void>
+```
+
+#### Highlight layer
+
+##### `ensureHighlightLayer(page, options?)`
+
+Injects the highlight layer into the page if it is not already present.
+
+```typescript  theme={null}
+async function ensureHighlightLayer(page: Page, options?: HighlightOptions): Promise<void>
+```
+
+##### `showHighlight(page, params)`
+
+Draws a highlight rectangle over a bounding box. The highlight fades out automatically after `durationMs`.
+
+```typescript  theme={null}
+async function showHighlight(
+  page: Page,
+  params: {
+    box: { x: number; y: number; width: number; height: number };
+    label?: string;
+    color?: string;
+    durationMs?: number;
+  }
+): Promise<void>
+```
+
+##### `clearHighlights(page)`
+
+Removes all highlight rectangles from the layer immediately.
+
+```typescript  theme={null}
+async function clearHighlights(page: Page): Promise<void>
+```
+
+#### Standalone example
+
+```typescript  theme={null}
+import {
+  ensureGhostCursor,
+  moveGhostCursor,
+  ghostClick,
+  ensureHighlightLayer,
+  showHighlight,
+  clearHighlights,
+} from "libretto";
+
+await ensureGhostCursor(page, { style: "dot", color: "rgba(0, 120, 255, 0.9)" });
+await ensureHighlightLayer(page);
+
+const box = await page.locator("#submit").boundingBox();
+if (box) {
+  await showHighlight(page, { box, durationMs: 400 });
+  await moveGhostCursor(page, {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  });
+  await ghostClick(page, { x: box.x + box.width / 2, y: box.y + box.height / 2 });
+}
+
+await clearHighlights(page);
+```

--- a/apps/website/src/docs/content/pages/interactive-script-building.mdx
+++ b/apps/website/src/docs/content/pages/interactive-script-building.mdx
@@ -1,0 +1,147 @@
+## Interactive script building
+
+> Record your actions in the browser and let your agent turn them into automation code.
+
+Some workflows are too complex to describe in words alone — especially in healthcare software and legacy web apps where the interaction sequence matters and the UI has unusual patterns. Interactive script building lets you perform the workflow yourself, with Libretto recording every click, fill, and navigation. Your agent then reads the action log and translates what you did into a reusable automation script.
+
+### Example prompt
+
+> I'm gonna show you a workflow in the eclinicalworks EHR to get a patient's primary insurance ID. Use libretto skill to turn it into a playwright script that takes patient name and dob as input to get back the insurance ID. URL is ...
+
+You perform the workflow once in the browser. Libretto captures the full action log. The agent reads it and writes a script that can run the same steps programmatically.
+
+### Step-by-step process
+
+<Steps>
+  <Step title="Agent opens a headed browser">
+    ```bash  theme={null}
+    npx libretto open https://your-ehr.example.com --headed
+    ```
+
+    The browser opens on your screen. You're in control from here.
+  </Step>
+
+  <Step title="You perform the workflow manually">
+    Navigate through the application exactly as you would normally. Log in, search for a patient, open their record, find the insurance tab — whatever the workflow requires. Libretto records everything happening in the browser as you go.
+  </Step>
+
+  <Step title="Libretto records your actions">
+    Every click, form fill, and navigation is written to the action log at:
+
+    ```
+    .libretto/sessions/<session>/actions.jsonl
+    ```
+
+    Each entry captures the action type, the element you interacted with, the value you typed (if any), and the URL of the page at that moment.
+  </Step>
+
+  <Step title="Agent reads what you did">
+    ```bash  theme={null}
+    npx libretto actions
+    ```
+
+    The agent reads the action log to reconstruct your workflow step by step. It can also query the log with `jq` to find specific actions or filter by page:
+
+    ```bash  theme={null}
+    # See all fill actions (form inputs you typed into)
+    jq 'select(.action == "fill")' .libretto/sessions/<session>/actions.jsonl
+
+    # See the last 20 actions
+    tail -n 20 .libretto/sessions/<session>/actions.jsonl | jq .
+    ```
+  </Step>
+
+  <Step title="Agent inspects network traffic">
+    ```bash  theme={null}
+    npx libretto network
+    ```
+
+    The agent cross-references your actions with the network requests they triggered. This helps identify the underlying API calls so the workflow can be converted to direct requests if needed.
+  </Step>
+
+  <Step title="Agent writes the workflow file">
+    Using the action log as a blueprint, the agent writes a TypeScript workflow that replicates your steps:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Input = {
+      patientName: string;
+      dob: string; // YYYY-MM-DD
+    };
+
+    type Output = {
+      primaryInsuranceId: string;
+    };
+
+    export const getInsuranceId = workflow<Input, Output>(
+      async (ctx, input): Promise<Output> => {
+        const { page } = ctx;
+
+        await page.goto("https://your-ehr.example.com");
+
+        // Search for the patient by name and DOB
+        await page.locator("#patientSearch").fill(input.patientName);
+        await page.locator("#dobField").fill(input.dob);
+        await page.locator("button[type='submit']").click();
+
+        // Open the patient record
+        await page.locator(".patient-result").first().click();
+
+        // Navigate to insurance tab
+        await page.locator("#insuranceTab").click();
+
+        // Extract the primary insurance ID
+        const insuranceId = await page
+          .locator("[data-field='primaryInsuranceId']").textContent();
+
+        return { primaryInsuranceId: insuranceId?.trim() ?? "" };
+      },
+    );
+    ```
+  </Step>
+
+  <Step title="Agent validates with a headless run">
+    ```bash  theme={null}
+    npx libretto run ./get-insurance-id.ts getInsuranceId --headless \
+      --params '{"patientName": "Jane Smith", "dob": "1985-04-12"}'
+    ```
+
+    The agent confirms the actual returned output matches what you'd expect.
+  </Step>
+</Steps>
+
+### What the action log captures
+
+Each entry in `actions.jsonl` is a JSON object on its own line. User-initiated events include:
+
+* `action` — what happened: `click`, `dblclick`, `fill`, `goto`, etc.
+* `bestSemanticSelector` — the most stable selector for the element you interacted with
+* `value` — the text you typed or option you selected
+* `url` — the page URL at the time of the action
+* `nearbyText` — visible text near the element, for human context
+
+Agent-initiated events include the Playwright locator used and whether the action succeeded.
+
+<Note>
+  The `bestSemanticSelector` field in user action entries is the most reliable selector to use in generated code. It's the canonical identifier Libretto chose for the element based on the DOM structure — prefer it over `targetSelector` or raw CSS paths when writing workflow code.
+</Note>
+
+### When to use this approach
+
+* The workflow involves many steps and is hard to describe concisely
+* You're working with EHR, healthcare, or legacy enterprise software with unusual UI patterns
+* You want to delegate the "figure out the selectors" work entirely to the agent
+* The workflow involves conditional paths that are easier to show than explain
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="#one-shot-script-generation">
+    Let the agent explore a site and build the workflow without your involvement.
+  </Card>
+
+  <Card title="Debugging workflows" href="#debugging-workflows">
+    Reproduce failures, inspect live page state, and fix broken automations.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/introduction.mdx
+++ b/apps/website/src/docs/content/pages/introduction.mdx
@@ -1,0 +1,94 @@
+## Introduction
+
+> Libretto is the AI toolkit for building and maintaining browser automations.
+
+Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to inspect pages, capture traffic, record actions, and debug workflows — all without flooding your agent's context window with raw HTML.
+
+Built by the team at [Saffron Health](https://saffron.health), Libretto was created to help maintain browser integrations to common healthcare software. It's open-source so other teams can do the same.
+
+### Core capabilities
+
+Libretto is organized around four capabilities that cover the full lifecycle of a browser automation:
+
+**Inspect live pages** — Take a snapshot of any open page and let a vision model extract selectors, identify interactive elements, and summarize the visible state. Snapshot analysis runs in a separate process so the results are token-efficient summaries, not raw DOM dumps.
+
+**Capture network traffic** — Record every HTTP request and response made by the browser. Libretto writes these to a structured JSONL log you can query with `jq` or pass directly to your agent to reverse-engineer the site's API.
+
+**Record user actions** — As you interact with a page manually, Libretto captures each DOM event with a semantic selector, nearby text, and coordinates. Your agent can read these recorded actions and reconstruct the workflow as a typed Playwright script.
+
+**Debug broken workflows** — When a workflow fails, Libretto keeps the browser open. Your agent can inspect the live page state with `snapshot` and `exec`, identify the broken selector or unexpected page change, patch the code, and re-run — all without restarting from scratch.
+
+### The skill concept
+
+Libretto is designed to be loaded as a **skill** in your coding agent. A skill is a set of instructions that tells your agent when and how to use a tool. When you give your agent the Libretto skill, it knows to:
+
+* Open a browser before guessing at page structure
+* Use `snapshot` as the primary observation tool instead of reading raw HTML
+* Prefer network request approaches over UI automation when the site allows it
+* Validate a finished workflow with a headless `run` before declaring it done
+
+The skill file ships with the package at `skills/libretto/SKILL.md` and is automatically copied into `.agents/skills/libretto` and `.claude/skills/libretto` when you run `npx libretto init`.
+
+You can invoke Libretto skills with natural language prompts like:
+
+> Use the Libretto skill. Go to LinkedIn and scrape the first 10 posts — content, author, reaction count, and first 25 comments.
+
+> I'll show you a workflow in eClinicalWorks to get a patient's primary insurance ID. Use the Libretto skill to turn it into a Playwright script.
+
+> We have a browser script at `./integration.ts` that's throwing a broken selector error. Fix it. Use the Libretto skill.
+
+### Architecture overview
+
+#### CLI vs Library API
+
+Libretto ships two interfaces:
+
+* **CLI** (`npx libretto <command>`) — the primary interface for both agents and humans. Commands open browsers, take snapshots, execute Playwright code, run workflow files, and manage sessions. Every command accepts `--session <name>` to target a specific browser session.
+
+* **Library API** (`import { workflow } from "libretto"`) — used inside workflow files you want to run with `npx libretto run`. The `workflow()` function wraps your automation handler and gives it typed access to `page`, `session`, `logger`, and optional application services.
+
+#### Sessions
+
+A **session** is a named browser context. When you run `npx libretto open https://example.com --session my-session`, Libretto launches a Chromium instance and registers it under that name. Subsequent commands (`snapshot`, `exec`, `network`, `actions`) all target that session by name.
+
+If you don't pass `--session`, Libretto uses a default session name. Sessions are independent — you can have multiple sessions open at the same time, each pointing to a different browser or URL.
+
+#### The `.libretto/` directory
+
+All Libretto state lives in a `.libretto/` directory at your project root:
+
+```
+.libretto/
+├── config.json          # AI model and viewport settings
+├── sessions/
+│   └── <name>/
+│       ├── state.json   # Debug port, PID, status
+│       ├── logs.jsonl   # Structured session logs
+│       ├── network.jsonl
+│       ├── actions.jsonl
+│       └── snapshots/   # PNG + HTML captures
+└── profiles/
+    └── <domain>.json    # Saved auth state
+```
+
+Sessions and profiles are automatically git-ignored by a `.libretto/.gitignore` file that `npx libretto init` creates.
+
+### Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quick start" icon="rocket" href="#quick-start">
+    Install Libretto and run your first browser automation in minutes.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="#open-connect">
+    Full reference for every Libretto command and flag.
+  </Card>
+
+  <Card title="Library API" icon="code" href="#workflow">
+    Write workflow files with the typed `workflow()` API.
+  </Card>
+
+  <Card title="Configuration" icon="settings" href="#configuration">
+    Configure Libretto's AI provider, viewport, and session defaults.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/introduction.mdx
+++ b/apps/website/src/docs/content/pages/introduction.mdx
@@ -27,7 +27,7 @@ Libretto is designed to be loaded as a **skill** in your coding agent. A skill i
 * Prefer network request approaches over UI automation when the site allows it
 * Validate a finished workflow with a headless `run` before declaring it done
 
-The skill file ships with the package at `skills/libretto/SKILL.md` and is automatically copied into `.agents/skills/libretto` and `.claude/skills/libretto` when you run `npx libretto init`.
+The skill file ships with the package at `skills/libretto/SKILL.md` and is automatically copied into `.agents/skills/libretto` and `.claude/skills/libretto` when you run `npx libretto setup`.
 
 You can invoke Libretto skills with natural language prompts like:
 
@@ -71,7 +71,7 @@ All Libretto state lives in a `.libretto/` directory at your project root:
     └── <domain>.json    # Saved auth state
 ```
 
-Sessions and profiles are automatically git-ignored by a `.libretto/.gitignore` file that `npx libretto init` creates.
+Sessions and profiles are automatically git-ignored by a `.libretto/.gitignore` file that `npx libretto setup` creates.
 
 ### Next steps
 

--- a/apps/website/src/docs/content/pages/logging.mdx
+++ b/apps/website/src/docs/content/pages/logging.mdx
@@ -1,0 +1,255 @@
+## Logging
+
+> Structured logging with pluggable sinks for browser automation workflows.
+
+Libretto ships a structured logger that routes log entries to one or more pluggable sinks. Every public API that accepts an optional `logger` parameter accepts a `MinimalLogger`, so you can pass in either the full `Logger` class or any compatible object.
+
+### `Logger`
+
+The main logger class. Construct it with an array of sinks.
+
+```typescript  theme={null}
+new Logger(
+  scopes?: string[],
+  sinks?: LoggerSink[],
+  scopeData?: Record<string, any>
+)
+```
+
+In practice you usually construct a `Logger` by passing only `sinks`:
+
+```typescript  theme={null}
+import { Logger, prettyConsoleSink, createFileLogSink } from "libretto";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({
+      filePath: ".libretto/sessions/my-session/logs.jsonl",
+    }),
+  ]
+);
+```
+
+`Logger` implements `LoggerApi` and also satisfies `MinimalLogger`.
+
+#### `Logger.withSink(sink)`
+
+Returns a new `Logger` that writes to all existing sinks plus the additional `sink`. The original logger is not modified.
+
+```typescript  theme={null}
+const fileLogger = logger.withSink(
+  createFileLogSink({ filePath: ".libretto/sessions/my-session/logs.jsonl" })
+);
+```
+
+#### `defaultLogger`
+
+A pre-built `MinimalLogger` that writes to `console.log / console.warn / console.error` with `[INFO]`, `[WARN]`, and `[ERROR]` prefixes. Used as the fallback when you omit the `logger` option on any Libretto function.
+
+```typescript  theme={null}
+import { defaultLogger } from "libretto";
+```
+
+***
+
+### `LoggerApi` interface
+
+The full interface implemented by `Logger`.
+
+<ResponseField name="log" type="(event: string, data?: Record<string, any>, options?: LogOptions) => void">
+  Logs an entry at `"log"` level.
+</ResponseField>
+
+<ResponseField name="info" type="(event: string, data?, options?: LogOptions) => void">
+  Logs an entry at `"info"` level. `data` can be an `Error`, `{ error: Error, ...rest }`, or any plain object.
+</ResponseField>
+
+<ResponseField name="warn" type="(event: string, data?, options?: LogOptions) => void">
+  Logs an entry at `"warn"` level.
+</ResponseField>
+
+<ResponseField name="error" type="(event: string, data?, options?: LogOptions) => Error">
+  Logs an entry at `"error"` level and returns an `Error` object. If `data` is or contains an `Error`, that error is returned; otherwise a new `Error` is constructed from `event`.
+</ResponseField>
+
+<ResponseField name="withScope" type="(scope: string, context?: Record<string, any>) => LoggerApi">
+  Returns a new `LoggerApi` with an additional scope segment prepended to all log entries. Scope segments are joined with `.` (e.g. `"workflow.network"`).
+</ResponseField>
+
+<ResponseField name="withContext" type="(context: Record<string, any>) => LoggerApi">
+  Returns a new `LoggerApi` with additional key-value pairs merged into every log entry's `data`.
+</ResponseField>
+
+<ResponseField name="flush" type="() => Promise<void>">
+  Flushes all sinks in reverse order (most recently added first).
+</ResponseField>
+
+***
+
+### `MinimalLogger` type
+
+A minimal subset of `LoggerApi`. Any object with `info`, `warn`, and `error` methods satisfies this type, which is what every Libretto runtime function accepts for its optional `logger` parameter.
+
+```typescript  theme={null}
+type MinimalLogger = {
+  info: (event: string, data?: any) => void;
+  warn: (event: string, data?: any) => void;
+  error: (event: string, data?: any) => any;
+};
+```
+
+***
+
+### `LogOptions`
+
+<ParamField path="timestamp" type="Date">
+  Override the timestamp written to the log entry. Defaults to `new Date()` at write time.
+</ParamField>
+
+***
+
+### `LoggerSink` type
+
+A sink is any object with a `write` method. Implement this interface to route log output to any destination.
+
+```typescript  theme={null}
+type LoggerSink = {
+  write: (args: {
+    id: string;
+    scope: string;
+    level: "log" | "error" | "warn" | "info";
+    event: string;
+    data: Record<string, any>;
+    options?: LogOptions;
+  }) => void;
+  flush?: () => Promise<void>;
+  close?: () => Promise<void>;
+};
+```
+
+<ResponseField name="write" type="(args) => void">
+  Called for every log entry. `id` is a unique random identifier per entry.
+</ResponseField>
+
+<ResponseField name="flush" type="() => Promise<void>">
+  Optional. Called by `Logger.flush()` to ensure buffered entries are written.
+</ResponseField>
+
+<ResponseField name="close" type="() => Promise<void>">
+  Optional. Called by `Logger.close()` to release resources (e.g. close file handles). Safe to call multiple times — subsequent calls are no-ops.
+</ResponseField>
+
+***
+
+### Built-in sinks
+
+#### `createFileLogSink({ filePath })`
+
+Writes JSONL (one JSON object per line) to a file. The directory is created automatically if it does not exist. Appends to the file if it already exists.
+
+```typescript  theme={null}
+function createFileLogSink({ filePath }: { filePath: string }): LoggerSink
+```
+
+<ParamField path="filePath" type="string" required>
+  Absolute or relative path to the log file.
+</ParamField>
+
+#### `prettyConsoleSink`
+
+A pre-built `LoggerSink` constant that writes human-readable, ANSI-colored output to the console. Timestamps, log levels, scopes, and events are each color-coded. Error stacks are printed on separate lines.
+
+```typescript  theme={null}
+import { prettyConsoleSink } from "libretto";
+```
+
+#### `jsonlConsoleSink`
+
+A pre-built `LoggerSink` constant that writes each log entry as a single JSON line to `console.log`. Useful for log aggregation systems that consume structured output from stdout.
+
+```typescript  theme={null}
+import { jsonlConsoleSink } from "libretto";
+```
+
+#### Full example
+
+```typescript  theme={null}
+import { Logger, createFileLogSink, prettyConsoleSink } from "libretto";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({
+      filePath: ".libretto/sessions/my-session/logs.jsonl",
+    }),
+  ]
+);
+
+logger.info("Starting workflow", { session: "my-session" });
+logger.warn("Element not found", { selector: "#submit" });
+
+const scopedLogger = logger.withScope("network", { requestId: "abc123" });
+scopedLogger.info("Request started", { url: "/api/items" });
+// Logged with scope "network" and data merged with { requestId: "abc123" }
+
+await logger.flush();
+```
+
+***
+
+### `createLLMClientFromModel()`
+
+Creates a Libretto `LLMClient` from a Vercel AI SDK `LanguageModel`. While logically an LLM utility, it is included here as a companion to the logger since both are commonly configured together at the top of a workflow file.
+
+```typescript  theme={null}
+function createLLMClientFromModel(model: LanguageModel): LLMClient
+```
+
+<ParamField path="model" type="LanguageModel" required>
+  A Vercel AI SDK language model instance. The result of calling a provider factory such as `openai("gpt-4o")` from `@ai-sdk/openai`, `anthropic("claude-3-5-sonnet-20241022")` from `@ai-sdk/anthropic`, or `google("gemini-1.5-pro")` from `@ai-sdk/google`.
+</ParamField>
+
+The returned `LLMClient` is used by `extractFromPage`, `attemptWithRecovery`, `executeRecoveryAgent`, and `detectSubmissionError`.
+
+#### `LLMClient` interface
+
+```typescript  theme={null}
+interface LLMClient {
+  generateObject<T extends z.ZodType>(opts: {
+    prompt: string;
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+
+  generateObjectFromMessages<T extends z.ZodType>(opts: {
+    messages: Message[];
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+}
+```
+
+#### Example
+
+```typescript  theme={null}
+import {
+  Logger,
+  prettyConsoleSink,
+  createFileLogSink,
+  createLLMClientFromModel,
+} from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({ filePath: ".libretto/sessions/my-run/logs.jsonl" }),
+  ]
+);
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+```

--- a/apps/website/src/docs/content/pages/network-and-actions.mdx
+++ b/apps/website/src/docs/content/pages/network-and-actions.mdx
@@ -1,0 +1,229 @@
+## network & actions
+
+> View captured network requests and recorded user actions from a session.
+
+Libretto automatically captures network requests and browser actions to JSONL log files during every session. The `network` and `actions` commands let you view these logs from the CLI. You can also query them directly with `jq`.
+
+***
+
+### network
+
+The `network` command displays HTTP requests captured during a session. Use it to reverse-engineer a site's internal API, identify endpoints to call directly, or debug unexpected network behavior.
+
+```bash  theme={null}
+npx libretto network --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session whose network log to read.
+</ParamField>
+
+<ParamField path="--last" type="number">
+  Show only the last N entries.
+</ParamField>
+
+<ParamField path="--filter" type="string">
+  Filter entries by a substring match on the URL.
+</ParamField>
+
+<ParamField path="--method" type="string">
+  Filter entries by HTTP method. Example: `--method POST`.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Filter entries by page ID. Useful when multiple pages are open in the session.
+</ParamField>
+
+<ParamField path="--clear" type="boolean">
+  Clear the network log for the session.
+</ParamField>
+
+#### Log file location
+
+Network logs are stored at:
+
+```
+.libretto/sessions/<session>/network.jsonl
+```
+
+One JSON object per line. Query directly with `jq` for advanced filtering.
+
+#### Key fields
+
+| Field          | Description                                |
+| -------------- | ------------------------------------------ |
+| `ts`           | ISO timestamp of the request               |
+| `method`       | HTTP method (`GET`, `POST`, `PUT`, etc.)   |
+| `url`          | Full request URL                           |
+| `status`       | HTTP response status code                  |
+| `contentType`  | Response content type                      |
+| `responseBody` | Response body string (may be `null`)       |
+| `pageId`       | Playwright page ID that produced the entry |
+
+#### Examples
+
+```bash  theme={null}
+# View all captured requests
+npx libretto network --session debug-example
+
+# View the last 20 requests
+npx libretto network --session debug-example --last 20
+
+# Filter to POST requests only
+npx libretto network --session debug-example --method POST
+
+# Filter by URL substring
+npx libretto network --session debug-example --filter "/api/referrals"
+
+# Query with jq directly — all POST requests
+jq 'select(.method == "POST")' .libretto/sessions/debug-example/network.jsonl
+
+# Extract URL and status for every request
+jq '{url: .url, status: .status}' .libretto/sessions/debug-example/network.jsonl
+```
+
+***
+
+### actions
+
+The `actions` command displays browser interactions recorded during a session — both actions Libretto performed as an agent and actions a user performed manually in the browser window. Use it to understand what happened during a session and reconstruct workflows from manual user behavior.
+
+```bash  theme={null}
+npx libretto actions --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session whose action log to read.
+</ParamField>
+
+<ParamField path="--last" type="number">
+  Show only the last N entries.
+</ParamField>
+
+<ParamField path="--filter" type="string">
+  Filter entries by a substring match.
+</ParamField>
+
+<ParamField path="--action" type="string">
+  Filter by action type. Example: `--action click`, `--action fill`.
+</ParamField>
+
+<ParamField path="--source" type="string">
+  Filter by source. `user` for manual browser actions, `agent` for Playwright actions.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Filter entries by page ID.
+</ParamField>
+
+<ParamField path="--clear" type="boolean">
+  Clear the action log for the session.
+</ParamField>
+
+#### Log file location
+
+Action logs are stored at:
+
+```
+.libretto/sessions/<session>/actions.jsonl
+```
+
+#### Key fields
+
+| Field                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `ts`                   | ISO timestamp                                                    |
+| `source`               | `user` (manual DOM event) or `agent` (Playwright call)           |
+| `action`               | Action name: `click`, `dblclick`, `fill`, `goto`, `reload`, etc. |
+| `selector`             | Locator used by the agent                                        |
+| `bestSemanticSelector` | Canonical selector from the user DOM event                       |
+| `targetSelector`       | Raw DOM event target selector (user events only)                 |
+| `ancestorSelectors`    | Meaningful ancestor selectors, closest to farthest               |
+| `nearbyText`           | Visible text near the event target                               |
+| `composedPath`         | Event path from raw target to farthest ancestor                  |
+| `coordinates`          | `{x, y}` for pointer events                                      |
+| `value`                | Typed, selected, or submitted value                              |
+| `url`                  | Navigation target or page URL for navigation actions             |
+| `duration`             | Elapsed time in milliseconds (agent entries)                     |
+| `success`              | `true` if the action completed, `false` on failure               |
+| `error`                | Error message when the action failed                             |
+| `pageId`               | Playwright page ID                                               |
+
+<Note>
+  Agent entries describe what Playwright tried to do (`selector`, `duration`). User entries describe what DOM element was actually interacted with (`bestSemanticSelector`, `targetSelector`, `ancestorSelectors`, `nearbyText`, `composedPath`, `coordinates`).
+</Note>
+
+#### Examples
+
+```bash  theme={null}
+# View all recorded actions
+npx libretto actions --session debug-example
+
+# View the last 20 actions
+npx libretto actions --session debug-example --last 20
+
+# Show only click actions
+npx libretto actions --session debug-example --action click
+
+# Show only user-initiated actions
+npx libretto actions --session debug-example --source user
+
+# Query with jq — last 20 entries
+tail -n 20 .libretto/sessions/debug-example/actions.jsonl | jq .
+
+# Find all failed actions
+jq 'select(.success == false)' .libretto/sessions/debug-example/actions.jsonl
+
+# Extract selector and action for agent entries
+jq 'select(.source == "agent") | {action: .action, selector: .selector}' \
+  .libretto/sessions/debug-example/actions.jsonl
+```
+
+***
+
+### JSONL log files
+
+Both logs use the [JSONL](https://jsonlines.org) format: one JSON object per line, appended in order. This makes them easy to query with standard Unix tools.
+
+```txt
+.libretto/
+  sessions/
+    <session>/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+```
+
+#### Querying with jq
+
+`jq` works directly on JSONL files because it processes one object per input line by default:
+
+```bash  theme={null}
+# All POST requests in the network log
+jq 'select(.method == "POST")' .libretto/sessions/<session>/network.jsonl
+
+# Last 20 action entries (requires tail)
+tail -n 20 .libretto/sessions/<session>/actions.jsonl | jq .
+
+# Count requests by HTTP method
+jq -r '.method' .libretto/sessions/<session>/network.jsonl | sort | uniq -c
+
+# Find requests to a specific endpoint
+jq 'select(.url | contains("/api/"))' .libretto/sessions/<session>/network.jsonl
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="#exec">
+    Access `networkLog` and `actionLog` as globals inside exec code.
+  </Card>
+
+  <Card title="snapshot" icon="camera" href="#snapshot">
+    Use snapshot alongside network logs to understand page state.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/network.mdx
+++ b/apps/website/src/docs/content/pages/network.mdx
@@ -1,0 +1,203 @@
+## Network
+
+> Execute typed HTTP requests inside the browser context and handle downloads.
+
+Libretto provides two ways to make HTTP requests from within a workflow: `pageRequest()` for API calls, and the download helpers for file downloads.
+
+### `pageRequest()`
+
+Executes a `fetch()` call inside the browser context via `page.evaluate()`. Because the request runs inside the real browser process, it uses the browser's TLS fingerprint, cookies, and session — the same as what the site's own JavaScript would send. This avoids bot-detection issues that arise when making the same request from Node.js directly.
+
+```typescript  theme={null}
+async function pageRequest<T extends z.ZodType | undefined = undefined>(
+  page: Page,
+  config: RequestConfig,
+  options?: PageRequestOptions<T>
+): Promise<PageRequestResult<T>>
+```
+
+The return type is `z.infer<T>` when a `schema` is provided, or `any` otherwise.
+
+<Note>
+  Non-2xx responses cause `pageRequest` to throw an error. The error message includes the HTTP method, URL, and status code.
+</Note>
+
+#### `RequestConfig`
+
+<ParamField path="url" type="string" required>
+  The URL to fetch. Relative URLs are resolved in the browser context.
+</ParamField>
+
+<ParamField path="method" type="&#x22;GET&#x22; | &#x22;POST&#x22; | &#x22;PUT&#x22; | &#x22;DELETE&#x22; | &#x22;PATCH&#x22;">
+  HTTP method. Defaults to `"GET"`.
+</ParamField>
+
+<ParamField path="headers" type="Record<string, string>">
+  Additional request headers to merge with any that `bodyType` adds automatically.
+</ParamField>
+
+<ParamField path="body" type="Record<string, any> | string">
+  Request body. When `bodyType` is `"json"` (the default), objects are serialized with `JSON.stringify`. When `bodyType` is `"form"`, objects are encoded as `application/x-www-form-urlencoded`.
+</ParamField>
+
+<ParamField path="bodyType" type="&#x22;json&#x22; | &#x22;form&#x22;">
+  How to serialize the `body`. Defaults to `"json"`. Setting this to `"form"` also sets `Content-Type: application/x-www-form-urlencoded` automatically.
+</ParamField>
+
+<ParamField path="responseType" type="&#x22;json&#x22; | &#x22;text&#x22; | &#x22;xml&#x22;">
+  How to parse the response. Defaults to `"json"`. Both `"text"` and `"xml"` return the raw response text.
+</ParamField>
+
+#### `PageRequestOptions<T>`
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. When provided, request details (method, URL, status, duration) are logged at `info` level, and failures at `warn`.
+</ParamField>
+
+<ParamField path="schema" type="T extends z.ZodType">
+  Optional Zod schema. When provided, the parsed response body is validated with `schema.parse()` before being returned. The return type of `pageRequest` becomes `z.infer<T>`.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { pageRequest } from "libretto";
+import { z } from "zod";
+
+const ResultSchema = z.object({
+  items: z.array(z.object({ id: z.string(), name: z.string() })),
+  total: z.number(),
+});
+
+const data = await pageRequest(
+  page,
+  {
+    url: "/api/search",
+    method: "POST",
+    body: { query: "example", page: 1 },
+  },
+  { schema: ResultSchema }
+);
+// data is typed as { items: Array<{ id: string; name: string }>; total: number }
+```
+
+***
+
+### `downloadViaClick()`
+
+Triggers a file download by clicking a DOM element and intercepts the resulting download using Playwright's download event. The download promise is registered **before** the click so the event is never missed.
+
+```typescript  theme={null}
+async function downloadViaClick(
+  page: Page,
+  selector: string,
+  options?: DownloadViaClickOptions
+): Promise<DownloadResult>
+```
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="selector" type="string" required>
+  CSS selector for the element that triggers the download when clicked.
+</ParamField>
+
+<ParamField path="options" type="DownloadViaClickOptions">
+  <Expandable title="properties">
+    <ParamField path="logger" type="MinimalLogger">
+      Optional logger. Logs download filename, size, and duration on completion.
+    </ParamField>
+
+    <ParamField path="timeout" type="number">
+      Milliseconds to wait for the download event. Defaults to `30000`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+#### `DownloadResult`
+
+<ResponseField name="buffer" type="Buffer">
+  The raw file contents.
+</ResponseField>
+
+<ResponseField name="filename" type="string">
+  The filename suggested by the server via the `Content-Disposition` header or the URL.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import { downloadViaClick } from "libretto";
+
+const { buffer, filename } = await downloadViaClick(page, "#export-btn", {
+  logger,
+  timeout: 60_000,
+});
+
+console.log(`Downloaded ${filename} (${buffer.length} bytes)`);
+```
+
+***
+
+### `downloadAndSave()`
+
+Convenience wrapper around `downloadViaClick()` that also writes the downloaded file to disk.
+
+```typescript  theme={null}
+async function downloadAndSave(
+  page: Page,
+  selector: string,
+  options?: SaveDownloadOptions
+): Promise<DownloadResult & { savedTo: string }>
+```
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="selector" type="string" required>
+  CSS selector for the element that triggers the download when clicked.
+</ParamField>
+
+<ParamField path="options" type="SaveDownloadOptions">
+  <Expandable title="properties">
+    <ParamField path="savePath" type="string">
+      Absolute or relative path to save the file to. When omitted, the suggested filename is used in the current working directory.
+    </ParamField>
+
+    <ParamField path="logger" type="MinimalLogger">
+      Optional logger.
+    </ParamField>
+
+    <ParamField path="timeout" type="number">
+      Milliseconds to wait for the download event. Defaults to `30000`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+#### Return value
+
+Returns `DownloadResult & { savedTo: string }` — the same `buffer` and `filename` as `downloadViaClick`, plus:
+
+<ResponseField name="savedTo" type="string">
+  The absolute path the file was written to.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import { downloadAndSave } from "libretto";
+
+const { filename, savedTo } = await downloadAndSave(
+  page,
+  "#export-btn",
+  { savePath: "/tmp/report.csv", logger }
+);
+
+console.log(`Saved ${filename} to ${savedTo}`);
+```

--- a/apps/website/src/docs/content/pages/one-shot-script-generation.mdx
+++ b/apps/website/src/docs/content/pages/one-shot-script-generation.mdx
@@ -115,7 +115,7 @@ Your agent opens a browser window for you to log in, then takes over: exploring 
 </Tip>
 
 <Note>
-  Make sure your coding agent has the Libretto skill installed before starting. Run `npx libretto init` in your project root to set up the workspace and configure snapshot analysis if you haven't already.
+  Make sure your coding agent has the Libretto skill installed before starting. Run `npx libretto setup` in your project root to set up the workspace and configure snapshot analysis if you haven't already.
 </Note>
 
 ### Related guides

--- a/apps/website/src/docs/content/pages/one-shot-script-generation.mdx
+++ b/apps/website/src/docs/content/pages/one-shot-script-generation.mdx
@@ -1,0 +1,131 @@
+## One-shot script generation
+
+> Ask your agent to explore a site and generate a complete browser automation script.
+
+One-shot generation means you give your agent a goal and a URL, and it does the rest. The agent opens a live browser, explores the site, figures out the page structure, and writes a complete workflow file — without you needing to record actions or hand-hold the process.
+
+This is the fastest path from idea to working automation when you're starting from scratch on a site you haven't automated before.
+
+### Example prompt
+
+> Use the Libretto skill. Go on LinkedIn and scrape the first 10 posts for content, who posted it, the number of reactions, the first 25 comments, and the first 25 reposts.
+
+Your agent opens a browser window for you to log in, then takes over: exploring the feed, identifying selectors, prototyping interactions, and assembling the final workflow file.
+
+### How the agent works
+
+<Steps>
+  <Step title="Opens a headed browser">
+    The agent starts with:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --headed
+    ```
+
+    Headed mode keeps the browser window visible so you can log in before the agent begins exploring.
+  </Step>
+
+  <Step title="Reviews the site's security posture">
+    Before choosing how to capture data, the agent reads the site-security reference and checks for bot detection, monkey-patched fetch, and challenge pages. This determines whether to use direct `fetch()` calls, passive network interception, or DOM extraction.
+  </Step>
+
+  <Step title="Takes a snapshot to understand the page">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --objective "Identify feed post elements and their structure" \
+      --context "I just loaded the main feed and need the post container selectors."
+    ```
+
+    Snapshot captures a screenshot and the page HTML, then uses an LLM to analyze it — keeping the heavy visual context out of your coding agent's context window.
+  </Step>
+
+  <Step title="Uses exec to prototype interactions">
+    The agent tests selectors and interaction patterns before committing them to code:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.locator('.feed-shared-update-v2').count()"
+    ```
+
+    Short `exec` calls let the agent validate each step against the live page without writing and re-running a full script each time.
+  </Step>
+
+  <Step title="Writes the workflow file">
+    Once the agent has a working path, it generates a TypeScript file that exports a `workflow()` instance:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Output = {
+      posts: Array<{
+        author: string;
+        content: string;
+        reactions: number;
+        comments: string[];
+        reposts: string[];
+      }>;
+    };
+
+    export const linkedInFeedScraper = workflow<{}, Output>(
+      async (ctx): Promise<Output> => {
+        const { page } = ctx;
+
+        await page.goto("https://www.linkedin.com/feed/");
+        await page.waitForSelector(".feed-shared-update-v2");
+
+        // Collect first 10 posts
+        const postElements = await page.locator(".feed-shared-update-v2").all();
+        const posts = [];
+
+        for (const post of postElements.slice(0, 10)) {
+          const author = await post.locator(".update-components-actor__name").textContent();
+          const content = await post.locator(".feed-shared-text").textContent();
+          // ... extract reactions, comments, reposts
+        }
+
+        return { posts };
+      },
+    );
+    ```
+  </Step>
+
+  <Step title="Validates with a headless run">
+    ```bash  theme={null}
+    npx libretto run ./linkedin-feed.ts linkedInFeedScraper --headless
+    ```
+
+    The agent confirms actual returned output, not just process exit status. If the run fails, the browser stays open for inspection.
+  </Step>
+</Steps>
+
+### When to use this approach
+
+* You're automating a site for the first time and don't know its structure
+* The task is self-contained and clearly scoped ("get the first 10 posts")
+* You want a working script with minimal back-and-forth
+* You don't need to demonstrate the workflow manually first
+
+### Tips
+
+<Tip>
+  Always use `--headed` when the site requires login. The browser window opens on your screen so you can authenticate, and then the agent takes over. Without `--headed`, the agent has no way to get past a login wall.
+</Tip>
+
+<Tip>
+  Give your agent a specific, measurable objective. "Scrape the first 10 posts" is actionable. "Get some LinkedIn data" is not — the agent will have to guess at scope and structure.
+</Tip>
+
+<Note>
+  Make sure your coding agent has the Libretto skill installed before starting. Run `npx libretto init` in your project root to set up the workspace and configure snapshot analysis if you haven't already.
+</Note>
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="Interactive script building" href="#interactive-script-building">
+    Show the agent your workflow manually and let it turn your actions into code.
+  </Card>
+
+  <Card title="Convert to network requests" href="#convert-to-network-requests">
+    Speed up an existing browser script by switching to direct API calls.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/open-and-connect.mdx
+++ b/apps/website/src/docs/content/pages/open-and-connect.mdx
@@ -1,0 +1,129 @@
+## open & connect
+
+> Launch a browser session or attach to an existing Chrome DevTools Protocol endpoint.
+
+### open
+
+The `open` command launches a browser and navigates to a URL, creating a new named session. It is the starting point for any interactive workflow: once a session is open, `exec`, `snapshot`, `network`, and `actions` all work against it.
+
+```bash  theme={null}
+npx libretto open https://example.com
+npx libretto open https://example.com --headless --session debug-example
+```
+
+#### When to use `open`
+
+* At the start of script authoring when you need live page state to decide how the workflow should work.
+* When the user needs to log in manually before automation begins (use `--headed`).
+* Any time you need a fresh, isolated browser instance on a specific URL.
+
+#### Flags
+
+<ParamField path="url" type="string" required>
+  The URL to open. Passed as the first positional argument.
+</ParamField>
+
+<ParamField path="--headed" type="boolean">
+  Run the browser in headed (visible) mode. This is the default when neither flag is passed.
+</ParamField>
+
+<ParamField path="--headless" type="boolean">
+  Run the browser in headless mode. Useful for automated runs that don't need a visible window.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this session. If omitted, Libretto generates a unique name automatically. Use a consistent name to target the session with later commands.
+</ParamField>
+
+<ParamField path="--viewport" type="string">
+  Viewport size in `WIDTHxHEIGHT` format, for example `1920x1080`. Falls back to the value in `.libretto/config.json`, then `1366x768`.
+</ParamField>
+
+<Note>
+  `--headed` and `--headless` are mutually exclusive. Passing both raises an error.
+</Note>
+
+#### Examples
+
+```bash  theme={null}
+# Open in headed mode (default)
+npx libretto open https://app.example.com --headed
+
+# Open in headless mode with an explicit session name
+npx libretto open https://example.com --headless --session debug-example
+
+# Open with a custom viewport
+npx libretto open https://example.com --viewport 1440x900 --session my-session
+
+# Open for a manual login flow, then save the session
+npx libretto open https://app.example.com --headed
+# ... user logs in ...
+npx libretto save app.example.com
+```
+
+***
+
+### connect
+
+The `connect` command attaches to an existing Chrome DevTools Protocol (CDP) endpoint rather than launching a new browser. Use it to drive a browser that is already running — for example, one started with `--remote-debugging-port`, an Electron application, or any other CDP-compatible target.
+
+```bash  theme={null}
+npx libretto connect http://127.0.0.1:9222 --session my-session
+npx libretto connect http://127.0.0.1:9223 --session another-session
+```
+
+#### When to use `connect`
+
+* You have an existing browser process you want to automate without restarting it.
+* You are driving an Electron app exposed over CDP.
+* You want to attach to a remote browser in a CI environment that has already navigated to the right state.
+
+#### Flags
+
+<ParamField path="cdp-url" type="string" required>
+  The CDP endpoint URL to connect to. Passed as the first positional argument. Example: `http://127.0.0.1:9222`.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this session. Recommended to set explicitly when using `connect` so you can reference it later.
+</ParamField>
+
+#### After connecting
+
+Once connected, all session-scoped commands work normally against the attached browser:
+
+* `exec` — run Playwright TypeScript code
+* `snapshot` — capture a screenshot and analyze the page
+* `pages` — list open pages
+* `network` — view captured network requests
+* `actions` — view recorded actions
+
+<Warning>
+  Libretto does **not** manage the lifecycle of a connected process. Running `npx libretto close --session <name>` clears the Libretto session record but does **not** terminate the remote browser or Electron app.
+</Warning>
+
+#### Examples
+
+```bash  theme={null}
+# Attach to a Chrome instance started with --remote-debugging-port
+npx libretto connect http://127.0.0.1:9222 --session chrome-debug
+
+# Inspect the attached page
+npx libretto snapshot \
+  --session chrome-debug \
+  --objective "What is the current page state?" \
+  --context "Just attached to a running browser."
+
+# Run code against it
+npx libretto exec --session chrome-debug "return await page.url()"
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="#exec">
+    Execute Playwright TypeScript against the open page.
+  </Card>
+
+  <Card title="snapshot" icon="camera" href="#snapshot">
+    Capture a screenshot and analyze page state.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/openapi-spec.mdx
+++ b/apps/website/src/docs/content/pages/openapi-spec.mdx
@@ -1,0 +1,7 @@
+## OpenAPI specs
+
+The Mintlify docs index also links to a published OpenAPI JSON file:
+
+- [openapi.json](https://www.mintlify.com/saffron-health/libretto/api-reference/openapi.json)
+
+Use it as machine-readable reference alongside the CLI and library API docs above.

--- a/apps/website/src/docs/content/pages/quickstart.mdx
+++ b/apps/website/src/docs/content/pages/quickstart.mdx
@@ -15,15 +15,15 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
     Libretto requires Node.js 18 or later. It installs Playwright as a direct dependency, so you don't need a separate Playwright install.
   </Step>
 
-  <Step title="Initialize your workspace">
-    Run `init` once per project. This command downloads Chromium if it isn't already installed, creates the `.libretto/` directory structure, writes a `.libretto/.gitignore`, and copies the agent skill files into `.agents/skills/libretto` and `.claude/skills/libretto`.
+  <Step title="Set up your workspace">
+    Run `setup` once per project. This command downloads Chromium if it isn't already installed, creates the `.libretto/` directory structure, writes a `.libretto/.gitignore`, and copies the agent skill files into `.agents/skills/libretto` and `.claude/skills/libretto`.
 
     ```bash  theme={null}
-    npx libretto init
+    npx libretto setup
     ```
 
     <Note>
-      Run `init` yourself in a terminal — not through an agent. It may prompt for input and starts a Chromium download that takes a moment.
+      Run `setup` yourself in a terminal — not through an agent. It may prompt for input and starts a Chromium download that takes a moment.
     </Note>
   </Step>
 
@@ -57,43 +57,35 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
 
     Provider credentials are read from your shell environment or a `.env` file at the project root. Set the appropriate key:
 
-    <CodeGroup>
-      ```bash OpenAI theme={null}
-      export OPENAI_API_KEY=sk-...
-      ```
+    ```bash theme={null} showLineNumbers={false}
+    # OpenAI
+    export OPENAI_API_KEY=sk-...
 
-      ```bash Anthropic theme={null}
-      export ANTHROPIC_API_KEY=sk-ant-...
-      ```
+    # Anthropic
+    export ANTHROPIC_API_KEY=sk-ant-...
 
-      ```bash Gemini theme={null}
-      export GEMINI_API_KEY=...
-      ```
+    # Gemini
+    export GEMINI_API_KEY=...
 
-      ```bash Vertex theme={null}
-      export GOOGLE_CLOUD_PROJECT=my-project
-      ```
-    </CodeGroup>
+    # Vertex
+    export GOOGLE_CLOUD_PROJECT=my-project
+    ```
 
     Libretto uses the Vercel AI SDK under the hood. Install only the peer dependency for your chosen provider:
 
-    <CodeGroup>
-      ```bash OpenAI theme={null}
-      npm install @ai-sdk/openai
-      ```
+    ```bash theme={null} showLineNumbers={false}
+    # OpenAI
+    npm install @ai-sdk/openai
 
-      ```bash Anthropic theme={null}
-      npm install @ai-sdk/anthropic
-      ```
+    # Anthropic
+    npm install @ai-sdk/anthropic
 
-      ```bash Gemini theme={null}
-      npm install @ai-sdk/google
-      ```
+    # Gemini
+    npm install @ai-sdk/google
 
-      ```bash Vertex theme={null}
-      npm install @ai-sdk/google-vertex
-      ```
-    </CodeGroup>
+    # Vertex
+    npm install @ai-sdk/google-vertex
+    ```
   </Step>
 
   <Step title="Open a browser">
@@ -191,7 +183,7 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
 ### What's next
 
 <Tip>
-  If you're using a coding agent like Claude or another AI assistant, load the Libretto skill so your agent knows how to use these commands effectively. After running `npx libretto init`, the skill is available at `.agents/skills/libretto/SKILL.md` and `.claude/skills/libretto/SKILL.md`.
+  If you're using a coding agent like Claude or another AI assistant, load the Libretto skill so your agent knows how to use these commands effectively. After running `npx libretto setup`, the skill is available at `.agents/skills/libretto/SKILL.md` and `.claude/skills/libretto/SKILL.md`.
 </Tip>
 
 Once Libretto is set up, explore the full command set:

--- a/apps/website/src/docs/content/pages/quickstart.mdx
+++ b/apps/website/src/docs/content/pages/quickstart.mdx
@@ -1,0 +1,212 @@
+## Quick start
+
+> Install Libretto and run your first browser automation in minutes.
+
+This guide walks you through installing Libretto, connecting an AI provider, opening a browser, and taking your first snapshot.
+
+<Steps>
+  <Step title="Install the package">
+    Install Libretto from npm:
+
+    ```bash  theme={null}
+    npm install libretto
+    ```
+
+    Libretto requires Node.js 18 or later. It installs Playwright as a direct dependency, so you don't need a separate Playwright install.
+  </Step>
+
+  <Step title="Initialize your workspace">
+    Run `init` once per project. This command downloads Chromium if it isn't already installed, creates the `.libretto/` directory structure, writes a `.libretto/.gitignore`, and copies the agent skill files into `.agents/skills/libretto` and `.claude/skills/libretto`.
+
+    ```bash  theme={null}
+    npx libretto init
+    ```
+
+    <Note>
+      Run `init` yourself in a terminal — not through an agent. It may prompt for input and starts a Chromium download that takes a moment.
+    </Note>
+  </Step>
+
+  <Step title="Configure an AI provider">
+    Snapshot analysis requires a vision-capable model. Choose your provider:
+
+    ```bash  theme={null}
+    npx libretto ai configure openai
+    # or
+    npx libretto ai configure anthropic
+    # or
+    npx libretto ai configure gemini
+    # or
+    npx libretto ai configure vertex
+    ```
+
+    This writes the selected model to `.libretto/config.json`. The default models are:
+
+    | Provider    | Default model                   |
+    | ----------- | ------------------------------- |
+    | `openai`    | `openai/gpt-5.4`                |
+    | `anthropic` | `anthropic/claude-sonnet-4-6`   |
+    | `gemini`    | `google/gemini-3-flash-preview` |
+    | `vertex`    | `vertex/gemini-2.5-pro`         |
+
+    You can also pass a full model string to use a specific version:
+
+    ```bash  theme={null}
+    npx libretto ai configure openai/gpt-4o
+    ```
+
+    Provider credentials are read from your shell environment or a `.env` file at the project root. Set the appropriate key:
+
+    <CodeGroup>
+      ```bash OpenAI theme={null}
+      export OPENAI_API_KEY=sk-...
+      ```
+
+      ```bash Anthropic theme={null}
+      export ANTHROPIC_API_KEY=sk-ant-...
+      ```
+
+      ```bash Gemini theme={null}
+      export GEMINI_API_KEY=...
+      ```
+
+      ```bash Vertex theme={null}
+      export GOOGLE_CLOUD_PROJECT=my-project
+      ```
+    </CodeGroup>
+
+    Libretto uses the Vercel AI SDK under the hood. Install only the peer dependency for your chosen provider:
+
+    <CodeGroup>
+      ```bash OpenAI theme={null}
+      npm install @ai-sdk/openai
+      ```
+
+      ```bash Anthropic theme={null}
+      npm install @ai-sdk/anthropic
+      ```
+
+      ```bash Gemini theme={null}
+      npm install @ai-sdk/google
+      ```
+
+      ```bash Vertex theme={null}
+      npm install @ai-sdk/google-vertex
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Open a browser">
+    Launch a headed Chromium window and navigate to a URL:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com
+    ```
+
+    To use a named session (recommended when running multiple automations):
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --session my-session
+    ```
+
+    Use `--headless` if you don't need to see the browser:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --headless --session my-session
+    ```
+  </Step>
+
+  <Step title="Take a snapshot">
+    `snapshot` captures a PNG screenshot and the page HTML, then sends both to your configured vision model. Always provide `--objective` (what you want the model to find or analyze) and `--context` (what you know about the current state):
+
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --objective "Find the main heading and any call-to-action buttons" \
+      --context "I just opened the example.com homepage and want to identify the key interactive elements."
+    ```
+
+    With a named session:
+
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session my-session \
+      --objective "Explain why the table is empty" \
+      --context "I applied filters on the referrals page and expected rows to appear."
+    ```
+
+    The model returns a structured summary of selectors, element descriptions, and any relevant observations — without putting raw HTML into your agent's context.
+
+    <Tip>
+      A single snapshot objective can include multiple questions. Instead of running several snapshots, combine them: `--objective "Find the submit button and check whether the form has validation errors."`
+    </Tip>
+  </Step>
+
+  <Step title="Execute Playwright code">
+    Use `exec` to run Playwright TypeScript against the open page. The code runs in a context that has `page`, `context`, `browser`, `state`, `fetch`, and `Buffer` available as globals:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.url()"
+    ```
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.locator('button').count()"
+    ```
+
+    ```bash  theme={null}
+    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    ```
+
+    For longer scripts, pipe from stdin with `-`:
+
+    ```bash  theme={null}
+    echo "return await page.url()" | npx libretto exec - --session my-session
+    ```
+
+    Let failures throw. Don't wrap `exec` code in `try/catch` — surfacing errors is how you debug.
+  </Step>
+
+  <Step title="Run a workflow file">
+    Once you've built a workflow file, run it with `npx libretto run`:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main
+    ```
+
+    Run headless with input parameters:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless --params '{"status":"open"}'
+    ```
+
+    Run with a saved auth profile:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --auth-profile app.example.com
+    ```
+
+    The second argument (`main`) is the name of the exported `workflow()` instance in the file. See the Library API reference for how to structure workflow files.
+  </Step>
+</Steps>
+
+### What's next
+
+<Tip>
+  If you're using a coding agent like Claude or another AI assistant, load the Libretto skill so your agent knows how to use these commands effectively. After running `npx libretto init`, the skill is available at `.agents/skills/libretto/SKILL.md` and `.claude/skills/libretto/SKILL.md`.
+</Tip>
+
+Once Libretto is set up, explore the full command set:
+
+```bash  theme={null}
+npx libretto --help
+```
+
+Common commands to try next:
+
+```bash  theme={null}
+npx libretto network                    # view captured HTTP requests
+npx libretto actions                    # view recorded user/agent actions
+npx libretto pages                      # list open pages in the session
+npx libretto save app.example.com       # save authenticated browser state
+npx libretto close                      # close the browser
+npx libretto close --all                # close all sessions
+```

--- a/apps/website/src/docs/content/pages/recovery.mdx
+++ b/apps/website/src/docs/content/pages/recovery.mdx
@@ -1,0 +1,238 @@
+## Recovery
+
+> Automatically handle errors and popups that interrupt browser automation workflows.
+
+Browser automation workflows are often interrupted by unexpected page state: cookie banners, newsletter modals, session-expired dialogs, or form submission errors. The recovery module provides three tools for handling these situations.
+
+### `attemptWithRecovery()`
+
+Runs a function, and if it throws, optionally runs an LLM-powered popup recovery agent and retries the function once.
+
+```typescript  theme={null}
+async function attemptWithRecovery<T>(
+  page: Page,
+  fn: () => Promise<T>,
+  logger?: MinimalLogger,
+  llmClient?: LLMClient
+): Promise<T>
+```
+
+#### How it works
+
+1. Calls `fn()`.
+2. If `fn()` succeeds, returns the result immediately.
+3. If `fn()` throws and `llmClient` is not provided, re-throws the error.
+4. If `fn()` throws and `llmClient` is provided, runs `executeRecoveryAgent()` with the instruction `"Look at the page to see if there is a popup blocking the screen. If so, close the popup."`
+5. After recovery, calls `fn()` a second time. If it throws again, that error propagates.
+
+<Warning>
+  Recovery is **not** attempted when the error message indicates the browser or page has been closed (`"Target closed"`, `"browser has been closed"`, `"context or browser has been closed"`). These errors are re-thrown immediately.
+</Warning>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` where the action is being attempted.
+</ParamField>
+
+<ParamField path="fn" type="() => Promise<T>" required>
+  The async function to run. This is the step you want to protect — typically a sequence of Playwright actions.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Recovery attempts and outcomes are logged at `info` level.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient">
+  Optional LLM client. When omitted, errors are re-thrown without any recovery attempt. When provided, the recovery agent runs on failure.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { attemptWithRecovery, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+// Wrap any step that might be interrupted by a popup
+const result = await attemptWithRecovery(
+  page,
+  async () => {
+    await page.click("#submit");
+    await page.waitForSelector(".success");
+    return await page.textContent(".confirmation-number");
+  },
+  logger,
+  llmClient
+);
+```
+
+***
+
+### `executeRecoveryAgent()`
+
+Runs a vision-based LLM agent to handle page state issues. The agent takes a screenshot, sends it to the LLM with your instruction, executes the suggested browser action, and repeats for up to 3 steps until the action type is `"done"`.
+
+```typescript  theme={null}
+async function executeRecoveryAgent(
+  page: Page,
+  instruction: string,
+  logger?: MinimalLogger,
+  llmClient?: LLMClient
+): Promise<void>
+```
+
+<Note>
+  When `llmClient` is not provided, `executeRecoveryAgent` returns immediately without doing anything.
+</Note>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="instruction" type="string" required>
+  A natural-language description of what the agent should do. For example: `"Dismiss any cookie consent banner or modal that is blocking the page."`
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Each recovery step's reasoning and action are logged.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient">
+  Optional LLM client. The backing model must support vision (multimodal) input.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { executeRecoveryAgent, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+await executeRecoveryAgent(
+  page,
+  "Dismiss any cookie consent banner or modal that is blocking the page.",
+  logger,
+  llmClient
+);
+```
+
+***
+
+### `detectSubmissionError()`
+
+Uses a CDP screenshot and LLM vision to detect whether a visible error appeared on the page after a form submission or other action. Useful when the site shows errors inline rather than throwing JavaScript exceptions.
+
+```typescript  theme={null}
+async function detectSubmissionError(
+  page: Page,
+  error: unknown,
+  logContext: string,
+  llmClient: LLMClient,
+  knownErrors?: KnownSubmissionError[],
+  logger?: MinimalLogger
+): Promise<DetectedSubmissionError>
+```
+
+If a `knownErrors` entry matches what the LLM sees on screen, `detectSubmissionError` returns a `DetectedSubmissionError`. If no known error matches, it re-throws the original `error`.
+
+<Note>
+  The screenshot is captured via CDP so it works even when the page is unresponsive (e.g. during a loading spinner or frozen UI). If the CDP screenshot itself fails, the original error is re-thrown.
+</Note>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to screenshot.
+</ParamField>
+
+<ParamField path="error" type="unknown" required>
+  The original error that triggered the detection call. Re-thrown if no known error matches.
+</ParamField>
+
+<ParamField path="logContext" type="string" required>
+  A string describing the operation being performed. Included in log output and passed to the LLM as context.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient" required>
+  An LLM client. The model must support vision input.
+</ParamField>
+
+<ParamField path="knownErrors" type="KnownSubmissionError[]">
+  An optional list of known error definitions to match against. Defaults to `[]`.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger.
+</ParamField>
+
+#### `KnownSubmissionError`
+
+<ResponseField name="id" type="string">
+  A stable identifier for this error type. Returned in `DetectedSubmissionError.errorId`.
+</ResponseField>
+
+<ResponseField name="errorPatterns" type="string[]">
+  Descriptions of what the LLM should look for on screen to match this error. For example: `["'Email already in use' message", "duplicate account warning"]`.
+</ResponseField>
+
+<ResponseField name="userMessage" type="string">
+  A human-friendly message returned in `DetectedSubmissionError.message` when this error is matched.
+</ResponseField>
+
+#### `DetectedSubmissionError`
+
+<ResponseField name="matched" type="true">
+  Always `true` — indicates a known error was detected.
+</ResponseField>
+
+<ResponseField name="errorId" type="string">
+  The `id` from the matched `KnownSubmissionError`.
+</ResponseField>
+
+<ResponseField name="message" type="string">
+  The `userMessage` from the matched `KnownSubmissionError`.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import {
+  detectSubmissionError,
+  createLLMClientFromModel,
+  type KnownSubmissionError,
+} from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+const knownErrors: KnownSubmissionError[] = [
+  {
+    id: "duplicate-email",
+    errorPatterns: ["email already in use", "duplicate account"],
+    userMessage: "An account with this email address already exists.",
+  },
+];
+
+try {
+  await page.click("#submit");
+  await page.waitForSelector(".success", { timeout: 5000 });
+} catch (err) {
+  const detected = await detectSubmissionError(
+    page,
+    err,
+    "submit-registration-form",
+    llmClient,
+    knownErrors,
+    logger
+  );
+  // detected.matched === true
+  // detected.errorId === "duplicate-email"
+  // detected.message === "An account with this email address already exists."
+  throw new Error(detected.message);
+}
+```

--- a/apps/website/src/docs/content/pages/run-and-resume.mdx
+++ b/apps/website/src/docs/content/pages/run-and-resume.mdx
@@ -1,0 +1,204 @@
+## run & resume
+
+> Execute a workflow file and resume paused workflows.
+
+### run
+
+The `run` command executes a named export from a TypeScript workflow file against a live browser. Use it to verify a workflow after creating or editing it.
+
+```bash  theme={null}
+npx libretto run ./integration.ts main
+npx libretto run ./integration.ts main --headless
+```
+
+#### Syntax
+
+```bash  theme={null}
+npx libretto run <file> <export> [flags]
+```
+
+* `<file>` — path to the TypeScript workflow file
+* `<export>` — the named export from that file (e.g., `main`, `myWorkflow`)
+
+#### Flags
+
+<ParamField path="--headless" type="boolean">
+  Run the browser in headless mode. Use this for the normal fix-and-verify loop.
+</ParamField>
+
+<ParamField path="--headed" type="boolean">
+  Run the browser in headed (visible) mode. This is the default when neither flag is passed.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this run session. Auto-generated if omitted. Use an explicit name to target the session with `exec`, `snapshot`, or `resume` after a failure or pause.
+</ParamField>
+
+<ParamField path="--params" type="string">
+  Inline JSON input for the workflow, passed as a quoted string. Example: `--params '{"status":"open"}'`.
+</ParamField>
+
+<ParamField path="--params-file" type="string">
+  Path to a JSON file to use as workflow input. Cannot be used together with `--params`.
+</ParamField>
+
+<ParamField path="--auth-profile" type="string">
+  Domain of a saved auth profile to load for this run. Example: `--auth-profile app.example.com`. Profiles are created with `npx libretto save <domain>`.
+</ParamField>
+
+<ParamField path="--viewport" type="string">
+  Viewport size in `WIDTHxHEIGHT` format, for example `1920x1080`. Falls back to `.libretto/config.json`, then `1366x768`.
+</ParamField>
+
+<ParamField path="--tsconfig" type="string">
+  Path to a `tsconfig.json` file for module resolution during workflow compilation.
+</ParamField>
+
+<ParamField path="--no-visualize" type="boolean">
+  Disable ghost cursor and element highlight visualization in headed mode.
+</ParamField>
+
+#### Behavior on failure
+
+When a workflow fails, Libretto keeps the browser open at the point of failure. You can then use `snapshot` and `exec` to inspect the live page state before editing the workflow code.
+
+```bash  theme={null}
+# Workflow fails — browser stays open
+npx libretto run ./integration.ts main --session debug-flow --headed
+
+# Inspect the failure state
+npx libretto snapshot \
+  --session debug-flow \
+  --objective "Find the blocking error or broken selector target" \
+  --context "The workflow failed after trying to continue from the review step."
+
+# Prototype a fix
+npx libretto exec --session debug-flow "return await page.locator('.error-message').textContent()"
+
+# Re-run after fixing the code
+npx libretto run ./integration.ts main --headless
+```
+
+#### Validation loop
+
+Prefer `run --headless` for the normal fix-and-verify loop. When the headless run passes, do a final headed run if you or the user wants to watch the finished workflow:
+
+```bash  theme={null}
+# Fix/verify loop — fast, no visible browser
+npx libretto run ./integration.ts main --headless
+
+# Final confirmation run — shows the browser
+npx libretto run ./integration.ts main --headed
+```
+
+#### Examples
+
+```bash  theme={null}
+# Basic run
+npx libretto run ./integration.ts main
+
+# Headless run with inline params
+npx libretto run ./integration.ts main --headless --params '{"status":"open"}'
+
+# Run with a params file
+npx libretto run ./integration.ts main --params-file ./params.json
+
+# Run with a saved auth profile
+npx libretto run ./integration.ts main --auth-profile app.example.com
+
+# Run with explicit session name for post-failure inspection
+npx libretto run ./integration.ts main --session debug-flow --headed
+```
+
+***
+
+### resume
+
+The `resume` command unpauses a workflow that has stopped at an `await pause(session)` call. Use it repeatedly until the workflow completes or pauses again at the next breakpoint.
+
+```bash  theme={null}
+npx libretto resume --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session name of the paused workflow to resume.
+</ParamField>
+
+#### The `pause()` API
+
+Insert `await pause(session)` calls in your workflow file to create interactive breakpoints — similar to debugger breakpoints in the browser flow. The workflow stops at each `pause()` call and waits for `resume` before continuing.
+
+```typescript  theme={null}
+import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
+
+export const myWorkflow = workflow(async (ctx, input) => {
+  const { session, page } = ctx;
+
+  await page.goto("https://app.example.com");
+
+  // Pause here for inspection
+  await pause(session);
+
+  await page.locator('#submit').click();
+
+  // Pause again before the final step
+  await pause(session);
+
+  return { done: true };
+});
+```
+
+<Note>
+  `pause()` is a **no-op when `NODE_ENV === "production"`**. You can leave `pause()` calls in your workflow code during development and they will be silently skipped in production.
+</Note>
+
+#### Complete debugging flow
+
+<Steps>
+  <Step title="Run the workflow and let it fail (or pause)">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --session debug-flow --headed
+    ```
+
+    If the workflow hits a `pause()`, it prints `Workflow paused.` and returns. The browser stays open.
+  </Step>
+
+  <Step title="Inspect the paused page state">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session debug-flow \
+      --objective "What is on the page and what is the next required action?" \
+      --context "The workflow paused before the submit step."
+
+    npx libretto exec --session debug-flow "return await page.url()"
+    ```
+  </Step>
+
+  <Step title="Resume the workflow">
+    ```bash  theme={null}
+    npx libretto resume --session debug-flow
+    ```
+
+    Keep running `resume` until the workflow prints `Integration completed.` or fails with an error.
+  </Step>
+
+  <Step title="Fix the code and re-run">
+    Edit the workflow file to fix any issues found during inspection, then re-run:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless
+    ```
+  </Step>
+</Steps>
+
+<CardGroup cols={2}>
+  <Card title="snapshot" icon="camera" href="#snapshot">
+    Inspect page state after a failure or pause.
+  </Card>
+
+  <Card title="exec" icon="code" href="#exec">
+    Prototype fixes against the paused browser before editing code.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/session-management.mdx
+++ b/apps/website/src/docs/content/pages/session-management.mdx
@@ -165,19 +165,19 @@ npx libretto close --all --force
 
 ***
 
-### init
+### setup
 
-The `init` command sets up Libretto in your project for the first time. It installs Chromium, copies the Libretto skill files to your agent directories, and walks you through configuring a snapshot analysis model.
+The `setup` command sets up Libretto in your project for the first time. It installs Chromium, copies the Libretto skill files to your agent directories, and walks you through configuring a snapshot analysis model.
 
 ```bash  theme={null}
-npx libretto init
+npx libretto setup
 ```
 
 <Warning>
-  `init` is interactive — it prompts for API credentials and requires a TTY. Run it yourself in a terminal, not through an agent.
+  `setup` is interactive — it prompts for API credentials and requires a TTY. Run it yourself in a terminal, not through an agent.
 </Warning>
 
-#### What `init` does
+#### What `setup` does
 
 1. Installs the Playwright Chromium browser via `npx playwright install chromium`.
 2. Copies skill files to `.agents/skills/libretto/` and `.claude/skills/libretto/` if those directories exist.
@@ -189,9 +189,9 @@ npx libretto init
   Skip the Playwright Chromium installation step. Useful if Chromium is already installed.
 </ParamField>
 
-#### After `init`
+#### After `setup`
 
-You can change or update the snapshot analysis model at any time without re-running `init`:
+You can change or update the snapshot analysis model at any time without re-running `setup`:
 
 ```bash  theme={null}
 npx libretto ai configure openai

--- a/apps/website/src/docs/content/pages/session-management.mdx
+++ b/apps/website/src/docs/content/pages/session-management.mdx
@@ -1,0 +1,214 @@
+## save, pages & close
+
+> Manage browser sessions, pages, and saved authentication profiles.
+
+### The `--session` flag
+
+Almost every Libretto command accepts `--session <name>` to target a specific browser session. When you omit `--session` on commands that support auto-generation (`open`, `run`), Libretto creates a unique name automatically.
+
+Session state is stored under `.libretto/sessions/<session>/`:
+
+```txt
+.libretto/
+  sessions/
+    <session>/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+  profiles/
+```
+
+Session directories are git-ignored. Each session runs an isolated browser instance on a dynamic port.
+
+***
+
+### pages
+
+The `pages` command lists all open pages (tabs) in a session and prints their IDs and URLs.
+
+```bash  theme={null}
+npx libretto pages --session debug-example
+```
+
+#### When to use `pages`
+
+* A popup or new tab opened during navigation or interaction.
+* `exec` or `snapshot` fails because more than one page is open in the session.
+* You are not sure which page holds the relevant state.
+
+After running `pages`, pass the target page ID to other commands with `--page <page-id>`:
+
+```bash  theme={null}
+# List pages
+npx libretto pages --session debug-example
+
+# Target a specific page
+npx libretto exec --session debug-example --page <page-id> "return await page.url()"
+npx libretto snapshot --session debug-example --page <page-id> \
+  --objective "Find the active form" \
+  --context "A modal opened in a new tab."
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session to list pages for.
+</ParamField>
+
+***
+
+### save
+
+The `save` command saves the current browser session's cookies and localStorage as a named auth profile. Load the profile later with `--auth-profile` to skip manual login.
+
+```bash  theme={null}
+npx libretto save app.example.com
+```
+
+#### When to use `save`
+
+Only use `save` when the user explicitly asks to save or reuse authenticated browser state. A typical flow:
+
+<Steps>
+  <Step title="Open the site in headed mode">
+    ```bash  theme={null}
+    npx libretto open https://app.example.com --headed
+    ```
+  </Step>
+
+  <Step title="Log in manually">
+    The browser window is visible. Log in as usual.
+  </Step>
+
+  <Step title="Save the session">
+    ```bash  theme={null}
+    npx libretto save app.example.com
+    ```
+
+    The profile is saved to `.libretto/profiles/app.example.com.json`.
+  </Step>
+
+  <Step title="Use the profile in future runs">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --auth-profile app.example.com
+    ```
+  </Step>
+</Steps>
+
+#### Profile storage
+
+Profiles are stored in `.libretto/profiles/<domain>.json`. They are:
+
+* Machine-local — not shared across environments or team members.
+* Git-ignored by default.
+* Subject to session expiry — if authentication stops working, repeat the login-and-save flow.
+
+#### Flags
+
+<ParamField path="domain" type="string" required>
+  The domain (or URL) used to name the saved profile. Passed as the first positional argument. Example: `app.example.com`.
+</ParamField>
+
+<ParamField path="--session" type="string" required>
+  The session to save. Use the same name you passed to `npx libretto open --session`.
+</ParamField>
+
+***
+
+### close
+
+The `close` command closes a browser session and cleans up its state.
+
+```bash  theme={null}
+npx libretto close --session debug-example
+npx libretto close --all
+```
+
+#### When to use `close`
+
+* When you are done with a session.
+* When an exploration session is no longer helping progress and you want to free up the browser.
+* For full workspace cleanup at the end of a task.
+
+<Note>
+  When using `connect` to attach to an external CDP endpoint, `close` clears the Libretto session record but **does not terminate the remote browser process**.
+</Note>
+
+#### Flags
+
+<ParamField path="--session" type="string">
+  The session to close. Required unless `--all` is passed.
+</ParamField>
+
+<ParamField path="--all" type="boolean">
+  Close all tracked sessions in this workspace.
+</ParamField>
+
+<ParamField path="--force" type="boolean">
+  Force-kill sessions that do not respond to SIGTERM. Requires `--all`.
+</ParamField>
+
+#### Examples
+
+```bash  theme={null}
+# Close a named session
+npx libretto close --session debug-example
+
+# Close all sessions in the workspace
+npx libretto close --all
+
+# Close all sessions, force-killing any that are unresponsive
+npx libretto close --all --force
+```
+
+***
+
+### init
+
+The `init` command sets up Libretto in your project for the first time. It installs Chromium, copies the Libretto skill files to your agent directories, and walks you through configuring a snapshot analysis model.
+
+```bash  theme={null}
+npx libretto init
+```
+
+<Warning>
+  `init` is interactive — it prompts for API credentials and requires a TTY. Run it yourself in a terminal, not through an agent.
+</Warning>
+
+#### What `init` does
+
+1. Installs the Playwright Chromium browser via `npx playwright install chromium`.
+2. Copies skill files to `.agents/skills/libretto/` and `.claude/skills/libretto/` if those directories exist.
+3. Prompts you to select an AI provider (OpenAI, Anthropic, Google Gemini, or Google Vertex AI) and enter your API key, which is written to `.env`.
+
+#### Flags
+
+<ParamField path="--skip-browsers" type="boolean">
+  Skip the Playwright Chromium installation step. Useful if Chromium is already installed.
+</ParamField>
+
+#### After `init`
+
+You can change or update the snapshot analysis model at any time without re-running `init`:
+
+```bash  theme={null}
+npx libretto ai configure openai
+npx libretto ai configure anthropic
+npx libretto ai configure gemini
+npx libretto ai configure vertex
+
+# Or specify a model directly
+npx libretto ai configure openai/gpt-4o
+```
+
+<CardGroup cols={2}>
+  <Card title="open & connect" icon="browser" href="#open-connect">
+    Start a session after init completes.
+  </Card>
+
+  <Card title="network & actions" icon="chart-network" href="#network-actions">
+    Explore session logs captured during a run.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/sessions-and-profiles.mdx
+++ b/apps/website/src/docs/content/pages/sessions-and-profiles.mdx
@@ -1,0 +1,219 @@
+## Sessions and profiles
+
+> Manage named browser sessions and persist authenticated browser state across runs.
+
+### Sessions
+
+Every Libretto session gets its own isolated directory under `.libretto/sessions/<name>/`. Sessions are git-ignored by default — they contain runtime state and machine-local data that should not be committed.
+
+You can run multiple sessions simultaneously. Each session targets a specific browser instance and has its own log files, network capture, and snapshot history.
+
+#### Starting and ending sessions
+
+```bash  theme={null}
+# Open a new browser and give the session a name
+npx libretto open https://example.com --session my-session
+
+# All commands accept --session to target a specific session
+npx libretto snapshot --session my-session --objective "..." --context "..."
+npx libretto exec --session my-session "return await page.url()"
+npx libretto network --session my-session
+
+# Close a specific session
+npx libretto close --session my-session
+
+# Close all open sessions (useful for workspace cleanup)
+npx libretto close --all
+```
+
+<Note>
+  Treat exploration sessions as disposable unless you explicitly need to keep a session open for continued investigation. Use `close --all` before starting a fresh automation run to avoid stale browser state.
+</Note>
+
+#### Session state file
+
+Each session writes a `state.json` file with metadata about the running browser process:
+
+```json  theme={null}
+{
+  "version": 1,
+  "session": "my-session",
+  "port": 9222,
+  "pid": 12345,
+  "startedAt": "2026-03-26T10:00:00.000Z",
+  "status": "active"
+}
+```
+
+| Field       | Type              | Description                                            |
+| ----------- | ----------------- | ------------------------------------------------------ |
+| `version`   | number            | State file schema version                              |
+| `session`   | string            | Session name                                           |
+| `port`      | number            | Chrome DevTools Protocol debug port                    |
+| `pid`       | number (optional) | Browser process ID                                     |
+| `startedAt` | string            | ISO 8601 timestamp when the session started            |
+| `status`    | string            | `active`, `paused`, `completed`, `failed`, or `exited` |
+
+***
+
+### Session logs
+
+Each session directory contains several log files you can query directly with `jq`:
+
+```
+.libretto/
+  config.json
+  sessions/
+    my-session/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+        snapshot-001.png
+        snapshot-001.html
+  profiles/
+    app.example.com.json
+```
+
+#### logs.jsonl
+
+Structured CLI and system logs. Contains debug output from Libretto itself — command execution, errors, and internal events.
+
+```bash  theme={null}
+# View the last 20 log entries
+tail -n 20 .libretto/sessions/my-session/logs.jsonl | jq .
+```
+
+#### actions.jsonl
+
+Recorded user and agent actions. Each line is a JSON object representing one interaction — a click, fill, navigation, or other Playwright action. Libretto records both actions you perform manually in the browser (`source: "user"`) and actions the agent performs programmatically (`source: "agent"`).
+
+Key fields:
+
+| Field                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `ts`                   | ISO timestamp                                                    |
+| `source`               | `"user"` for captured DOM events, `"agent"` for Playwright calls |
+| `action`               | Action type: `click`, `fill`, `goto`, `reload`, etc.             |
+| `selector`             | Selector or locator hint (agent entries)                         |
+| `bestSemanticSelector` | Canonical selector for user DOM events                           |
+| `success`              | `true` if the action completed, `false` on failure               |
+| `value`                | Typed, selected, or submitted value when the action had one      |
+| `url`                  | Navigation target for goto-style actions                         |
+| `error`                | Error message when the action failed                             |
+
+```bash  theme={null}
+# View all recorded actions
+tail -n 20 .libretto/sessions/my-session/actions.jsonl | jq .
+
+# Show only failed actions
+jq 'select(.success == false)' .libretto/sessions/my-session/actions.jsonl
+
+# Show only user actions
+jq 'select(.source == "user")' .libretto/sessions/my-session/actions.jsonl
+```
+
+#### network.jsonl
+
+Captured HTTP requests and responses. Each line represents one request/response pair.
+
+Key fields:
+
+| Field          | Description                        |
+| -------------- | ---------------------------------- |
+| `ts`           | ISO timestamp                      |
+| `method`       | HTTP method: `GET`, `POST`, etc.   |
+| `url`          | Request URL                        |
+| `status`       | HTTP status code                   |
+| `contentType`  | Response content type              |
+| `responseBody` | Response body string (may be null) |
+
+```bash  theme={null}
+# View all captured network requests
+jq . .libretto/sessions/my-session/network.jsonl
+
+# Filter to POST requests only
+jq 'select(.method == "POST")' .libretto/sessions/my-session/network.jsonl
+
+# Find requests to a specific API endpoint
+jq 'select(.url | contains("/api/"))' .libretto/sessions/my-session/network.jsonl
+
+# View JSON API responses
+jq 'select(.contentType | contains("application/json")) | .responseBody' \
+  .libretto/sessions/my-session/network.jsonl
+```
+
+#### snapshots/
+
+The `snapshots/` directory contains paired PNG screenshots and HTML files captured by `npx libretto snapshot`. Each snapshot produces:
+
+* `snapshot-NNN.png` — a full-page screenshot
+* `snapshot-NNN.html` — the full DOM at capture time, used by the AI analysis model
+
+***
+
+### Profiles
+
+Profiles save browser sessions — cookies and localStorage — so you can reuse authenticated state across multiple runs without logging in every time.
+
+#### Creating a profile
+
+```bash  theme={null}
+# Open the site in headed mode so you can log in manually
+npx libretto open https://app.example.com --headed
+
+# After logging in, save the current session as a profile
+npx libretto save app.example.com
+```
+
+The profile is stored at `.libretto/profiles/app.example.com.json`. It contains:
+
+* The full cookie jar for the domain
+* localStorage contents for the domain
+
+#### Using a profile
+
+Pass `--auth-profile` when running a workflow to inject the saved browser state:
+
+```bash  theme={null}
+npx libretto run ./workflow.ts main --auth-profile app.example.com
+```
+
+Libretto loads the profile before executing the workflow, so the browser starts in an already-authenticated state.
+
+#### Profile storage
+
+Profiles are:
+
+* Stored at `.libretto/profiles/<domain>.json`
+* Machine-local — not shared between machines
+* Git-ignored — never committed to version control
+
+<Note>
+  Sessions can expire. If a profile stops working, repeat the manual login flow and run `npx libretto save <domain>` again to refresh it.
+</Note>
+
+***
+
+### Best practices
+
+* **Give sessions meaningful names.** Use names like `debug-login`, `scrape-run-1`, or `test-checkout` instead of the default. Meaningful names make it easier to identify which browser is which when running `npx libretto pages` or reading log files.
+* **Use profiles to avoid repeated logins.** Save authenticated state once and reuse it across runs. This reduces friction during development and avoids login rate limits on the target site.
+* **Keep exploration sessions disposable.** Unless you explicitly need to return to a browser state, close sessions when you're done. Stale sessions consume resources and can interfere with fresh runs.
+* **Clean up before fresh starts.** Run `npx libretto close --all` before beginning a new automation run to ensure you're starting with a clean state.
+* **Don't commit profile files.** Profiles contain session cookies that are effectively credentials. The `.libretto/` directory is already git-ignored, but double-check your `.gitignore` if you're storing Libretto state in a non-standard location.
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Automation approaches" icon="code" href="#automation-approaches">
+    Compare the four integration strategies and their detection risk profiles.
+  </Card>
+
+  <Card title="Bot detection" icon="shield" href="#bot-detection">
+    Understand how sites detect automation and choose approaches that minimize risk.
+  </Card>
+</Columns>

--- a/apps/website/src/docs/content/pages/snapshot.mdx
+++ b/apps/website/src/docs/content/pages/snapshot.mdx
@@ -65,7 +65,7 @@ Snapshot sends a request to an external AI API and waits for the full analysis r
 
 ### Configuration
 
-Snapshot analysis requires a configured AI model. Run `npx libretto init` on first setup, or use `npx libretto ai configure <provider>` to set or change the model later. Credentials are read from environment variables or a `.env` file at your project root.
+Snapshot analysis requires a configured AI model. Run `npx libretto setup` on first setup, or use `npx libretto ai configure <provider>` to set or change the model later. Credentials are read from environment variables or a `.env` file at your project root.
 
 Supported providers: `openai`, `anthropic`, `gemini`, `vertex`.
 

--- a/apps/website/src/docs/content/pages/snapshot.mdx
+++ b/apps/website/src/docs/content/pages/snapshot.mdx
@@ -1,0 +1,108 @@
+## snapshot
+
+> Capture a screenshot and HTML analysis of the current page using an AI model.
+
+The `snapshot` command is the primary page observation tool. It captures a screenshot and the full HTML of the current page, then sends both to an AI model for analysis against your stated objective.
+
+Use `snapshot` before guessing at selectors, after workflow failures, and whenever the visible page state is unclear.
+
+```bash  theme={null}
+npx libretto snapshot \
+  --objective "Find the sign-in form and submit button" \
+  --context "I just opened the login page and need the email field, password field, and submit button."
+```
+
+### Required flags
+
+<ParamField path="--objective" type="string" required>
+  What you want the AI to find, analyze, or explain. A single objective can include multiple questions or analysis tasks — you don't need to run separate snapshots for each question.
+</ParamField>
+
+<ParamField path="--context" type="string" required>
+  Background information that helps the AI understand the current state of the page. Describe what you just did, what you expected to happen, and what the page should contain.
+</ParamField>
+
+### Optional flags
+
+<ParamField path="--session" type="string" required>
+  The session to snapshot.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Target a specific page ID within the session. Use `npx libretto pages --session <name>` to list page IDs when a popup or new tab is open. See [pages & close](#save-pages-close) for details.
+</ParamField>
+
+### What snapshot produces
+
+For each run, `snapshot` saves three files under `.libretto/sessions/<session>/snapshots/<snapshot-id>/`:
+
+| File                  | Contents                                         |
+| --------------------- | ------------------------------------------------ |
+| `page.png`            | Full-page screenshot                             |
+| `page.html`           | Raw page HTML                                    |
+| `page.condensed.html` | Token-optimized condensed HTML sent to the model |
+
+The command prints the paths to all three files before the AI analysis output.
+
+### When to use snapshot
+
+* Before writing a selector — use snapshot to confirm the element structure rather than guessing.
+* After a workflow step fails — inspect the exact page state the failure left behind.
+* When the page has rendered content that isn't obvious from the URL alone.
+* When you need answers to multiple questions about a page in a single call.
+
+<Tip>
+  A single `--objective` can ask several things at once. For example: `"Find the submit button selector, confirm whether there are validation errors, and identify the field that currently has focus."` Batching questions into one snapshot is more efficient than calling snapshot repeatedly.
+</Tip>
+
+### Timeout
+
+Snapshot sends a request to an external AI API and waits for the full analysis response. Depending on page complexity and model speed, this can take 30–90 seconds or more.
+
+<Warning>
+  If you are calling `snapshot` from a shell script or wrapping it in another tool, set a timeout of **at least 2 minutes** to avoid premature cancellation.
+</Warning>
+
+### Configuration
+
+Snapshot analysis requires a configured AI model. Run `npx libretto init` on first setup, or use `npx libretto ai configure <provider>` to set or change the model later. Credentials are read from environment variables or a `.env` file at your project root.
+
+Supported providers: `openai`, `anthropic`, `gemini`, `vertex`.
+
+### Examples
+
+```bash  theme={null}
+# Basic snapshot — find a form
+npx libretto snapshot \
+  --objective "Find the sign-in form and submit button" \
+  --context "I just opened the login page and need the email field, password field, and submit button."
+
+# Snapshot a specific session after a failure
+npx libretto snapshot \
+  --session debug-example \
+  --objective "Explain why the table is empty" \
+  --context "I opened the referrals page, applied filters, and expected rows to appear."
+
+# Snapshot a specific page in a multi-page session
+npx libretto snapshot \
+  --session debug-example \
+  --page <page-id> \
+  --objective "Find the active form" \
+  --context "A modal opened after clicking the Edit button. I need the form fields inside it."
+
+# Snapshot during debugging — ask multiple things at once
+npx libretto snapshot \
+  --session debug-flow \
+  --objective "Find the blocking error or broken selector target. Also describe the current page URL and any visible error messages." \
+  --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="#exec">
+    Run Playwright code to prototype interactions after using snapshot to identify elements.
+  </Card>
+
+  <Card title="run & resume" icon="play" href="#run-resume">
+    Run a full workflow file and use snapshot to debug failures.
+  </Card>
+</CardGroup>

--- a/apps/website/src/docs/content/pages/ui-kit.mdx
+++ b/apps/website/src/docs/content/pages/ui-kit.mdx
@@ -1,0 +1,192 @@
+## UI Kit components
+
+> Development-only reference for the MDX components used across the docs.
+
+<Note>
+  This page is only included in local development builds so docs styling and component changes can be reviewed in one place.
+</Note>
+
+This page demonstrates headings, `inline code`, **strong text**, links like [Quick start](/docs/#quick-start), callouts, steps, API fields, cards, tabs, and tables.
+
+Rendered here:
+
+* `SectionHeading(id, level, children)` via markdown headings
+* `Code(children)` via inline code spans
+* `A(href, children)` via links
+* native `strong` text
+
+### UI Kit callouts
+
+Components in this section:
+
+* `Note(children)`
+* `Tip(children)`
+* `Warning(children)`
+
+<Note>
+  Notes use the same surface styling as docs code blocks.
+</Note>
+
+<Tip>
+  Tips use the same aside flow, so they move out of the main reading column when space allows.
+</Tip>
+
+<Warning>
+  Warnings use the same aside flow as notes and tips.
+</Warning>
+
+### UI Kit code blocks
+
+Component in this section:
+
+* `CodeBlock(lang, title, showLineNumbers, lineHeight, children)` via fenced code blocks
+
+```bash theme={null}
+npx libretto open https://example.com --session ui-kit-demo
+```
+
+```bash theme={null} showLineNumbers={false}
+# OpenAI
+export OPENAI_API_KEY=sk-...
+
+# Anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+```typescript theme={null}
+import { workflow } from "libretto";
+
+export const uiKitDemo = workflow("ui-kit-demo", async ({ page }) => {
+  return await page.title();
+});
+```
+
+### UI Kit steps
+
+Components in this section:
+
+* `Steps(children)`
+* `Step(title, children)`
+
+<Steps>
+  <Step title="Open a page">
+    ```bash theme={null}
+    npx libretto open https://example.com --session ui-kit-demo
+    ```
+
+    <Note>
+      Direct callout children render in the page aside instead of inline.
+    </Note>
+  </Step>
+
+  <Step title="Inspect the current state">
+    ```bash theme={null}
+    npx libretto snapshot \
+      --session ui-kit-demo \
+      --objective "Summarize the current page" \
+      --context "This is the UI kit demo session."
+    ```
+
+    <Tip>
+      Use line numbers for sequential examples that are easier to scan step by step.
+    </Tip>
+  </Step>
+</Steps>
+
+### UI Kit tabs
+
+Components in this section:
+
+* `Tabs(children)`
+* `Tab(title, children)`
+
+<Tabs>
+  <Tab title="CLI">
+    Use the CLI when you want to inspect a live browser session, take snapshots, or prototype commands quickly.
+  </Tab>
+
+  <Tab title="Library">
+    Use the library API when you want a reusable workflow file with typed parameters and return values.
+  </Tab>
+</Tabs>
+
+### UI Kit API fields
+
+Components in this section:
+
+* `ParamField(path, type, required, children)`
+* `ResponseField(name, type, required, children)`
+* `Expandable(title, children)`
+
+<ParamField path="--session" type="string" required>
+  Names the browser session to reuse across commands.
+</ParamField>
+
+<ResponseField name="page" type="Page">
+  The Playwright page instance for the active tab.
+</ResponseField>
+
+<Expandable title="UI Kit expandable">
+  Expandables work well for nested option lists inside parameter documentation.
+</Expandable>
+
+### UI Kit cards and columns
+
+Components in this section:
+
+* `CardGroup(cols, children)`
+* `Columns(cols, children)`
+* `Card(title, href, children)`
+
+<CardGroup cols={2}>
+  <Card title="Quick start" href="/docs/#quick-start">
+    Start with installation, setup, and your first snapshot.
+  </Card>
+  <Card title="CLI reference" href="/docs/#cli-reference">
+    Browse the interactive commands for live browser sessions.
+  </Card>
+</CardGroup>
+
+<Columns cols={2}>
+  <Card title="Library API" href="/docs/#library-api">
+    Workflow, extraction, network, recovery, and logging APIs.
+  </Card>
+  <Card title="Changelog" href="https://github.com/saffron-health/libretto/releases">
+    Track releases and breaking changes.
+  </Card>
+</Columns>
+
+### UI Kit tables
+
+Components in this section:
+
+* `Table(children)` via markdown table syntax
+* `Caption(children)`
+
+| Component | Best for | Example |
+| --------- | -------- | ------- |
+| `Note`    | Non-blocking context | Extra setup guidance |
+| `Tip`     | Tactics and shortcuts | Faster debugging patterns |
+| `Warning` | Risk or irreversible actions | Destructive cleanup commands |
+
+<Caption>
+  Tables inherit the editorial prose rhythm and stay readable inside narrow docs columns.
+</Caption>
+
+Component below:
+
+* `FullWidth(children)`
+
+<FullWidth>
+  <CardGroup cols={3}>
+    <Card title="Full width" href="/docs/#ui-kit-components">
+      Use `FullWidth` for content that benefits from the main column and right gutter together.
+    </Card>
+    <Card title="Callout asides" href="/docs/#ui-kit-callouts">
+      `Note`, `Tip`, and `Warning` drive the right-rail callout interface.
+    </Card>
+    <Card title="Code blocks" href="/docs/#ui-kit-code-blocks">
+      Use `showLineNumbers` to control when numbered code improves comprehension.
+    </Card>
+  </CardGroup>
+</FullWidth>

--- a/apps/website/src/docs/content/pages/workflow.mdx
+++ b/apps/website/src/docs/content/pages/workflow.mdx
@@ -1,0 +1,197 @@
+## Workflow
+
+> Define and run reusable browser automation workflows.
+
+The `workflow()` factory is the entry point for every Libretto automation. You wrap your Playwright logic in a typed handler, export the result, and the CLI (or your own runner) takes care of launching a browser, wiring up context, and invoking your handler.
+
+### `workflow()`
+
+Creates a `LibrettoWorkflow` from a handler function.
+
+```typescript  theme={null}
+function workflow<Input, Output, S>(
+  handler: LibrettoWorkflowHandler<Input, Output, S>
+): LibrettoWorkflow<Input, Output, S>
+```
+
+The handler receives a `LibrettoWorkflowContext` and typed `input`, and must return a `Promise<Output>`.
+
+```typescript  theme={null}
+type LibrettoWorkflowHandler<Input, Output, S> = (
+  ctx: LibrettoWorkflowContext<S>,
+  input: Input
+) => Promise<Output>
+```
+
+#### `LibrettoWorkflowContext<S>`
+
+<ResponseField name="session" type="string">
+  The session identifier for this workflow run. Use it to correlate logs and state files.
+</ResponseField>
+
+<ResponseField name="page" type="Page">
+  A Playwright `Page` instance ready for navigation and interaction.
+</ResponseField>
+
+<ResponseField name="logger" type="MinimalLogger">
+  A structured logger scoped to this workflow run. See [Logging](#logging) for details.
+</ResponseField>
+
+<ResponseField name="services" type="S">
+  An optional generic services object. Defaults to `{}`. Pass domain services (API clients, repositories, etc.) through here so your handler stays testable.
+</ResponseField>
+
+#### Full example
+
+```typescript  theme={null}
+import { workflow, launchBrowser, pause } from "libretto";
+
+export const main = workflow<{ query: string }, string[]>(async (ctx, input) => {
+  const { page, logger } = ctx;
+
+  await page.goto("https://example.com/search");
+  await page.fill("#query", input.query);
+  await page.click("#submit");
+  await page.waitForSelector(".results");
+
+  const results = await page.$$eval(".result-item", (els) =>
+    els.map((el) => el.textContent ?? "")
+  );
+
+  logger.info("Search complete", { count: results.length });
+  return results;
+});
+```
+
+#### Running with the CLI
+
+Pass the file path and the exported name to `libretto run`:
+
+```bash  theme={null}
+npx libretto run ./my-workflow.ts main
+```
+
+The CLI compiles the file with `tsx`, launches a Chromium browser, and calls your handler with the session context it constructs.
+
+***
+
+### `launchBrowser()`
+
+Launches a Playwright Chromium browser and returns a ready-to-use `BrowserSession`. Use this when you want to run workflows programmatically — outside the CLI — or when you need direct access to the `Browser` or `BrowserContext` objects.
+
+```typescript  theme={null}
+async function launchBrowser(args: LaunchBrowserArgs): Promise<BrowserSession>
+```
+
+#### `LaunchBrowserArgs`
+
+<ParamField path="sessionName" type="string" required>
+  A unique identifier for this browser session. Used to name the session state file written under `.libretto/sessions/`.
+</ParamField>
+
+<ParamField path="headless" type="boolean">
+  Whether to run Chromium in headless mode. Defaults to `false` (visible window).
+</ParamField>
+
+<ParamField path="viewport" type="{ width: number; height: number }">
+  The browser viewport size. Defaults to `{ width: 1366, height: 768 }`.
+</ParamField>
+
+<ParamField path="storageStatePath" type="string">
+  Path to a Playwright storage state JSON file (cookies, localStorage). Useful for resuming authenticated sessions.
+</ParamField>
+
+#### `BrowserSession` return value
+
+<ResponseField name="browser" type="Browser">
+  The underlying Playwright `Browser` instance.
+</ResponseField>
+
+<ResponseField name="context" type="BrowserContext">
+  The Playwright `BrowserContext` created for this session.
+</ResponseField>
+
+<ResponseField name="page" type="Page">
+  The initial `Page` opened in the context. Pass this to your workflow handler.
+</ResponseField>
+
+<ResponseField name="debugPort" type="number">
+  The remote debugging port Chromium is listening on.
+</ResponseField>
+
+<ResponseField name="metadataPath" type="string">
+  Absolute path to the session state JSON file written by `launchBrowser`.
+</ResponseField>
+
+<ResponseField name="close" type="() => Promise<void>">
+  Closes the browser and releases all resources.
+</ResponseField>
+
+#### Programmatic usage
+
+```typescript  theme={null}
+import { launchBrowser } from "libretto";
+import { defaultLogger } from "libretto";
+import { main } from "./my-workflow";
+
+const session = await launchBrowser({
+  sessionName: "my-run",
+  headless: true,
+});
+
+try {
+  const result = await main.run(
+    {
+      session: "my-run",
+      page: session.page,
+      logger: defaultLogger,
+      services: {},
+    },
+    { query: "hello world" }
+  );
+  console.log(result);
+} finally {
+  await session.close();
+}
+```
+
+***
+
+### `pause()`
+
+Pauses a running workflow so you can inspect browser state interactively, then resume from the CLI.
+
+```typescript  theme={null}
+async function pause(session: string): Promise<void>
+```
+
+<ParamField path="session" type="string" required>
+  The session identifier. Must match the session name used when the workflow was started.
+</ParamField>
+
+<Note>
+  `pause()` is a no-op when `NODE_ENV === "production"`. It is safe to leave `pause()` calls in your code without worrying about them blocking production runs.
+</Note>
+
+When called in a non-production environment, `pause()` writes a `.paused` signal file and polls for a `.resume` signal. Use the Libretto CLI to send the resume signal:
+
+```bash  theme={null}
+npx libretto resume --session <session-name>
+```
+
+#### Example
+
+```typescript  theme={null}
+import { workflow, pause } from "libretto";
+
+export const main = workflow<{ id: string }, void>(async (ctx, input) => {
+  const { page, session } = ctx;
+
+  await page.goto(`https://example.com/items/${input.id}`);
+
+  // Pause here to inspect the page before continuing
+  await pause(session);
+
+  await page.click("#confirm");
+});
+```

--- a/apps/website/src/docs/styles/docs.css
+++ b/apps/website/src/docs/styles/docs.css
@@ -1,0 +1,1010 @@
+@import "./editorial-prism.css";
+
+.docs-root {
+  --font-primary:
+    "Inter", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", sans-serif;
+  --font-secondary: "PP Editorial New", "Newsreader", serif;
+  --font-code:
+    "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+    monospace;
+
+  --type-body-size: 14px;
+  --type-heading-1-size: 15px;
+  --type-heading-2-size: 14px;
+  --type-heading-3-size: 13px;
+  --type-caption-size: 13px;
+  --type-toc-size: 13px;
+  --type-code-size: 12px;
+  --type-table-size: 11px;
+
+  --bleed: 0px;
+  --bleed-image: 0px;
+
+  --header-padding-y: 16px;
+  --logo-height: 30px;
+  --header-row-height: calc(2 * var(--header-padding-y) + var(--logo-height));
+  --tab-bar-height: 36px;
+  --tab-bar-border: 1px;
+  --header-height: calc(
+    var(--header-row-height) + var(--tab-bar-height) + var(--tab-bar-border)
+  );
+  --layout-gap: 21px;
+  --sticky-top: calc(var(--header-height) + var(--layout-gap));
+  --fade-top: calc(var(--header-row-height) + 19px);
+  --fade-height: 48px;
+
+  --grid-toc-width: 210px;
+  --grid-gap: 50px;
+  --grid-content-width: 520px;
+  --grid-sidebar-width: var(--grid-toc-width);
+  --grid-max-width: calc(
+    var(--grid-toc-width) + var(--grid-gap) + var(--grid-content-width) +
+      var(--grid-gap) + var(--grid-sidebar-width)
+  );
+  --mobile-padding: 1.25rem;
+
+  --border-radius-md: 8px;
+  --duration-smooth: 300ms;
+  --ease-smooth: cubic-bezier(0.19, 1, 0.22, 1);
+
+  --text-primary: oklch(0.153 0.006 107.1);
+  --text-secondary: color-mix(in oklab, oklch(0.153 0.006 107.1) 45%, transparent);
+  --text-tertiary: color-mix(in oklab, oklch(0.153 0.006 107.1) 24%, transparent);
+  --text-muted: color-mix(in oklab, oklch(0.153 0.006 107.1) 55%, transparent);
+  --text-hover: color-mix(in oklab, oklch(0.153 0.006 107.1) 75%, transparent);
+  --text-tree-label: color-mix(in oklab, oklch(0.153 0.006 107.1) 64%, transparent);
+  --bg: oklch(0.966 0.005 106.5);
+  --page-border: color-mix(in oklab, oklch(0.153 0.006 107.1) 10%, transparent);
+  --divider: color-mix(in oklab, oklch(0.153 0.006 107.1) 7%, transparent);
+  --border-subtle: color-mix(in oklab, oklch(0.153 0.006 107.1) 8%, transparent);
+  --code-line-nr: color-mix(in oklab, oklch(0.153 0.006 107.1) 30%, transparent);
+  --selection-bg: color-mix(in oklab, oklch(0.153 0.006 107.1) 8%, transparent);
+  --btn-bg: color-mix(in oklab, white 82%, var(--bg));
+  --btn-shadow:
+    rgba(17, 17, 17, 0.08) 0px 2px 8px,
+    rgba(17, 17, 17, 0.04) 0px 4px 16px,
+    rgba(17, 17, 17, 0.06) 0px 0px 0px 1px inset;
+  --link-accent: #0969da;
+  --logo-color: var(--text-primary);
+
+  --fade-0: var(--bg);
+  --fade-1: color-mix(in oklab, var(--bg) 73.7%, transparent);
+  --fade-2: color-mix(in oklab, var(--bg) 54.1%, transparent);
+  --fade-3: color-mix(in oklab, var(--bg) 38.2%, transparent);
+  --fade-4: color-mix(in oklab, var(--bg) 27.8%, transparent);
+  --fade-5: color-mix(in oklab, var(--bg) 19.4%, transparent);
+  --fade-6: color-mix(in oklab, var(--bg) 12.6%, transparent);
+  --fade-7: color-mix(in oklab, var(--bg) 7.5%, transparent);
+  --fade-8: color-mix(in oklab, var(--bg) 4.2%, transparent);
+  --fade-9: color-mix(in oklab, var(--bg) 2.1%, transparent);
+  --fade-10: color-mix(in oklab, var(--bg) 0.8%, transparent);
+  --fade-11: color-mix(in oklab, var(--bg) 0.2%, transparent);
+  --fade-12: transparent;
+
+  background: var(--bg);
+  color: var(--text-primary);
+}
+
+.docs-root,
+.docs-root * {
+  box-sizing: border-box;
+}
+
+.docs-root a {
+  color: inherit;
+}
+
+.slot-page {
+  font-optical-sizing: auto;
+  font-feature-settings:
+    "liga" 1,
+    "calt" 1;
+}
+
+.slot-page::before {
+  content: "";
+  pointer-events: none;
+  z-index: 9;
+  position: fixed;
+  top: var(--fade-top);
+  left: 0;
+  right: 0;
+  height: var(--fade-height);
+  background: linear-gradient(
+    var(--fade-0) 0px,
+    var(--fade-1) 19%,
+    var(--fade-2) 34%,
+    var(--fade-3) 47%,
+    var(--fade-4) 56.5%,
+    var(--fade-5) 65%,
+    var(--fade-6) 73%,
+    var(--fade-7) 80.2%,
+    var(--fade-8) 86.1%,
+    var(--fade-9) 91%,
+    var(--fade-10) 95.2%,
+    var(--fade-11) 98.2%,
+    var(--fade-12) 100%
+  );
+}
+
+.slot-page ::selection {
+  background: var(--selection-bg);
+}
+
+.editorial-prose strong,
+.editorial-prose .inline-code {
+  opacity: calc(1 / 0.82);
+}
+
+.docs-back-button {
+  background: var(--btn-bg);
+  color: var(--text-secondary);
+  box-shadow: var(--btn-shadow);
+  transition: color 0.15s, transform 0.15s;
+}
+
+.docs-back-button:hover {
+  color: var(--text-hover);
+  transform: scale(1.05);
+}
+
+.docs-back-button:active {
+  transform: scale(0.95);
+}
+
+.docs-section-heading {
+  font-family: var(--font-primary);
+  color: var(--text-primary);
+  margin: 0;
+  padding: 0;
+}
+
+.docs-section-heading-1 {
+  font-size: var(--type-heading-1-size);
+  font-weight: 560;
+  line-height: 1.4;
+  letter-spacing: -0.09px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+
+.docs-section-heading-2 {
+  font-size: var(--type-heading-2-size);
+  font-weight: 560;
+  line-height: 1.4;
+  letter-spacing: -0.09px;
+  padding-top: 10px;
+  padding-bottom: 4px;
+}
+
+.docs-section-heading-3 {
+  font-size: var(--type-heading-3-size);
+  font-weight: 560;
+  line-height: 1.4;
+  letter-spacing: -0.09px;
+  padding-top: 4px;
+  padding-bottom: 2px;
+  color: var(--text-secondary);
+}
+
+.docs-section-heading-text-nowrap {
+  white-space: nowrap;
+}
+
+.docs-section-heading-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--divider);
+}
+
+.docs-prose-p,
+.docs-list,
+.docs-caption {
+  font-family: var(--font-primary);
+  line-height: 1.6;
+  letter-spacing: -0.09px;
+  margin: 0;
+}
+
+.docs-prose-p,
+.docs-list {
+  font-weight: 475;
+  color: var(--text-primary);
+}
+
+.docs-prose-p {
+  opacity: 0.82;
+}
+
+.docs-caption {
+  font-weight: 475;
+  font-size: var(--type-caption-size);
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.docs-link {
+  color: var(--link-accent, #0969da);
+  font-weight: 560;
+  text-decoration: none;
+}
+
+.docs-link:hover {
+  text-decoration: underline;
+}
+
+.docs-bleed {
+  margin-left: calc(-1 * var(--bleed-image));
+  margin-right: calc(-1 * var(--bleed-image));
+  display: flex;
+  justify-content: center;
+  max-width: calc(100% + 2 * var(--bleed-image));
+  overflow: hidden;
+}
+
+.docs-divider {
+  padding: 24px 0;
+  display: flex;
+  align-items: center;
+}
+
+.docs-divider-line {
+  height: 1px;
+  background: var(--divider);
+  flex: 1;
+}
+
+.docs-list-ordered {
+  list-style-type: decimal;
+}
+
+.docs-list-unordered {
+  list-style-type: disc;
+}
+
+.docs-list-item {
+  padding: 0 0 8px 12px;
+}
+
+.docs-code-pre {
+  border-radius: var(--border-radius-md);
+  margin: 0;
+  padding: 0;
+}
+
+.docs-code-body {
+  padding: 12px 8px 8px;
+  font-family: var(--font-code);
+  font-size: var(--type-code-size);
+  font-weight: 400;
+  line-height: var(--docs-code-line-height, 1.85);
+  letter-spacing: normal;
+  color: var(--text-primary);
+  tab-size: 2;
+}
+
+.docs-code-line-numbers {
+  color: var(--code-line-nr);
+  text-align: right;
+  padding-right: 20px;
+  width: 36px;
+  user-select: none;
+}
+
+.docs-code-content {
+  white-space: pre;
+  background: none;
+  padding: 0;
+  line-height: var(--docs-code-line-height, 1.85);
+}
+
+.docs-media-frame {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+
+.docs-media-placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  image-rendering: pixelated;
+  z-index: 0;
+}
+
+.docs-media-image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity 0.4s ease;
+  z-index: 1;
+}
+
+.docs-media-poster {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity 0.4s ease;
+  z-index: 1;
+}
+
+.docs-media-video {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 2;
+  background: transparent;
+}
+
+.docs-chart-placeholder {
+  background: rgb(17, 17, 17);
+}
+
+.docs-chart-label {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+  font-family: var(--font-code);
+  font-weight: 475;
+  font-size: var(--type-table-size);
+}
+
+.docs-comparison-table-wrap {
+  padding: 8px 0;
+}
+
+.docs-comparison-table-title {
+  font-family: var(--font-primary);
+  font-size: var(--type-table-size);
+  font-weight: 400;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+  padding: 0 0 6px;
+}
+
+.docs-comparison-table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.docs-comparison-table-header {
+  padding: 4px 12px 4px 0;
+  font-size: var(--type-table-size);
+  font-weight: 400;
+  font-family: var(--font-primary);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--page-border);
+}
+
+.docs-comparison-table-cell {
+  padding: 4px 12px 4px 0;
+  font-size: var(--type-table-size);
+  font-weight: 475;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--page-border);
+}
+
+.docs-comparison-table-cell-code {
+  font-family: var(--font-code);
+}
+
+.docs-comparison-table-cell-nowrap {
+  white-space: nowrap;
+}
+
+.docs-root .slot-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg);
+}
+
+.docs-root .slot-logo {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.docs-root .slot-tabbar {
+  border-bottom: 1px solid var(--page-border);
+}
+
+.docs-root .slot-tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.docs-root .slot-sidebar-left,
+.docs-root .slot-sidebar-right {
+  display: none;
+}
+
+.docs-root .slot-main {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.docs-toc {
+  max-width: var(--grid-toc-width);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.docs-toc-search {
+  padding-bottom: 12px;
+  display: flex;
+  align-items: center;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.docs-toc-search-input {
+  width: 100%;
+  padding: 2px 24px 2px 8px;
+  font-size: var(--type-toc-size);
+  font-family: var(--font-primary);
+  font-weight: 475;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid var(--page-border);
+  border-radius: 6px;
+  outline: none;
+  letter-spacing: normal;
+  line-height: 1.6;
+  box-sizing: border-box;
+}
+
+.docs-toc-hotkey {
+  position: absolute;
+  right: 6px;
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  border: 1px solid var(--text-tertiary);
+  border-radius: 4px;
+  padding: 0 4px;
+  line-height: 16px;
+  pointer-events: none;
+}
+
+.docs-toc-nav {
+  overflow-y: auto;
+  min-height: 0;
+  padding-right: 4px;
+}
+
+.docs-toc-link {
+  --docs-toc-line-height: 1.5;
+  --docs-toc-prefix-scale: 0.92;
+  display: flex;
+  align-items: flex-start;
+  font-size: var(--type-toc-size);
+  font-weight: var(--toc-link-font-weight, 400);
+  letter-spacing: normal;
+  line-height: var(--docs-toc-line-height);
+  padding: 4px 8px;
+  color: var(--toc-link-color);
+  font-family: var(--font-primary);
+  background: var(--toc-link-bg);
+  border-radius: 6px;
+  opacity: var(--toc-link-opacity);
+}
+
+.docs-toc-link-prefix {
+  color: var(--toc-prefix-color);
+  white-space: pre;
+  font-family: var(--font-code);
+  font-size: calc(var(--type-toc-size) * var(--docs-toc-prefix-scale));
+  display: inline-flex;
+  align-items: center;
+  height: calc(var(--type-toc-size) * var(--docs-toc-line-height));
+  line-height: 1;
+  margin: 0;
+}
+
+.docs-toc-link-label {
+  overflow-wrap: anywhere;
+  font-family: var(--font-primary);
+  flex: 1;
+  line-height: inherit;
+}
+
+.docs-toc-chevron {
+  color: var(--toc-prefix-color);
+  display: inline-flex;
+  align-items: center;
+  min-height: calc(1em * var(--docs-toc-line-height));
+}
+
+.docs-toc-link:hover .docs-toc-chevron {
+  color: var(--text-primary);
+}
+
+.docs-section-aside {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.docs-sidebar-banner {
+  position: relative;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--border-radius-md);
+  padding: 10px;
+  font-size: var(--type-toc-size);
+  font-weight: 475;
+  line-height: 1.4;
+  color: var(--text-tree-label);
+  overflow: visible;
+}
+
+.docs-sidebar-banner-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 32px;
+  margin-top: 8px;
+  border-radius: var(--border-radius-md);
+  font-size: var(--type-toc-size);
+  font-weight: 475;
+  background-color: var(--text-primary);
+  color: var(--bg);
+  text-decoration: none;
+  position: relative;
+  z-index: 2;
+  transition: opacity 0.15s ease;
+}
+
+.docs-sidebar-banner-button:hover {
+  opacity: 0.85;
+}
+
+.docs-sidebar-banner-image {
+  position: absolute;
+  z-index: 1;
+  top: -32px;
+  right: -32px;
+  height: 120px;
+  width: auto;
+  pointer-events: none;
+}
+
+.docs-sidebar-sticky {
+  position: sticky;
+  display: flex;
+  flex-direction: column;
+}
+
+.docs-sidebar-right-sticky {
+  position: sticky;
+  padding-top: 4px;
+}
+
+.docs-tab-link {
+  color: var(--text-secondary);
+  text-shadow: none;
+}
+
+.docs-tab-link:hover {
+  color: var(--text-primary);
+}
+
+.docs-tab-link:hover .docs-tab-indicator {
+  background-color: var(--text-tertiary);
+}
+
+.docs-tab-link-active {
+  color: var(--text-primary);
+  text-shadow: -0.2px 0 0 currentColor, 0.2px 0 0 currentColor;
+}
+
+.docs-tab-link-active .docs-tab-indicator {
+  background-color: var(--text-primary);
+}
+
+.docs-tab-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 1.5px;
+  background-color: transparent;
+  border-radius: 1px;
+  transition: background-color 0.15s ease;
+}
+
+.slot-main img {
+  max-width: 100% !important;
+  height: auto;
+}
+
+.slot-main .bleed > * {
+  max-width: 100% !important;
+}
+
+.slot-main .bleed {
+  overflow: hidden;
+}
+
+.bleed {
+  margin-left: calc(-1 * var(--bleed));
+  margin-right: calc(-1 * var(--bleed));
+}
+
+.inline-code {
+  position: relative;
+  display: inline-block;
+  font-family: var(--font-code);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 13px;
+  letter-spacing: 0.01em;
+  padding: 2px 4px;
+  color: rgba(17, 17, 17, 0.78);
+}
+
+.inline-code::before {
+  content: "";
+  position: absolute;
+  inset: -1px 0;
+  background: rgba(17, 17, 17, 0.04);
+  border-radius: 4px;
+  z-index: -1;
+}
+
+.docs-root ::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+  background: transparent;
+  border-radius: var(--border-radius-md);
+}
+
+.docs-root ::-webkit-scrollbar-thumb {
+  background: rgba(17, 17, 17, 0.15);
+  border-radius: var(--border-radius-md);
+}
+
+.docs-root ::-webkit-scrollbar-thumb:hover {
+  background: rgba(17, 17, 17, 0.3);
+}
+
+.toc-children-container {
+  view-transition-class: toc-children;
+}
+
+::view-transition-group(root) {
+  animation: none;
+}
+
+::view-transition-new(.toc-children) {
+  animation: toc-clip-in 180ms var(--ease-smooth) both;
+}
+
+::view-transition-old(.toc-children) {
+  animation: toc-clip-out 140ms ease-in both;
+}
+
+::view-transition-group(.toc-children) {
+  animation: none;
+}
+
+@keyframes stagger-in {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toc-clip-in {
+  from {
+    clip-path: inset(0 0 100% 0);
+    opacity: 0;
+  }
+  to {
+    clip-path: inset(0);
+    opacity: 1;
+  }
+}
+
+@keyframes toc-clip-out {
+  from {
+    clip-path: inset(0);
+    opacity: 1;
+  }
+  to {
+    clip-path: inset(0 0 100% 0);
+    opacity: 0;
+  }
+}
+
+@media (min-width: 1080px) {
+  .docs-root {
+    --bleed: 44px;
+    --bleed-image: 28px;
+  }
+
+  .docs-root .slot-sidebar-left {
+    display: block;
+    grid-column: 1;
+    grid-row: 1 / span 100;
+  }
+
+  .docs-root .slot-sidebar-right {
+    display: block;
+    grid-column: 3;
+  }
+}
+
+.docs-blockquote {
+  margin: 0;
+  padding: 0 0 0 16px;
+  border-left: 1px solid var(--page-border);
+  color: var(--text-secondary);
+}
+
+.docs-blockquote > * {
+  margin: 0;
+}
+
+.docs-blockquote > * + * {
+  margin-top: 10px;
+}
+
+.docs-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 4px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--page-border);
+  border-radius: var(--border-radius-md);
+  background: color-mix(in oklab, white 55%, var(--bg));
+}
+
+.docs-callout-label {
+  font-family: var(--font-primary);
+  font-size: var(--type-toc-size);
+  font-weight: 560;
+  color: var(--text-primary);
+}
+
+.docs-callout-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.docs-callout-note {
+  background: color-mix(in oklab, white 65%, var(--bg));
+}
+
+.docs-callout-tip {
+  background: color-mix(in oklab, oklch(0.89 0.04 160) 32%, white);
+}
+
+.docs-callout-warning {
+  background: color-mix(in oklab, oklch(0.88 0.05 70) 36%, white);
+}
+
+.docs-steps {
+  counter-reset: docs-step;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.docs-step {
+  counter-increment: docs-step;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.docs-step-badge {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid var(--page-border);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-code);
+  font-size: var(--type-code-size);
+  font-weight: 475;
+}
+
+.docs-step-badge::before {
+  content: counter(docs-step);
+}
+
+.docs-step-content,
+.docs-step-body,
+.docs-tab-body,
+.docs-field-body,
+.docs-accordion-body,
+.docs-expandable-body,
+.docs-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.docs-step-title,
+.docs-tab-title,
+.docs-accordion-title,
+.docs-expandable-title,
+.docs-card-title {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: var(--type-heading-2-size);
+  font-weight: 560;
+  line-height: 1.4;
+  letter-spacing: -0.09px;
+  color: var(--text-primary);
+}
+
+.docs-card-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--docs-card-columns, 2), minmax(0, 1fr));
+  gap: 12px;
+}
+
+.docs-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--page-border);
+  border-radius: var(--border-radius-md);
+  background: color-mix(in oklab, white 60%, var(--bg));
+  transition:
+    border-color 150ms ease,
+    transform 150ms ease,
+    background-color 150ms ease;
+}
+
+.docs-card:hover {
+  border-color: color-mix(in oklab, var(--text-tertiary) 45%, transparent);
+  background: color-mix(in oklab, white 72%, var(--bg));
+  transform: translateY(-1px);
+}
+
+.docs-card-grid + .docs-card-grid {
+  margin-top: 12px;
+}
+
+.docs-tabs,
+.docs-code-group,
+.docs-accordion-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.docs-tab-panel,
+.docs-accordion,
+.docs-expandable {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--page-border);
+  border-radius: var(--border-radius-md);
+  background: color-mix(in oklab, white 55%, var(--bg));
+}
+
+.docs-expandable {
+  padding: 12px;
+}
+
+.docs-expandable-title {
+  font-size: var(--type-heading-3-size);
+}
+
+.docs-code-title {
+  margin-bottom: 6px;
+  font-family: var(--font-code);
+  font-size: var(--type-table-size);
+  font-weight: 475;
+  color: var(--text-secondary);
+}
+
+.docs-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.docs-table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.docs-table-header,
+.docs-table-cell {
+  padding: 8px 10px 8px 0;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--page-border);
+}
+
+.docs-table-header {
+  font-family: var(--font-primary);
+  font-size: var(--type-table-size);
+  font-weight: 560;
+  color: var(--text-secondary);
+}
+
+.docs-table-cell {
+  font-family: var(--font-primary);
+  font-size: var(--type-caption-size);
+  font-weight: 475;
+  color: var(--text-primary);
+}
+
+.docs-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--page-border);
+}
+
+.docs-field-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.docs-field-name,
+.docs-field-type {
+  font-family: var(--font-code);
+  font-size: var(--type-code-size);
+  font-weight: 475;
+}
+
+.docs-field-name {
+  color: var(--text-primary);
+}
+
+.docs-field-type {
+  color: var(--text-secondary);
+}
+
+.docs-field-required {
+  font-family: var(--font-primary);
+  font-size: var(--type-table-size);
+  font-weight: 560;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 768px) {
+  .docs-card-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/website/src/docs/styles/docs.css
+++ b/apps/website/src/docs/styles/docs.css
@@ -10,9 +10,14 @@
     monospace;
 
   --type-body-size: 14px;
+  --type-scale-ratio: 1.61803398875;
   --type-heading-1-size: 15px;
   --type-heading-2-size: 14px;
   --type-heading-3-size: 13px;
+  --type-section-heading-3-size: 16px;
+  --type-section-heading-2-size: calc(
+    var(--type-section-heading-3-size) * var(--type-scale-ratio)
+  );
   --type-caption-size: 13px;
   --type-toc-size: 13px;
   --type-code-size: 12px;
@@ -178,23 +183,23 @@
 }
 
 .docs-section-heading-2 {
-  font-size: var(--type-heading-2-size);
+  font-size: var(--type-section-heading-2-size);
   font-weight: 560;
-  line-height: 1.4;
+  line-height: 1.25;
   letter-spacing: -0.09px;
-  margin-top: 12px;
+  margin-top: 24px;
   padding-top: 0;
-  padding-bottom: 4px;
+  padding-bottom: 8px;
 }
 
 .docs-section-heading-3 {
-  font-size: 14px;
+  font-size: var(--type-section-heading-3-size);
   font-weight: 560;
-  line-height: 1.4;
+  line-height: 1.35;
   letter-spacing: normal;
-  margin-top: 4px;
+  margin-top: 16px;
   padding-top: 0;
-  padding-bottom: 2px;
+  padding-bottom: 4px;
   color: var(--text-primary);
 }
 
@@ -664,29 +669,21 @@
 }
 
 .inline-code {
-  position: relative;
   display: inline-block;
   font-family: var(--font-code);
   font-size: 12px;
   font-weight: 500;
-  line-height: 16px;
+  line-height: 14px;
   letter-spacing: 0.01em;
   padding: 2px 4px;
   color: rgba(17, 17, 17, 0.78);
+  background: rgba(17, 17, 17, 0.04);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
 }
 
 .docs-section-heading .inline-code {
   vertical-align: baseline;
-}
-
-.inline-code::before {
-  content: "";
-  position: absolute;
-  inset: -1px 0;
-  background: rgba(17, 17, 17, 0.04);
-  border: 1px solid var(--border-subtle);
-  border-radius: 3px;
-  z-index: -1;
 }
 
 .docs-root ::-webkit-scrollbar {

--- a/apps/website/src/docs/styles/docs.css
+++ b/apps/website/src/docs/styles/docs.css
@@ -58,6 +58,7 @@
   --page-border: color-mix(in oklab, oklch(0.153 0.006 107.1) 10%, transparent);
   --divider: color-mix(in oklab, oklch(0.153 0.006 107.1) 7%, transparent);
   --border-subtle: color-mix(in oklab, oklch(0.153 0.006 107.1) 8%, transparent);
+  --surface-note: color-mix(in oklab, white 65%, var(--bg));
   --code-line-nr: color-mix(in oklab, oklch(0.153 0.006 107.1) 30%, transparent);
   --selection-bg: color-mix(in oklab, oklch(0.153 0.006 107.1) 8%, transparent);
   --btn-bg: color-mix(in oklab, white 82%, var(--bg));
@@ -137,6 +138,10 @@
   opacity: calc(1 / 0.82);
 }
 
+.docs-root strong {
+  font-weight: 560;
+}
+
 .docs-back-button {
   background: var(--btn-bg);
   color: var(--text-secondary);
@@ -177,18 +182,20 @@
   font-weight: 560;
   line-height: 1.4;
   letter-spacing: -0.09px;
-  padding-top: 10px;
+  margin-top: 12px;
+  padding-top: 0;
   padding-bottom: 4px;
 }
 
 .docs-section-heading-3 {
-  font-size: var(--type-heading-3-size);
+  font-size: 14px;
   font-weight: 560;
   line-height: 1.4;
-  letter-spacing: -0.09px;
-  padding-top: 4px;
+  letter-spacing: normal;
+  margin-top: 4px;
+  padding-top: 0;
   padding-bottom: 2px;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .docs-section-heading-text-nowrap {
@@ -270,6 +277,13 @@
   padding: 0 0 8px 12px;
 }
 
+.docs-code-frame {
+  border: 1px solid var(--page-border);
+  border-radius: var(--border-radius-md);
+  background: var(--surface-note);
+  overflow: hidden;
+}
+
 .docs-code-pre {
   border-radius: var(--border-radius-md);
   margin: 0;
@@ -277,7 +291,7 @@
 }
 
 .docs-code-body {
-  padding: 12px 8px 8px;
+  padding: 12px 14px 10px;
   font-family: var(--font-code);
   font-size: var(--type-code-size);
   font-weight: 400;
@@ -290,9 +304,11 @@
 .docs-code-line-numbers {
   color: var(--code-line-nr);
   text-align: right;
-  padding-right: 20px;
-  width: 36px;
+  padding-right: 14px;
+  margin-right: 14px;
+  width: 30px;
   user-select: none;
+  border-right: 1px solid var(--page-border);
 }
 
 .docs-code-content {
@@ -534,8 +550,11 @@
 }
 
 .docs-section-aside {
-  margin-top: 4px;
-  margin-bottom: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 .docs-sidebar-banner {
@@ -648,12 +667,16 @@
   position: relative;
   display: inline-block;
   font-family: var(--font-code);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
-  line-height: 13px;
+  line-height: 16px;
   letter-spacing: 0.01em;
   padding: 2px 4px;
   color: rgba(17, 17, 17, 0.78);
+}
+
+.docs-section-heading .inline-code {
+  vertical-align: baseline;
 }
 
 .inline-code::before {
@@ -661,7 +684,8 @@
   position: absolute;
   inset: -1px 0;
   background: rgba(17, 17, 17, 0.04);
-  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
   z-index: -1;
 }
 
@@ -768,21 +792,45 @@
 }
 
 .docs-callout {
+  --docs-callout-accent: var(--text-secondary);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   margin: 4px 0;
   padding: 12px 14px;
   border: 1px solid var(--page-border);
   border-radius: var(--border-radius-md);
   background: color-mix(in oklab, white 55%, var(--bg));
+  font-size: var(--type-body-size);
+  line-height: 1.6;
+}
+
+.docs-callout-header {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.docs-callout-icon-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--docs-callout-accent);
+}
+
+.docs-callout-icon {
+  width: 16px;
+  height: 16px;
+  display: block;
+  flex-shrink: 0;
 }
 
 .docs-callout-label {
   font-family: var(--font-primary);
-  font-size: var(--type-toc-size);
+  font-size: var(--type-code-size);
   font-weight: 560;
-  color: var(--text-primary);
+  line-height: 1.45;
+  color: var(--docs-callout-accent);
 }
 
 .docs-callout-body {
@@ -792,14 +840,29 @@
 }
 
 .docs-callout-note {
-  background: color-mix(in oklab, white 65%, var(--bg));
+  --docs-callout-accent: color-mix(
+    in oklab,
+    oklch(0.62 0.14 88) 82%,
+    white
+  );
+  background: color-mix(in oklab, oklch(0.9 0.05 95) 46%, white);
 }
 
 .docs-callout-tip {
+  --docs-callout-accent: color-mix(
+    in oklab,
+    oklch(0.55 0.12 170) 76%,
+    white
+  );
   background: color-mix(in oklab, oklch(0.89 0.04 160) 32%, white);
 }
 
 .docs-callout-warning {
+  --docs-callout-accent: color-mix(
+    in oklab,
+    oklch(0.62 0.14 75) 80%,
+    white
+  );
   background: color-mix(in oklab, oklch(0.88 0.05 70) 36%, white);
 }
 
@@ -816,6 +879,17 @@
   grid-template-columns: 28px minmax(0, 1fr);
   gap: 14px;
   align-items: start;
+  position: relative;
+}
+
+.docs-step:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 13.5px;
+  top: 30px;
+  bottom: -16px;
+  width: 1px;
+  background: var(--page-border);
 }
 
 .docs-step-badge {
@@ -837,10 +911,8 @@
 }
 
 .docs-step-content,
-.docs-step-body,
 .docs-tab-body,
 .docs-field-body,
-.docs-accordion-body,
 .docs-expandable-body,
 .docs-card-body {
   display: flex;
@@ -849,9 +921,7 @@
   min-width: 0;
 }
 
-.docs-step-title,
 .docs-tab-title,
-.docs-accordion-title,
 .docs-expandable-title,
 .docs-card-title {
   margin: 0;
@@ -861,6 +931,57 @@
   line-height: 1.4;
   letter-spacing: -0.09px;
   color: var(--text-primary);
+}
+
+.docs-step-title {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: var(--type-body-size);
+  font-weight: 500;
+  line-height: 1.5;
+  letter-spacing: normal;
+  color: var(--text-primary);
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+}
+
+.docs-step-body,
+.docs-step-main,
+.docs-tab-main,
+.docs-tab-aside,
+.docs-expandable-main,
+.docs-expandable-aside,
+.docs-callout-aside-layout,
+.docs-callout-aside-main,
+.docs-callout-aside-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.docs-tab-aside .docs-callout,
+.docs-expandable-aside .docs-callout,
+.docs-section-aside .docs-callout,
+.docs-callout-aside-rail .docs-callout {
+  margin: 0;
+}
+
+.docs-card-link-surface {
+  position: relative;
+}
+
+.docs-card-link-icon {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  color: var(--text-tertiary);
+}
+
+.docs-card-title,
+.docs-tab-title {
+  padding-right: 24px;
 }
 
 .docs-card-grid {
@@ -895,15 +1016,27 @@
 }
 
 .docs-tabs,
-.docs-code-group,
-.docs-accordion-group {
+.docs-code-group {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+@media (min-width: 1080px) {
+  .docs-callout-aside-layout-with-aside {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(170px, 190px);
+    gap: 16px;
+    align-items: start;
+  }
+
+  .docs-section-aside {
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+}
+
 .docs-tab-panel,
-.docs-accordion,
 .docs-expandable {
   display: flex;
   flex-direction: column;
@@ -923,7 +1056,7 @@
 }
 
 .docs-code-title {
-  margin-bottom: 6px;
+  padding: 10px 14px 0;
   font-family: var(--font-code);
   font-size: var(--type-table-size);
   font-weight: 475;

--- a/apps/website/src/docs/styles/editorial-prism.css
+++ b/apps/website/src/docs/styles/editorial-prism.css
@@ -1,0 +1,98 @@
+/* Adapted from playwriter.dev Prism theme */
+
+.docs-root code[class*="language-"],
+.docs-root pre[class*="language-"] {
+  color: #1e293b;
+  background: none;
+  text-shadow: none;
+  font-family: var(--font-code);
+  font-size: var(--type-code-size);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.85;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  tab-size: 2;
+  hyphens: none;
+}
+
+.docs-root .token.keyword,
+.docs-root .token.module,
+.docs-root .token.imports,
+.docs-root .token.control-flow {
+  color: #b42318;
+}
+
+.docs-root .token.string,
+.docs-root .token.template-string,
+.docs-root .token.attr-value {
+  color: #0b5ed7;
+}
+
+.docs-root .token.function,
+.docs-root .token.class-name {
+  color: #7c3aed;
+}
+
+.docs-root .token.property,
+.docs-root .token.parameter {
+  color: #b45309;
+}
+
+.docs-root .token.tag .token.tag,
+.docs-root .token.tag .token.class-name {
+  color: #15803d;
+}
+
+.docs-root .token.tag .token.attr-name,
+.docs-root .token.attr-name,
+.docs-root .token.number,
+.docs-root .token.boolean,
+.docs-root .token.constant,
+.docs-root .token.builtin,
+.docs-root .language-bash .token.function {
+  color: #2563eb;
+}
+
+.docs-root .token.operator,
+.docs-root .token.spread {
+  color: #b42318;
+}
+
+.docs-root .token.punctuation,
+.docs-root .token.plain-text,
+.docs-root .token.tag .token.punctuation {
+  color: #1e293b;
+}
+
+.docs-root .token.comment,
+.docs-root .token.prolog,
+.docs-root .token.doctype,
+.docs-root .token.cdata {
+  color: #6b7280;
+  font-style: italic;
+}
+
+.docs-root .token.regex {
+  color: #0b5ed7;
+}
+
+.docs-root code.language-diagram {
+  font-weight: 400;
+}
+
+.docs-root .language-diagram .token.box-drawing,
+.docs-root .language-diagram .token.line-char {
+  color: #8a8a8a;
+}
+
+.docs-root .language-diagram .token.label {
+  color: #0d7a5f;
+}
+
+.docs-root .token {
+  text-shadow: none;
+}

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -70,6 +70,126 @@ body {
   color: var(--color-ink);
 }
 
+.libretto-button {
+  position: relative;
+  min-width: fit-content;
+  border: 0;
+  cursor: pointer;
+  color: var(--color-cream);
+  font-family: var(--font-sans);
+  letter-spacing: 0.01em;
+  line-height: 1;
+  text-decoration: none;
+  text-rendering: geometricPrecision;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0.03) 100%),
+    linear-gradient(180deg, oklch(0.248 0.007 107.1) 0%, oklch(0.176 0.006 107.1) 100%),
+    radial-gradient(
+      130% 160% at 50% 0%,
+      oklch(0.288 0.008 107.1) 0%,
+      oklch(0.22 0.007 107.1) 46%,
+      oklch(0.156 0.006 107.1) 100%
+    );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.16),
+    inset 0 0 0 1px oklch(0.418 0.009 107.1 / 0.72),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.24),
+    0 1px 1px rgba(17, 17, 17, 0.16),
+    0 12px 28px rgba(17, 17, 17, 0.09);
+  transition:
+    background 120ms ease-in-out,
+    box-shadow 120ms ease-in-out,
+    color 120ms ease-in-out,
+    transform 80ms ease-in-out;
+}
+
+.libretto-button:hover {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.04) 100%),
+    linear-gradient(180deg, oklch(0.268 0.007 107.1) 0%, oklch(0.192 0.006 107.1) 100%),
+    radial-gradient(
+      130% 160% at 50% 0%,
+      oklch(0.308 0.008 107.1) 0%,
+      oklch(0.236 0.007 107.1) 46%,
+      oklch(0.17 0.006 107.1) 100%
+    );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.18),
+    inset 0 0 0 1px oklch(0.49 0.01 107.1 / 0.84),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.24),
+    0 1px 1px rgba(17, 17, 17, 0.16),
+    0 14px 30px rgba(17, 17, 17, 0.12);
+}
+
+.libretto-button[aria-pressed="true"] {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.05) 100%),
+    linear-gradient(180deg, oklch(0.276 0.008 107.1) 0%, oklch(0.2 0.006 107.1) 100%),
+    radial-gradient(
+      130% 160% at 50% 0%,
+      oklch(0.318 0.009 107.1) 0%,
+      oklch(0.246 0.007 107.1) 46%,
+      oklch(0.176 0.006 107.1) 100%
+    );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.2),
+    inset 0 0 0 1px oklch(0.53 0.011 107.1 / 0.9),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.22),
+    0 0 0 1px oklch(0.68 0.009 107.1 / 0.12),
+    0 14px 30px rgba(17, 17, 17, 0.12);
+}
+
+.libretto-button:focus-visible {
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.2),
+    inset 0 0 0 1px oklch(0.53 0.011 107.1 / 0.9),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.22),
+    0 0 0 3px oklch(0.735 0.01 107.1 / 0.28),
+    0 14px 30px rgba(17, 17, 17, 0.12);
+}
+
+.libretto-button:active {
+  transform: translateY(1px);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.02) 100%),
+    linear-gradient(180deg, oklch(0.228 0.007 107.1) 0%, oklch(0.166 0.006 107.1) 100%),
+    radial-gradient(
+      130% 160% at 50% 0%,
+      oklch(0.268 0.008 107.1) 0%,
+      oklch(0.208 0.007 107.1) 46%,
+      oklch(0.152 0.006 107.1) 100%
+    );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.13),
+    inset 0 0 0 1px oklch(0.43 0.009 107.1 / 0.78),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.28),
+    0 8px 18px rgba(17, 17, 17, 0.09);
+}
+
+.libretto-button:disabled,
+.libretto-button[aria-disabled="true"] {
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.1),
+    inset 0 0 0 1px oklch(0.37 0.008 107.1 / 0.42),
+    0 6px 14px rgba(17, 17, 17, 0.06);
+}
+
+.libretto-button--default {
+  min-height: 2.25rem;
+  padding-inline: 1.375rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.libretto-button--sm {
+  min-height: 1.9375rem;
+  padding-inline: 0.9375rem;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
 @keyframes blink {
   0%,
   100% {

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -61,6 +61,15 @@
   --color-faint: oklch(0.6 0.015 107);
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--color-cream);
+  color: var(--color-ink);
+}
+
 @keyframes blink {
   0%,
   100% {

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -1,0 +1,86 @@
+import type * as React from "react";
+import { Link } from "wouter";
+
+type AppLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string;
+};
+
+export function normalizeAppPathname(pathname: string): string {
+  if (pathname === "/") {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/, "");
+}
+
+export function isAppOwnedPathname(pathname: string): boolean {
+  const normalizedPathname = normalizeAppPathname(pathname);
+
+  return (
+    normalizedPathname === "/" ||
+    normalizedPathname === "/docs" ||
+    normalizedPathname === "/docs/index.html" ||
+    normalizedPathname.startsWith("/docs/")
+  );
+}
+
+function shouldUseSpaNavigation({
+  href,
+  target,
+  download,
+}: {
+  href: string;
+  target?: React.HTMLAttributeAnchorTarget;
+  download?: React.AnchorHTMLAttributes<HTMLAnchorElement>["download"];
+}): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (href.startsWith("#")) {
+    return false;
+  }
+
+  if (target && target !== "_self") {
+    return false;
+  }
+
+  if (typeof download !== "undefined") {
+    return false;
+  }
+
+  try {
+    const url = new URL(href, window.location.origin);
+
+    if (!["http:", "https:"].includes(url.protocol)) {
+      return false;
+    }
+
+    if (url.origin !== window.location.origin) {
+      return false;
+    }
+
+    if (!isAppOwnedPathname(url.pathname)) {
+      return false;
+    }
+
+    const currentPathname = normalizeAppPathname(window.location.pathname);
+    const nextPathname = normalizeAppPathname(url.pathname);
+    const isSameDocumentHashNavigation =
+      nextPathname === currentPathname &&
+      url.search === window.location.search &&
+      Boolean(url.hash);
+
+    return !isSameDocumentHashNavigation;
+  } catch {
+    return false;
+  }
+}
+
+export function AppLink({ href, target, download, ...props }: AppLinkProps) {
+  if (shouldUseSpaNavigation({ href, target, download })) {
+    return <Link href={href} target={target} download={download} {...props} />;
+  }
+
+  return <a href={href} target={target} download={download} {...props} />;
+}

--- a/apps/website/src/site.ts
+++ b/apps/website/src/site.ts
@@ -1,0 +1,3 @@
+export const REPO_URL = "https://github.com/saffron-health/libretto";
+export const DISCUSSIONS_URL = `${REPO_URL}/discussions`;
+export const RELEASES_URL = `${REPO_URL}/releases`;

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from "vite-plus";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        docs: fileURLToPath(new URL("./docs/index.html", import.meta.url)),
+      },
+    },
+  },
   lint: { options: { typeAware: true, typeCheck: true } },
   test: { exclude: ["**/node_modules/**", "tmp/**"] },
   staged: { "*": "vp check --fix" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   apps/website:
     dependencies:
+      '@orama/orama':
+        specifier: ^3.1.18
+        version: 3.1.18
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
@@ -44,12 +47,18 @@ importers:
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      prismjs:
+        specifier: ^1.30.0
+        version: 1.30.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      safe-mdx:
+        specifier: ^1.3.9
+        version: 1.3.9(react@19.2.4)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -57,6 +66,12 @@ importers:
       '@ai-sdk/google-vertex':
         specifier: ^4.0.95
         version: 4.0.95(zod@4.3.6)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/prismjs':
+        specifier: ^1.26.6
+        version: 1.26.6
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -83,7 +98,7 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: latest
-        version: 0.1.14(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.15(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
 
   benchmarks:
     dependencies:
@@ -395,8 +410,25 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@borewit/text-codec@0.2.2':
@@ -872,6 +904,10 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@orama/orama@3.1.18':
+    resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
+    engines: {node: '>= 20.0.0'}
+
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     resolution: {integrity: sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -995,6 +1031,10 @@ packages:
     resolution: {integrity: sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@oxc-project/runtime@0.122.0':
+    resolution: {integrity: sha512-vevyz3bNjevQFCV2Yg5o6Sp9BSoiYiJVymMrzA3S1ZGj4J8ak4YiywhFyQMueQ3UNlJU6HZOZYDy70TUc99aHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/types@0.120.0':
     resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
@@ -1101,260 +1141,260 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxfmt/binding-android-arm-eabi@0.42.0':
-    resolution: {integrity: sha512-dsqPTYsozeokRjlrt/b4E7Pj0z3eS3Eg74TWQuuKbjY4VttBmA88rB7d50Xrd+TZ986qdXCNeZRPEzZHAe+jow==}
+  '@oxfmt/binding-android-arm-eabi@0.43.0':
+    resolution: {integrity: sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.42.0':
-    resolution: {integrity: sha512-t+aAjHxcr5eOBphFHdg1ouQU9qmZZoRxnX7UOJSaTwSoKsb6TYezNKO0YbWytGXCECObRqNcUxPoPr0KaraAIg==}
+  '@oxfmt/binding-android-arm64@0.43.0':
+    resolution: {integrity: sha512-T9OfRwjA/EdYxAqbvR7TtqLv5nIrwPXuCtTwOHtS7aR9uXyn74ZYgzgTo6/ZwvTq9DY4W+DsV09hB2EXgn9EbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.42.0':
-    resolution: {integrity: sha512-ulpSEYMKg61C5bRMZinFHrKJYRoKGVbvMEXA5zM1puX3O9T6Q4XXDbft20yrDijpYWeuG59z3Nabt+npeTsM1A==}
+  '@oxfmt/binding-darwin-arm64@0.43.0':
+    resolution: {integrity: sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.42.0':
-    resolution: {integrity: sha512-ttxLKhQYPdFiM8I/Ri37cvqChE4Xa562nNOsZFcv1CKTVLeEozXjKuYClNvxkXmNlcF55nzM80P+CQkdFBu+uQ==}
+  '@oxfmt/binding-darwin-x64@0.43.0':
+    resolution: {integrity: sha512-vWECzzCFkb0kK6jaHjbtC5sC3adiNWtqawFCxhpvsWlzVeKmv5bNvkB4nux+o4JKWTpHCM57NDK/MeXt44txmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.42.0':
-    resolution: {integrity: sha512-Og7QS3yI3tdIKYZ58SXik0rADxIk2jmd+/YvuHRyKULWpG4V2fR5V4hvKm624Mc0cQET35waPXiCQWvjQEjwYQ==}
+  '@oxfmt/binding-freebsd-x64@0.43.0':
+    resolution: {integrity: sha512-rgz8JpkKiI/umOf7fl9gwKyQasC8bs5SYHy6g7e4SunfLBY3+8ATcD5caIg8KLGEtKFm5ujKaH8EfjcmnhzTLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
-    resolution: {integrity: sha512-jwLOw/3CW4H6Vxcry4/buQHk7zm9Ne2YsidzTL1kpiMe4qqrRCwev3dkyWe2YkFmP+iZCQ7zku4KwjcLRoh8ew==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.43.0':
+    resolution: {integrity: sha512-nWYnF3vIFzT4OM1qL/HSf1Yuj96aBuKWSaObXHSWliwAk2rcj7AWd6Lf7jowEBQMo4wCZVnueIGw/7C4u0KTBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
-    resolution: {integrity: sha512-XwXu2vkMtiq2h7tfvN+WA/9/5/1IoGAVCFPiiQUvcAuG3efR97KNcRGM8BetmbYouFotQ2bDal3yyjUx6IPsTg==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.43.0':
+    resolution: {integrity: sha512-sFg+NWJbLfupYTF4WELHAPSnLPOn1jiDZ33Z1jfDnTaA+cC3iB35x0FMMZTFdFOz3icRIArncwCcemJFGXu6TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
-    resolution: {integrity: sha512-ea7s/XUJoT7ENAtUQDudFe3nkSM3e3Qpz4nJFRdzO2wbgXEcjnchKLEsV3+t4ev3r8nWxIYr9NRjPWtnyIFJVA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.43.0':
+    resolution: {integrity: sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-musl@0.42.0':
-    resolution: {integrity: sha512-+JA0YMlSdDqmacygGi2REp57c3fN+tzARD8nwsukx9pkCHK+6DkbAA9ojS4lNKsiBjIW8WWa0pBrBWhdZEqfuw==}
+  '@oxfmt/binding-linux-arm64-musl@0.43.0':
+    resolution: {integrity: sha512-ROaWfYh+6BSJ1Arwy5ujijTlwnZetxDxzBpDc1oBR4d7rfrPBqzeyjd5WOudowzQUgyavl2wEpzn1hw3jWcqLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
-    resolution: {integrity: sha512-VfnET0j4Y5mdfCzh5gBt0NK28lgn5DKx+8WgSMLYYeSooHhohdbzwAStLki9pNuGy51y4I7IoW8bqwAaCMiJQg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.43.0':
+    resolution: {integrity: sha512-PJRs/uNxmFipJJ8+SyKHh7Y7VZIKQicqrrBzvfyM5CtKi8D7yZKTwUOZV3ffxmiC2e7l1SDJpkBEOyue5NAFsg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
-    resolution: {integrity: sha512-gVlCbmBkB0fxBWbhBj9rcxezPydsQHf4MFKeHoTSPicOQ+8oGeTQgQ8EeesSybWeiFPVRx3bgdt4IJnH6nOjAA==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.43.0':
+    resolution: {integrity: sha512-j6biGAgzIhj+EtHXlbNumvwG7XqOIdiU4KgIWRXAEj/iUbHKukKW8eXa4MIwpQwW1YkxovduKtzEAPnjlnAhVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
-    resolution: {integrity: sha512-zN5OfstL0avgt/IgvRu0zjQzVh/EPkcLzs33E9LMAzpqlLWiPWeMDZyMGFlSRGOdDjuNmlZBCgj0pFnK5u32TQ==}
+  '@oxfmt/binding-linux-riscv64-musl@0.43.0':
+    resolution: {integrity: sha512-RYWxAcslKxvy7yri24Xm9cmD0RiANaiEPs007EFG6l9h1ChM69Q5SOzACaCoz4Z9dEplnhhneeBaTWMEdpgIbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
-    resolution: {integrity: sha512-9X6+H2L0qMc2sCAgO9HS03bkGLMKvOFjmEdchaFlany3vNZOjnVui//D8k/xZAtQv2vaCs1reD5KAgPoIU4msA==}
+  '@oxfmt/binding-linux-s390x-gnu@0.43.0':
+    resolution: {integrity: sha512-DT6Q8zfQQy3jxpezAsBACEHNUUixKSYTwdXeXojNHe4DQOoxjPdjr3Szu6BRNjxLykZM/xMNmp9ElOIyDppwtw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-gnu@0.42.0':
-    resolution: {integrity: sha512-BajxJ6KQvMMdpXGPWhBGyjb2Jvx4uec0w+wi6TJZ6Tv7+MzPwe0pO8g5h1U0jyFgoaF7mDl6yKPW3ykWcbUJRw==}
+  '@oxfmt/binding-linux-x64-gnu@0.43.0':
+    resolution: {integrity: sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-musl@0.42.0':
-    resolution: {integrity: sha512-0wV284I6vc5f0AqAhgAbHU2935B4bVpncPoe5n/WzVZY/KnHgqxC8iSFGeSyLWEgstFboIcWkOPck7tqbdHkzA==}
+  '@oxfmt/binding-linux-x64-musl@0.43.0':
+    resolution: {integrity: sha512-F2YYqyvnQNvi320RWZNAvsaWEHwmW3k4OwNJ1hZxRKXupY63expbBaNp6jAgvYs7y/g546vuQnGHQuCBhslhLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-openharmony-arm64@0.42.0':
-    resolution: {integrity: sha512-p4BG6HpGnhfgHk1rzZfyR6zcWkE7iLrWxyehHfXUy4Qa5j3e0roglFOdP/Nj5cJJ58MA3isQ5dlfkW2nNEpolw==}
+  '@oxfmt/binding-openharmony-arm64@0.43.0':
+    resolution: {integrity: sha512-OE6TdietLXV3F6c7pNIhx/9YC1/2YFwjU9DPc/fbjxIX19hNIaP1rS0cFjCGJlGX+cVJwIKWe8Mos+LdQ1yAJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
-    resolution: {integrity: sha512-mn//WV60A+IetORDxYieYGAoQso4KnVRRjORDewMcod4irlRe0OSC7YPhhwaexYNPQz/GCFk+v9iUcZ2W22yxQ==}
+  '@oxfmt/binding-win32-arm64-msvc@0.43.0':
+    resolution: {integrity: sha512-0nWK6a7pGkbdoypfVicmV9k/N1FwjPZENoqhlTU+5HhZnAhpIO3za30nEE33u6l6tuy9OVfpdXUqxUgZ+4lbZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
-    resolution: {integrity: sha512-3gWltUrvuz4LPJXWivoAxZ28Of2O4N7OGuM5/X3ubPXCEV8hmgECLZzjz7UYvSDUS3grfdccQwmjynm+51EFpw==}
+  '@oxfmt/binding-win32-ia32-msvc@0.43.0':
+    resolution: {integrity: sha512-9aokTR4Ft+tRdvgN/pKzSkVy2ksc4/dCpDm9L/xFrbIw0yhLtASLbvoG/5WOTUh/BRPPnfGTsWznEqv0dlOmhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.42.0':
-    resolution: {integrity: sha512-Wg4TMAfQRL9J9AZevJ/ZNy3uyyDztDYQtGr4P8UyyzIhLhFrdSmz1J/9JT+rv0fiCDLaFOBQnj3f3K3+a5PzDQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.43.0':
+    resolution: {integrity: sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.17.3':
-    resolution: {integrity: sha512-5aDl4mxXWs+Bj02pNrX6YY6v9KMZjLIytXoqolLEo0dfBNVeZUonZgJAa/w0aUmijwIRrBhxEzb42oLuUtfkGw==}
+  '@oxlint-tsgolint/darwin-arm64@0.18.1':
+    resolution: {integrity: sha512-CxSd15ZwHn70UJFTXVvy76bZ9zwI097cVyjvUFmYRJwvkQF3VnrTf2oe1gomUacErksvtqLgn9OKvZhLMYwvog==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.17.3':
-    resolution: {integrity: sha512-gPBy4DS5ueCgXzko20XsNZzDe/Cxde056B+QuPLGvz05CGEAtmRfpImwnyY2lAXXjPL+SmnC/OYexu8zI12yHQ==}
+  '@oxlint-tsgolint/darwin-x64@0.18.1':
+    resolution: {integrity: sha512-LE7VW/T/VcKhl3Z1ev5BusrxdlQ3DWweSeOB+qpBeur2h8+vCWq+M7tCO29C7lveBDfx1+rNwj4aiUVlA+Qs+g==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.17.3':
-    resolution: {integrity: sha512-+pkunvCfB6pB0G9qHVVXUao3nqzXQPo4O3DReIi+5nGa+bOU3J3Srgy+Zb8VyOL+WDsSMJ+U7+r09cKHWhz3hg==}
+  '@oxlint-tsgolint/linux-arm64@0.18.1':
+    resolution: {integrity: sha512-2AG8YIXVJJbnM0rcsJmzzWOjZXBu5REwowgUpbHZueF7OYM3wR7Xu8pXEpAojEHAtYYZ3X4rpPoetomkJx7kCw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.17.3':
-    resolution: {integrity: sha512-/kW5oXtBThu4FjmgIBthdmMjWLzT3M1TEDQhxDu7hQU5xDeTd60CDXb2SSwKCbue9xu7MbiFoJu83LN0Z/d38g==}
+  '@oxlint-tsgolint/linux-x64@0.18.1':
+    resolution: {integrity: sha512-f8vDYPEdiwpA2JaDEkadTXfuqIgweQ8zcL4SX75EN2kkW2oAynjN7cd8m86uXDgB0JrcyOywbRtwnXdiIzXn2A==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.17.3':
-    resolution: {integrity: sha512-NMELRvbz4Ed4dxg8WiqZxtu3k4OJEp2B9KInZW+BMfqEqbwZdEJY83tbqz2hD1EjKO2akrqBQ0GpRUJEkd8kKw==}
+  '@oxlint-tsgolint/win32-arm64@0.18.1':
+    resolution: {integrity: sha512-fBdML05KMDAL9ebWeoHIzkyI86Eq6r9YH5UDRuXJ9vAIo1EnKo0ti7hLUxNdc2dy2FF/T4k98p5wkkXvLyXqfA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.17.3':
-    resolution: {integrity: sha512-+pJ7r8J3SLPws5uoidVplZc8R/lpKyKPE6LoPGv9BME00Y1VjT6jWGx/dtUN8PWvcu3iTC6k+8u3ojFSJNmWTg==}
+  '@oxlint-tsgolint/win32-x64@0.18.1':
+    resolution: {integrity: sha512-cYZMhNrsq9ZZ3OUWHyawqiS+c8HfieYG0zuZP2LbEuWWPfdZM/22iAlo608J+27G1s9RXQhvgX6VekwWbXbD7A==}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.57.0':
-    resolution: {integrity: sha512-C7EiyfAJG4B70496eV543nKiq5cH0o/xIh/ufbjQz3SIvHhlDDsyn+mRFh+aW8KskTyUpyH2LGWL8p2oN6bl1A==}
+  '@oxlint/binding-android-arm-eabi@1.58.0':
+    resolution: {integrity: sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.57.0':
-    resolution: {integrity: sha512-9i80AresjZ/FZf5xK8tKFbhQnijD4s1eOZw6/FHUwD59HEZbVLRc2C88ADYJfLZrF5XofWDiRX/Ja9KefCLy7w==}
+  '@oxlint/binding-android-arm64@1.58.0':
+    resolution: {integrity: sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.57.0':
-    resolution: {integrity: sha512-0eUfhRz5L2yKa9I8k3qpyl37XK3oBS5BvrgdVIx599WZK63P8sMbg+0s4IuxmIiZuBK68Ek+Z+gcKgeYf0otsg==}
+  '@oxlint/binding-darwin-arm64@1.58.0':
+    resolution: {integrity: sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.57.0':
-    resolution: {integrity: sha512-UvrSuzBaYOue+QMAcuDITe0k/Vhj6KZGjfnI6x+NkxBTke/VoM7ZisaxgNY0LWuBkTnd1OmeQfEQdQ48fRjkQg==}
+  '@oxlint/binding-darwin-x64@1.58.0':
+    resolution: {integrity: sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.57.0':
-    resolution: {integrity: sha512-wtQq0dCoiw4bUwlsNVDJJ3pxJA218fOezpgtLKrbQqUtQJcM9yP8z+I9fu14aHg0uyAxIY+99toL6uBa2r7nxA==}
+  '@oxlint/binding-freebsd-x64@1.58.0':
+    resolution: {integrity: sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.57.0':
-    resolution: {integrity: sha512-qxFWl2BBBFcT4djKa+OtMdnLgoHEJXpqjyGwz8OhW35ImoCwR5qtAGqApNYce5260FQqoAHW8S8eZTjiX67Tsg==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.58.0':
+    resolution: {integrity: sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.57.0':
-    resolution: {integrity: sha512-SQoIsBU7J0bDW15/f0/RvxHfY3Y0+eB/caKBQtNFbuerTiA6JCYx9P1MrrFTwY2dTm/lMgTSgskvCEYk2AtG/Q==}
+  '@oxlint/binding-linux-arm-musleabihf@1.58.0':
+    resolution: {integrity: sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.57.0':
-    resolution: {integrity: sha512-jqxYd1W6WMeozsCmqe9Rzbu3SRrGTyGDAipRlRggetyYbUksJqJKvUNTQtZR/KFoJPb+grnSm5SHhdWrywv3RQ==}
+  '@oxlint/binding-linux-arm64-gnu@1.58.0':
+    resolution: {integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-musl@1.57.0':
-    resolution: {integrity: sha512-i66WyEPVEvq9bxRUCJ/MP5EBfnTDN3nhwEdFZFTO5MmLLvzngfWEG3NSdXQzTT3vk5B9i6C2XSIYBh+aG6uqyg==}
+  '@oxlint/binding-linux-arm64-musl@1.58.0':
+    resolution: {integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.57.0':
-    resolution: {integrity: sha512-oMZDCwz4NobclZU3pH+V1/upVlJZiZvne4jQP+zhJwt+lmio4XXr4qG47CehvrW1Lx2YZiIHuxM2D4YpkG3KVA==}
+  '@oxlint/binding-linux-ppc64-gnu@1.58.0':
+    resolution: {integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.57.0':
-    resolution: {integrity: sha512-uoBnjJ3MMEBbfnWC1jSFr7/nSCkcQYa72NYoNtLl1imshDnWSolYCjzb8LVCwYCCfLJXD+0gBLD7fyC14c0+0g==}
+  '@oxlint/binding-linux-riscv64-gnu@1.58.0':
+    resolution: {integrity: sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-musl@1.57.0':
-    resolution: {integrity: sha512-BdrwD7haPZ8a9KrZhKJRSj6jwCor+Z8tHFZ3PT89Y3Jq5v3LfMfEePeAmD0LOTWpiTmzSzdmyw9ijneapiVHKQ==}
+  '@oxlint/binding-linux-riscv64-musl@1.58.0':
+    resolution: {integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-s390x-gnu@1.57.0':
-    resolution: {integrity: sha512-BNs+7ZNsRstVg2tpNxAXfMX/Iv5oZh204dVyb8Z37+/gCh+yZqNTlg6YwCLIMPSk5wLWIGOaQjT0GUOahKYImw==}
+  '@oxlint/binding-linux-s390x-gnu@1.58.0':
+    resolution: {integrity: sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-gnu@1.57.0':
-    resolution: {integrity: sha512-AghS18w+XcENcAX0+BQGLiqjpqpaxKJa4cWWP0OWNLacs27vHBxu7TYkv9LUSGe5w8lOJHeMxcYfZNOAPqw2bg==}
+  '@oxlint/binding-linux-x64-gnu@1.58.0':
+    resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-musl@1.57.0':
-    resolution: {integrity: sha512-E/FV3GB8phu/Rpkhz5T96hAiJlGzn91qX5yj5gU754P5cmVGXY1Jw/VSjDSlZBCY3VHjsVLdzgdkJaomEmcNOg==}
+  '@oxlint/binding-linux-x64-musl@1.58.0':
+    resolution: {integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-openharmony-arm64@1.57.0':
-    resolution: {integrity: sha512-xvZ2yZt0nUVfU14iuGv3V25jpr9pov5N0Wr28RXnHFxHCRxNDMtYPHV61gGLhN9IlXM96gI4pyYpLSJC5ClLCQ==}
+  '@oxlint/binding-openharmony-arm64@1.58.0':
+    resolution: {integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.57.0':
-    resolution: {integrity: sha512-Z4D8Pd0AyHBKeazhdIXeUUy5sIS3Mo0veOlzlDECg6PhRRKgEsBJCCV1n+keUZtQ04OP+i7+itS3kOykUyNhDg==}
+  '@oxlint/binding-win32-arm64-msvc@1.58.0':
+    resolution: {integrity: sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.57.0':
-    resolution: {integrity: sha512-StOZ9nFMVKvevicbQfql6Pouu9pgbeQnu60Fvhz2S6yfMaii+wnueLnqQ5I1JPgNF0Syew4voBlAaHD13wH6tw==}
+  '@oxlint/binding-win32-ia32-msvc@1.58.0':
+    resolution: {integrity: sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.57.0':
-    resolution: {integrity: sha512-6PuxhYgth8TuW0+ABPOIkGdBYw+qYGxgIdXPHSVpiCDm+hqTTWCmC739St1Xni0DJBt8HnSHTG67i1y6gr8qrA==}
+  '@oxlint/binding-win32-x64-msvc@1.58.0':
+    resolution: {integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1960,17 +2000,35 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1992,6 +2050,12 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -2102,50 +2166,110 @@ packages:
       yaml:
         optional: true
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.14':
-    resolution: {integrity: sha512-q2ESUSbapwsxVRe/KevKATahNRraoX5nti3HT9S3266OHT5sMroBY14jaxTv74ekjQc9E6EPhyLGQWuWQuuBRw==}
+  '@voidzero-dev/vite-plus-core@0.1.15':
+    resolution: {integrity: sha512-0qAbqwcvQwiC8xGKSSuFtsjJUEM4LZzpXF7dffRazghGEQ8HH8NAvVryp/PiMSFwreJlV3rujwL4amKjnwCHpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.21.7
+      '@tsdown/exe': 0.21.7
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      publint: ^0.3.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      yaml:
+        optional: true
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.15':
+    resolution: {integrity: sha512-arFq8phXg96rQ5J+FYvkBYdEGxIhP1ePAXlUeQY2hV8hJPzse+CdxusWxcjfpTgvFi+dpsKzE4KSNS22PyBo7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.14':
-    resolution: {integrity: sha512-UpcDZc9G99E/4HDRoobvYHxMvFOG5uv3RwEcq0HF70u4DsnEMl1z8RaJLeWV7a09LGwj9Q+YWC3Z4INWnTLs8g==}
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.15':
+    resolution: {integrity: sha512-2eY+gTEIZvLH33nQmcL2tKlf+iHfClaqaSMYIlUpTp/CN+xqh4Ir4y2vN1XGEuFDIW0FshSZTg3ulPtduneEDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.14':
-    resolution: {integrity: sha512-GIjn35RABUEDB9gHD26nRq7T72Te+Qy2+NIzogwEaUE728PvPkatF5gMCeF4sigCoc8c4qxDwsG+A2A2LYGnDg==}
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.15':
+    resolution: {integrity: sha512-jJgz84pp61oHeXAYIUXKsVwQsMQ7NHK0+dBe6v1Q+Z034xXsyBrxi/JASSeVmCpAd6CN+xzOCsfMyn3whVTTxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.14':
-    resolution: {integrity: sha512-qo2RToGirG0XCcxZ2AEOuonLM256z6dNbJzDDIo5gWYA+cIKigFQJbkPyr25zsT1tsP2aY0OTxt2038XbVlRkQ==}
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.15':
+    resolution: {integrity: sha512-F0Wig+We0ERhGecf3fDIwM/kfqT0vP2htH0vKUnV/inHIVbPc1MsrjcExX1eJ6KFSp5YTfchRN8HGecqtsudPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.14':
-    resolution: {integrity: sha512-BsMWKZfdfGcYLxxLyaePpg6NW54xqzzcfq8sFUwKfwby0kgOKQ4WymUXyBvO9nnBb0ZPsJQrV0sx+Onac/LTaw==}
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.15':
+    resolution: {integrity: sha512-aT5Yr2GphvRjoc2URmELDqjWwhe5VPvyy15Tzum+jPhEjY4I/lPXxKXEROjQe3TIv6MmFSHCe3oNCSaFdUE1pA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.14':
-    resolution: {integrity: sha512-mOrEpj7ntW9RopGbcOYG/L0pOs0qHzUG4Vz7NXbuf4dbOSlY4JjyoMOIWxjKQORQht02Hzuf8YrMGNwa6AjVSQ==}
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.15':
+    resolution: {integrity: sha512-Q6qMBMdVp5v84YVzFvMUpzVIHLfJuwZQR/KUtAOn/hzpfNITigKR2GrZZDgQvszFW+0CPhDFcK3kqLkxlJCdFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@voidzero-dev/vite-plus-test@0.1.14':
-    resolution: {integrity: sha512-rjF+qpYD+5+THOJZ3gbE3+cxsk5sW7nJ0ODK7y6ZKeS4amREUMedEDYykzKBwR7OZDC/WwE90A0iLWCr6qAXhA==}
+  '@voidzero-dev/vite-plus-test@0.1.15':
+    resolution: {integrity: sha512-jxMUEX6PDpzMUz+KOVOoB8HiODMf5mWjH19pof0k9l/RZT4iLDyVXB+p9PoWjbVrEMMGzq9BTOVob7wfOZeZEA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/ui': 4.1.1
+      '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2163,14 +2287,14 @@ packages:
       jsdom:
         optional: true
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.14':
-    resolution: {integrity: sha512-7iC+Ig+8D/zACy0IJf7w/vQ7duTjux9Ttmm3KOBdVWH4dl3JihydA7+SQVMhz71a4WiqJ6nPidoG8D6hUP4MVQ==}
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.15':
+    resolution: {integrity: sha512-EePrs+NIUy3gE60qaXPXzj8mw+JAXEBfGKsfweYBgNK6jo9ZXZto5ViKTuQsVVuWLVaELZSjoudbkzXB8wnJoQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.14':
-    resolution: {integrity: sha512-yRJ/8yAYFluNHx0Ej6Kevx65MIeM3wFKklnxosVZRlz2ZRL1Ea1Qh3tWATr3Ipk1ciRxBv8KJgp6zXqjxtZSoQ==}
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.15':
+    resolution: {integrity: sha512-vfYfwOG/5a/WUtgGrbUCatRkc5x0Rq/9GDlCzQQIAFGDB5BfyIjGbdCOqamQWOh+yQbeOHwvgAhqjZ7Dv1oo/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2178,6 +2302,11 @@ packages:
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -2257,6 +2386,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2273,6 +2405,9 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -2312,6 +2447,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2323,6 +2461,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2342,6 +2492,9 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2372,6 +2525,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2392,6 +2555,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -2400,13 +2566,33 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2433,6 +2619,14 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2465,6 +2659,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -2479,12 +2677,21 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eval-estree-expression@3.0.1:
+    resolution: {integrity: sha512-zTLKGbiVdQYp4rQkSoXPibrFf5ZoPn6jzExegRLEQ13F+FSxu5iLgaRH6hlDs2kWSUa6vp8yD20cdJi0me6pEw==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -2526,6 +2733,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
 
@@ -2563,6 +2773,10 @@ packages:
   form-data@2.5.5:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -2719,6 +2933,12 @@ packages:
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -2745,9 +2965,21 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2761,9 +2993,16 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2795,6 +3034,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -2887,6 +3129,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2896,6 +3147,9 @@ packages:
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2911,6 +3165,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
@@ -2920,9 +3177,165 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3024,6 +3437,9 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3069,21 +3485,21 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
-  oxfmt@0.42.0:
-    resolution: {integrity: sha512-QhejGErLSMReNuZ6vxgFHDyGoPbjTRNi6uGHjy0cvIjOQFqD6xmr/T+3L41ixR3NIgzcNiJ6ylQKpvShTgDfqg==}
+  oxfmt@0.43.0:
+    resolution: {integrity: sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.17.3:
-    resolution: {integrity: sha512-1eh4bcpOMw0e7+YYVxmhFc2mo/V6hJ2+zfukqf+GprvVn3y94b69M/xNrYLmx5A+VdYe0i/bJ2xOs6Hp/jRmRA==}
+  oxlint-tsgolint@0.18.1:
+    resolution: {integrity: sha512-Hgb0wMfuXBYL0ddY+1hAG8IIfC40ADwPnBuUaC6ENAuCtTF4dHwsy7mCYtQ2e7LoGvfoSJRY0+kqQRiembJ/jQ==}
     hasBin: true
 
-  oxlint@1.57.0:
-    resolution: {integrity: sha512-DGFsuBX5MFZX9yiDdtKjTrYPq45CZ8Fft6qCltJITYZxfwYjVdGf/6wycGYTACloauwIPxUnYhBVeZbHvleGhw==}
+  oxlint@1.58.0:
+    resolution: {integrity: sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.15.0'
+      oxlint-tsgolint: '>=0.18.0'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -3106,6 +3522,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -3199,6 +3618,10 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -3239,6 +3662,24 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3294,6 +3735,11 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-mdx@1.3.9:
+    resolution: {integrity: sha512-lg5YY55sd+3kQk5FDhUObqnTXDr8H6WU3feXql0ZMMImuT5mbvV6zKibUy8OjhK4M5nQtP5Bkof9D7Szyj3x3w==}
+    peerDependencies:
+      react: '*'
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3383,6 +3829,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3404,6 +3853,9 @@ packages:
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -3477,6 +3929,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -3522,6 +3977,9 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
@@ -3537,6 +3995,24 @@ packages:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3548,8 +4024,14 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  vite-plus@0.1.14:
-    resolution: {integrity: sha512-p4pWlpZZNiEsHxPWNdeIU9iuPix3ydm3ficb0dXPggoyIkdotfXtvn2NPX9KwfiQImU72EVEs4+VYBZYNcUYrw==}
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-plus@0.1.15:
+    resolution: {integrity: sha512-PBUvTq4D4BJcuusCA3mrSQmXcGVdPX9CIPpS7Y6+T+LbDsrmAZ+ITl9FzuE6zXvpT6Nht9cpHtwOLJw7m3adog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3721,6 +4203,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4167,7 +4652,20 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -4607,6 +5105,8 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@orama/orama@3.1.18': {}
+
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     optional: true
 
@@ -4670,6 +5170,8 @@ snapshots:
     optional: true
 
   '@oxc-project/runtime@0.121.0': {}
+
+  '@oxc-project/runtime@0.122.0': {}
 
   '@oxc-project/types@0.120.0': {}
 
@@ -4737,136 +5239,136 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     optional: true
 
-  '@oxfmt/binding-android-arm-eabi@0.42.0':
+  '@oxfmt/binding-android-arm-eabi@0.43.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.42.0':
+  '@oxfmt/binding-android-arm64@0.43.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.42.0':
+  '@oxfmt/binding-darwin-arm64@0.43.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.42.0':
+  '@oxfmt/binding-darwin-x64@0.43.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.42.0':
+  '@oxfmt/binding-freebsd-x64@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.42.0':
+  '@oxfmt/binding-linux-arm64-musl@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.42.0':
+  '@oxfmt/binding-linux-x64-gnu@0.43.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.42.0':
+  '@oxfmt/binding-linux-x64-musl@0.43.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.42.0':
+  '@oxfmt/binding-openharmony-arm64@0.43.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.43.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.43.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.42.0':
+  '@oxfmt/binding-win32-x64-msvc@0.43.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.17.3':
+  '@oxlint-tsgolint/darwin-arm64@0.18.1':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.17.3':
+  '@oxlint-tsgolint/darwin-x64@0.18.1':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.17.3':
+  '@oxlint-tsgolint/linux-arm64@0.18.1':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.17.3':
+  '@oxlint-tsgolint/linux-x64@0.18.1':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.17.3':
+  '@oxlint-tsgolint/win32-arm64@0.18.1':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.17.3':
+  '@oxlint-tsgolint/win32-x64@0.18.1':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.57.0':
+  '@oxlint/binding-android-arm-eabi@1.58.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.57.0':
+  '@oxlint/binding-android-arm64@1.58.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.57.0':
+  '@oxlint/binding-darwin-arm64@1.58.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.57.0':
+  '@oxlint/binding-darwin-x64@1.58.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.57.0':
+  '@oxlint/binding-freebsd-x64@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.57.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.57.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.57.0':
+  '@oxlint/binding-linux-arm64-gnu@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.57.0':
+  '@oxlint/binding-linux-arm64-musl@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.57.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.57.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.57.0':
+  '@oxlint/binding-linux-riscv64-musl@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.57.0':
+  '@oxlint/binding-linux-s390x-gnu@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.57.0':
+  '@oxlint/binding-linux-x64-gnu@1.58.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.57.0':
+  '@oxlint/binding-linux-x64-musl@1.58.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.57.0':
+  '@oxlint/binding-openharmony-arm64@1.58.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.57.0':
+  '@oxlint/binding-win32-arm64-msvc@1.58.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.57.0':
+  '@oxlint/binding-win32-ia32-msvc@1.58.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.57.0':
+  '@oxlint/binding-win32-x64-msvc@1.58.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -5445,15 +5947,35 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mime-types@2.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -5477,6 +5999,10 @@ snapshots:
       sharp: 0.34.5
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -5546,29 +6072,44 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.14':
+  '@voidzero-dev/vite-plus-core@0.1.15(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+    dependencies:
+      '@oxc-project/runtime': 0.122.0
+      '@oxc-project/types': 0.122.0
+      lightningcss: 1.32.0
+      postcss: 8.5.8
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      typescript: 5.9.3
+      yaml: 2.8.3
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.14':
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.14':
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.14':
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.14':
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.14':
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.14(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.15(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.15(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -5604,15 +6145,19 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.14':
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.15':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.14':
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.15':
     optional: true
 
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn@8.16.0: {}
 
@@ -5674,6 +6219,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5683,6 +6230,8 @@ snapshots:
   basic-ftp@5.2.0: {}
 
   bignumber.js@9.3.1: {}
+
+  boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
 
@@ -5716,6 +6265,8 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -5724,6 +6275,14 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -5752,6 +6311,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5776,6 +6337,18 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  cssom@0.5.0: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -5786,6 +6359,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -5794,9 +6371,33 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff@8.0.4: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5829,6 +6430,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -5880,6 +6485,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -5892,11 +6499,20 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eval-estree-expression@3.0.1: {}
 
   event-target-shim@5.0.1: {}
 
@@ -5941,6 +6557,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
 
   fd-package-json@2.0.0:
     dependencies:
@@ -5991,6 +6611,8 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
       safe-buffer: 5.2.1
+
+  format@0.2.2: {}
 
   formatly@0.3.0:
     dependencies:
@@ -6187,6 +6809,15 @@ snapshots:
 
   html-entities@2.6.0: {}
 
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -6222,7 +6853,18 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.1.0: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -6232,7 +6874,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -6260,6 +6906,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
+
+  jsonc-parser@3.3.1: {}
 
   jwa@2.0.1:
     dependencies:
@@ -6346,11 +6994,21 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   load-tsconfig@0.2.5: {}
 
   lodash.camelcase@4.3.0: {}
 
   long@5.3.2: {}
+
+  longest-streak@3.1.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -6362,11 +7020,446 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -6446,6 +7539,10 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -6514,61 +7611,61 @@ snapshots:
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
 
-  oxfmt@0.42.0:
+  oxfmt@0.43.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.42.0
-      '@oxfmt/binding-android-arm64': 0.42.0
-      '@oxfmt/binding-darwin-arm64': 0.42.0
-      '@oxfmt/binding-darwin-x64': 0.42.0
-      '@oxfmt/binding-freebsd-x64': 0.42.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.42.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.42.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.42.0
-      '@oxfmt/binding-linux-arm64-musl': 0.42.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.42.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.42.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.42.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.42.0
-      '@oxfmt/binding-linux-x64-gnu': 0.42.0
-      '@oxfmt/binding-linux-x64-musl': 0.42.0
-      '@oxfmt/binding-openharmony-arm64': 0.42.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.42.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.42.0
-      '@oxfmt/binding-win32-x64-msvc': 0.42.0
+      '@oxfmt/binding-android-arm-eabi': 0.43.0
+      '@oxfmt/binding-android-arm64': 0.43.0
+      '@oxfmt/binding-darwin-arm64': 0.43.0
+      '@oxfmt/binding-darwin-x64': 0.43.0
+      '@oxfmt/binding-freebsd-x64': 0.43.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.43.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.43.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.43.0
+      '@oxfmt/binding-linux-arm64-musl': 0.43.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.43.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.43.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.43.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.43.0
+      '@oxfmt/binding-linux-x64-gnu': 0.43.0
+      '@oxfmt/binding-linux-x64-musl': 0.43.0
+      '@oxfmt/binding-openharmony-arm64': 0.43.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.43.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.43.0
+      '@oxfmt/binding-win32-x64-msvc': 0.43.0
 
-  oxlint-tsgolint@0.17.3:
+  oxlint-tsgolint@0.18.1:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.17.3
-      '@oxlint-tsgolint/darwin-x64': 0.17.3
-      '@oxlint-tsgolint/linux-arm64': 0.17.3
-      '@oxlint-tsgolint/linux-x64': 0.17.3
-      '@oxlint-tsgolint/win32-arm64': 0.17.3
-      '@oxlint-tsgolint/win32-x64': 0.17.3
+      '@oxlint-tsgolint/darwin-arm64': 0.18.1
+      '@oxlint-tsgolint/darwin-x64': 0.18.1
+      '@oxlint-tsgolint/linux-arm64': 0.18.1
+      '@oxlint-tsgolint/linux-x64': 0.18.1
+      '@oxlint-tsgolint/win32-arm64': 0.18.1
+      '@oxlint-tsgolint/win32-x64': 0.18.1
 
-  oxlint@1.57.0(oxlint-tsgolint@0.17.3):
+  oxlint@1.58.0(oxlint-tsgolint@0.18.1):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.57.0
-      '@oxlint/binding-android-arm64': 1.57.0
-      '@oxlint/binding-darwin-arm64': 1.57.0
-      '@oxlint/binding-darwin-x64': 1.57.0
-      '@oxlint/binding-freebsd-x64': 1.57.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.57.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.57.0
-      '@oxlint/binding-linux-arm64-gnu': 1.57.0
-      '@oxlint/binding-linux-arm64-musl': 1.57.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.57.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.57.0
-      '@oxlint/binding-linux-riscv64-musl': 1.57.0
-      '@oxlint/binding-linux-s390x-gnu': 1.57.0
-      '@oxlint/binding-linux-x64-gnu': 1.57.0
-      '@oxlint/binding-linux-x64-musl': 1.57.0
-      '@oxlint/binding-openharmony-arm64': 1.57.0
-      '@oxlint/binding-win32-arm64-msvc': 1.57.0
-      '@oxlint/binding-win32-ia32-msvc': 1.57.0
-      '@oxlint/binding-win32-x64-msvc': 1.57.0
-      oxlint-tsgolint: 0.17.3
+      '@oxlint/binding-android-arm-eabi': 1.58.0
+      '@oxlint/binding-android-arm64': 1.58.0
+      '@oxlint/binding-darwin-arm64': 1.58.0
+      '@oxlint/binding-darwin-x64': 1.58.0
+      '@oxlint/binding-freebsd-x64': 1.58.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.58.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.58.0
+      '@oxlint/binding-linux-arm64-gnu': 1.58.0
+      '@oxlint/binding-linux-arm64-musl': 1.58.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.58.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.58.0
+      '@oxlint/binding-linux-riscv64-musl': 1.58.0
+      '@oxlint/binding-linux-s390x-gnu': 1.58.0
+      '@oxlint/binding-linux-x64-gnu': 1.58.0
+      '@oxlint/binding-linux-x64-musl': 1.58.0
+      '@oxlint/binding-openharmony-arm64': 1.58.0
+      '@oxlint/binding-win32-arm64-msvc': 1.58.0
+      '@oxlint/binding-win32-ia32-msvc': 1.58.0
+      '@oxlint/binding-win32-x64-msvc': 1.58.0
+      oxlint-tsgolint: 0.18.1
 
   p-limit@3.1.0:
     dependencies:
@@ -6598,6 +7695,16 @@ snapshots:
       netmask: 2.0.2
 
   package-json-from-dist@1.0.1: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -6670,6 +7777,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prismjs@1.30.0: {}
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -6731,6 +7840,57 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   require-directory@2.1.1: {}
 
@@ -6823,6 +7983,27 @@ snapshots:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
+
+  safe-mdx@1.3.9(react@19.2.4):
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@standard-schema/spec': 1.1.0
+      collapse-white-space: 2.1.0
+      eval-estree-expression: 3.0.1
+      linkedom: 0.18.12
+      react: 19.2.4
+      remark: 15.0.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.1
+      remark-mdx: 3.1.1
+      style-to-object: 1.0.14
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - canvas
+      - supports-color
 
   scheduler@0.27.0: {}
 
@@ -6929,6 +8110,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6946,6 +8132,10 @@ snapshots:
       '@tokenizer/token': 0.3.0
 
   stubs@3.0.0: {}
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -7024,6 +8214,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trough@2.2.0: {}
+
   ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -7078,6 +8270,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  uhyphen@0.2.0: {}
+
   uint8array-extras@1.5.0: {}
 
   unbash@2.2.0: {}
@@ -7086,32 +8280,76 @@ snapshots:
 
   undici@7.24.6: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 
-  vite-plus@0.1.14(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-plus@0.1.15(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.122.0
-      '@voidzero-dev/vite-plus-core': 0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.14(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.15(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.15(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@voidzero-dev/vite-plus-core@0.1.14(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       cac: 7.0.0
       cross-spawn: 7.0.6
-      oxfmt: 0.42.0
-      oxlint: 1.57.0(oxlint-tsgolint@0.17.3)
-      oxlint-tsgolint: 0.17.3
+      jsonc-parser: 3.3.1
+      oxfmt: 0.43.0
+      oxlint: 1.58.0(oxlint-tsgolint@0.18.1)
+      oxlint-tsgolint: 0.18.1
       picocolors: 1.1.1
     optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.14
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.14
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.14
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.14
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.14
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.14
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.14
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.14
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.15
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.15
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.15
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.15
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.15
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.15
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.15
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.15
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@edge-runtime/vm'
@@ -7261,3 +8499,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      wouter:
+        specifier: ^3.9.0
+        version: 3.9.0(react@19.2.4)
     devDependencies:
       '@ai-sdk/google-vertex':
         specifier: ^4.0.95
@@ -3379,6 +3382,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -3664,6 +3670,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -4015,6 +4025,11 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4138,6 +4153,11 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wouter@3.9.0:
+    resolution: {integrity: sha512-sF/od/PIgqEQBQcrN7a2x3MX6MQE6nW0ygCfy9hQuUkuB28wEZuu/6M5GyqkrrEu9M6jxdkgE12yDFsQMKos4Q==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -7494,6 +7514,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -7842,6 +7864,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
+
+  regexparam@3.0.0: {}
 
   remark-frontmatter@5.0.0:
     dependencies:
@@ -8315,6 +8339,10 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
@@ -8442,6 +8470,13 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wouter@3.9.0(react@19.2.4):
+    dependencies:
+      mitt: 3.0.1
+      react: 19.2.4
+      regexparam: 3.0.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/specs/website-docs-filesystem-routing-spec.md
+++ b/specs/website-docs-filesystem-routing-spec.md
@@ -1,0 +1,152 @@
+## Problem overview
+
+The docs site currently keeps its content inside the website app at `apps/website/src/docs/content/pages` and hard-codes the docs hierarchy in `apps/website/src/docs/content/index.ts`. Every new page requires a manual import, a manual manifest entry, and a manual placement in the sidebar order.
+
+That setup makes docs authoring fragile and blocks a simpler content model where the filesystem defines the docs hierarchy. We want a repo-root `docs/` directory, folder-driven top-level docs pages, lightweight frontmatter for overrides, and build-time docs loading so the app no longer parses structure from a hand-written manifest.
+
+## Solution overview
+
+Move docs content to a repo-root `docs/` directory where each top-level folder becomes one docs route, such as `docs/getting-started/` becoming `/docs/getting-started`. Within each folder, `.mdx` files remain stitched into a single long-form page for that route, preserving the current hash-fragment navigation model.
+
+Replace the hard-coded manifest with a Vite-generated virtual module that scans the docs filesystem, reads lightweight frontmatter, parses MDX to `mdast` at build time, and exports a typed docs tree to the app. Keep `safe-mdx` for rendering, but stop doing per-page `mdxParse(...)` work in the browser. Do not adopt `comptime.ts` in v1; Vite's plugin and virtual-module model is a better fit for filesystem scanning, watch mode, and generated content metadata in this app.
+
+## Goals
+
+- Store docs content under repo-root `docs/` instead of `apps/website/src/docs/content/pages`.
+- Make top-level folders under `docs/` define top-level docs routes and sidebar groups.
+- Remove the hard-coded docs manifest and derive docs hierarchy from the filesystem.
+- Preserve the current grouped-page UX where one folder maps to one `/docs/<group>` route.
+- Preserve current hash-fragment navigation behavior so existing `/docs/<group>#<heading>` links continue to work.
+- Support lightweight frontmatter overrides for `title`, `order`, `draft`, and `devOnly`.
+- Parse MDX structure at build time so the client consumes generated docs data instead of calling `mdxParse(...)` on startup.
+- Keep the current docs rendering model based on `safe-mdx`, TOC generation, and section grouping.
+- Make `/docs` resolve to the first visible docs group without a hard-coded default group id.
+
+## Non-goals
+
+- No migrations or backfills.
+- No switch to page-per-file routes like `/docs/getting-started/quickstart` in v1.
+- No redesign of docs styling, editorial layout, or MDX components.
+- No replacement of `safe-mdx` with a different MDX runtime.
+- No adoption of `comptime.ts` in v1.
+- No SSR or static prerendering work for the docs site.
+- No new metadata manifest format checked into the repo.
+
+## Future work
+
+- None yet. Add follow-up items here during implementation if new non-blocking work appears.
+
+## Important files/docs/websites for implementation
+
+- `apps/website/src/docs/content/index.ts` - current hard-coded docs manifest and docs-path helpers that should disappear or shrink to generated-data helpers.
+- `apps/website/src/docs/DocsPage.tsx` - current docs bootstrap, runtime `mdxParse(...)` calls, heading-id generation, and grouped-page rendering.
+- `apps/website/src/docs/components/toc-tree.ts` - TOC tree builder that currently assumes manifest groups and pages.
+- `apps/website/src/docs/components/markdown.tsx` - docs layout and link behavior that must keep working with generated hrefs and hash navigation.
+- `apps/website/src/App.tsx` - top-level route gate for `/docs/**`.
+- `apps/website/src/routing.tsx` - SPA navigation rules for docs URLs and same-document hash behavior.
+- `apps/website/vite.config.ts` - Vite entrypoint config; add the docs virtual module/plugin here.
+- `apps/website/package.json` - website build and type-check commands used for verification.
+- `apps/website/docs/index.html` - current docs HTML entrypoint; must keep working alongside the new repo-root `docs/` content directory.
+- `apps/website/src/docs/content/pages/*.mdx` - current docs source files that will move to repo-root `docs/`.
+- `docs/` - new repo-root docs content source directory introduced by this spec.
+- `apps/website/node_modules/safe-mdx/README.md` - renderer and parser reference; relevant because the site already uses `SafeMdxRenderer` and `mdxParse`.
+- `https://vite.dev/guide/features` - Vite glob/virtual-module behavior reference for filesystem-derived content.
+- `https://comptime.js.org/` - compile-time evaluation reference considered for this change; useful for documenting why it is not the chosen v1 mechanism.
+
+## Implementation
+
+### Phase 1: Add a generated docs-content pipeline with frontmatter and build-time MDX parsing
+
+Create a Vite-owned docs loader that can scan docs files, normalize folder/file metadata, and export a typed docs tree. Keep this phase focused on build-time content discovery and validation so the rendering layer can switch over cleanly in the next phase.
+
+```ts
+type DocsPageData = {
+  id: string;
+  label: string;
+  content: string;
+  mdast: Root;
+  order: number | null;
+};
+
+type DocsGroupData = {
+  id: string;
+  label: string;
+  path: `/docs/${string}`;
+  order: number | null;
+  pages: DocsPageData[];
+};
+
+export function buildDocsTree(files: DocsSourceFile[]): DocsGroupData[] {
+  const grouped = groupFilesByTopLevelFolder(files);
+  return sortGroupsAndPages(normalizeFrontmatter(grouped));
+}
+```
+
+- [ ] Add a small docs-loader module under `apps/website/src/docs/content/` or `apps/website/src/docs/build/` that scans MDX files and groups them by top-level folder.
+- [ ] Add a Vite virtual module such as `virtual:docs-content` in `apps/website/vite.config.ts` that exports the generated docs tree.
+- [ ] Parse each MDX file at build time with the existing `safe-mdx/parse` parser and export both raw markdown and serialized `mdast`.
+- [ ] Support lightweight frontmatter fields: `title?: string`, `order?: number`, `draft?: boolean`, `devOnly?: boolean`.
+- [ ] Define folder conventions:
+- [ ] each top-level folder under `docs/` becomes one docs route,
+- [ ] `index.mdx` is optional and renders first when present,
+- [ ] non-`index.mdx` files render after `index.mdx`, ordered by `order` then filename,
+- [ ] folder label defaults to `index.mdx` frontmatter `title` when present, otherwise title-cased folder slug.
+- [ ] Filter `draft` pages out in all builds and `devOnly` pages out in production builds.
+- [ ] Add build-time validation for missing top-level folder names, duplicate group ids, duplicate page ids within a group, invalid frontmatter types, and pages missing an initial heading.
+- [ ] Add temporary support for reading the current in-app docs directory when repo-root `docs/` is still empty so the app can switch incrementally.
+- [ ] Verify `pnpm --filter libretto-website type-check` passes after the generated module types are wired in.
+- [ ] Verify `pnpm --filter libretto-website build` succeeds with generated docs data and fails with a clear error when a docs file has invalid frontmatter or no heading.
+
+### Phase 2: Switch the docs app to generated groups and preserve hash-link behavior
+
+Replace the hard-coded manifest with the generated docs tree and remove browser-side `mdxParse(...)` work. Keep the existing route shape and anchor semantics so current `/docs/<group>#<heading>` links remain valid.
+
+```ts
+import { docsGroups, getDocsGroupByPath } from "virtual:docs-content";
+
+export function DocsPage({ pathname }: { pathname?: string }) {
+  const currentGroup = getDocsGroupByPath(pathname ?? window.location.pathname);
+  const currentHeadingIds = buildHeadingIdMap(currentGroup.pages.map((page) => page.mdast));
+  const tocItems = flattenTocTree({
+    roots: buildDocsTocTree({ groups: docsGroups, currentGroupId: currentGroup.id }),
+  });
+  return <EditorialPage toc={tocItems} sections={buildSections(currentGroup)} />;
+}
+```
+
+- [ ] Update `apps/website/src/docs/DocsPage.tsx` to consume generated groups/pages from the virtual module instead of `docsManifest`.
+- [ ] Remove runtime `mdxParse(...)` calls from `DocsPage.tsx` and rely on build-generated `mdast`.
+- [ ] Replace `defaultDocsGroupId` logic with "first visible group by sort order" logic exported from the generated module.
+- [ ] Keep the current grouped-page rendering model where all files in a folder are stitched into one editorial page.
+- [ ] Keep the current heading slug algorithm and duplicate-heading suffix behavior so existing hash links remain stable.
+- [ ] Update `apps/website/src/docs/components/toc-tree.ts` types to accept generated group/page data without assuming a hand-written manifest module.
+- [ ] Update docs link resolution so `#fragment` and `/docs/#fragment` still resolve within the current group when possible, and fall back to the generated cross-group heading lookup otherwise.
+- [ ] Remove unused exports such as `docsManifest`, `docsPages`, and `docsMdxContent` from the current content module.
+- [ ] Verify `pnpm --filter libretto-website type-check` passes after the docs app consumes generated content.
+- [ ] Run `pnpm --filter libretto-website dev`, open `/docs/get-started#quick-start` and `/docs/library-api#workflow`, and confirm the correct group loads and scrolls to the requested section.
+- [ ] Run `pnpm --filter libretto-website build` and confirm the built docs app still serves `/docs`, `/docs/<group>`, and hash-fragment links without route changes.
+
+### Phase 3: Move docs content to repo-root `docs/` and delete the old in-app content source
+
+Rehome the actual MDX content into the new folder-based docs source now that the app can read generated docs data. This phase makes the filesystem the source of truth and removes the last hard-coded content coupling from the website app.
+
+```mdx
+---
+title: Getting Started
+order: 1
+---
+
+## Introduction
+
+Libretto is the AI toolkit for building and maintaining browser automations.
+```
+
+- [ ] Create a repo-root `docs/` directory and move existing docs groups into top-level folders such as `docs/get-started/`, `docs/cli-reference/`, and `docs/library-api/`.
+- [ ] Add `index.mdx` where a folder needs explicit group-level `title` or `order` metadata; otherwise rely on the folder slug.
+- [ ] Add lightweight frontmatter to migrated files where explicit `title`, `order`, `draft`, or `devOnly` behavior is needed.
+- [ ] Move the dev-only UI kit page into the new structure and mark it with `devOnly: true` instead of keeping a runtime-only manifest special case.
+- [ ] Remove `apps/website/src/docs/content/pages/` once the generated loader reads from repo-root `docs/`.
+- [ ] Remove the temporary fallback to the old in-app docs directory from the loader.
+- [ ] Keep page headings and file ordering aligned with current hash ids so existing deep links continue to work.
+- [ ] Verify `pnpm --filter libretto-website build` succeeds with repo-root `docs/` as the only content source.
+- [ ] Run `pnpm --filter libretto-website dev` and manually verify the sidebar order, page labels, and `devOnly` behavior in local development versus production build output.


### PR DESCRIPTION
## Summary
- add the website docs experience, including grouped docs content, route-aware rendering, TOC/search plumbing, and the docs app shell
- fix same-page hash navigation so TOC links resolve against the current docs URL instead of the site root
- make TOC selection hash-aware so deep links like `/docs/library-api#workflow` activate the correct page node and keep its branch expanded
- refresh docs presentation styles, including section heading scale/spacing and inline code treatment
- add a follow-up spec for moving website docs content to repo-root filesystem routing

## Validation
- `pnpm --dir apps/website type-check`
- `pnpm --dir apps/website build`
