### PR TITLE
docs: add Mintlify documentation site

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,7 @@
+# Mintlify automatically ignores these files and directories:
+# .git, .github, .claude, .agents, .idea, node_modules,
+# README.md, LICENSE.md, CHANGELOG.md, CONTRIBUTING.md
+
+# Draft content
+drafts/
+*.draft.mdx

--- a/docs/cli-reference/exec.mdx
+++ b/docs/cli-reference/exec.mdx
@@ -5,7 +5,7 @@
 The `exec` command runs TypeScript Playwright code against a live browser session. Use it to validate selectors, inspect page data, prototype individual steps, and experiment with interactions before encoding them in a workflow file.
 
 ```bash  theme={null}
-npx libretto exec "return await page.url()"
+npx libretto exec --session debug-example "return await page.url()"
 ```
 
 ### Usage
@@ -15,9 +15,9 @@ npx libretto exec "return await page.url()"
     Pass the code as a quoted string argument:
 
     ```bash  theme={null}
-    npx libretto exec "return await page.url()"
-    npx libretto exec "return await page.locator('button').count()"
-    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    npx libretto exec --session debug-example "return await page.url()"
+    npx libretto exec --session debug-example "return await page.locator('button').count()"
+    npx libretto exec --session debug-example "await page.locator('button:has-text(\"Continue\")').click()"
     ```
   </Tab>
 
@@ -84,10 +84,10 @@ If the code returns a value, `exec` prints it to stdout:
 * If the code returns nothing (`undefined`), `exec` prints `Executed successfully`.
 
 ```bash  theme={null}
-npx libretto exec "return await page.title()"
+npx libretto exec --session debug-example "return await page.title()"
 # My Page Title
 
-npx libretto exec "return await page.locator('li').count()"
+npx libretto exec --session debug-example "return await page.locator('li').count()"
 # 12
 ```
 
@@ -110,16 +110,16 @@ npx libretto exec "return await page.locator('li').count()"
 
 ```bash  theme={null}
 # Return the current URL
-npx libretto exec "return await page.url()"
+npx libretto exec --session debug-example "return await page.url()"
 
 # Count how many buttons are on the page
-npx libretto exec "return await page.locator('button').count()"
+npx libretto exec --session debug-example "return await page.locator('button').count()"
 
 # Click a button
-npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+npx libretto exec --session debug-example "await page.locator('button:has-text(\"Continue\")').click()"
 
 # Read a value from an input field
-npx libretto exec "return await page.locator('input[name=\"email\"]').inputValue()"
+npx libretto exec --session debug-example "return await page.locator('input[name=\"email\"]').inputValue()"
 
 # Run against a named session
 npx libretto exec --session debug-example "return await page.url()"

--- a/docs/cli-reference/exec.mdx
+++ b/docs/cli-reference/exec.mdx
@@ -1,0 +1,142 @@
+## exec
+
+> Execute Playwright TypeScript code against the open browser page.
+
+The `exec` command runs TypeScript Playwright code against a live browser session. Use it to validate selectors, inspect page data, prototype individual steps, and experiment with interactions before encoding them in a workflow file.
+
+```bash  theme={null}
+npx libretto exec "return await page.url()"
+```
+
+### Usage
+
+<Tabs>
+  <Tab title="Single-line">
+    Pass the code as a quoted string argument:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.url()"
+    npx libretto exec "return await page.locator('button').count()"
+    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    ```
+  </Tab>
+
+  <Tab title="stdin (multi-line)">
+    Pipe code into `exec -` for complex or multi-line scripts:
+
+    ```bash  theme={null}
+    echo "return await page.url()" | npx libretto exec - --session debug-example
+    ```
+
+    ```bash  theme={null}
+    cat <<'EOF' | npx libretto exec - --session debug-example
+    const rows = await page.locator('table tbody tr').all();
+    const data = [];
+    for (const row of rows) {
+      const cells = await row.locator('td').allTextContents();
+      data.push(cells);
+    }
+    return data;
+    EOF
+    ```
+  </Tab>
+</Tabs>
+
+### Available globals
+
+Inside the code you pass to `exec`, these variables are available without any imports:
+
+| Global       | Type                      | Description                                 |
+| ------------ | ------------------------- | ------------------------------------------- |
+| `page`       | `Page`                    | The active Playwright page                  |
+| `context`    | `BrowserContext`          | The browser context for the session         |
+| `browser`    | `Browser`                 | The browser instance                        |
+| `state`      | `Record<string, unknown>` | A mutable object scoped to this `exec` call |
+| `fetch`      | `typeof fetch`            | The global fetch function                   |
+| `Buffer`     | `typeof Buffer`           | Node.js `Buffer`                            |
+| `networkLog` | `function`                | Read captured network log entries           |
+| `actionLog`  | `function`                | Read captured action log entries            |
+
+### Flags
+
+<ParamField path="code" type="string" required>
+  The Playwright TypeScript code to execute, passed as the first positional argument. Pass `-` to read from stdin.
+</ParamField>
+
+<ParamField path="--session" type="string" required>
+  The session to execute against.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Target a specific page ID within the session. Use `npx libretto pages --session <name>` to list page IDs when a popup or new tab is open.
+</ParamField>
+
+<ParamField path="--visualize" type="boolean">
+  Enable ghost cursor and highlight visualization. Shows a visible cursor trace and element highlights as Playwright interacts with the page.
+</ParamField>
+
+### Return values
+
+If the code returns a value, `exec` prints it to stdout:
+
+* Strings are printed as-is.
+* All other values are printed as pretty-printed JSON.
+* If the code returns nothing (`undefined`), `exec` prints `Executed successfully`.
+
+```bash  theme={null}
+npx libretto exec "return await page.title()"
+# My Page Title
+
+npx libretto exec "return await page.locator('li').count()"
+# 12
+```
+
+### Rules
+
+<Warning>
+  **Let failures throw.** Do not hide `exec` failures with `try/catch` or `.catch()`. Swallowed errors make debugging harder — surface them so you can see exactly what failed.
+</Warning>
+
+<Warning>
+  **Do not run multiple `exec` commands in parallel.** Each `exec` call drives the same browser page. Running them concurrently causes race conditions.
+</Warning>
+
+* Use `exec` for focused inspection and short-lived interaction experiments.
+* Use `exec -` (stdin) for complex multi-line scripts.
+* Validate a selector with `exec` before encoding it in a workflow file.
+* Use `exec` to prototype a single step, then move the working code into your `.ts` workflow file.
+
+### Examples
+
+```bash  theme={null}
+# Return the current URL
+npx libretto exec "return await page.url()"
+
+# Count how many buttons are on the page
+npx libretto exec "return await page.locator('button').count()"
+
+# Click a button
+npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+
+# Read a value from an input field
+npx libretto exec "return await page.locator('input[name=\"email\"]').inputValue()"
+
+# Run against a named session
+npx libretto exec --session debug-example "return await page.url()"
+
+# Run against a specific page in a session
+npx libretto exec --session debug-example --page <page-id> "return await page.url()"
+
+# Pipe from stdin (multi-line, named session)
+echo "return await page.url()" | npx libretto exec - --session debug-example
+```
+
+<CardGroup cols={2}>
+  <Card title="snapshot" icon="camera" href="./snapshot">
+    Use snapshot to identify selectors before running exec.
+  </Card>
+
+  <Card title="run & resume" icon="play" href="./run-and-resume">
+    Move validated exec code into a workflow file and run it end to end.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/network-and-actions.mdx
+++ b/docs/cli-reference/network-and-actions.mdx
@@ -1,0 +1,229 @@
+## network & actions
+
+> View captured network requests and recorded user actions from a session.
+
+Libretto automatically captures network requests and browser actions to JSONL log files during every session. The `network` and `actions` commands let you view these logs from the CLI. You can also query them directly with `jq`.
+
+***
+
+### network
+
+The `network` command displays HTTP requests captured during a session. Use it to reverse-engineer a site's internal API, identify endpoints to call directly, or debug unexpected network behavior.
+
+```bash  theme={null}
+npx libretto network --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session whose network log to read.
+</ParamField>
+
+<ParamField path="--last" type="number">
+  Show only the last N entries.
+</ParamField>
+
+<ParamField path="--filter" type="string">
+  Filter entries by a substring match on the URL.
+</ParamField>
+
+<ParamField path="--method" type="string">
+  Filter entries by HTTP method. Example: `--method POST`.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Filter entries by page ID. Useful when multiple pages are open in the session.
+</ParamField>
+
+<ParamField path="--clear" type="boolean">
+  Clear the network log for the session.
+</ParamField>
+
+#### Log file location
+
+Network logs are stored at:
+
+```
+.libretto/sessions/<session>/network.jsonl
+```
+
+One JSON object per line. Query directly with `jq` for advanced filtering.
+
+#### Key fields
+
+| Field          | Description                                |
+| -------------- | ------------------------------------------ |
+| `ts`           | ISO timestamp of the request               |
+| `method`       | HTTP method (`GET`, `POST`, `PUT`, etc.)   |
+| `url`          | Full request URL                           |
+| `status`       | HTTP response status code                  |
+| `contentType`  | Response content type                      |
+| `responseBody` | Response body string (may be `null`)       |
+| `pageId`       | Playwright page ID that produced the entry |
+
+#### Examples
+
+```bash  theme={null}
+# View all captured requests
+npx libretto network --session debug-example
+
+# View the last 20 requests
+npx libretto network --session debug-example --last 20
+
+# Filter to POST requests only
+npx libretto network --session debug-example --method POST
+
+# Filter by URL substring
+npx libretto network --session debug-example --filter "/api/referrals"
+
+# Query with jq directly — all POST requests
+jq 'select(.method == "POST")' .libretto/sessions/debug-example/network.jsonl
+
+# Extract URL and status for every request
+jq '{url: .url, status: .status}' .libretto/sessions/debug-example/network.jsonl
+```
+
+***
+
+### actions
+
+The `actions` command displays browser interactions recorded during a session — both actions Libretto performed as an agent and actions a user performed manually in the browser window. Use it to understand what happened during a session and reconstruct workflows from manual user behavior.
+
+```bash  theme={null}
+npx libretto actions --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session whose action log to read.
+</ParamField>
+
+<ParamField path="--last" type="number">
+  Show only the last N entries.
+</ParamField>
+
+<ParamField path="--filter" type="string">
+  Filter entries by a substring match.
+</ParamField>
+
+<ParamField path="--action" type="string">
+  Filter by action type. Example: `--action click`, `--action fill`.
+</ParamField>
+
+<ParamField path="--source" type="string">
+  Filter by source. `user` for manual browser actions, `agent` for Playwright actions.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Filter entries by page ID.
+</ParamField>
+
+<ParamField path="--clear" type="boolean">
+  Clear the action log for the session.
+</ParamField>
+
+#### Log file location
+
+Action logs are stored at:
+
+```
+.libretto/sessions/<session>/actions.jsonl
+```
+
+#### Key fields
+
+| Field                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `ts`                   | ISO timestamp                                                    |
+| `source`               | `user` (manual DOM event) or `agent` (Playwright call)           |
+| `action`               | Action name: `click`, `dblclick`, `fill`, `goto`, `reload`, etc. |
+| `selector`             | Locator used by the agent                                        |
+| `bestSemanticSelector` | Canonical selector from the user DOM event                       |
+| `targetSelector`       | Raw DOM event target selector (user events only)                 |
+| `ancestorSelectors`    | Meaningful ancestor selectors, closest to farthest               |
+| `nearbyText`           | Visible text near the event target                               |
+| `composedPath`         | Event path from raw target to farthest ancestor                  |
+| `coordinates`          | `{x, y}` for pointer events                                      |
+| `value`                | Typed, selected, or submitted value                              |
+| `url`                  | Navigation target or page URL for navigation actions             |
+| `duration`             | Elapsed time in milliseconds (agent entries)                     |
+| `success`              | `true` if the action completed, `false` on failure               |
+| `error`                | Error message when the action failed                             |
+| `pageId`               | Playwright page ID                                               |
+
+<Note>
+  Agent entries describe what Playwright tried to do (`selector`, `duration`). User entries describe what DOM element was actually interacted with (`bestSemanticSelector`, `targetSelector`, `ancestorSelectors`, `nearbyText`, `composedPath`, `coordinates`).
+</Note>
+
+#### Examples
+
+```bash  theme={null}
+# View all recorded actions
+npx libretto actions --session debug-example
+
+# View the last 20 actions
+npx libretto actions --session debug-example --last 20
+
+# Show only click actions
+npx libretto actions --session debug-example --action click
+
+# Show only user-initiated actions
+npx libretto actions --session debug-example --source user
+
+# Query with jq — last 20 entries
+tail -n 20 .libretto/sessions/debug-example/actions.jsonl | jq .
+
+# Find all failed actions
+jq 'select(.success == false)' .libretto/sessions/debug-example/actions.jsonl
+
+# Extract selector and action for agent entries
+jq 'select(.source == "agent") | {action: .action, selector: .selector}' \
+  .libretto/sessions/debug-example/actions.jsonl
+```
+
+***
+
+### JSONL log files
+
+Both logs use the [JSONL](https://jsonlines.org) format: one JSON object per line, appended in order. This makes them easy to query with standard Unix tools.
+
+```txt
+.libretto/
+  sessions/
+    <session>/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+```
+
+#### Querying with jq
+
+`jq` works directly on JSONL files because it processes one object per input line by default:
+
+```bash  theme={null}
+# All POST requests in the network log
+jq 'select(.method == "POST")' .libretto/sessions/<session>/network.jsonl
+
+# Last 20 action entries (requires tail)
+tail -n 20 .libretto/sessions/<session>/actions.jsonl | jq .
+
+# Count requests by HTTP method
+jq -r '.method' .libretto/sessions/<session>/network.jsonl | sort | uniq -c
+
+# Find requests to a specific endpoint
+jq 'select(.url | contains("/api/"))' .libretto/sessions/<session>/network.jsonl
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="./exec">
+    Access `networkLog` and `actionLog` as globals inside exec code.
+  </Card>
+
+  <Card title="snapshot" icon="camera" href="./snapshot">
+    Use snapshot alongside network logs to understand page state.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/open-and-connect.mdx
+++ b/docs/cli-reference/open-and-connect.mdx
@@ -1,0 +1,129 @@
+## open & connect
+
+> Launch a browser session or attach to an existing Chrome DevTools Protocol endpoint.
+
+### open
+
+The `open` command launches a browser and navigates to a URL, creating a new named session. It is the starting point for any interactive workflow: once a session is open, `exec`, `snapshot`, `network`, and `actions` all work against it.
+
+```bash  theme={null}
+npx libretto open https://example.com
+npx libretto open https://example.com --headless --session debug-example
+```
+
+#### When to use `open`
+
+* At the start of script authoring when you need live page state to decide how the workflow should work.
+* When the user needs to log in manually before automation begins (use `--headed`).
+* Any time you need a fresh, isolated browser instance on a specific URL.
+
+#### Flags
+
+<ParamField path="url" type="string" required>
+  The URL to open. Passed as the first positional argument.
+</ParamField>
+
+<ParamField path="--headed" type="boolean">
+  Run the browser in headed (visible) mode. This is the default when neither flag is passed.
+</ParamField>
+
+<ParamField path="--headless" type="boolean">
+  Run the browser in headless mode. Useful for automated runs that don't need a visible window.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this session. If omitted, Libretto generates a unique name automatically. Use a consistent name to target the session with later commands.
+</ParamField>
+
+<ParamField path="--viewport" type="string">
+  Viewport size in `WIDTHxHEIGHT` format, for example `1920x1080`. Falls back to the value in `.libretto/config.json`, then `1366x768`.
+</ParamField>
+
+<Note>
+  `--headed` and `--headless` are mutually exclusive. Passing both raises an error.
+</Note>
+
+#### Examples
+
+```bash  theme={null}
+# Open in headed mode (default)
+npx libretto open https://app.example.com --headed
+
+# Open in headless mode with an explicit session name
+npx libretto open https://example.com --headless --session debug-example
+
+# Open with a custom viewport
+npx libretto open https://example.com --viewport 1440x900 --session my-session
+
+# Open for a manual login flow, then save the session
+npx libretto open https://app.example.com --headed
+# ... user logs in ...
+npx libretto save app.example.com
+```
+
+***
+
+### connect
+
+The `connect` command attaches to an existing Chrome DevTools Protocol (CDP) endpoint rather than launching a new browser. Use it to drive a browser that is already running — for example, one started with `--remote-debugging-port`, an Electron application, or any other CDP-compatible target.
+
+```bash  theme={null}
+npx libretto connect http://127.0.0.1:9222 --session my-session
+npx libretto connect http://127.0.0.1:9223 --session another-session
+```
+
+#### When to use `connect`
+
+* You have an existing browser process you want to automate without restarting it.
+* You are driving an Electron app exposed over CDP.
+* You want to attach to a remote browser in a CI environment that has already navigated to the right state.
+
+#### Flags
+
+<ParamField path="cdp-url" type="string" required>
+  The CDP endpoint URL to connect to. Passed as the first positional argument. Example: `http://127.0.0.1:9222`.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this session. Recommended to set explicitly when using `connect` so you can reference it later.
+</ParamField>
+
+#### After connecting
+
+Once connected, all session-scoped commands work normally against the attached browser:
+
+* `exec` — run Playwright TypeScript code
+* `snapshot` — capture a screenshot and analyze the page
+* `pages` — list open pages
+* `network` — view captured network requests
+* `actions` — view recorded actions
+
+<Warning>
+  Libretto does **not** manage the lifecycle of a connected process. Running `npx libretto close --session <name>` clears the Libretto session record but does **not** terminate the remote browser or Electron app.
+</Warning>
+
+#### Examples
+
+```bash  theme={null}
+# Attach to a Chrome instance started with --remote-debugging-port
+npx libretto connect http://127.0.0.1:9222 --session chrome-debug
+
+# Inspect the attached page
+npx libretto snapshot \
+  --session chrome-debug \
+  --objective "What is the current page state?" \
+  --context "Just attached to a running browser."
+
+# Run code against it
+npx libretto exec --session chrome-debug "return await page.url()"
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="./exec">
+    Execute Playwright TypeScript against the open page.
+  </Card>
+
+  <Card title="snapshot" icon="camera" href="./snapshot">
+    Capture a screenshot and analyze page state.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/open-and-connect.mdx
+++ b/docs/cli-reference/open-and-connect.mdx
@@ -56,9 +56,9 @@ npx libretto open https://example.com --headless --session debug-example
 npx libretto open https://example.com --viewport 1440x900 --session my-session
 
 # Open for a manual login flow, then save the session
-npx libretto open https://app.example.com --headed
+npx libretto open https://app.example.com --headed --session app-login
 # ... user logs in ...
-npx libretto save app.example.com
+npx libretto save app.example.com --session app-login
 ```
 
 ***

--- a/docs/cli-reference/run-and-resume.mdx
+++ b/docs/cli-reference/run-and-resume.mdx
@@ -43,7 +43,7 @@ npx libretto run <file> <export> [flags]
 </ParamField>
 
 <ParamField path="--auth-profile" type="string">
-  Domain of a saved auth profile to load for this run. Example: `--auth-profile app.example.com`. Profiles are created with `npx libretto save <domain>`.
+  Domain of a saved auth profile to load for this run. Example: `--auth-profile app.example.com`. Profiles are created with `npx libretto save <domain> --session <name>`.
 </ParamField>
 
 <ParamField path="--viewport" type="string">

--- a/docs/cli-reference/run-and-resume.mdx
+++ b/docs/cli-reference/run-and-resume.mdx
@@ -1,0 +1,204 @@
+## run & resume
+
+> Execute a workflow file and resume paused workflows.
+
+### run
+
+The `run` command executes a named export from a TypeScript workflow file against a live browser. Use it to verify a workflow after creating or editing it.
+
+```bash  theme={null}
+npx libretto run ./integration.ts main
+npx libretto run ./integration.ts main --headless
+```
+
+#### Syntax
+
+```bash  theme={null}
+npx libretto run <file> <export> [flags]
+```
+
+* `<file>` — path to the TypeScript workflow file
+* `<export>` — the named export from that file (e.g., `main`, `myWorkflow`)
+
+#### Flags
+
+<ParamField path="--headless" type="boolean">
+  Run the browser in headless mode. Use this for the normal fix-and-verify loop.
+</ParamField>
+
+<ParamField path="--headed" type="boolean">
+  Run the browser in headed (visible) mode. This is the default when neither flag is passed.
+</ParamField>
+
+<ParamField path="--session" type="string">
+  Name for this run session. Auto-generated if omitted. Use an explicit name to target the session with `exec`, `snapshot`, or `resume` after a failure or pause.
+</ParamField>
+
+<ParamField path="--params" type="string">
+  Inline JSON input for the workflow, passed as a quoted string. Example: `--params '{"status":"open"}'`.
+</ParamField>
+
+<ParamField path="--params-file" type="string">
+  Path to a JSON file to use as workflow input. Cannot be used together with `--params`.
+</ParamField>
+
+<ParamField path="--auth-profile" type="string">
+  Domain of a saved auth profile to load for this run. Example: `--auth-profile app.example.com`. Profiles are created with `npx libretto save <domain>`.
+</ParamField>
+
+<ParamField path="--viewport" type="string">
+  Viewport size in `WIDTHxHEIGHT` format, for example `1920x1080`. Falls back to `.libretto/config.json`, then `1366x768`.
+</ParamField>
+
+<ParamField path="--tsconfig" type="string">
+  Path to a `tsconfig.json` file for module resolution during workflow compilation.
+</ParamField>
+
+<ParamField path="--no-visualize" type="boolean">
+  Disable ghost cursor and element highlight visualization in headed mode.
+</ParamField>
+
+#### Behavior on failure
+
+When a workflow fails, Libretto keeps the browser open at the point of failure. You can then use `snapshot` and `exec` to inspect the live page state before editing the workflow code.
+
+```bash  theme={null}
+# Workflow fails — browser stays open
+npx libretto run ./integration.ts main --session debug-flow --headed
+
+# Inspect the failure state
+npx libretto snapshot \
+  --session debug-flow \
+  --objective "Find the blocking error or broken selector target" \
+  --context "The workflow failed after trying to continue from the review step."
+
+# Prototype a fix
+npx libretto exec --session debug-flow "return await page.locator('.error-message').textContent()"
+
+# Re-run after fixing the code
+npx libretto run ./integration.ts main --headless
+```
+
+#### Validation loop
+
+Prefer `run --headless` for the normal fix-and-verify loop. When the headless run passes, do a final headed run if you or the user wants to watch the finished workflow:
+
+```bash  theme={null}
+# Fix/verify loop — fast, no visible browser
+npx libretto run ./integration.ts main --headless
+
+# Final confirmation run — shows the browser
+npx libretto run ./integration.ts main --headed
+```
+
+#### Examples
+
+```bash  theme={null}
+# Basic run
+npx libretto run ./integration.ts main
+
+# Headless run with inline params
+npx libretto run ./integration.ts main --headless --params '{"status":"open"}'
+
+# Run with a params file
+npx libretto run ./integration.ts main --params-file ./params.json
+
+# Run with a saved auth profile
+npx libretto run ./integration.ts main --auth-profile app.example.com
+
+# Run with explicit session name for post-failure inspection
+npx libretto run ./integration.ts main --session debug-flow --headed
+```
+
+***
+
+### resume
+
+The `resume` command unpauses a workflow that has stopped at an `await pause(session)` call. Use it repeatedly until the workflow completes or pauses again at the next breakpoint.
+
+```bash  theme={null}
+npx libretto resume --session debug-example
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session name of the paused workflow to resume.
+</ParamField>
+
+#### The `pause()` API
+
+Insert `await pause(session)` calls in your workflow file to create interactive breakpoints — similar to debugger breakpoints in the browser flow. The workflow stops at each `pause()` call and waits for `resume` before continuing.
+
+```typescript  theme={null}
+import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
+
+export const myWorkflow = workflow(async (ctx, input) => {
+  const { session, page } = ctx;
+
+  await page.goto("https://app.example.com");
+
+  // Pause here for inspection
+  await pause(session);
+
+  await page.locator('#submit').click();
+
+  // Pause again before the final step
+  await pause(session);
+
+  return { done: true };
+});
+```
+
+<Note>
+  `pause()` is a **no-op when `NODE_ENV === "production"`**. You can leave `pause()` calls in your workflow code during development and they will be silently skipped in production.
+</Note>
+
+#### Complete debugging flow
+
+<Steps>
+  <Step title="Run the workflow and let it fail (or pause)">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --session debug-flow --headed
+    ```
+
+    If the workflow hits a `pause()`, it prints `Workflow paused.` and returns. The browser stays open.
+  </Step>
+
+  <Step title="Inspect the paused page state">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session debug-flow \
+      --objective "What is on the page and what is the next required action?" \
+      --context "The workflow paused before the submit step."
+
+    npx libretto exec --session debug-flow "return await page.url()"
+    ```
+  </Step>
+
+  <Step title="Resume the workflow">
+    ```bash  theme={null}
+    npx libretto resume --session debug-flow
+    ```
+
+    Keep running `resume` until the workflow prints `Integration completed.` or fails with an error.
+  </Step>
+
+  <Step title="Fix the code and re-run">
+    Edit the workflow file to fix any issues found during inspection, then re-run:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless
+    ```
+  </Step>
+</Steps>
+
+<CardGroup cols={2}>
+  <Card title="snapshot" icon="camera" href="./snapshot">
+    Inspect page state after a failure or pause.
+  </Card>
+
+  <Card title="exec" icon="code" href="./exec">
+    Prototype fixes against the paused browser before editing code.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/run-and-resume.mdx
+++ b/docs/cli-reference/run-and-resume.mdx
@@ -131,9 +131,9 @@ npx libretto resume --session debug-example
 Insert `await pause(session)` calls in your workflow file to create interactive breakpoints — similar to debugger breakpoints in the browser flow. The workflow stops at each `pause()` call and waits for `resume` before continuing.
 
 ```typescript  theme={null}
-import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
+import { workflow, pause } from "libretto";
 
-export const myWorkflow = workflow(async (ctx, input) => {
+export const myWorkflow = workflow("myWorkflow", async (ctx, input) => {
   const { session, page } = ctx;
 
   await page.goto("https://app.example.com");

--- a/docs/cli-reference/session-management.mdx
+++ b/docs/cli-reference/session-management.mdx
@@ -1,0 +1,214 @@
+## save, pages & close
+
+> Manage browser sessions, pages, and saved authentication profiles.
+
+### The `--session` flag
+
+Almost every Libretto command accepts `--session <name>` to target a specific browser session. When you omit `--session` on commands that support auto-generation (`open`, `run`), Libretto creates a unique name automatically.
+
+Session state is stored under `.libretto/sessions/<session>/`:
+
+```txt
+.libretto/
+  sessions/
+    <session>/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+  profiles/
+```
+
+Session directories are git-ignored. Each session runs an isolated browser instance on a dynamic port.
+
+***
+
+### pages
+
+The `pages` command lists all open pages (tabs) in a session and prints their IDs and URLs.
+
+```bash  theme={null}
+npx libretto pages --session debug-example
+```
+
+#### When to use `pages`
+
+* A popup or new tab opened during navigation or interaction.
+* `exec` or `snapshot` fails because more than one page is open in the session.
+* You are not sure which page holds the relevant state.
+
+After running `pages`, pass the target page ID to other commands with `--page <page-id>`:
+
+```bash  theme={null}
+# List pages
+npx libretto pages --session debug-example
+
+# Target a specific page
+npx libretto exec --session debug-example --page <page-id> "return await page.url()"
+npx libretto snapshot --session debug-example --page <page-id> \
+  --objective "Find the active form" \
+  --context "A modal opened in a new tab."
+```
+
+#### Flags
+
+<ParamField path="--session" type="string" required>
+  The session to list pages for.
+</ParamField>
+
+***
+
+### save
+
+The `save` command saves the current browser session's cookies and localStorage as a named auth profile. Load the profile later with `--auth-profile` to skip manual login.
+
+```bash  theme={null}
+npx libretto save app.example.com
+```
+
+#### When to use `save`
+
+Only use `save` when the user explicitly asks to save or reuse authenticated browser state. A typical flow:
+
+<Steps>
+  <Step title="Open the site in headed mode">
+    ```bash  theme={null}
+    npx libretto open https://app.example.com --headed
+    ```
+  </Step>
+
+  <Step title="Log in manually">
+    The browser window is visible. Log in as usual.
+  </Step>
+
+  <Step title="Save the session">
+    ```bash  theme={null}
+    npx libretto save app.example.com
+    ```
+
+    The profile is saved to `.libretto/profiles/app.example.com.json`.
+  </Step>
+
+  <Step title="Use the profile in future runs">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --auth-profile app.example.com
+    ```
+  </Step>
+</Steps>
+
+#### Profile storage
+
+Profiles are stored in `.libretto/profiles/<domain>.json`. They are:
+
+* Machine-local — not shared across environments or team members.
+* Git-ignored by default.
+* Subject to session expiry — if authentication stops working, repeat the login-and-save flow.
+
+#### Flags
+
+<ParamField path="domain" type="string" required>
+  The domain (or URL) used to name the saved profile. Passed as the first positional argument. Example: `app.example.com`.
+</ParamField>
+
+<ParamField path="--session" type="string" required>
+  The session to save. Use the same name you passed to `npx libretto open --session`.
+</ParamField>
+
+***
+
+### close
+
+The `close` command closes a browser session and cleans up its state.
+
+```bash  theme={null}
+npx libretto close --session debug-example
+npx libretto close --all
+```
+
+#### When to use `close`
+
+* When you are done with a session.
+* When an exploration session is no longer helping progress and you want to free up the browser.
+* For full workspace cleanup at the end of a task.
+
+<Note>
+  When using `connect` to attach to an external CDP endpoint, `close` clears the Libretto session record but **does not terminate the remote browser process**.
+</Note>
+
+#### Flags
+
+<ParamField path="--session" type="string">
+  The session to close. Required unless `--all` is passed.
+</ParamField>
+
+<ParamField path="--all" type="boolean">
+  Close all tracked sessions in this workspace.
+</ParamField>
+
+<ParamField path="--force" type="boolean">
+  Force-kill sessions that do not respond to SIGTERM. Requires `--all`.
+</ParamField>
+
+#### Examples
+
+```bash  theme={null}
+# Close a named session
+npx libretto close --session debug-example
+
+# Close all sessions in the workspace
+npx libretto close --all
+
+# Close all sessions, force-killing any that are unresponsive
+npx libretto close --all --force
+```
+
+***
+
+### setup
+
+The `setup` command sets up Libretto in your project for the first time. It installs Chromium, copies the Libretto skill files to your agent directories, and walks you through configuring a snapshot analysis model.
+
+```bash  theme={null}
+npx libretto setup
+```
+
+<Warning>
+  `setup` is interactive — it prompts for API credentials and requires a TTY. Run it yourself in a terminal, not through an agent.
+</Warning>
+
+#### What `setup` does
+
+1. Installs the Playwright Chromium browser via `npx playwright install chromium`.
+2. Copies skill files to `.agents/skills/libretto/` and `.claude/skills/libretto/` if those directories exist.
+3. Prompts you to select an AI provider (OpenAI, Anthropic, Google Gemini, or Google Vertex AI) and enter your API key, which is written to `.env`.
+
+#### Flags
+
+<ParamField path="--skip-browsers" type="boolean">
+  Skip the Playwright Chromium installation step. Useful if Chromium is already installed.
+</ParamField>
+
+#### After `setup`
+
+You can change or update the snapshot analysis model at any time without re-running `setup`:
+
+```bash  theme={null}
+npx libretto ai configure openai
+npx libretto ai configure anthropic
+npx libretto ai configure gemini
+npx libretto ai configure vertex
+
+# Or specify a model directly
+npx libretto ai configure openai/gpt-4o
+```
+
+<CardGroup cols={2}>
+  <Card title="open & connect" icon="browser" href="./open-and-connect">
+    Start a session after init completes.
+  </Card>
+
+  <Card title="network & actions" icon="chart-network" href="./network-and-actions">
+    Explore session logs captured during a run.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/session-management.mdx
+++ b/docs/cli-reference/session-management.mdx
@@ -64,7 +64,7 @@ npx libretto snapshot --session debug-example --page <page-id> \
 The `save` command saves the current browser session's cookies and localStorage as a named auth profile. Load the profile later with `--auth-profile` to skip manual login.
 
 ```bash  theme={null}
-npx libretto save app.example.com
+npx libretto save app.example.com --session app-login
 ```
 
 #### When to use `save`
@@ -74,7 +74,7 @@ Only use `save` when the user explicitly asks to save or reuse authenticated bro
 <Steps>
   <Step title="Open the site in headed mode">
     ```bash  theme={null}
-    npx libretto open https://app.example.com --headed
+    npx libretto open https://app.example.com --headed --session app-login
     ```
   </Step>
 
@@ -84,7 +84,7 @@ Only use `save` when the user explicitly asks to save or reuse authenticated bro
 
   <Step title="Save the session">
     ```bash  theme={null}
-    npx libretto save app.example.com
+    npx libretto save app.example.com --session app-login
     ```
 
     The profile is saved to `.libretto/profiles/app.example.com.json`.

--- a/docs/cli-reference/sessions-and-profiles.mdx
+++ b/docs/cli-reference/sessions-and-profiles.mdx
@@ -208,7 +208,7 @@ Profiles are:
 
 ### Related pages
 
-<Columns cols={2}>
+<CardGroup cols={2}>
   <Card title="Automation approaches" icon="code" href="../get-started/automation-approaches">
     Compare the four integration strategies and their detection risk profiles.
   </Card>
@@ -216,4 +216,4 @@ Profiles are:
   <Card title="Bot detection" icon="shield" href="../get-started/bot-detection">
     Understand how sites detect automation and choose approaches that minimize risk.
   </Card>
-</Columns>
+</CardGroup>

--- a/docs/cli-reference/sessions-and-profiles.mdx
+++ b/docs/cli-reference/sessions-and-profiles.mdx
@@ -1,0 +1,219 @@
+## Sessions and profiles
+
+> Manage named browser sessions and persist authenticated browser state across runs.
+
+### Sessions
+
+Every Libretto session gets its own isolated directory under `.libretto/sessions/<name>/`. Sessions are git-ignored by default — they contain runtime state and machine-local data that should not be committed.
+
+You can run multiple sessions simultaneously. Each session targets a specific browser instance and has its own log files, network capture, and snapshot history.
+
+#### Starting and ending sessions
+
+```bash  theme={null}
+# Open a new browser and give the session a name
+npx libretto open https://example.com --session my-session
+
+# All commands accept --session to target a specific session
+npx libretto snapshot --session my-session --objective "..." --context "..."
+npx libretto exec --session my-session "return await page.url()"
+npx libretto network --session my-session
+
+# Close a specific session
+npx libretto close --session my-session
+
+# Close all open sessions (useful for workspace cleanup)
+npx libretto close --all
+```
+
+<Note>
+  Treat exploration sessions as disposable unless you explicitly need to keep a session open for continued investigation. Use `close --all` before starting a fresh automation run to avoid stale browser state.
+</Note>
+
+#### Session state file
+
+Each session writes a `state.json` file with metadata about the running browser process:
+
+```json  theme={null}
+{
+  "version": 1,
+  "session": "my-session",
+  "port": 9222,
+  "pid": 12345,
+  "startedAt": "2026-03-26T10:00:00.000Z",
+  "status": "active"
+}
+```
+
+| Field       | Type              | Description                                            |
+| ----------- | ----------------- | ------------------------------------------------------ |
+| `version`   | number            | State file schema version                              |
+| `session`   | string            | Session name                                           |
+| `port`      | number            | Chrome DevTools Protocol debug port                    |
+| `pid`       | number (optional) | Browser process ID                                     |
+| `startedAt` | string            | ISO 8601 timestamp when the session started            |
+| `status`    | string            | `active`, `paused`, `completed`, `failed`, or `exited` |
+
+***
+
+### Session logs
+
+Each session directory contains several log files you can query directly with `jq`:
+
+```
+.libretto/
+  config.json
+  sessions/
+    my-session/
+      state.json
+      logs.jsonl
+      network.jsonl
+      actions.jsonl
+      snapshots/
+        snapshot-001.png
+        snapshot-001.html
+  profiles/
+    app.example.com.json
+```
+
+#### logs.jsonl
+
+Structured CLI and system logs. Contains debug output from Libretto itself — command execution, errors, and internal events.
+
+```bash  theme={null}
+# View the last 20 log entries
+tail -n 20 .libretto/sessions/my-session/logs.jsonl | jq .
+```
+
+#### actions.jsonl
+
+Recorded user and agent actions. Each line is a JSON object representing one interaction — a click, fill, navigation, or other Playwright action. Libretto records both actions you perform manually in the browser (`source: "user"`) and actions the agent performs programmatically (`source: "agent"`).
+
+Key fields:
+
+| Field                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `ts`                   | ISO timestamp                                                    |
+| `source`               | `"user"` for captured DOM events, `"agent"` for Playwright calls |
+| `action`               | Action type: `click`, `fill`, `goto`, `reload`, etc.             |
+| `selector`             | Selector or locator hint (agent entries)                         |
+| `bestSemanticSelector` | Canonical selector for user DOM events                           |
+| `success`              | `true` if the action completed, `false` on failure               |
+| `value`                | Typed, selected, or submitted value when the action had one      |
+| `url`                  | Navigation target for goto-style actions                         |
+| `error`                | Error message when the action failed                             |
+
+```bash  theme={null}
+# View all recorded actions
+tail -n 20 .libretto/sessions/my-session/actions.jsonl | jq .
+
+# Show only failed actions
+jq 'select(.success == false)' .libretto/sessions/my-session/actions.jsonl
+
+# Show only user actions
+jq 'select(.source == "user")' .libretto/sessions/my-session/actions.jsonl
+```
+
+#### network.jsonl
+
+Captured HTTP requests and responses. Each line represents one request/response pair.
+
+Key fields:
+
+| Field          | Description                        |
+| -------------- | ---------------------------------- |
+| `ts`           | ISO timestamp                      |
+| `method`       | HTTP method: `GET`, `POST`, etc.   |
+| `url`          | Request URL                        |
+| `status`       | HTTP status code                   |
+| `contentType`  | Response content type              |
+| `responseBody` | Response body string (may be null) |
+
+```bash  theme={null}
+# View all captured network requests
+jq . .libretto/sessions/my-session/network.jsonl
+
+# Filter to POST requests only
+jq 'select(.method == "POST")' .libretto/sessions/my-session/network.jsonl
+
+# Find requests to a specific API endpoint
+jq 'select(.url | contains("/api/"))' .libretto/sessions/my-session/network.jsonl
+
+# View JSON API responses
+jq 'select(.contentType | contains("application/json")) | .responseBody' \
+  .libretto/sessions/my-session/network.jsonl
+```
+
+#### snapshots/
+
+The `snapshots/` directory contains paired PNG screenshots and HTML files captured by `npx libretto snapshot`. Each snapshot produces:
+
+* `snapshot-NNN.png` — a full-page screenshot
+* `snapshot-NNN.html` — the full DOM at capture time, used by the AI analysis model
+
+***
+
+### Profiles
+
+Profiles save browser sessions — cookies and localStorage — so you can reuse authenticated state across multiple runs without logging in every time.
+
+#### Creating a profile
+
+```bash  theme={null}
+# Open the site in headed mode so you can log in manually
+npx libretto open https://app.example.com --headed
+
+# After logging in, save the current session as a profile
+npx libretto save app.example.com
+```
+
+The profile is stored at `.libretto/profiles/app.example.com.json`. It contains:
+
+* The full cookie jar for the domain
+* localStorage contents for the domain
+
+#### Using a profile
+
+Pass `--auth-profile` when running a workflow to inject the saved browser state:
+
+```bash  theme={null}
+npx libretto run ./workflow.ts main --auth-profile app.example.com
+```
+
+Libretto loads the profile before executing the workflow, so the browser starts in an already-authenticated state.
+
+#### Profile storage
+
+Profiles are:
+
+* Stored at `.libretto/profiles/<domain>.json`
+* Machine-local — not shared between machines
+* Git-ignored — never committed to version control
+
+<Note>
+  Sessions can expire. If a profile stops working, repeat the manual login flow and run `npx libretto save <domain>` again to refresh it.
+</Note>
+
+***
+
+### Best practices
+
+* **Give sessions meaningful names.** Use names like `debug-login`, `scrape-run-1`, or `test-checkout` instead of the default. Meaningful names make it easier to identify which browser is which when running `npx libretto pages` or reading log files.
+* **Use profiles to avoid repeated logins.** Save authenticated state once and reuse it across runs. This reduces friction during development and avoids login rate limits on the target site.
+* **Keep exploration sessions disposable.** Unless you explicitly need to return to a browser state, close sessions when you're done. Stale sessions consume resources and can interfere with fresh runs.
+* **Clean up before fresh starts.** Run `npx libretto close --all` before beginning a new automation run to ensure you're starting with a clean state.
+* **Don't commit profile files.** Profiles contain session cookies that are effectively credentials. The `.libretto/` directory is already git-ignored, but double-check your `.gitignore` if you're storing Libretto state in a non-standard location.
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Automation approaches" icon="code" href="../get-started/automation-approaches">
+    Compare the four integration strategies and their detection risk profiles.
+  </Card>
+
+  <Card title="Bot detection" icon="shield" href="../get-started/bot-detection">
+    Understand how sites detect automation and choose approaches that minimize risk.
+  </Card>
+</Columns>

--- a/docs/cli-reference/sessions-and-profiles.mdx
+++ b/docs/cli-reference/sessions-and-profiles.mdx
@@ -161,10 +161,10 @@ Profiles save browser sessions — cookies and localStorage — so you can reuse
 
 ```bash  theme={null}
 # Open the site in headed mode so you can log in manually
-npx libretto open https://app.example.com --headed
+npx libretto open https://app.example.com --headed --session app-login
 
 # After logging in, save the current session as a profile
-npx libretto save app.example.com
+npx libretto save app.example.com --session app-login
 ```
 
 The profile is stored at `.libretto/profiles/app.example.com.json`. It contains:
@@ -191,7 +191,7 @@ Profiles are:
 * Git-ignored — never committed to version control
 
 <Note>
-  Sessions can expire. If a profile stops working, repeat the manual login flow and run `npx libretto save <domain>` again to refresh it.
+  Sessions can expire. If a profile stops working, repeat the manual login flow and run `npx libretto save <domain> --session <name>` again to refresh it.
 </Note>
 
 ***

--- a/docs/cli-reference/snapshot.mdx
+++ b/docs/cli-reference/snapshot.mdx
@@ -1,0 +1,108 @@
+## snapshot
+
+> Capture a screenshot and HTML analysis of the current page using an AI model.
+
+The `snapshot` command is the primary page observation tool. It captures a screenshot and the full HTML of the current page, then sends both to an AI model for analysis against your stated objective.
+
+Use `snapshot` before guessing at selectors, after workflow failures, and whenever the visible page state is unclear.
+
+```bash  theme={null}
+npx libretto snapshot \
+  --objective "Find the sign-in form and submit button" \
+  --context "I just opened the login page and need the email field, password field, and submit button."
+```
+
+### Required flags
+
+<ParamField path="--objective" type="string" required>
+  What you want the AI to find, analyze, or explain. A single objective can include multiple questions or analysis tasks — you don't need to run separate snapshots for each question.
+</ParamField>
+
+<ParamField path="--context" type="string" required>
+  Background information that helps the AI understand the current state of the page. Describe what you just did, what you expected to happen, and what the page should contain.
+</ParamField>
+
+### Optional flags
+
+<ParamField path="--session" type="string" required>
+  The session to snapshot.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  Target a specific page ID within the session. Use `npx libretto pages --session <name>` to list page IDs when a popup or new tab is open. See [pages & close](./session-management) for details.
+</ParamField>
+
+### What snapshot produces
+
+For each run, `snapshot` saves three files under `.libretto/sessions/<session>/snapshots/<snapshot-id>/`:
+
+| File                  | Contents                                         |
+| --------------------- | ------------------------------------------------ |
+| `page.png`            | Full-page screenshot                             |
+| `page.html`           | Raw page HTML                                    |
+| `page.condensed.html` | Token-optimized condensed HTML sent to the model |
+
+The command prints the paths to all three files before the AI analysis output.
+
+### When to use snapshot
+
+* Before writing a selector — use snapshot to confirm the element structure rather than guessing.
+* After a workflow step fails — inspect the exact page state the failure left behind.
+* When the page has rendered content that isn't obvious from the URL alone.
+* When you need answers to multiple questions about a page in a single call.
+
+<Tip>
+  A single `--objective` can ask several things at once. For example: `"Find the submit button selector, confirm whether there are validation errors, and identify the field that currently has focus."` Batching questions into one snapshot is more efficient than calling snapshot repeatedly.
+</Tip>
+
+### Timeout
+
+Snapshot sends a request to an external AI API and waits for the full analysis response. Depending on page complexity and model speed, this can take 30–90 seconds or more.
+
+<Warning>
+  If you are calling `snapshot` from a shell script or wrapping it in another tool, set a timeout of **at least 2 minutes** to avoid premature cancellation.
+</Warning>
+
+### Configuration
+
+Snapshot analysis requires a configured AI model. Run `npx libretto setup` on first setup, or use `npx libretto ai configure <provider>` to set or change the model later. Credentials are read from environment variables or a `.env` file at your project root.
+
+Supported providers: `openai`, `anthropic`, `gemini`, `vertex`.
+
+### Examples
+
+```bash  theme={null}
+# Basic snapshot — find a form
+npx libretto snapshot \
+  --objective "Find the sign-in form and submit button" \
+  --context "I just opened the login page and need the email field, password field, and submit button."
+
+# Snapshot a specific session after a failure
+npx libretto snapshot \
+  --session debug-example \
+  --objective "Explain why the table is empty" \
+  --context "I opened the referrals page, applied filters, and expected rows to appear."
+
+# Snapshot a specific page in a multi-page session
+npx libretto snapshot \
+  --session debug-example \
+  --page <page-id> \
+  --objective "Find the active form" \
+  --context "A modal opened after clicking the Edit button. I need the form fields inside it."
+
+# Snapshot during debugging — ask multiple things at once
+npx libretto snapshot \
+  --session debug-flow \
+  --objective "Find the blocking error or broken selector target. Also describe the current page URL and any visible error messages." \
+  --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."
+```
+
+<CardGroup cols={2}>
+  <Card title="exec" icon="code" href="./exec">
+    Run Playwright code to prototype interactions after using snapshot to identify elements.
+  </Card>
+
+  <Card title="run & resume" icon="play" href="./run-and-resume">
+    Run a full workflow file and use snapshot to debug failures.
+  </Card>
+</CardGroup>

--- a/docs/cli-reference/snapshot.mdx
+++ b/docs/cli-reference/snapshot.mdx
@@ -8,11 +8,16 @@ Use `snapshot` before guessing at selectors, after workflow failures, and whenev
 
 ```bash  theme={null}
 npx libretto snapshot \
+  --session debug-example \
   --objective "Find the sign-in form and submit button" \
   --context "I just opened the login page and need the email field, password field, and submit button."
 ```
 
 ### Required flags
+
+<ParamField path="--session" type="string" required>
+  The session to snapshot.
+</ParamField>
 
 <ParamField path="--objective" type="string" required>
   What you want the AI to find, analyze, or explain. A single objective can include multiple questions or analysis tasks — you don't need to run separate snapshots for each question.
@@ -23,10 +28,6 @@ npx libretto snapshot \
 </ParamField>
 
 ### Optional flags
-
-<ParamField path="--session" type="string">
-  The session to snapshot.
-</ParamField>
 
 <ParamField path="--page" type="string">
   Target a specific page ID within the session. Use `npx libretto pages --session <name>` to list page IDs when a popup or new tab is open. See [pages & close](./session-management) for details.
@@ -74,6 +75,7 @@ Supported providers: `openai`, `anthropic`, `gemini`, `vertex`.
 ```bash  theme={null}
 # Basic snapshot — find a form
 npx libretto snapshot \
+  --session debug-example \
   --objective "Find the sign-in form and submit button" \
   --context "I just opened the login page and need the email field, password field, and submit button."
 

--- a/docs/cli-reference/snapshot.mdx
+++ b/docs/cli-reference/snapshot.mdx
@@ -24,7 +24,7 @@ npx libretto snapshot \
 
 ### Optional flags
 
-<ParamField path="--session" type="string" required>
+<ParamField path="--session" type="string">
   The session to snapshot.
 </ParamField>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Libretto",
+  "description": "Toolkit for building, debugging, and maintaining browser automations.",
+  "colors": {
+    "primary": "#16A34A",
+    "light": "#07C983",
+    "dark": "#15803D"
+  },
+  "favicon": "/favicon.svg",
+  "navigation": {
+    "groups": [
+      {
+        "group": "Overview",
+        "pages": [
+          "index"
+        ]
+      },
+      {
+        "group": "Get started",
+        "pages": [
+          "get-started/introduction",
+          "get-started/quickstart",
+          "get-started/configuration",
+          "get-started/automation-approaches",
+          "get-started/bot-detection"
+        ]
+      },
+      {
+        "group": "CLI reference",
+        "pages": [
+          "cli-reference/open-and-connect",
+          "cli-reference/sessions-and-profiles",
+          "cli-reference/snapshot",
+          "cli-reference/exec",
+          "cli-reference/run-and-resume",
+          "cli-reference/network-and-actions",
+          "cli-reference/session-management"
+        ]
+      },
+      {
+        "group": "Workflow guides",
+        "pages": [
+          "workflow-guides/one-shot-script-generation",
+          "workflow-guides/interactive-script-building",
+          "workflow-guides/debugging-workflows",
+          "workflow-guides/convert-to-network-requests"
+        ]
+      },
+      {
+        "group": "Library API",
+        "pages": [
+          "library-api/workflow",
+          "library-api/extraction",
+          "library-api/network",
+          "library-api/recovery",
+          "library-api/instrumentation",
+          "library-api/logging",
+          "library-api/openapi-spec"
+        ]
+      }
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/saffron-health/libretto"
+        },
+        {
+          "anchor": "npm",
+          "href": "https://www.npmjs.com/package/libretto"
+        }
+      ]
+    }
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "Discussions",
+        "href": "https://github.com/saffron-health/libretto/discussions"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "GitHub",
+      "href": "https://github.com/saffron-health/libretto"
+    }
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/saffron-health/libretto",
+      "linkedin": "https://linkedin.com/company/saffron-health"
+    }
+  }
+}

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="126.6 126.6 258.9 258.9">
+  <polygon points="297.79,370.81 239.83,333.97 172.00,344.72" fill="#1e1d1a" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="214.21,141.19 272.17,178.03 340.00,167.28" fill="#c9c3b5" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="214.21,141.19 140.42,232.03 272.17,178.03" fill="#5a5546" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="272.17,178.03 371.58,279.97 340.00,167.28" fill="#c9c3b5" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="140.42,232.03 172.00,344.72 239.83,333.97" fill="#1e1d1a" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="297.79,370.81 371.58,279.97 239.83,333.97" fill="#1e1d1a" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="140.42,232.03 239.83,333.97 272.17,178.03" fill="#5a5546" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+  <polygon points="272.17,178.03 239.83,333.97 371.58,279.97" fill="#908879" stroke="#0f0e0b" stroke-width="4" stroke-linejoin="round"/>
+</svg>

--- a/docs/get-started/automation-approaches.mdx
+++ b/docs/get-started/automation-approaches.mdx
@@ -1,0 +1,261 @@
+## Automation approaches
+
+> Choose the right integration strategy: Playwright UI, passive interception, in-browser fetch, or direct HTTP.
+
+### Overview
+
+Libretto supports four distinct approaches to capturing data and automating web interactions. Each makes different trade-offs between detection risk, setup complexity, data quality, and control. Understanding the trade-offs helps you pick the right tool for your target site.
+
+| Approach                                     | Bot detection risk | Best for                                            |
+| -------------------------------------------- | ------------------ | --------------------------------------------------- |
+| Regular Playwright                           | Moderate           | Simple DOM extraction, server-rendered sites        |
+| Passive interception (`page.on('response')`) | Low                | SPAs that load data via API calls during navigation |
+| In-browser fetch (`pageRequest()`)           | Low to moderate    | Deep pagination, bulk queries without UI clicking   |
+| Direct HTTP from Node.js                     | Very high          | Public/documented APIs with no bot detection        |
+
+<Tip>
+  **Recommended hybrid:** Combine Regular Playwright for navigation with passive `page.on('response')` interception for data capture. This gives you browser-based reliability with structured API data quality at minimal detection risk.
+</Tip>
+
+***
+
+### Approach details
+
+<Tabs>
+  <Tab title="Regular Playwright">
+    Standard Playwright usage — navigate pages, click elements, fill forms, and read DOM content using selectors and `page.evaluate()`.
+
+    ```typescript  theme={null}
+    // Navigate and interact
+    await page.goto('https://example.com/search');
+    await page.fill('#query', 'search term');
+    await page.click('#submit');
+    await page.waitForSelector('.results');
+
+    // Extract data from the DOM
+    const results = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('.result-item')).map(el => ({
+        title: el.querySelector('h2')?.textContent,
+        price: el.querySelector('.price')?.textContent,
+      }));
+    });
+    ```
+
+    **Pros:**
+
+    * Simplest approach — uses Playwright as intended
+    * No need to understand the site's API structure
+    * Works with any site regardless of how data is rendered (server-side, client-side, or hybrid)
+    * Data extraction is visual/DOM-based, which maps naturally to what a user sees
+    * Easy to debug with `headless: false` and Playwright's trace viewer
+    * Integrates directly with Libretto's step-based workflow, recovery, and extraction features
+
+    **Cons:**
+
+    * Slower than API-based approaches — requires full page rendering
+    * Fragile against DOM changes — selectors break when the site updates its markup
+    * Harder to get structured data — you're scraping rendered HTML rather than clean API responses
+    * Cannot access data that isn't rendered in the DOM (e.g., API responses with fields the UI doesn't display)
+
+    **Bot detection risk: MODERATE**
+
+    Plain Playwright is detectable by browser fingerprinting (Layer 1). Sites with any enterprise bot protection will likely flag it. Sites without active detection won't notice.
+
+    <Note>
+      Use `playwright-extra` with the stealth plugin to patch common fingerprint leaks, or run Playwright with a persistent browser context that looks more like a real browser profile.
+    </Note>
+  </Tab>
+
+  <Tab title="Passive Interception">
+    Listen to network responses the browser naturally makes as you navigate. You don't make any extra requests — you just capture the data flowing through.
+
+    ```typescript  theme={null}
+    const capturedData: any[] = [];
+
+    page.on('response', async (response) => {
+      const url = response.url();
+      if (url.includes('/api/search/results')) {
+        const json = await response.json();
+        capturedData.push(json);
+      }
+    });
+
+    // Trigger the data load by interacting with the UI normally
+    await page.goto('https://example.com/search?q=term');
+    await page.waitForSelector('.results');
+    // capturedData now has the raw API response
+    ```
+
+    **Pros:**
+
+    * Zero additional bot detection risk from network requests — you're not making any extra calls. The requests that happen are the ones the site's own code triggers.
+    * Gets clean, structured API data (JSON) rather than scraped DOM content
+    * API responses often contain more data than the UI displays (hidden fields, IDs, metadata)
+    * Not fragile against DOM changes — the API contract tends to be more stable than CSS selectors
+    * Works with Playwright's existing page context — no additional setup
+
+    **Cons:**
+
+    * You only get data that the page naturally loads — you must trigger the right UI flow to cause the requests you need
+    * Still requires Playwright browser automation to drive the page, so you have the browser fingerprinting risk for the navigation itself
+    * Timing can be tricky — you must set up the listener before the navigation that triggers the request
+    * Responses may be paginated or partial — the site's UI might lazy-load data, requiring you to trigger scrolling or "load more" interactions
+    * If the site uses GraphQL or batched API calls, parsing the right data out of responses requires understanding the API structure
+    * Some responses may be encrypted or obfuscated by bot protection services
+
+    **Bot detection risk: LOW**
+
+    The network requests themselves carry zero additional risk since they originate from the site's own JavaScript. The only risk is from the browser automation layer needed to drive the UI. No extra fetch calls means no anomalous network patterns for API-level monitoring to flag.
+  </Tab>
+
+  <Tab title="In-Browser Fetch">
+    Execute fetch calls from within the browser page's JavaScript context. The requests originate from the browser process itself with all the right credentials and fingerprints. Libretto's `pageRequest()` function provides a typed wrapper for this pattern.
+
+    ```typescript  theme={null}
+    const data = await page.evaluate(async () => {
+      const res = await fetch('/api/search/results?q=term&page=2', {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+      return res.json();
+    });
+    ```
+
+    **Pros:**
+
+    * Requests come from the real browser — same TLS fingerprint, same cookies, same origin, same HTTP/2 settings. From the server's perspective, it looks identical to a request the site's own JS would make.
+    * Full control over which endpoints you call and with what parameters — no need to trigger UI flows
+    * Can call endpoints the UI doesn't naturally hit (e.g., fetch page 50 of results without clicking "next" 49 times)
+    * Gets clean, structured API data (JSON)
+    * Faster than driving the UI — skip page rendering and go straight to the data
+
+    **Cons:**
+
+    * Requires understanding the site's API — you need to know the endpoint URLs, required headers, authentication tokens, and request body format. This requires reverse-engineering the site's network traffic first.
+    * Vulnerable to fetch/XHR monkey-patching — if the site wraps `window.fetch`, your calls may be intercepted and flagged because the call stack won't match the site's expected code paths
+    * Still requires a Playwright browser to be running (for the execution context)
+    * API endpoints can change without notice
+    * Must handle authentication tokens and CSRF tokens that the site's own code normally manages
+
+    **Bot detection risk: LOW to MODERATE**
+
+    The network-level risk is very low — the requests are genuine browser requests. The risk comes from browser fingerprinting (same as regular Playwright), fetch/XHR monkey-patching detecting unexpected call stacks, and timing/pattern analysis if your requests don't match normal UI flow patterns.
+
+    <Note>
+      Most sites do not implement fetch call stack monitoring. This approach is effectively undetectable on the vast majority of sites. Only sites with enterprise-grade bot protection from services like PerimeterX or Shape Security are likely to catch this.
+    </Note>
+  </Tab>
+
+  <Tab title="Direct HTTP">
+    Make HTTP requests directly from Node.js using `fetch`, `axios`, `got`, or similar libraries. No browser involved.
+
+    ```typescript  theme={null}
+    import axios from 'axios';
+
+    const response = await axios.get('https://example.com/api/search/results', {
+      params: { q: 'term', page: 1 },
+      headers: {
+        'User-Agent': 'Mozilla/5.0 ...',
+        'Cookie': 'session=abc123; ...',
+      },
+    });
+    const data = response.data;
+    ```
+
+    **Pros:**
+
+    * Fastest approach — no browser overhead, no page rendering, minimal memory usage
+    * Simple code — just HTTP requests, no browser lifecycle management
+    * Easy to parallelize — make many concurrent requests without launching multiple browser instances
+    * Lowest resource consumption — suitable for high-volume data collection
+
+    **Cons:**
+
+    * No cookies unless manually managed — you must extract cookies from a browser session and replicate them, including HttpOnly cookies you can't access from JS
+    * No browser-specific headers — `sec-ch-ua`, `sec-fetch-*`, and other headers that browsers add automatically must be manually fabricated
+    * No JavaScript execution — if the site requires JS to set cookies, generate tokens, or solve challenges, you can't do it
+    * CSRF and auth tokens must be manually extracted and refreshed
+    * Breaks easily — API changes, new security headers, or updated bot protection will break requests with no fallback
+
+    <Warning>
+      **Bot detection risk: VERY HIGH.** This approach is detectable at nearly every layer. TLS fingerprinting alone will catch Node.js HTTP clients on any site with even basic bot protection — the TLS fingerprint is fundamentally different from any real browser, and this is one of the strongest detection signals. This approach only works reliably against sites with zero bot detection, or against documented public APIs that expect programmatic access.
+    </Warning>
+  </Tab>
+</Tabs>
+
+***
+
+### Comparison matrix
+
+| Criteria                           | Regular Playwright      | Passive interception         | In-browser fetch        | Direct HTTP             |
+| ---------------------------------- | ----------------------- | ---------------------------- | ----------------------- | ----------------------- |
+| **Bot detection risk**             | Moderate                | Low                          | Low–Moderate            | Very High               |
+| **Browser fingerprint risk**       | Yes                     | Yes                          | Yes                     | N/A (wrong fingerprint) |
+| **Network fingerprint risk**       | None (browser requests) | None (browser requests)      | None (browser requests) | Very High               |
+| **API monitoring risk**            | None                    | None                         | Low (fetch patching)    | N/A                     |
+| **Data quality**                   | DOM-dependent           | Structured JSON              | Structured JSON         | Structured JSON         |
+| **Setup complexity**               | Low                     | Medium                       | Medium–High             | Low–Medium              |
+| **API reverse-engineering needed** | No                      | Partial (identify endpoints) | Yes (full)              | Yes (full)              |
+| **Control over data fetching**     | Low                     | Low                          | High                    | High                    |
+| **Speed**                          | Slow                    | Medium                       | Medium–Fast             | Fast                    |
+| **Resource usage**                 | High                    | High                         | High                    | Low                     |
+| **Resilience to DOM changes**      | Low                     | High                         | High                    | High                    |
+| **Resilience to API changes**      | Medium                  | Low                          | Low                     | Low                     |
+
+***
+
+### Decision guide
+
+**Use Regular Playwright when:**
+
+* The data you need is visible in the DOM and straightforward to extract with selectors
+* The site doesn't have aggressive bot protection, or you're using stealth plugins
+* You want the simplest implementation that integrates with Libretto's recovery and extraction features
+* The data is rendered server-side and doesn't come from a separate API call
+
+**Use passive interception (`page.on('response')`) when:**
+
+* The site loads data via API calls during normal navigation (most modern SPAs)
+* You want structured JSON data without reverse-engineering the full API
+* Minimizing detection risk is important
+* You're already navigating through the UI and want to passively capture data along the way
+
+**Use in-browser fetch (`pageRequest()`) when:**
+
+* You need data from API endpoints that the UI doesn't naturally trigger (e.g., deep pagination, bulk exports)
+* You've verified the site doesn't monkey-patch `fetch` (or you can work around it)
+* You want maximum control over which data you fetch and when
+* You've already reverse-engineered the relevant API endpoints
+
+**Use Direct Node.js HTTP when:**
+
+* The target site has zero bot detection
+* Speed and resource efficiency are the primary concerns
+* You're hitting a public/documented API (not scraping a website)
+* You need to make thousands of concurrent requests
+
+***
+
+### Recommended hybrid
+
+<Tip>
+  For most browser automation workflows, combine Approach 1 and Approach 2: use Regular Playwright to navigate and interact with the site (handling popups, login flows, and anything requiring UI interaction with Libretto's recovery features), and passively intercept API responses with `page.on('response')` to capture structured data.
+
+  This gives you the reliability of browser-based navigation with the data quality of API responses, at minimal detection risk.
+</Tip>
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Bot detection" icon="shield" href="./bot-detection">
+    Understand how sites detect automation and which signals each approach exposes.
+  </Card>
+
+  <Card title="Sessions and profiles" icon="user" href="../cli-reference/sessions-and-profiles">
+    Manage named browser sessions and persist authenticated state across runs.
+  </Card>
+</Columns>

--- a/docs/get-started/automation-approaches.mdx
+++ b/docs/get-started/automation-approaches.mdx
@@ -250,7 +250,7 @@ Libretto supports four distinct approaches to capturing data and automating web 
 
 ### Related pages
 
-<Columns cols={2}>
+<CardGroup cols={2}>
   <Card title="Bot detection" icon="shield" href="./bot-detection">
     Understand how sites detect automation and which signals each approach exposes.
   </Card>
@@ -258,4 +258,4 @@ Libretto supports four distinct approaches to capturing data and automating web 
   <Card title="Sessions and profiles" icon="user" href="../cli-reference/sessions-and-profiles">
     Manage named browser sessions and persist authenticated state across runs.
   </Card>
-</Columns>
+</CardGroup>

--- a/docs/get-started/bot-detection.mdx
+++ b/docs/get-started/bot-detection.mdx
@@ -214,7 +214,7 @@ Bot detection is adversarial — both sides are continuously updating. Enterpris
 
 ### Related pages
 
-<Columns cols={2}>
+<CardGroup cols={2}>
   <Card title="Automation approaches" icon="code" href="./automation-approaches">
     Compare the four integration strategies and their detection risk profiles.
   </Card>
@@ -222,4 +222,4 @@ Bot detection is adversarial — both sides are continuously updating. Enterpris
   <Card title="Sessions and profiles" icon="user" href="../cli-reference/sessions-and-profiles">
     Manage named browser sessions and persist authenticated state across runs.
   </Card>
-</Columns>
+</CardGroup>

--- a/docs/get-started/bot-detection.mdx
+++ b/docs/get-started/bot-detection.mdx
@@ -1,0 +1,225 @@
+## Bot detection
+
+> Understand how sites detect automation and choose approaches that minimize detection risk.
+
+### Overview
+
+Bot detection operates at multiple independent layers. A site doesn't need to implement all of them — even one active layer can block your automation. Knowing which layers are present on your target site is the first step to choosing an approach that won't get flagged.
+
+The five layers range from passive browser fingerprinting (which fires the moment your browser connects) to enterprise bot protection services that aggregate all signals and apply machine learning. Each layer has different mitigations.
+
+#### Layer 1: Browser fingerprinting
+
+When a browser connects to a site, the site can inspect dozens of signals to determine if the browser is real or automated:
+
+* **`navigator.webdriver`**: Set to `true` in automated browsers. Detection scripts check this immediately. Playwright sets this by default.
+* **Browser plugin and extension footprint**: Real browsers have plugins like PDF viewers, font lists, and media codecs. Automated browsers often have none. In headless mode, `navigator.plugins.length === 0` is a strong signal.
+* **WebGL and Canvas fingerprinting**: The site renders invisible graphics and hashes the output. Headless browsers produce distinct rendering artifacts.
+* **Screen and window dimensions**: Headless browsers often report unusual viewport sizes or have `window.outerWidth === 0`.
+* **User-Agent consistency**: The User-Agent string must match actual browser behavior. Claiming to be Chrome 120 but having Firefox-like JS engine behavior is a red flag.
+* **CDP detection**: Some sites detect whether a Chrome DevTools Protocol (CDP) session is attached, which is how Playwright controls the browser.
+* **Headless-specific object detection**: Automated browsers are missing objects and properties that exist in real headed Chrome. Detection scripts check for a missing `chrome.runtime`, absent `Notification.permission` prompts, `navigator.permissions.query()` behaving differently, and `window.chrome` being undefined or incomplete. `navigator.languages` may also be empty or contain only `"en"` in headless mode.
+* **Iframe and sandbox detection**: Some sites check if their code is running inside an iframe or sandboxed context by comparing `window.self !== window.top`, inspecting `window.frameElement`, or checking whether `document.hasFocus()` returns `false` (common in headless or background contexts) and whether `document.visibilityState` is `"visible"`.
+
+**Affected approaches:** All Playwright-based approaches (Regular Playwright, passive interception, in-browser fetch). Direct HTTP has a different problem — a completely wrong fingerprint.
+
+#### Layer 2: Behavioral analysis
+
+Beyond the browser itself, detection systems analyze how the user behaves:
+
+* **Mouse movement patterns**: Real users have natural mouse trajectories with acceleration curves. Automated clicks happen without preceding mouse movement.
+* **Typing cadence**: Real typing has variable delays between keystrokes. `page.fill()` inserts text instantly. `page.type()` with default settings uses uniform delays.
+* **Scroll behavior**: Real users scroll with momentum and variable speed. Programmatic scrolling is instant or perfectly uniform.
+* **Navigation timing**: Real users take time to read content before clicking. Bots navigate instantly between actions.
+* **Interaction sequence**: Clicking a submit button without first clicking or focusing the input fields is suspicious.
+
+**Mitigation:** Add realistic delays between actions. Use `page.type()` with random inter-key delays instead of `page.fill()` for sensitive fields. Add scroll interactions before clicking. Never navigate faster than a human could read.
+
+#### Layer 3: Network-level detection
+
+The network request itself carries signals independent of what the browser reports:
+
+* **TLS fingerprint (JA3/JA4)**: Every HTTP client has a unique TLS handshake fingerprint based on the cipher suites, extensions, and elliptic curves it offers. Node.js `fetch`/`axios` have a completely different TLS fingerprint than Chrome. This is one of the strongest detection signals and is very hard to fake from outside a browser.
+* **HTTP/2 fingerprint**: The SETTINGS frame, WINDOW\_UPDATE behavior, and header ordering in HTTP/2 differ between browsers and HTTP libraries.
+* **Header ordering and values**: Browsers send headers in a specific order — Chrome always sends `sec-ch-ua` headers, for example. Node.js HTTP clients send headers in a different order or omit browser-specific headers entirely.
+* **Cookie state**: Requests from a real browser session carry the full cookie jar. External HTTP requests must manually replicate cookies and may miss HttpOnly cookies or cookies set by JavaScript.
+* **Referer and Origin**: Browser requests automatically include the correct `Referer` and `Origin` headers based on navigation state. External requests must fabricate these.
+
+**Affected approaches:** Direct HTTP is maximally exposed here. Playwright-based requests (including in-browser fetch) use the real browser's TLS stack and header ordering, so they pass network-level checks.
+
+#### Layer 4: API-level monitoring
+
+Some sophisticated sites monitor the behavior of their own frontend code at runtime:
+
+* **Fetch/XHR monkey-patching**: The site overrides `window.fetch` and/or `XMLHttpRequest.prototype.open` with wrapper functions that log every request, including its call stack. If a `fetch()` call originates from code that isn't part of the site's own bundle, it can be flagged.
+
+```javascript  theme={null}
+// What the site does (runs very early, before your code):
+const _fetch = window.fetch;
+window.fetch = function(...args) {
+  const stack = new Error().stack;
+  if (!isExpectedCallSite(stack)) {
+    reportAnomaly({ url: args[0], stack });
+  }
+  return _fetch.apply(this, args);
+};
+```
+
+* **Proxy-based interception**: Instead of replacing `fetch`, some sites use `Proxy` objects to wrap it. This is harder to detect because `fetch.toString()` still returns `"function fetch() { [native code] }"`.
+* **Timing correlation**: The site knows which API calls its own code makes and when. If an endpoint is called at a time when the UI flow wouldn't trigger it, that's anomalous.
+* **Request frequency and patterns**: The site's own code calls APIs in predictable patterns — pagination calls come in sequence, search calls follow debounce timings. Automation that deviates from these patterns can be flagged.
+
+**Affected approaches:** In-browser fetch (`pageRequest()`) is the primary target here. Passive interception (`page.on('response')`) is immune — it makes no additional fetch calls at all.
+
+<Note>
+  Most sites do not implement Layer 4 monitoring. It is primarily found on sites with enterprise-grade bot protection from services like PerimeterX or Shape Security. Check for fetch patching before committing to an in-browser fetch approach.
+</Note>
+
+#### Layer 5: Enterprise bot protection services
+
+Many sites don't build their own detection — they use third-party services that combine all the layers above into a continuously updated product:
+
+| Service                       | Common indicators                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------- |
+| **Akamai Bot Manager**        | Scripts from `*.akamaized.net`, `_abck` cookie, `sensor_data` payloads        |
+| **PerimeterX (HUMAN)**        | Scripts loading from `*.perimeterx.net` or `*.px-cdn.net`, `_px` cookies      |
+| **DataDome**                  | Scripts from `*.datadome.co`, `datadome` cookie, interstitial challenge pages |
+| **Cloudflare Bot Management** | `cf_clearance` cookie, challenge pages with "Checking your browser" message   |
+| **Shape Security (F5)**       | Obfuscated inline scripts that collect telemetry, `_imp_apg_r_` style cookies |
+| **Kasada**                    | Scripts from `*.kasada.io`, `x-kpsdk-*` headers                               |
+
+These services push updates frequently. An automation that works today may break next week with no changes on your end.
+
+***
+
+### Identifying bot detection on your target site
+
+Before building your automation, audit the target site to understand what you're up against.
+
+<Steps>
+  <Step title="Check for enterprise bot protection">
+    Open the site in a normal browser with DevTools open on the Network tab:
+
+    1. Filter by JS in the Network tab. Look for domains associated with known bot protection services (listed in the table above).
+    2. In DevTools **Application > Cookies**, look for telltale cookies like `_abck`, `_px`, `datadome`, `cf_clearance`, etc.
+    3. Navigate around the site. If you see a "Checking your browser..." interstitial, the site uses active bot protection.
+    4. View source and look at the first `<script>` tags. Enterprise bot protection scripts are typically injected before any application code.
+  </Step>
+
+  <Step title="Check if fetch/XHR is patched">
+    Open the browser console and run:
+
+    ```javascript  theme={null}
+    // Check if fetch has been wrapped
+    window.fetch.toString()
+    // Native (safe):     "function fetch() { [native code] }"
+    // Patched (flagged): will show actual JavaScript source
+
+    // Check XMLHttpRequest
+    XMLHttpRequest.prototype.open.toString()
+    // Native: "function open() { [native code] }"
+
+    // Check for property descriptor tampering
+    Object.getOwnPropertyDescriptor(window, 'fetch')
+    // Native: { value: ƒ, writable: true, enumerable: true, configurable: true }
+    // Tampered: may have getters/setters or different configurability
+    ```
+
+    <Note>
+      If the site uses `Proxy` to wrap `fetch`, the `toString()` check will still return `"[native code]"`. To detect Proxy-based wrapping:
+
+      ```javascript  theme={null}
+      try {
+        const desc = Object.getOwnPropertyDescriptor(window, 'fetch');
+        console.log('configurable:', desc.configurable);
+        console.log('writable:', desc.writable);
+        console.log(window.fetch instanceof Function); // should be true
+        console.log(window.fetch.prototype); // native fetch has no prototype
+      } catch (e) {
+        console.log('fetch access is trapped');
+      }
+      ```
+    </Note>
+  </Step>
+
+  <Step title="Check for behavioral monitoring">
+    Look for signs that the site collects behavioral telemetry:
+
+    ```javascript  theme={null}
+    // Check if common event listeners are heavily registered
+    getEventListeners(document)
+    // In Chrome DevTools, this shows all listeners. An unusually large number
+    // of mousemove, keydown, scroll, and touchstart listeners suggests telemetry.
+
+    // Check for known telemetry globals
+    // PerimeterX:
+    typeof window._pxAppId !== 'undefined'
+    // Akamai:
+    typeof window.bmak !== 'undefined'
+    // DataDome:
+    typeof window.ddjskey !== 'undefined'
+    ```
+  </Step>
+
+  <Step title="Test with plain Playwright">
+    The simplest test: run a basic Playwright script against the site and observe what happens.
+
+    ```typescript  theme={null}
+    import { chromium } from 'playwright';
+    const browser = await chromium.launch({ headless: false });
+    const page = await browser.newPage();
+    await page.goto('https://target-site.com');
+    // If you get a challenge page, CAPTCHA, or block — bot detection is active.
+    ```
+
+    If plain Playwright gets blocked, the site has browser-level detection. If it works, the site likely has only basic or no detection.
+  </Step>
+</Steps>
+
+***
+
+### Infrastructure considerations
+
+Even with a well-fingerprinted browser, infrastructure-level signals can expose automation:
+
+**IP reputation and rate limiting**
+
+* Cloud provider IP ranges (AWS, GCP, Azure) are well-known and flagged by most bot protection services. Requests from these ranges face higher scrutiny or outright blocking regardless of browser fingerprint quality.
+* Even without bot detection, sites enforce per-IP request limits. Hitting the same site too frequently from one IP triggers throttling or temporary bans.
+* If your IP geolocates to one region but your browser reports a timezone and locale from another, that inconsistency is a signal.
+* Residential proxy services provide IP addresses from real ISPs, making requests appear to originate from normal households. Rotating proxies distribute requests across many IPs to avoid rate limits.
+
+**CAPTCHA and challenge handling**
+
+* **reCAPTCHA v2**: The checkbox or image-selection challenge. Can sometimes be bypassed in automated browsers if the risk score is low enough (it evaluates browser fingerprint and behavior first).
+* **reCAPTCHA v3**: Invisible — returns a score from 0.0 to 1.0 with no user interaction. A well-fingerprinted browser with natural behavior scores higher.
+* **hCaptcha**: Similar to reCAPTCHA v2. Cloudflare uses it as a fallback.
+* **Cloudflare Turnstile**: Non-interactive challenge that evaluates browser signals. Replaces traditional CAPTCHAs on many Cloudflare-protected sites.
+
+<Note>
+  If a CAPTCHA is triggered during automation, it usually means the browser fingerprint or behavior failed earlier checks. Fixing the root cause — better stealth, slower interaction patterns — is more effective than trying to solve CAPTCHAs programmatically.
+</Note>
+
+**Block manifestations**
+
+* **Soft blocks**: The site returns degraded results (fewer items, missing data, slower responses) without an explicit error. These are hard to detect — you may not realize you're getting incomplete data.
+* **Hard blocks**: HTTP 403, CAPTCHA pages, "Access Denied" responses, or redirects to a challenge page.
+* **Cookie consent and GDPR banners**: Not bot detection, but a common obstacle. These overlays block interactions with the underlying page and must be detected and dismissed before proceeding.
+
+**Anti-detection maintenance**
+
+Bot detection is adversarial — both sides are continuously updating. Enterprise bot protection services push updates frequently. Browser updates change fingerprints. Stealth patches need to keep pace with detection updates. Budget time for ongoing maintenance of any automation targeting a site with active bot protection.
+
+***
+
+### Related pages
+
+<Columns cols={2}>
+  <Card title="Automation approaches" icon="code" href="./automation-approaches">
+    Compare the four integration strategies and their detection risk profiles.
+  </Card>
+
+  <Card title="Sessions and profiles" icon="user" href="../cli-reference/sessions-and-profiles">
+    Manage named browser sessions and persist authenticated state across runs.
+  </Card>
+</Columns>

--- a/docs/get-started/configuration.mdx
+++ b/docs/get-started/configuration.mdx
@@ -1,0 +1,223 @@
+## Configuration
+
+> Configure Libretto's AI model, viewport, and session settings.
+
+All Libretto state lives in a `.libretto/` directory at your project root. This page covers the config file, environment variables, sessions, and auth profiles.
+
+<Note>
+  Add `.libretto/` to your `.gitignore`. Libretto creates a `.libretto/.gitignore` that automatically ignores `sessions/` and `profiles/`, but the `config.json` file itself is not ignored. If you prefer to exclude the entire directory, add `.libretto/` to your root `.gitignore`.
+</Note>
+
+### Config file
+
+**Location:** `.libretto/config.json`
+
+The config file controls snapshot analysis and the default viewport. The easiest way to create or update it is through the CLI:
+
+```bash  theme={null}
+npx libretto ai configure <openai|anthropic|gemini|vertex>
+```
+
+You can also edit the file directly. The full schema is:
+
+```json  theme={null}
+{
+  "version": 1,
+  "ai": {
+    "model": "openai/gpt-5.4",
+    "updatedAt": "2026-01-01T00:00:00.000Z"
+  },
+  "viewport": { "width": 1280, "height": 800 }
+}
+```
+
+#### Fields
+
+<ParamField path="version" type="number" required>
+  Config schema version. Always `1`.
+</ParamField>
+
+<ParamField path="ai" type="object">
+  Configures the model used for `snapshot` analysis. Snapshot analysis is required — without it, `npx libretto snapshot` will fail.
+</ParamField>
+
+<ParamField path="ai.model" type="string">
+  A `provider/model-id` string, for example `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`, `google/gemini-3-flash-preview`, or `vertex/gemini-2.5-pro`. This is the model Libretto sends screenshot and HTML data to when you run `snapshot`.
+</ParamField>
+
+<ParamField path="ai.updatedAt" type="string">
+  ISO 8601 timestamp of the last time the AI config was written. Set automatically by `npx libretto ai configure`.
+</ParamField>
+
+<ParamField path="viewport" type="object">
+  Default viewport size used by `open` and `run` when you don't pass `--viewport`. Precedence: CLI `--viewport` flag > `config.json` > built-in default of `1366x768`.
+</ParamField>
+
+<ParamField path="viewport.width" type="number">
+  Viewport width in pixels. Must be a positive integer.
+</ParamField>
+
+<ParamField path="viewport.height" type="number">
+  Viewport height in pixels. Must be a positive integer.
+</ParamField>
+
+<ParamField path="windowPosition" type="object">
+  Optional. Sets the initial position of the headed browser window on screen. Has no effect in headless mode.
+</ParamField>
+
+<ParamField path="windowPosition.x" type="number">
+  Horizontal position in pixels from the left edge of the screen.
+</ParamField>
+
+<ParamField path="windowPosition.y" type="number">
+  Vertical position in pixels from the top of the screen.
+</ParamField>
+
+### AI provider setup
+
+To set your model, run:
+
+```bash  theme={null}
+npx libretto ai configure <provider>
+```
+
+Accepted provider shorthands and their default models:
+
+| Provider    | Default model                   |
+| ----------- | ------------------------------- |
+| `openai`    | `openai/gpt-5.4`                |
+| `anthropic` | `anthropic/claude-sonnet-4-6`   |
+| `gemini`    | `google/gemini-3-flash-preview` |
+| `vertex`    | `vertex/gemini-2.5-pro`         |
+
+You can also pass a full `provider/model-id` string to pin a specific version:
+
+```bash  theme={null}
+npx libretto ai configure openai/gpt-4o
+```
+
+To view the current configuration:
+
+```bash  theme={null}
+npx libretto ai configure
+```
+
+To clear it:
+
+```bash  theme={null}
+npx libretto ai configure --clear
+```
+
+#### Environment variables
+
+Provider credentials are read from your shell environment or a `.env` file at the project root. Set the variable for your chosen provider:
+
+```bash theme={null} showLineNumbers={false}
+# OpenAI
+OPENAI_API_KEY=sk-...
+
+# Anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Gemini
+# Either of these is accepted:
+GEMINI_API_KEY=...
+GOOGLE_GENERATIVE_AI_API_KEY=...
+
+# Vertex
+GOOGLE_CLOUD_PROJECT=my-gcp-project
+```
+
+You also need to install the matching Vercel AI SDK peer dependency:
+
+```bash theme={null} showLineNumbers={false}
+# OpenAI
+npm install @ai-sdk/openai
+
+# Anthropic
+npm install @ai-sdk/anthropic
+
+# Gemini
+npm install @ai-sdk/google
+
+# Vertex
+npm install @ai-sdk/google-vertex
+```
+
+All four peer dependencies are optional — install only the one you need.
+
+### Sessions
+
+Each Libretto session gets its own directory under `.libretto/sessions/<name>/`. Sessions are created automatically when you run `npx libretto open` and are cleaned up with `npx libretto close`.
+
+**Session directory layout:**
+
+```
+.libretto/sessions/<name>/
+├── state.json      # Debug port, browser PID, session status
+├── logs.jsonl      # Structured CLI and runtime logs
+├── network.jsonl   # Captured HTTP requests and responses
+├── actions.jsonl   # Recorded user and agent actions
+└── snapshots/      # PNG screenshots and HTML captures
+    └── <run-id>/
+```
+
+#### Session files
+
+**`state.json`** — Metadata Libretto uses to reconnect to a running browser: the CDP debug port, the browser process PID, and the session status (`running`, `paused`, `exited`).
+
+**`logs.jsonl`** — Structured JSONL log of CLI events for the session. Useful for tracing what happened during a run.
+
+**`network.jsonl`** — One entry per HTTP request/response captured while the session was open. Each entry includes `ts`, `method`, `url`, `status`, `contentType`, and `responseBody`. Query with `jq`:
+
+```bash  theme={null}
+# Show all POST requests
+jq 'select(.method == "POST")' .libretto/sessions/my-session/network.jsonl
+```
+
+**`actions.jsonl`** — One entry per user or agent action. User entries include `bestSemanticSelector`, `nearbyText`, and coordinates. Agent entries include the Playwright locator and duration. Query with `jq`:
+
+```bash  theme={null}
+# Last 20 actions
+tail -n 20 .libretto/sessions/my-session/actions.jsonl | jq .
+```
+
+**`snapshots/`** — One subdirectory per `snapshot` run, containing the captured PNG and HTML file.
+
+Sessions are git-ignored by `.libretto/.gitignore`.
+
+### Profiles
+
+Profiles save browser session state — cookies, localStorage, and other persistent storage — so you can reuse authenticated state across runs without logging in again each time.
+
+**Location:** `.libretto/profiles/<domain>.json`
+
+#### Saving a profile
+
+1. Open the site in headed mode so you can log in manually:
+
+   ```bash  theme={null}
+   npx libretto open https://app.example.com --headed
+   ```
+
+2. Log in to the site in the browser window.
+
+3. Save the current session state as a profile:
+
+   ```bash  theme={null}
+   npx libretto save app.example.com
+   ```
+
+#### Using a profile
+
+Pass `--auth-profile <domain>` to `run`:
+
+```bash  theme={null}
+npx libretto run ./integration.ts main --auth-profile app.example.com
+```
+
+<Warning>
+  Sessions can expire. If a profile stops working, repeat the login and save flow to refresh it.
+</Warning>
+
+Profiles are machine-local and git-ignored. They are not safe to commit or share — they contain authentication tokens for live accounts.

--- a/docs/get-started/configuration.mdx
+++ b/docs/get-started/configuration.mdx
@@ -197,7 +197,7 @@ Profiles save browser session state — cookies, localStorage, and other persist
 1. Open the site in headed mode so you can log in manually:
 
    ```bash  theme={null}
-   npx libretto open https://app.example.com --headed
+   npx libretto open https://app.example.com --headed --session app-login
    ```
 
 2. Log in to the site in the browser window.
@@ -205,7 +205,7 @@ Profiles save browser session state — cookies, localStorage, and other persist
 3. Save the current session state as a profile:
 
    ```bash  theme={null}
-   npx libretto save app.example.com
+   npx libretto save app.example.com --session app-login
    ```
 
 #### Using a profile

--- a/docs/get-started/configuration.mdx
+++ b/docs/get-started/configuration.mdx
@@ -164,7 +164,7 @@ Each Libretto session gets its own directory under `.libretto/sessions/<name>/`.
 
 #### Session files
 
-**`state.json`** — Metadata Libretto uses to reconnect to a running browser: the CDP debug port, the browser process PID, and the session status (`running`, `paused`, `exited`).
+**`state.json`** — Metadata Libretto uses to reconnect to a browser session: the CDP debug port, the browser process PID, and the session status (`active`, `paused`, `completed`, `failed`, `exited`).
 
 **`logs.jsonl`** — Structured JSONL log of CLI events for the session. Useful for tracing what happened during a run.
 

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -45,13 +45,13 @@ Libretto ships two interfaces:
 
 * **CLI** (`npx libretto <command>`) — the primary interface for both agents and humans. Commands open browsers, take snapshots, execute Playwright code, run workflow files, and manage sessions. Every command accepts `--session <name>` to target a specific browser session.
 
-* **Library API** (`import { workflow } from "libretto"`) — used inside workflow files you want to run with `npx libretto run`. The `workflow()` function wraps your automation handler and gives it typed access to `page`, `session`, `logger`, and optional application services.
+* **Library API** (`import { workflow } from "libretto"`) — used inside workflow files you want to run with `npx libretto run`. The `workflow()` function wraps your automation handler and gives it typed access to `page` and `session`.
 
 #### Sessions
 
 A **session** is a named browser context. When you run `npx libretto open https://example.com --session my-session`, Libretto launches a Chromium instance and registers it under that name. Subsequent commands (`snapshot`, `exec`, `network`, `actions`) all target that session by name.
 
-If you don't pass `--session`, Libretto uses a default session name. Sessions are independent — you can have multiple sessions open at the same time, each pointing to a different browser or URL.
+If you don't pass `--session`, Libretto generates a unique session name automatically. Sessions are independent — you can have multiple sessions open at the same time, each pointing to a different browser or URL.
 
 #### The `.libretto/` directory
 

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -1,0 +1,94 @@
+## Introduction
+
+> Libretto is the AI toolkit for building and maintaining browser automations.
+
+Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to inspect pages, capture traffic, record actions, and debug workflows — all without flooding your agent's context window with raw HTML.
+
+Built by the team at [Saffron Health](https://saffron.health), Libretto was created to help maintain browser integrations to common healthcare software. It's open-source so other teams can do the same.
+
+### Core capabilities
+
+Libretto is organized around four capabilities that cover the full lifecycle of a browser automation:
+
+**Inspect live pages** — Take a snapshot of any open page and let a vision model extract selectors, identify interactive elements, and summarize the visible state. Snapshot analysis runs in a separate process so the results are token-efficient summaries, not raw DOM dumps.
+
+**Capture network traffic** — Record every HTTP request and response made by the browser. Libretto writes these to a structured JSONL log you can query with `jq` or pass directly to your agent to reverse-engineer the site's API.
+
+**Record user actions** — As you interact with a page manually, Libretto captures each DOM event with a semantic selector, nearby text, and coordinates. Your agent can read these recorded actions and reconstruct the workflow as a typed Playwright script.
+
+**Debug broken workflows** — When a workflow fails, Libretto keeps the browser open. Your agent can inspect the live page state with `snapshot` and `exec`, identify the broken selector or unexpected page change, patch the code, and re-run — all without restarting from scratch.
+
+### The skill concept
+
+Libretto is designed to be loaded as a **skill** in your coding agent. A skill is a set of instructions that tells your agent when and how to use a tool. When you give your agent the Libretto skill, it knows to:
+
+* Open a browser before guessing at page structure
+* Use `snapshot` as the primary observation tool instead of reading raw HTML
+* Prefer network request approaches over UI automation when the site allows it
+* Validate a finished workflow with a headless `run` before declaring it done
+
+The skill file ships with the package at `skills/libretto/SKILL.md` and is automatically copied into `.agents/skills/libretto` and `.claude/skills/libretto` when you run `npx libretto setup`.
+
+You can invoke Libretto skills with natural language prompts like:
+
+> Use the Libretto skill. Go to LinkedIn and scrape the first 10 posts — content, author, reaction count, and first 25 comments.
+
+> I'll show you a workflow in eClinicalWorks to get a patient's primary insurance ID. Use the Libretto skill to turn it into a Playwright script.
+
+> We have a browser script at `./integration.ts` that's throwing a broken selector error. Fix it. Use the Libretto skill.
+
+### Architecture overview
+
+#### CLI vs Library API
+
+Libretto ships two interfaces:
+
+* **CLI** (`npx libretto <command>`) — the primary interface for both agents and humans. Commands open browsers, take snapshots, execute Playwright code, run workflow files, and manage sessions. Every command accepts `--session <name>` to target a specific browser session.
+
+* **Library API** (`import { workflow } from "libretto"`) — used inside workflow files you want to run with `npx libretto run`. The `workflow()` function wraps your automation handler and gives it typed access to `page`, `session`, `logger`, and optional application services.
+
+#### Sessions
+
+A **session** is a named browser context. When you run `npx libretto open https://example.com --session my-session`, Libretto launches a Chromium instance and registers it under that name. Subsequent commands (`snapshot`, `exec`, `network`, `actions`) all target that session by name.
+
+If you don't pass `--session`, Libretto uses a default session name. Sessions are independent — you can have multiple sessions open at the same time, each pointing to a different browser or URL.
+
+#### The `.libretto/` directory
+
+All Libretto state lives in a `.libretto/` directory at your project root:
+
+```
+.libretto/
+├── config.json          # AI model and viewport settings
+├── sessions/
+│   └── <name>/
+│       ├── state.json   # Debug port, PID, status
+│       ├── logs.jsonl   # Structured session logs
+│       ├── network.jsonl
+│       ├── actions.jsonl
+│       └── snapshots/   # PNG + HTML captures
+└── profiles/
+    └── <domain>.json    # Saved auth state
+```
+
+Sessions and profiles are automatically git-ignored by a `.libretto/.gitignore` file that `npx libretto setup` creates.
+
+### Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quick start" icon="rocket" href="./quickstart">
+    Install Libretto and run your first browser automation in minutes.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="../cli-reference/open-and-connect">
+    Full reference for every Libretto command and flag.
+  </Card>
+
+  <Card title="Library API" icon="code" href="../library-api/workflow">
+    Write workflow files with the typed `workflow()` API.
+  </Card>
+
+  <Card title="Configuration" icon="settings" href="./configuration">
+    Configure Libretto's AI provider, viewport, and session defaults.
+  </Card>
+</CardGroup>

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -1,0 +1,204 @@
+## Quick start
+
+> Install Libretto and run your first browser automation in minutes.
+
+This guide walks you through installing Libretto, connecting an AI provider, opening a browser, and taking your first snapshot.
+
+<Steps>
+  <Step title="Install the package">
+    Install Libretto from npm:
+
+    ```bash  theme={null}
+    npm install libretto
+    ```
+
+    Libretto requires Node.js 18 or later. It installs Playwright as a direct dependency, so you don't need a separate Playwright install.
+  </Step>
+
+  <Step title="Set up your workspace">
+    Run `setup` once per project. This command downloads Chromium if it isn't already installed, creates the `.libretto/` directory structure, writes a `.libretto/.gitignore`, and copies the agent skill files into `.agents/skills/libretto` and `.claude/skills/libretto`.
+
+    ```bash  theme={null}
+    npx libretto setup
+    ```
+
+    <Note>
+      Run `setup` yourself in a terminal — not through an agent. It may prompt for input and starts a Chromium download that takes a moment.
+    </Note>
+  </Step>
+
+  <Step title="Configure an AI provider">
+    Snapshot analysis requires a vision-capable model. Choose your provider:
+
+    ```bash  theme={null}
+    npx libretto ai configure openai
+    # or
+    npx libretto ai configure anthropic
+    # or
+    npx libretto ai configure gemini
+    # or
+    npx libretto ai configure vertex
+    ```
+
+    This writes the selected model to `.libretto/config.json`. The default models are:
+
+    | Provider    | Default model                   |
+    | ----------- | ------------------------------- |
+    | `openai`    | `openai/gpt-5.4`                |
+    | `anthropic` | `anthropic/claude-sonnet-4-6`   |
+    | `gemini`    | `google/gemini-3-flash-preview` |
+    | `vertex`    | `vertex/gemini-2.5-pro`         |
+
+    You can also pass a full model string to use a specific version:
+
+    ```bash  theme={null}
+    npx libretto ai configure openai/gpt-4o
+    ```
+
+    Provider credentials are read from your shell environment or a `.env` file at the project root. Set the appropriate key:
+
+    ```bash theme={null} showLineNumbers={false}
+    # OpenAI
+    export OPENAI_API_KEY=sk-...
+
+    # Anthropic
+    export ANTHROPIC_API_KEY=sk-ant-...
+
+    # Gemini
+    export GEMINI_API_KEY=...
+
+    # Vertex
+    export GOOGLE_CLOUD_PROJECT=my-project
+    ```
+
+    Libretto uses the Vercel AI SDK under the hood. Install only the peer dependency for your chosen provider:
+
+    ```bash theme={null} showLineNumbers={false}
+    # OpenAI
+    npm install @ai-sdk/openai
+
+    # Anthropic
+    npm install @ai-sdk/anthropic
+
+    # Gemini
+    npm install @ai-sdk/google
+
+    # Vertex
+    npm install @ai-sdk/google-vertex
+    ```
+  </Step>
+
+  <Step title="Open a browser">
+    Launch a headed Chromium window and navigate to a URL:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com
+    ```
+
+    To use a named session (recommended when running multiple automations):
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --session my-session
+    ```
+
+    Use `--headless` if you don't need to see the browser:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --headless --session my-session
+    ```
+  </Step>
+
+  <Step title="Take a snapshot">
+    `snapshot` captures a PNG screenshot and the page HTML, then sends both to your configured vision model. Always provide `--objective` (what you want the model to find or analyze) and `--context` (what you know about the current state):
+
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --objective "Find the main heading and any call-to-action buttons" \
+      --context "I just opened the example.com homepage and want to identify the key interactive elements."
+    ```
+
+    With a named session:
+
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session my-session \
+      --objective "Explain why the table is empty" \
+      --context "I applied filters on the referrals page and expected rows to appear."
+    ```
+
+    The model returns a structured summary of selectors, element descriptions, and any relevant observations — without putting raw HTML into your agent's context.
+
+    <Tip>
+      A single snapshot objective can include multiple questions. Instead of running several snapshots, combine them: `--objective "Find the submit button and check whether the form has validation errors."`
+    </Tip>
+  </Step>
+
+  <Step title="Execute Playwright code">
+    Use `exec` to run Playwright TypeScript against the open page. The code runs in a context that has `page`, `context`, `browser`, `state`, `fetch`, and `Buffer` available as globals:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.url()"
+    ```
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.locator('button').count()"
+    ```
+
+    ```bash  theme={null}
+    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    ```
+
+    For longer scripts, pipe from stdin with `-`:
+
+    ```bash  theme={null}
+    echo "return await page.url()" | npx libretto exec - --session my-session
+    ```
+
+    Let failures throw. Don't wrap `exec` code in `try/catch` — surfacing errors is how you debug.
+  </Step>
+
+  <Step title="Run a workflow file">
+    Once you've built a workflow file, run it with `npx libretto run`:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main
+    ```
+
+    Run headless with input parameters:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless --params '{"status":"open"}'
+    ```
+
+    Run with a saved auth profile:
+
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --auth-profile app.example.com
+    ```
+
+    The second argument (`main`) is the name of the exported `workflow()` instance in the file. See the Library API reference for how to structure workflow files.
+  </Step>
+</Steps>
+
+### What's next
+
+<Tip>
+  If you're using a coding agent like Claude or another AI assistant, load the Libretto skill so your agent knows how to use these commands effectively. After running `npx libretto setup`, the skill is available at `.agents/skills/libretto/SKILL.md` and `.claude/skills/libretto/SKILL.md`.
+</Tip>
+
+Once Libretto is set up, explore the full command set:
+
+```bash  theme={null}
+npx libretto --help
+```
+
+Common commands to try next:
+
+```bash  theme={null}
+npx libretto network                    # view captured HTTP requests
+npx libretto actions                    # view recorded user/agent actions
+npx libretto pages                      # list open pages in the session
+npx libretto save app.example.com       # save authenticated browser state
+npx libretto close                      # close the browser
+npx libretto close --all                # close all sessions
+```

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -177,7 +177,7 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
     npx libretto run ./integration.ts main --auth-profile app.example.com
     ```
 
-    The second argument (`main`) is the name of the exported `workflow()` instance in the file. See the Library API reference for how to structure workflow files.
+    The second argument (`main`) is the workflow name passed to `workflow(name, handler)` in the file. In most projects, this matches the exported symbol name. See the Library API reference for how to structure workflow files.
   </Step>
 </Steps>
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -196,10 +196,10 @@ npx libretto --help
 Common commands to try next:
 
 ```bash  theme={null}
-npx libretto network                    # view captured HTTP requests
-npx libretto actions                    # view recorded user/agent actions
-npx libretto pages                      # list open pages in the session
-npx libretto save app.example.com       # save authenticated browser state
-npx libretto close                      # close the browser
+npx libretto network --session my-session              # view captured HTTP requests
+npx libretto actions --session my-session              # view recorded user/agent actions
+npx libretto pages --session my-session                # list open pages in the session
+npx libretto save app.example.com --session my-session # save authenticated browser state
+npx libretto close --session my-session                # close the browser
 npx libretto close --all                # close all sessions
 ```

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -113,6 +113,7 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
 
     ```bash  theme={null}
     npx libretto snapshot \
+      --session my-session \
       --objective "Find the main heading and any call-to-action buttons" \
       --context "I just opened the example.com homepage and want to identify the key interactive elements."
     ```
@@ -137,15 +138,15 @@ This guide walks you through installing Libretto, connecting an AI provider, ope
     Use `exec` to run Playwright TypeScript against the open page. The code runs in a context that has `page`, `context`, `browser`, `state`, `fetch`, and `Buffer` available as globals:
 
     ```bash  theme={null}
-    npx libretto exec "return await page.url()"
+    npx libretto exec --session my-session "return await page.url()"
     ```
 
     ```bash  theme={null}
-    npx libretto exec "return await page.locator('button').count()"
+    npx libretto exec --session my-session "return await page.locator('button').count()"
     ```
 
     ```bash  theme={null}
-    npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+    npx libretto exec --session my-session "await page.locator('button:has-text(\"Continue\")').click()"
     ```
 
     For longer scripts, pipe from stdin with `-`:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,8 +40,8 @@ npx libretto ai configure openai
 ## Common commands
 
 ```bash
-npx libretto open https://example.com
-npx libretto snapshot --objective "Find the submit button" --context "I just opened the homepage."
-npx libretto exec "return await page.url()"
+npx libretto open https://example.com --session my-session
+npx libretto snapshot --session my-session --objective "Find the submit button" --context "I just opened the homepage."
+npx libretto exec --session my-session "return await page.url()"
 npx libretto run ./integration.ts main
 ```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,47 @@
+---
+title: Libretto
+sidebarTitle: Overview
+---
+
+# Libretto
+
+> Toolkit for building, debugging, and maintaining browser automations.
+
+Libretto gives coding agents a live browser and a token-efficient CLI for inspecting pages, capturing network traffic, replaying user actions, and repairing broken workflows.
+
+Built by [Saffron Health](https://saffron.health), Libretto is open source and designed for teams that need reliable browser integrations.
+
+<CardGroup cols={2}>
+  <Card title="Quick start" icon="rocket" href="./get-started/quickstart">
+    Install Libretto, configure a model, and run your first browser session.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="./cli-reference/open-and-connect">
+    Learn the commands for opening sessions, taking snapshots, and executing code.
+  </Card>
+
+  <Card title="Workflow guides" icon="sparkles" href="./workflow-guides/one-shot-script-generation">
+    See how Libretto fits into real agent-driven automation workflows.
+  </Card>
+
+  <Card title="Library API" icon="code" href="./library-api/workflow">
+    Use the typed workflow API for reusable automations and programmatic runs.
+  </Card>
+</CardGroup>
+
+## Install
+
+```bash
+npm install libretto
+npx libretto setup
+npx libretto ai configure openai
+```
+
+## Common commands
+
+```bash
+npx libretto open https://example.com
+npx libretto snapshot --objective "Find the submit button" --context "I just opened the homepage."
+npx libretto exec "return await page.url()"
+npx libretto run ./integration.ts main
+```

--- a/docs/library-api/extraction.mdx
+++ b/docs/library-api/extraction.mdx
@@ -1,0 +1,134 @@
+## AI Extraction
+
+> Extract structured data from pages using AI-powered analysis.
+
+`extractFromPage()` combines a screenshot with DOM content and sends both to an LLM to extract structured data matching a Zod schema. Because the visual analysis happens in a separate LLM call, it keeps your coding agent's context window free of raw HTML.
+
+### `extractFromPage()`
+
+```typescript  theme={null}
+async function extractFromPage<T extends z.ZodType>(
+  options: ExtractOptions<T>
+): Promise<z.infer<T>>
+```
+
+#### How it works
+
+* **With `selector`**: waits for the element to be visible, takes a screenshot of just that element, and reads its `innerHTML` (truncated at 30 000 characters).
+* **Without `selector`**: takes a full-page screenshot via CDP and reads the full page HTML (truncated at 50 000 characters).
+
+Both the screenshot and the DOM snippet are sent to the LLM together with your instruction. The response is parsed and validated against your Zod schema before being returned.
+
+#### `ExtractOptions<T>`
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to extract from.
+</ParamField>
+
+<ParamField path="instruction" type="string" required>
+  A natural-language description of what to extract. For example: `"Extract the first 5 search results"`.
+</ParamField>
+
+<ParamField path="schema" type="T extends z.ZodType" required>
+  A Zod schema that describes the shape of the data you want back. The return type of `extractFromPage` is `z.infer<T>`.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient" required>
+  An LLM client instance. Create one with [`createLLMClientFromModel()`](#createllmclientfrommodel). The backing model must support vision (multimodal) input because `extractFromPage` always sends a screenshot.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Defaults to a simple `console`-based logger when omitted.
+</ParamField>
+
+<ParamField path="selector" type="string">
+  Optional CSS selector. When provided, the screenshot and DOM capture are scoped to the matching element instead of the full page. Useful for large pages where you only care about one section.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { extractFromPage, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+const SearchResult = z.object({
+  title: z.string(),
+  url: z.string(),
+  snippet: z.string(),
+});
+
+const results = await extractFromPage({
+  page,
+  instruction: "Extract the first 5 search results",
+  schema: z.array(SearchResult),
+  llmClient,
+  // Optional: scope to a specific element
+  selector: ".search-results",
+});
+// results is typed as Array<{ title: string; url: string; snippet: string }>
+```
+
+<Tip>
+  Use `selector` to narrow extraction to a single widget or table when the full page HTML is large. Scoped extraction is faster and uses fewer tokens.
+</Tip>
+
+***
+
+### `createLLMClientFromModel()`
+
+Creates a Libretto `LLMClient` from a Vercel AI SDK `LanguageModel`. This is the standard way to supply an LLM client to `extractFromPage`, `attemptWithRecovery`, and `detectSubmissionError`.
+
+```typescript  theme={null}
+function createLLMClientFromModel(model: LanguageModel): LLMClient
+```
+
+<ParamField path="model" type="LanguageModel" required>
+  A Vercel AI SDK language model instance. Pass the result of calling a provider factory such as `openai("gpt-4o")`, `anthropic("claude-3-5-sonnet-20241022")`, or `google("gemini-1.5-pro")`.
+</ParamField>
+
+#### Supported providers
+
+Any provider that implements the Vercel AI SDK `LanguageModel` interface works. The most common ones:
+
+| Package                 | Example                                   |
+| ----------------------- | ----------------------------------------- |
+| `@ai-sdk/openai`        | `openai("gpt-4o")`                        |
+| `@ai-sdk/anthropic`     | `anthropic("claude-3-5-sonnet-20241022")` |
+| `@ai-sdk/google`        | `google("gemini-1.5-pro")`                |
+| `@ai-sdk/google-vertex` | `vertex("gemini-1.5-pro")`                |
+
+#### Example
+
+```typescript  theme={null}
+import { createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+```
+
+#### `LLMClient` interface
+
+You can also implement `LLMClient` directly if you want to use a provider that is not in the Vercel AI SDK:
+
+```typescript  theme={null}
+interface LLMClient {
+  generateObject<T extends z.ZodType>(opts: {
+    prompt: string;
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+
+  generateObjectFromMessages<T extends z.ZodType>(opts: {
+    messages: Message[];
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+}
+```
+
+<Note>
+  Implementations should throw on failure rather than returning sentinel values like `null` or `undefined`. Libretto relies on thrown exceptions to trigger retry and recovery logic.
+</Note>

--- a/docs/library-api/instrumentation.mdx
+++ b/docs/library-api/instrumentation.mdx
@@ -1,0 +1,274 @@
+## Instrumentation
+
+> Add ghost cursor visualization and error enrichment to Playwright pages.
+
+Instrumentation wraps Playwright's locator and page actions with two capabilities:
+
+* **Visualization** — before each action, a ghost cursor animates to the target element and the element is highlighted. After the action, the highlight clears.
+* **Error enrichment** — when a pointer action (`click`, `dblclick`, `hover`) times out, additional context is captured and attached to the error.
+
+### `instrumentPage()`
+
+Applies instrumentation to a `Page` in place and returns it typed as `InstrumentedPage`. The original page object is modified directly.
+
+```typescript  theme={null}
+async function instrumentPage(
+  page: Page,
+  options?: InstrumentationOptions
+): Promise<InstrumentedPage>
+```
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to instrument.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { instrumentPage } from "libretto";
+
+const instrumented = await instrumentPage(page, {
+  visualize: true,
+  highlightBeforeActionMs: 500,
+  logger,
+});
+
+// All subsequent locator actions show ghost cursor + element highlights
+await instrumented.locator("#submit").click();
+await instrumented.locator("#email").fill("user@example.com");
+```
+
+***
+
+### `installInstrumentation()`
+
+Same as `instrumentPage()` but returns `void` instead of the page. Useful when you don't need the typed return value, or when you want to instrument a page that was passed in from elsewhere.
+
+```typescript  theme={null}
+async function installInstrumentation(
+  page: Page,
+  options?: InstrumentationOptions
+): Promise<void>
+```
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to patch in place.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+<Note>
+  Calling `installInstrumentation()` (or `instrumentPage()`) on an already-instrumented page is a no-op. The check is based on the presence of `page.__librettoInstrumented`.
+</Note>
+
+***
+
+### `instrumentContext()`
+
+Instruments all current pages in a `BrowserContext` and automatically instruments any pages that open in the future. Useful when connecting to an existing browser via CDP, or when your workflow opens multiple tabs.
+
+```typescript  theme={null}
+async function instrumentContext(
+  context: BrowserContext,
+  options?: InstrumentationOptions
+): Promise<void>
+```
+
+<ParamField path="context" type="BrowserContext" required>
+  The Playwright `BrowserContext` to instrument.
+</ParamField>
+
+<ParamField path="options" type="InstrumentationOptions">
+  See [InstrumentationOptions](#instrumentationoptions) below.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { instrumentContext } from "libretto";
+
+await instrumentContext(browserContext, { visualize: true, logger });
+
+// All existing pages are now instrumented.
+// Any new page opened in this context will be instrumented automatically.
+const newPage = await browserContext.newPage();
+```
+
+***
+
+### `InstrumentationOptions`
+
+<ParamField path="visualize" type="boolean">
+  Enable ghost cursor animation and element highlight overlays. Defaults to `false`.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Navigation actions (`goto`, `reload`, `goBack`, `goForward`) are logged at `info` level when a logger is provided.
+</ParamField>
+
+<ParamField path="highlightBeforeActionMs" type="number">
+  How long (in milliseconds) to show the element highlight before performing the action. Defaults to `350`.
+</ParamField>
+
+<ParamField path="ghostCursor" type="GhostCursorOptions">
+  Options for the ghost cursor overlay.
+
+  <Expandable title="GhostCursorOptions">
+    <ParamField path="style" type="&#x22;minimal&#x22; | &#x22;dot&#x22; | &#x22;screenstudio&#x22;">
+      Visual style of the cursor. `"minimal"` is a small arrow SVG (default). `"dot"` is a filled circle. `"screenstudio"` is a glowing circle.
+    </ParamField>
+
+    <ParamField path="color" type="string">
+      CSS color for the cursor. Defaults to `"rgba(255, 70, 70, 0.9)"`.
+    </ParamField>
+
+    <ParamField path="size" type="number">
+      Cursor size in pixels. Defaults to `23`.
+    </ParamField>
+
+    <ParamField path="zIndex" type="number">
+      CSS `z-index` for the cursor overlay. Defaults to `2147483646`.
+    </ParamField>
+
+    <ParamField path="easing" type="string">
+      CSS easing function for cursor movement. Defaults to `"cubic-bezier(0.16, 1, 0.3, 1)"`.
+    </ParamField>
+
+    <ParamField path="minDurationMs" type="number">
+      Minimum movement duration in milliseconds. Defaults to `100`.
+    </ParamField>
+
+    <ParamField path="maxDurationMs" type="number">
+      Maximum movement duration in milliseconds. Defaults to `600`.
+    </ParamField>
+
+    <ParamField path="speedPxPerMs" type="number">
+      Cursor speed in pixels per millisecond used to calculate distance-based duration. Defaults to `1.5`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField path="highlight" type="HighlightOptions">
+  Options for the element highlight overlay.
+
+  <Expandable title="HighlightOptions">
+    <ParamField path="color" type="string">
+      CSS color for the highlight rectangle. Defaults to `"rgba(59, 130, 246, 0.25)"`.
+    </ParamField>
+
+    <ParamField path="zIndex" type="number">
+      CSS `z-index` for the highlight layer. Defaults to `2147483645`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+***
+
+### Standalone visualization functions
+
+You can use the ghost cursor and highlight primitives directly without going through `instrumentPage`.
+
+#### Ghost cursor
+
+##### `ensureGhostCursor(page, options?)`
+
+Injects the ghost cursor overlay into the page if it is not already present. Also installs a `page.addInitScript` so the cursor reappears after navigation.
+
+```typescript  theme={null}
+async function ensureGhostCursor(page: Page, options?: GhostCursorOptions): Promise<void>
+```
+
+##### `moveGhostCursor(page, target)`
+
+Animates the ghost cursor to a specific coordinate.
+
+```typescript  theme={null}
+async function moveGhostCursor(
+  page: Page,
+  target: { x: number; y: number; durationMs?: number }
+): Promise<void>
+```
+
+##### `ghostClick(page, target)`
+
+Animates a press-and-release visual feedback on the ghost cursor at the given coordinates.
+
+```typescript  theme={null}
+async function ghostClick(page: Page, target: { x: number; y: number }): Promise<void>
+```
+
+##### `hideGhostCursor(page)`
+
+Fades the ghost cursor out.
+
+```typescript  theme={null}
+async function hideGhostCursor(page: Page): Promise<void>
+```
+
+#### Highlight layer
+
+##### `ensureHighlightLayer(page, options?)`
+
+Injects the highlight layer into the page if it is not already present.
+
+```typescript  theme={null}
+async function ensureHighlightLayer(page: Page, options?: HighlightOptions): Promise<void>
+```
+
+##### `showHighlight(page, params)`
+
+Draws a highlight rectangle over a bounding box. The highlight fades out automatically after `durationMs`.
+
+```typescript  theme={null}
+async function showHighlight(
+  page: Page,
+  params: {
+    box: { x: number; y: number; width: number; height: number };
+    label?: string;
+    color?: string;
+    durationMs?: number;
+  }
+): Promise<void>
+```
+
+##### `clearHighlights(page)`
+
+Removes all highlight rectangles from the layer immediately.
+
+```typescript  theme={null}
+async function clearHighlights(page: Page): Promise<void>
+```
+
+#### Standalone example
+
+```typescript  theme={null}
+import {
+  ensureGhostCursor,
+  moveGhostCursor,
+  ghostClick,
+  ensureHighlightLayer,
+  showHighlight,
+  clearHighlights,
+} from "libretto";
+
+await ensureGhostCursor(page, { style: "dot", color: "rgba(0, 120, 255, 0.9)" });
+await ensureHighlightLayer(page);
+
+const box = await page.locator("#submit").boundingBox();
+if (box) {
+  await showHighlight(page, { box, durationMs: 400 });
+  await moveGhostCursor(page, {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  });
+  await ghostClick(page, { x: box.x + box.width / 2, y: box.y + box.height / 2 });
+}
+
+await clearHighlights(page);
+```

--- a/docs/library-api/logging.mdx
+++ b/docs/library-api/logging.mdx
@@ -1,0 +1,255 @@
+## Logging
+
+> Structured logging with pluggable sinks for browser automation workflows.
+
+Libretto ships a structured logger that routes log entries to one or more pluggable sinks. Every public API that accepts an optional `logger` parameter accepts a `MinimalLogger`, so you can pass in either the full `Logger` class or any compatible object.
+
+### `Logger`
+
+The main logger class. Construct it with an array of sinks.
+
+```typescript  theme={null}
+new Logger(
+  scopes?: string[],
+  sinks?: LoggerSink[],
+  scopeData?: Record<string, any>
+)
+```
+
+In practice you usually construct a `Logger` by passing only `sinks`:
+
+```typescript  theme={null}
+import { Logger, prettyConsoleSink, createFileLogSink } from "libretto";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({
+      filePath: ".libretto/sessions/my-session/logs.jsonl",
+    }),
+  ]
+);
+```
+
+`Logger` implements `LoggerApi` and also satisfies `MinimalLogger`.
+
+#### `Logger.withSink(sink)`
+
+Returns a new `Logger` that writes to all existing sinks plus the additional `sink`. The original logger is not modified.
+
+```typescript  theme={null}
+const fileLogger = logger.withSink(
+  createFileLogSink({ filePath: ".libretto/sessions/my-session/logs.jsonl" })
+);
+```
+
+#### `defaultLogger`
+
+A pre-built `MinimalLogger` that writes to `console.log / console.warn / console.error` with `[INFO]`, `[WARN]`, and `[ERROR]` prefixes. Used as the fallback when you omit the `logger` option on any Libretto function.
+
+```typescript  theme={null}
+import { defaultLogger } from "libretto";
+```
+
+***
+
+### `LoggerApi` interface
+
+The full interface implemented by `Logger`.
+
+<ResponseField name="log" type="(event: string, data?: Record<string, any>, options?: LogOptions) => void">
+  Logs an entry at `"log"` level.
+</ResponseField>
+
+<ResponseField name="info" type="(event: string, data?, options?: LogOptions) => void">
+  Logs an entry at `"info"` level. `data` can be an `Error`, `{ error: Error, ...rest }`, or any plain object.
+</ResponseField>
+
+<ResponseField name="warn" type="(event: string, data?, options?: LogOptions) => void">
+  Logs an entry at `"warn"` level.
+</ResponseField>
+
+<ResponseField name="error" type="(event: string, data?, options?: LogOptions) => Error">
+  Logs an entry at `"error"` level and returns an `Error` object. If `data` is or contains an `Error`, that error is returned; otherwise a new `Error` is constructed from `event`.
+</ResponseField>
+
+<ResponseField name="withScope" type="(scope: string, context?: Record<string, any>) => LoggerApi">
+  Returns a new `LoggerApi` with an additional scope segment prepended to all log entries. Scope segments are joined with `.` (e.g. `"workflow.network"`).
+</ResponseField>
+
+<ResponseField name="withContext" type="(context: Record<string, any>) => LoggerApi">
+  Returns a new `LoggerApi` with additional key-value pairs merged into every log entry's `data`.
+</ResponseField>
+
+<ResponseField name="flush" type="() => Promise<void>">
+  Flushes all sinks in reverse order (most recently added first).
+</ResponseField>
+
+***
+
+### `MinimalLogger` type
+
+A minimal subset of `LoggerApi`. Any object with `info`, `warn`, and `error` methods satisfies this type, which is what every Libretto runtime function accepts for its optional `logger` parameter.
+
+```typescript  theme={null}
+type MinimalLogger = {
+  info: (event: string, data?: any) => void;
+  warn: (event: string, data?: any) => void;
+  error: (event: string, data?: any) => any;
+};
+```
+
+***
+
+### `LogOptions`
+
+<ParamField path="timestamp" type="Date">
+  Override the timestamp written to the log entry. Defaults to `new Date()` at write time.
+</ParamField>
+
+***
+
+### `LoggerSink` type
+
+A sink is any object with a `write` method. Implement this interface to route log output to any destination.
+
+```typescript  theme={null}
+type LoggerSink = {
+  write: (args: {
+    id: string;
+    scope: string;
+    level: "log" | "error" | "warn" | "info";
+    event: string;
+    data: Record<string, any>;
+    options?: LogOptions;
+  }) => void;
+  flush?: () => Promise<void>;
+  close?: () => Promise<void>;
+};
+```
+
+<ResponseField name="write" type="(args) => void">
+  Called for every log entry. `id` is a unique random identifier per entry.
+</ResponseField>
+
+<ResponseField name="flush" type="() => Promise<void>">
+  Optional. Called by `Logger.flush()` to ensure buffered entries are written.
+</ResponseField>
+
+<ResponseField name="close" type="() => Promise<void>">
+  Optional. Called by `Logger.close()` to release resources (e.g. close file handles). Safe to call multiple times — subsequent calls are no-ops.
+</ResponseField>
+
+***
+
+### Built-in sinks
+
+#### `createFileLogSink({ filePath })`
+
+Writes JSONL (one JSON object per line) to a file. The directory is created automatically if it does not exist. Appends to the file if it already exists.
+
+```typescript  theme={null}
+function createFileLogSink({ filePath }: { filePath: string }): LoggerSink
+```
+
+<ParamField path="filePath" type="string" required>
+  Absolute or relative path to the log file.
+</ParamField>
+
+#### `prettyConsoleSink`
+
+A pre-built `LoggerSink` constant that writes human-readable, ANSI-colored output to the console. Timestamps, log levels, scopes, and events are each color-coded. Error stacks are printed on separate lines.
+
+```typescript  theme={null}
+import { prettyConsoleSink } from "libretto";
+```
+
+#### `jsonlConsoleSink`
+
+A pre-built `LoggerSink` constant that writes each log entry as a single JSON line to `console.log`. Useful for log aggregation systems that consume structured output from stdout.
+
+```typescript  theme={null}
+import { jsonlConsoleSink } from "libretto";
+```
+
+#### Full example
+
+```typescript  theme={null}
+import { Logger, createFileLogSink, prettyConsoleSink } from "libretto";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({
+      filePath: ".libretto/sessions/my-session/logs.jsonl",
+    }),
+  ]
+);
+
+logger.info("Starting workflow", { session: "my-session" });
+logger.warn("Element not found", { selector: "#submit" });
+
+const scopedLogger = logger.withScope("network", { requestId: "abc123" });
+scopedLogger.info("Request started", { url: "/api/items" });
+// Logged with scope "network" and data merged with { requestId: "abc123" }
+
+await logger.flush();
+```
+
+***
+
+### `createLLMClientFromModel()`
+
+Creates a Libretto `LLMClient` from a Vercel AI SDK `LanguageModel`. While logically an LLM utility, it is included here as a companion to the logger since both are commonly configured together at the top of a workflow file.
+
+```typescript  theme={null}
+function createLLMClientFromModel(model: LanguageModel): LLMClient
+```
+
+<ParamField path="model" type="LanguageModel" required>
+  A Vercel AI SDK language model instance. The result of calling a provider factory such as `openai("gpt-4o")` from `@ai-sdk/openai`, `anthropic("claude-3-5-sonnet-20241022")` from `@ai-sdk/anthropic`, or `google("gemini-1.5-pro")` from `@ai-sdk/google`.
+</ParamField>
+
+The returned `LLMClient` is used by `extractFromPage`, `attemptWithRecovery`, `executeRecoveryAgent`, and `detectSubmissionError`.
+
+#### `LLMClient` interface
+
+```typescript  theme={null}
+interface LLMClient {
+  generateObject<T extends z.ZodType>(opts: {
+    prompt: string;
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+
+  generateObjectFromMessages<T extends z.ZodType>(opts: {
+    messages: Message[];
+    schema: T;
+    temperature?: number;
+  }): Promise<z.output<T>>;
+}
+```
+
+#### Example
+
+```typescript  theme={null}
+import {
+  Logger,
+  prettyConsoleSink,
+  createFileLogSink,
+  createLLMClientFromModel,
+} from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const logger = new Logger(
+  [],
+  [
+    prettyConsoleSink,
+    createFileLogSink({ filePath: ".libretto/sessions/my-run/logs.jsonl" }),
+  ]
+);
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+```

--- a/docs/library-api/network.mdx
+++ b/docs/library-api/network.mdx
@@ -1,0 +1,203 @@
+## Network
+
+> Execute typed HTTP requests inside the browser context and handle downloads.
+
+Libretto provides two ways to make HTTP requests from within a workflow: `pageRequest()` for API calls, and the download helpers for file downloads.
+
+### `pageRequest()`
+
+Executes a `fetch()` call inside the browser context via `page.evaluate()`. Because the request runs inside the real browser process, it uses the browser's TLS fingerprint, cookies, and session — the same as what the site's own JavaScript would send. This avoids bot-detection issues that arise when making the same request from Node.js directly.
+
+```typescript  theme={null}
+async function pageRequest<T extends z.ZodType | undefined = undefined>(
+  page: Page,
+  config: RequestConfig,
+  options?: PageRequestOptions<T>
+): Promise<PageRequestResult<T>>
+```
+
+The return type is `z.infer<T>` when a `schema` is provided, or `any` otherwise.
+
+<Note>
+  Non-2xx responses cause `pageRequest` to throw an error. The error message includes the HTTP method, URL, and status code.
+</Note>
+
+#### `RequestConfig`
+
+<ParamField path="url" type="string" required>
+  The URL to fetch. Relative URLs are resolved in the browser context.
+</ParamField>
+
+<ParamField path="method" type="&#x22;GET&#x22; | &#x22;POST&#x22; | &#x22;PUT&#x22; | &#x22;DELETE&#x22; | &#x22;PATCH&#x22;">
+  HTTP method. Defaults to `"GET"`.
+</ParamField>
+
+<ParamField path="headers" type="Record<string, string>">
+  Additional request headers to merge with any that `bodyType` adds automatically.
+</ParamField>
+
+<ParamField path="body" type="Record<string, any> | string">
+  Request body. When `bodyType` is `"json"` (the default), objects are serialized with `JSON.stringify`. When `bodyType` is `"form"`, objects are encoded as `application/x-www-form-urlencoded`.
+</ParamField>
+
+<ParamField path="bodyType" type="&#x22;json&#x22; | &#x22;form&#x22;">
+  How to serialize the `body`. Defaults to `"json"`. Setting this to `"form"` also sets `Content-Type: application/x-www-form-urlencoded` automatically.
+</ParamField>
+
+<ParamField path="responseType" type="&#x22;json&#x22; | &#x22;text&#x22; | &#x22;xml&#x22;">
+  How to parse the response. Defaults to `"json"`. Both `"text"` and `"xml"` return the raw response text.
+</ParamField>
+
+#### `PageRequestOptions<T>`
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. When provided, request details (method, URL, status, duration) are logged at `info` level, and failures at `warn`.
+</ParamField>
+
+<ParamField path="schema" type="T extends z.ZodType">
+  Optional Zod schema. When provided, the parsed response body is validated with `schema.parse()` before being returned. The return type of `pageRequest` becomes `z.infer<T>`.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { pageRequest } from "libretto";
+import { z } from "zod";
+
+const ResultSchema = z.object({
+  items: z.array(z.object({ id: z.string(), name: z.string() })),
+  total: z.number(),
+});
+
+const data = await pageRequest(
+  page,
+  {
+    url: "/api/search",
+    method: "POST",
+    body: { query: "example", page: 1 },
+  },
+  { schema: ResultSchema }
+);
+// data is typed as { items: Array<{ id: string; name: string }>; total: number }
+```
+
+***
+
+### `downloadViaClick()`
+
+Triggers a file download by clicking a DOM element and intercepts the resulting download using Playwright's download event. The download promise is registered **before** the click so the event is never missed.
+
+```typescript  theme={null}
+async function downloadViaClick(
+  page: Page,
+  selector: string,
+  options?: DownloadViaClickOptions
+): Promise<DownloadResult>
+```
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="selector" type="string" required>
+  CSS selector for the element that triggers the download when clicked.
+</ParamField>
+
+<ParamField path="options" type="DownloadViaClickOptions">
+  <Expandable title="properties">
+    <ParamField path="logger" type="MinimalLogger">
+      Optional logger. Logs download filename, size, and duration on completion.
+    </ParamField>
+
+    <ParamField path="timeout" type="number">
+      Milliseconds to wait for the download event. Defaults to `30000`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+#### `DownloadResult`
+
+<ResponseField name="buffer" type="Buffer">
+  The raw file contents.
+</ResponseField>
+
+<ResponseField name="filename" type="string">
+  The filename suggested by the server via the `Content-Disposition` header or the URL.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import { downloadViaClick } from "libretto";
+
+const { buffer, filename } = await downloadViaClick(page, "#export-btn", {
+  logger,
+  timeout: 60_000,
+});
+
+console.log(`Downloaded ${filename} (${buffer.length} bytes)`);
+```
+
+***
+
+### `downloadAndSave()`
+
+Convenience wrapper around `downloadViaClick()` that also writes the downloaded file to disk.
+
+```typescript  theme={null}
+async function downloadAndSave(
+  page: Page,
+  selector: string,
+  options?: SaveDownloadOptions
+): Promise<DownloadResult & { savedTo: string }>
+```
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="selector" type="string" required>
+  CSS selector for the element that triggers the download when clicked.
+</ParamField>
+
+<ParamField path="options" type="SaveDownloadOptions">
+  <Expandable title="properties">
+    <ParamField path="savePath" type="string">
+      Absolute or relative path to save the file to. When omitted, the suggested filename is used in the current working directory.
+    </ParamField>
+
+    <ParamField path="logger" type="MinimalLogger">
+      Optional logger.
+    </ParamField>
+
+    <ParamField path="timeout" type="number">
+      Milliseconds to wait for the download event. Defaults to `30000`.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+#### Return value
+
+Returns `DownloadResult & { savedTo: string }` — the same `buffer` and `filename` as `downloadViaClick`, plus:
+
+<ResponseField name="savedTo" type="string">
+  The absolute path the file was written to.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import { downloadAndSave } from "libretto";
+
+const { filename, savedTo } = await downloadAndSave(
+  page,
+  "#export-btn",
+  { savePath: "/tmp/report.csv", logger }
+);
+
+console.log(`Saved ${filename} to ${savedTo}`);
+```

--- a/docs/library-api/openapi-spec.mdx
+++ b/docs/library-api/openapi-spec.mdx
@@ -1,0 +1,7 @@
+## OpenAPI specs
+
+The Mintlify docs index also links to a published OpenAPI JSON file:
+
+- [openapi.json](https://www.mintlify.com/saffron-health/libretto/api-reference/openapi.json)
+
+Use it as machine-readable reference alongside the CLI and library API docs above.

--- a/docs/library-api/recovery.mdx
+++ b/docs/library-api/recovery.mdx
@@ -1,0 +1,238 @@
+## Recovery
+
+> Automatically handle errors and popups that interrupt browser automation workflows.
+
+Browser automation workflows are often interrupted by unexpected page state: cookie banners, newsletter modals, session-expired dialogs, or form submission errors. The recovery module provides three tools for handling these situations.
+
+### `attemptWithRecovery()`
+
+Runs a function, and if it throws, optionally runs an LLM-powered popup recovery agent and retries the function once.
+
+```typescript  theme={null}
+async function attemptWithRecovery<T>(
+  page: Page,
+  fn: () => Promise<T>,
+  logger?: MinimalLogger,
+  llmClient?: LLMClient
+): Promise<T>
+```
+
+#### How it works
+
+1. Calls `fn()`.
+2. If `fn()` succeeds, returns the result immediately.
+3. If `fn()` throws and `llmClient` is not provided, re-throws the error.
+4. If `fn()` throws and `llmClient` is provided, runs `executeRecoveryAgent()` with the instruction `"Look at the page to see if there is a popup blocking the screen. If so, close the popup."`
+5. After recovery, calls `fn()` a second time. If it throws again, that error propagates.
+
+<Warning>
+  Recovery is **not** attempted when the error message indicates the browser or page has been closed (`"Target closed"`, `"browser has been closed"`, `"context or browser has been closed"`). These errors are re-thrown immediately.
+</Warning>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` where the action is being attempted.
+</ParamField>
+
+<ParamField path="fn" type="() => Promise<T>" required>
+  The async function to run. This is the step you want to protect — typically a sequence of Playwright actions.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Recovery attempts and outcomes are logged at `info` level.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient">
+  Optional LLM client. When omitted, errors are re-thrown without any recovery attempt. When provided, the recovery agent runs on failure.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { attemptWithRecovery, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+// Wrap any step that might be interrupted by a popup
+const result = await attemptWithRecovery(
+  page,
+  async () => {
+    await page.click("#submit");
+    await page.waitForSelector(".success");
+    return await page.textContent(".confirmation-number");
+  },
+  logger,
+  llmClient
+);
+```
+
+***
+
+### `executeRecoveryAgent()`
+
+Runs a vision-based LLM agent to handle page state issues. The agent takes a screenshot, sends it to the LLM with your instruction, executes the suggested browser action, and repeats for up to 3 steps until the action type is `"done"`.
+
+```typescript  theme={null}
+async function executeRecoveryAgent(
+  page: Page,
+  instruction: string,
+  logger?: MinimalLogger,
+  llmClient?: LLMClient
+): Promise<void>
+```
+
+<Note>
+  When `llmClient` is not provided, `executeRecoveryAgent` returns immediately without doing anything.
+</Note>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to operate on.
+</ParamField>
+
+<ParamField path="instruction" type="string" required>
+  A natural-language description of what the agent should do. For example: `"Dismiss any cookie consent banner or modal that is blocking the page."`
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger. Each recovery step's reasoning and action are logged.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient">
+  Optional LLM client. The backing model must support vision (multimodal) input.
+</ParamField>
+
+#### Example
+
+```typescript  theme={null}
+import { executeRecoveryAgent, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+await executeRecoveryAgent(
+  page,
+  "Dismiss any cookie consent banner or modal that is blocking the page.",
+  logger,
+  llmClient
+);
+```
+
+***
+
+### `detectSubmissionError()`
+
+Uses a CDP screenshot and LLM vision to detect whether a visible error appeared on the page after a form submission or other action. Useful when the site shows errors inline rather than throwing JavaScript exceptions.
+
+```typescript  theme={null}
+async function detectSubmissionError(
+  page: Page,
+  error: unknown,
+  logContext: string,
+  llmClient: LLMClient,
+  knownErrors?: KnownSubmissionError[],
+  logger?: MinimalLogger
+): Promise<DetectedSubmissionError>
+```
+
+If a `knownErrors` entry matches what the LLM sees on screen, `detectSubmissionError` returns a `DetectedSubmissionError`. If no known error matches, it re-throws the original `error`.
+
+<Note>
+  The screenshot is captured via CDP so it works even when the page is unresponsive (e.g. during a loading spinner or frozen UI). If the CDP screenshot itself fails, the original error is re-thrown.
+</Note>
+
+#### Parameters
+
+<ParamField path="page" type="Page" required>
+  The Playwright `Page` to screenshot.
+</ParamField>
+
+<ParamField path="error" type="unknown" required>
+  The original error that triggered the detection call. Re-thrown if no known error matches.
+</ParamField>
+
+<ParamField path="logContext" type="string" required>
+  A string describing the operation being performed. Included in log output and passed to the LLM as context.
+</ParamField>
+
+<ParamField path="llmClient" type="LLMClient" required>
+  An LLM client. The model must support vision input.
+</ParamField>
+
+<ParamField path="knownErrors" type="KnownSubmissionError[]">
+  An optional list of known error definitions to match against. Defaults to `[]`.
+</ParamField>
+
+<ParamField path="logger" type="MinimalLogger">
+  Optional logger.
+</ParamField>
+
+#### `KnownSubmissionError`
+
+<ResponseField name="id" type="string">
+  A stable identifier for this error type. Returned in `DetectedSubmissionError.errorId`.
+</ResponseField>
+
+<ResponseField name="errorPatterns" type="string[]">
+  Descriptions of what the LLM should look for on screen to match this error. For example: `["'Email already in use' message", "duplicate account warning"]`.
+</ResponseField>
+
+<ResponseField name="userMessage" type="string">
+  A human-friendly message returned in `DetectedSubmissionError.message` when this error is matched.
+</ResponseField>
+
+#### `DetectedSubmissionError`
+
+<ResponseField name="matched" type="true">
+  Always `true` — indicates a known error was detected.
+</ResponseField>
+
+<ResponseField name="errorId" type="string">
+  The `id` from the matched `KnownSubmissionError`.
+</ResponseField>
+
+<ResponseField name="message" type="string">
+  The `userMessage` from the matched `KnownSubmissionError`.
+</ResponseField>
+
+#### Example
+
+```typescript  theme={null}
+import {
+  detectSubmissionError,
+  createLLMClientFromModel,
+  type KnownSubmissionError,
+} from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+const knownErrors: KnownSubmissionError[] = [
+  {
+    id: "duplicate-email",
+    errorPatterns: ["email already in use", "duplicate account"],
+    userMessage: "An account with this email address already exists.",
+  },
+];
+
+try {
+  await page.click("#submit");
+  await page.waitForSelector(".success", { timeout: 5000 });
+} catch (err) {
+  const detected = await detectSubmissionError(
+    page,
+    err,
+    "submit-registration-form",
+    llmClient,
+    knownErrors,
+    logger
+  );
+  // detected.matched === true
+  // detected.errorId === "duplicate-email"
+  // detected.message === "An account with this email address already exists."
+  throw new Error(detected.message);
+}
+```

--- a/docs/library-api/workflow.mdx
+++ b/docs/library-api/workflow.mdx
@@ -1,0 +1,197 @@
+## Workflow
+
+> Define and run reusable browser automation workflows.
+
+The `workflow()` factory is the entry point for every Libretto automation. You wrap your Playwright logic in a typed handler, export the result, and the CLI (or your own runner) takes care of launching a browser, wiring up context, and invoking your handler.
+
+### `workflow()`
+
+Creates a `LibrettoWorkflow` from a handler function.
+
+```typescript  theme={null}
+function workflow<Input, Output, S>(
+  handler: LibrettoWorkflowHandler<Input, Output, S>
+): LibrettoWorkflow<Input, Output, S>
+```
+
+The handler receives a `LibrettoWorkflowContext` and typed `input`, and must return a `Promise<Output>`.
+
+```typescript  theme={null}
+type LibrettoWorkflowHandler<Input, Output, S> = (
+  ctx: LibrettoWorkflowContext<S>,
+  input: Input
+) => Promise<Output>
+```
+
+#### `LibrettoWorkflowContext<S>`
+
+<ResponseField name="session" type="string">
+  The session identifier for this workflow run. Use it to correlate logs and state files.
+</ResponseField>
+
+<ResponseField name="page" type="Page">
+  A Playwright `Page` instance ready for navigation and interaction.
+</ResponseField>
+
+<ResponseField name="logger" type="MinimalLogger">
+  A structured logger scoped to this workflow run. See [Logging](./logging) for details.
+</ResponseField>
+
+<ResponseField name="services" type="S">
+  An optional generic services object. Defaults to `{}`. Pass domain services (API clients, repositories, etc.) through here so your handler stays testable.
+</ResponseField>
+
+#### Full example
+
+```typescript  theme={null}
+import { workflow, launchBrowser, pause } from "libretto";
+
+export const main = workflow<{ query: string }, string[]>(async (ctx, input) => {
+  const { page, logger } = ctx;
+
+  await page.goto("https://example.com/search");
+  await page.fill("#query", input.query);
+  await page.click("#submit");
+  await page.waitForSelector(".results");
+
+  const results = await page.$$eval(".result-item", (els) =>
+    els.map((el) => el.textContent ?? "")
+  );
+
+  logger.info("Search complete", { count: results.length });
+  return results;
+});
+```
+
+#### Running with the CLI
+
+Pass the file path and the exported name to `libretto run`:
+
+```bash  theme={null}
+npx libretto run ./my-workflow.ts main
+```
+
+The CLI compiles the file with `tsx`, launches a Chromium browser, and calls your handler with the session context it constructs.
+
+***
+
+### `launchBrowser()`
+
+Launches a Playwright Chromium browser and returns a ready-to-use `BrowserSession`. Use this when you want to run workflows programmatically — outside the CLI — or when you need direct access to the `Browser` or `BrowserContext` objects.
+
+```typescript  theme={null}
+async function launchBrowser(args: LaunchBrowserArgs): Promise<BrowserSession>
+```
+
+#### `LaunchBrowserArgs`
+
+<ParamField path="sessionName" type="string" required>
+  A unique identifier for this browser session. Used to name the session state file written under `.libretto/sessions/`.
+</ParamField>
+
+<ParamField path="headless" type="boolean">
+  Whether to run Chromium in headless mode. Defaults to `false` (visible window).
+</ParamField>
+
+<ParamField path="viewport" type="{ width: number; height: number }">
+  The browser viewport size. Defaults to `{ width: 1366, height: 768 }`.
+</ParamField>
+
+<ParamField path="storageStatePath" type="string">
+  Path to a Playwright storage state JSON file (cookies, localStorage). Useful for resuming authenticated sessions.
+</ParamField>
+
+#### `BrowserSession` return value
+
+<ResponseField name="browser" type="Browser">
+  The underlying Playwright `Browser` instance.
+</ResponseField>
+
+<ResponseField name="context" type="BrowserContext">
+  The Playwright `BrowserContext` created for this session.
+</ResponseField>
+
+<ResponseField name="page" type="Page">
+  The initial `Page` opened in the context. Pass this to your workflow handler.
+</ResponseField>
+
+<ResponseField name="debugPort" type="number">
+  The remote debugging port Chromium is listening on.
+</ResponseField>
+
+<ResponseField name="metadataPath" type="string">
+  Absolute path to the session state JSON file written by `launchBrowser`.
+</ResponseField>
+
+<ResponseField name="close" type="() => Promise<void>">
+  Closes the browser and releases all resources.
+</ResponseField>
+
+#### Programmatic usage
+
+```typescript  theme={null}
+import { launchBrowser } from "libretto";
+import { defaultLogger } from "libretto";
+import { main } from "./my-workflow";
+
+const session = await launchBrowser({
+  sessionName: "my-run",
+  headless: true,
+});
+
+try {
+  const result = await main.run(
+    {
+      session: "my-run",
+      page: session.page,
+      logger: defaultLogger,
+      services: {},
+    },
+    { query: "hello world" }
+  );
+  console.log(result);
+} finally {
+  await session.close();
+}
+```
+
+***
+
+### `pause()`
+
+Pauses a running workflow so you can inspect browser state interactively, then resume from the CLI.
+
+```typescript  theme={null}
+async function pause(session: string): Promise<void>
+```
+
+<ParamField path="session" type="string" required>
+  The session identifier. Must match the session name used when the workflow was started.
+</ParamField>
+
+<Note>
+  `pause()` is a no-op when `NODE_ENV === "production"`. It is safe to leave `pause()` calls in your code without worrying about them blocking production runs.
+</Note>
+
+When called in a non-production environment, `pause()` writes a `.paused` signal file and polls for a `.resume` signal. Use the Libretto CLI to send the resume signal:
+
+```bash  theme={null}
+npx libretto resume --session <session-name>
+```
+
+#### Example
+
+```typescript  theme={null}
+import { workflow, pause } from "libretto";
+
+export const main = workflow<{ id: string }, void>(async (ctx, input) => {
+  const { page, session } = ctx;
+
+  await page.goto(`https://example.com/items/${input.id}`);
+
+  // Pause here to inspect the page before continuing
+  await pause(session);
+
+  await page.click("#confirm");
+});
+```

--- a/docs/library-api/workflow.mdx
+++ b/docs/library-api/workflow.mdx
@@ -6,24 +6,25 @@ The `workflow()` factory is the entry point for every Libretto automation. You w
 
 ### `workflow()`
 
-Creates a `LibrettoWorkflow` from a handler function.
+Creates a named `LibrettoWorkflow` from a handler function.
 
 ```typescript  theme={null}
-function workflow<Input, Output, S>(
-  handler: LibrettoWorkflowHandler<Input, Output, S>
-): LibrettoWorkflow<Input, Output, S>
+function workflow<Input = unknown, Output = unknown>(
+  name: string,
+  handler: LibrettoWorkflowHandler<Input, Output>
+): LibrettoWorkflow<Input, Output>
 ```
 
 The handler receives a `LibrettoWorkflowContext` and typed `input`, and must return a `Promise<Output>`.
 
 ```typescript  theme={null}
-type LibrettoWorkflowHandler<Input, Output, S> = (
-  ctx: LibrettoWorkflowContext<S>,
+type LibrettoWorkflowHandler<Input, Output> = (
+  ctx: LibrettoWorkflowContext,
   input: Input
 ) => Promise<Output>
 ```
 
-#### `LibrettoWorkflowContext<S>`
+#### `LibrettoWorkflowContext`
 
 <ResponseField name="session" type="string">
   The session identifier for this workflow run. Use it to correlate logs and state files.
@@ -33,21 +34,13 @@ type LibrettoWorkflowHandler<Input, Output, S> = (
   A Playwright `Page` instance ready for navigation and interaction.
 </ResponseField>
 
-<ResponseField name="logger" type="MinimalLogger">
-  A structured logger scoped to this workflow run. See [Logging](./logging) for details.
-</ResponseField>
-
-<ResponseField name="services" type="S">
-  An optional generic services object. Defaults to `{}`. Pass domain services (API clients, repositories, etc.) through here so your handler stays testable.
-</ResponseField>
-
 #### Full example
 
 ```typescript  theme={null}
 import { workflow, launchBrowser, pause } from "libretto";
 
-export const main = workflow<{ query: string }, string[]>(async (ctx, input) => {
-  const { page, logger } = ctx;
+export const main = workflow<{ query: string }, string[]>("main", async (ctx, input) => {
+  const { page } = ctx;
 
   await page.goto("https://example.com/search");
   await page.fill("#query", input.query);
@@ -58,7 +51,6 @@ export const main = workflow<{ query: string }, string[]>(async (ctx, input) => 
     els.map((el) => el.textContent ?? "")
   );
 
-  logger.info("Search complete", { count: results.length });
   return results;
 });
 ```
@@ -131,7 +123,6 @@ async function launchBrowser(args: LaunchBrowserArgs): Promise<BrowserSession>
 
 ```typescript  theme={null}
 import { launchBrowser } from "libretto";
-import { defaultLogger } from "libretto";
 import { main } from "./my-workflow";
 
 const session = await launchBrowser({
@@ -144,8 +135,6 @@ try {
     {
       session: "my-run",
       page: session.page,
-      logger: defaultLogger,
-      services: {},
     },
     { query: "hello world" }
   );
@@ -184,7 +173,7 @@ npx libretto resume --session <session-name>
 ```typescript  theme={null}
 import { workflow, pause } from "libretto";
 
-export const main = workflow<{ id: string }, void>(async (ctx, input) => {
+export const main = workflow<{ id: string }, void>("main", async (ctx, input) => {
   const { page, session } = ctx;
 
   await page.goto(`https://example.com/items/${input.id}`);

--- a/docs/workflow-guides/convert-to-network-requests.mdx
+++ b/docs/workflow-guides/convert-to-network-requests.mdx
@@ -25,7 +25,7 @@ The agent runs the existing script, examines the captured network log, identifie
 
   <Step title="Examine the network log">
     ```bash  theme={null}
-    npx libretto network
+    npx libretto network --session conversion-flow
     ```
 
     The agent reviews the captured requests to find API calls that return the data you need:

--- a/docs/workflow-guides/convert-to-network-requests.mdx
+++ b/docs/workflow-guides/convert-to-network-requests.mdx
@@ -129,7 +129,7 @@ The agent runs the existing script, examines the captured network log, identifie
       }
     }
 
-    export const topPosts = workflow<{}, Output>(async (ctx): Promise<Output> => {
+    export const topPosts = workflow<{}, Output>("topPosts", async (ctx): Promise<Output> => {
       const { page } = ctx;
       await page.goto("https://news.ycombinator.com");
 

--- a/docs/workflow-guides/convert-to-network-requests.mdx
+++ b/docs/workflow-guides/convert-to-network-requests.mdx
@@ -1,0 +1,204 @@
+## Convert to network requests
+
+> Convert browser automations to direct API calls for speed and reliability.
+
+Browser automation is reliable, but it's not always the fastest approach. When a site's internal API is accessible from within the browser context, calling those endpoints directly is faster and less fragile than driving the UI — no selectors to maintain, no page rendering to wait for, and no DOM changes to break your script.
+
+Libretto captures all network traffic during a browser session, so your agent can inspect exactly which API calls the site makes and convert a UI-based workflow to direct requests.
+
+### Example prompt
+
+> We have a browser script at ./integration.ts that automates going to Hacker News and getting the first 10 posts. Convert it to direct network scripts instead. Use the Libretto skill.
+
+The agent runs the existing script, examines the captured network log, identifies the API endpoints that return the data, and rewrites the integration to call them directly from within the browser context.
+
+### The process
+
+<Steps>
+  <Step title="Run the existing script and capture traffic">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headed
+    ```
+
+    Running the script with Libretto automatically captures all network requests and responses to `.libretto/sessions/<session>/network.jsonl`.
+  </Step>
+
+  <Step title="Examine the network log">
+    ```bash  theme={null}
+    npx libretto network
+    ```
+
+    The agent reviews the captured requests to find API calls that return the data you need:
+
+    ```bash  theme={null}
+    # Filter for JSON API responses
+    jq 'select(.contentType | test("application/json"))' \
+      .libretto/sessions/<session>/network.jsonl
+
+    # Find POST requests
+    jq 'select(.method == "POST")' \
+      .libretto/sessions/<session>/network.jsonl
+    ```
+  </Step>
+
+  <Step title="Run a site security review">
+    Before committing to a network-first approach, the agent checks whether direct API calls are safe on this site:
+
+    * Is there enterprise bot protection (Akamai, PerimeterX, Cloudflare)?
+    * Is `window.fetch` monkey-patched to inspect call stacks?
+    * Does the site do API-level monitoring?
+
+    This determines which network strategy to use.
+  </Step>
+
+  <Step title="Choose the right network approach">
+    <Tabs>
+      <Tab title="In-browser fetch">
+        Call endpoints from within the browser's JavaScript context. The requests share the browser's cookies, TLS fingerprint, and origin — they look identical to requests the site's own code would make.
+
+        ```typescript  theme={null}
+        // In your workflow file
+        const data = await page.evaluate(async () => {
+          const res = await fetch("/api/items?page=1");
+          return res.json();
+        });
+        ```
+
+        Use this when the site has no bot protection and `fetch` is not monkey-patched.
+      </Tab>
+
+      <Tab title="Passive interception">
+        Set up a `page.on('response', ...)` listener before navigating. The requests happen naturally as the site loads; you capture the responses without making any extra calls.
+
+        ```typescript  theme={null}
+        const capturedData: unknown[] = [];
+
+        page.on("response", async (response) => {
+          if (response.url().includes("/api/items")) {
+            capturedData.push(await response.json());
+          }
+        });
+
+        await page.goto("https://example.com");
+        await page.waitForSelector(".item-list");
+        ```
+
+        Use this when the site has bot protection or monkey-patches `fetch` — no extra requests means no anomalous call stack patterns to flag.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Rewrite the workflow">
+    The agent replaces the DOM-extraction logic with typed API client methods:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Post = {
+      id: number;
+      title: string;
+      url: string;
+      score: number;
+      by: string;
+    };
+
+    type Output = { posts: Post[] };
+
+    class HackerNewsClient {
+      constructor(private page: import("playwright").Page) {}
+
+      private async apiFetch(path: string): Promise<string> {
+        return await this.page.evaluate(
+          async ({ path }) => {
+            const res = await fetch(`https://hacker-news.firebaseio.com${path}`);
+            if (!res.ok) throw new Error(`${res.status} for ${path}`);
+            return res.text();
+          },
+          { path },
+        );
+      }
+
+      async getTopStoryIds(): Promise<number[]> {
+        const raw = await this.apiFetch("/v0/topstories.json");
+        return JSON.parse(raw);
+      }
+
+      async getItem(id: number): Promise<Post> {
+        const raw = await this.apiFetch(`/v0/item/${id}.json`);
+        return JSON.parse(raw);
+      }
+    }
+
+    export const topPosts = workflow<{}, Output>(async (ctx): Promise<Output> => {
+      const { page } = ctx;
+      await page.goto("https://news.ycombinator.com");
+
+      const client = new HackerNewsClient(page);
+      const ids = (await client.getTopStoryIds()).slice(0, 10);
+      const posts = await Promise.all(ids.map((id) => client.getItem(id)));
+
+      return { posts };
+    });
+    ```
+  </Step>
+
+  <Step title="Validate headless">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts topPosts --headless
+    ```
+
+    Confirm the output matches what the browser-based version returned.
+  </Step>
+</Steps>
+
+### When to use direct network calls
+
+The network approach is the default preference for new integrations. Use it when:
+
+* The site exposes a usable JSON API
+* You need to paginate deeply (fetching page 50 without clicking "next" 49 times)
+* You want data the UI doesn't display (hidden fields, metadata, IDs)
+* Speed and reliability matter more than DOM fidelity
+
+### When not to use the network approach
+
+<Warning>
+  Check the site's security posture before committing to a network-first strategy. Do not use direct `fetch()` calls if:
+
+  * The site has enterprise bot protection (Akamai, PerimeterX, Shape Security) **and** you've confirmed fetch is monkey-patched
+  * `window.fetch` is wrapped with call-stack inspection — your calls will be flagged because they don't originate from the site's own bundled code
+  * The site does API-level monitoring that correlates request timing to UI interactions
+
+  In these cases, use passive interception (`page.on('response', ...)`) instead. It captures the same data at zero additional detection risk because the requests come from the site's own code.
+</Warning>
+
+### Security analysis
+
+The Libretto skill includes a site-security review reference that guides your agent through checking for bot protection services, fetch interception, and challenge flows. The agent uses this to produce a **Site Assessment Summary** before choosing an integration strategy:
+
+```text  theme={null}
+## Site Assessment: https://example.com
+
+### Bot Detection Profile
+- Enterprise bot protection: None detected
+- Fetch/XHR interception: Native (not patched)
+- Challenge pages: None
+- Overall security posture: Low
+
+### Safe Approaches
+- page.evaluate(fetch(...)): Safe
+- page.on('response', ...): Viable
+- DOM extraction: Always available as fallback
+```
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="./one-shot-script-generation">
+    Start from scratch — give your agent a goal and let it build the workflow.
+  </Card>
+
+  <Card title="Debugging workflows" href="./debugging-workflows">
+    Reproduce failures and fix broken automations interactively.
+  </Card>
+</CardGroup>

--- a/docs/workflow-guides/debugging-workflows.mdx
+++ b/docs/workflow-guides/debugging-workflows.mdx
@@ -1,0 +1,167 @@
+## Debugging workflows
+
+> Reproduce failures, inspect live page state, and fix broken browser automations.
+
+When a Libretto workflow fails, the browser stays open at the exact point of failure. This is the key difference between debugging with Libretto and debugging with a generic test runner — you don't lose the state. Your agent can inspect the live page, test new selectors, and fix the issue before re-running to verify.
+
+### Example prompt
+
+> We have a browser script at ./integration.ts that is supposed to go to Availity and perform an eligibility check for a patient. But I'm getting a broken selector error when I run it. Fix it. Use the Libretto skill.
+
+The agent reproduces the failure, snapshots the broken state, finds the correct selector in the current DOM, patches the code, and re-runs to confirm.
+
+### The debugging workflow
+
+<Steps>
+  <Step title="Run the failing script">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --session debug-flow --headed
+    ```
+
+    Use `--headed` so you can watch the browser and see where it stops. Name the session something descriptive — you'll use it for all subsequent commands.
+  </Step>
+
+  <Step title="Browser stays open at the failure point">
+    When a workflow fails, Libretto keeps the browser open and returns control to the CLI. The agent sees the error message and knows to inspect the current page state before touching any code.
+  </Step>
+
+  <Step title="Snapshot the broken state">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --session debug-flow \
+      --objective "Find the blocking error or broken selector target" \
+      --context "The workflow failed while trying to submit the eligibility form. I need to identify the element that can't be found."
+    ```
+
+    Snapshot captures the current screenshot and HTML, then uses LLM analysis to identify what's on the page, what's missing, and what the correct selectors should be. This keeps the heavy visual context out of your coding agent's context window.
+  </Step>
+
+  <Step title="Test selectors with exec">
+    Once the snapshot identifies candidate selectors, the agent validates them against the live page:
+
+    ```bash  theme={null}
+    npx libretto exec --session debug-flow \
+      "return await page.locator('[data-testid=\"member-id-input\"]').count()"
+    ```
+
+    If the count is `0`, the selector doesn't match. Try alternatives until you find one that returns `1`:
+
+    ```bash  theme={null}
+    npx libretto exec --session debug-flow \
+      "return await page.locator('input[name=\"memberId\"]').count()"
+    ```
+  </Step>
+
+  <Step title="Fix the code">
+    With the correct selector confirmed, the agent updates the workflow file. Read the code generation rules before editing production code — Playwright locator APIs, no `querySelectorAll` in `page.evaluate()`, type-safe output.
+  </Step>
+
+  <Step title="Re-run to verify">
+    ```bash  theme={null}
+    npx libretto run ./integration.ts main --headless
+    ```
+
+    Switch to `--headless` for the verify loop — it's faster. If the run succeeds, confirm the actual returned output is correct. If it fails again, the browser stays open and you repeat from step 3.
+  </Step>
+</Steps>
+
+### Using `pause()` as a breakpoint
+
+If you need to stop a workflow at a specific point — not at failure, but at a known state you want to inspect — add a `pause()` call:
+
+```typescript  theme={null}
+import { workflow, pause } from "libretto";
+
+export const eligibilityCheck = workflow(async (ctx, input) => {
+  const { session, page } = ctx;
+
+  await page.goto("https://availity.com");
+  await page.locator("#memberSearch").fill(input.memberId);
+
+  // Pause here to inspect the page before submitting
+  await pause(session);
+
+  await page.locator("button[type='submit']").click();
+  // ...
+});
+```
+
+Run the workflow and it will halt at the `pause()` call with the browser open. Inspect, test selectors, then resume:
+
+```bash  theme={null}
+npx libretto resume --session debug-flow
+```
+
+`pause()` is a no-op when `NODE_ENV === "production"`, so you can leave it in during development and it won't affect production runs. Remove it once you're done debugging.
+
+### Reading logs for error context
+
+The session log at `.libretto/sessions/<session>/logs.jsonl` contains structured entries for every step the workflow took. Use `jq` to find the error:
+
+```bash  theme={null}
+# Find error entries
+jq 'select(.level == "error")' .libretto/sessions/debug-flow/logs.jsonl
+
+# See the last 20 log entries
+tail -n 20 .libretto/sessions/debug-flow/logs.jsonl | jq .
+```
+
+Libretto's instrumentation enriches timeout errors with element context — what was being waited for, its selector, and the page state at the time — so you're not left reading a raw timeout message.
+
+### Common errors
+
+**Broken selectors**
+
+The most common failure. A selector that worked last week no longer matches because the site updated its markup. Fix:
+
+1. Use `snapshot` to see the current DOM and identify the updated element
+2. Use `exec` to test new selectors against the live page
+3. Prefer stable selectors: `data-testid` attributes, ARIA roles, and visible label text over class names and positional selectors
+
+**Popups blocking the workflow**
+
+A modal, cookie banner, or session-expiry dialog appears unexpectedly and blocks interaction with the underlying page. Consider using `attemptWithRecovery()` from the Library API to handle known popup patterns:
+
+```typescript  theme={null}
+const result = await attemptWithRecovery(
+  ctx,
+  async () => {
+    await page.locator("#continueButton").click();
+  },
+  [
+    {
+      detect: async () =>
+        (await page.locator("#sessionExpiredModal").count()) > 0,
+      recover: async () => {
+        await page.locator("#sessionExpiredModal button").click();
+      },
+    },
+  ],
+);
+```
+
+**Timeout errors**
+
+A `waitForSelector` or locator action times out because the expected element never appeared. Check the snapshot to see what the page actually shows — it may be a loading spinner, an error state, or a redirect you didn't expect. The structured log entry will include which selector was being waited for.
+
+### Tips
+
+<Tip>
+  Use `--headless` for the fix/verify loop and `--headed` when you need to watch what's happening. Headed mode is slower but lets you see exactly what the browser is doing at each step. Switch back to headless once you've confirmed the visual behavior is correct.
+</Tip>
+
+<Tip>
+  Give your debug session a descriptive name with `--session`. If you run multiple debug sessions, names like `debug-eligibility-submit` are much easier to work with than the default session name.
+</Tip>
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="./one-shot-script-generation">
+    Build a new automation from scratch without any prior knowledge of the site.
+  </Card>
+
+  <Card title="Interactive script building" href="./interactive-script-building">
+    Show the workflow manually and let your agent turn it into reusable code.
+  </Card>
+</CardGroup>

--- a/docs/workflow-guides/debugging-workflows.mdx
+++ b/docs/workflow-guides/debugging-workflows.mdx
@@ -72,7 +72,7 @@ If you need to stop a workflow at a specific point — not at failure, but at a 
 ```typescript  theme={null}
 import { workflow, pause } from "libretto";
 
-export const eligibilityCheck = workflow(async (ctx, input) => {
+export const eligibilityCheck = workflow("eligibilityCheck", async (ctx, input) => {
   const { session, page } = ctx;
 
   await page.goto("https://availity.com");

--- a/docs/workflow-guides/debugging-workflows.mdx
+++ b/docs/workflow-guides/debugging-workflows.mdx
@@ -120,23 +120,22 @@ The most common failure. A selector that worked last week no longer matches beca
 
 **Popups blocking the workflow**
 
-A modal, cookie banner, or session-expiry dialog appears unexpectedly and blocks interaction with the underlying page. Consider using `attemptWithRecovery()` from the Library API to handle known popup patterns:
+A modal, cookie banner, or session-expiry dialog appears unexpectedly and blocks interaction with the underlying page. Consider wrapping the blocked step with `attemptWithRecovery()` from the Library API so Libretto can run the recovery agent before retrying:
 
 ```typescript  theme={null}
-const result = await attemptWithRecovery(
-  ctx,
+import { attemptWithRecovery, createLLMClientFromModel } from "libretto";
+import { openai } from "@ai-sdk/openai";
+
+const llmClient = createLLMClientFromModel(openai("gpt-4o"));
+
+await attemptWithRecovery(
+  page,
   async () => {
     await page.locator("#continueButton").click();
+    await page.waitForSelector(".success-banner");
   },
-  [
-    {
-      detect: async () =>
-        (await page.locator("#sessionExpiredModal").count()) > 0,
-      recover: async () => {
-        await page.locator("#sessionExpiredModal button").click();
-      },
-    },
-  ],
+  logger,
+  llmClient,
 );
 ```
 

--- a/docs/workflow-guides/interactive-script-building.mdx
+++ b/docs/workflow-guides/interactive-script-building.mdx
@@ -37,7 +37,7 @@ You perform the workflow once in the browser. Libretto captures the full action 
 
   <Step title="Agent reads what you did">
     ```bash  theme={null}
-    npx libretto actions
+    npx libretto actions --session interactive-flow
     ```
 
     The agent reads the action log to reconstruct your workflow step by step. It can also query the log with `jq` to find specific actions or filter by page:
@@ -53,7 +53,7 @@ You perform the workflow once in the browser. Libretto captures the full action 
 
   <Step title="Agent inspects network traffic">
     ```bash  theme={null}
-    npx libretto network
+    npx libretto network --session interactive-flow
     ```
 
     The agent cross-references your actions with the network requests they triggered. This helps identify the underlying API calls so the workflow can be converted to direct requests if needed.

--- a/docs/workflow-guides/interactive-script-building.mdx
+++ b/docs/workflow-guides/interactive-script-building.mdx
@@ -75,6 +75,7 @@ You perform the workflow once in the browser. Libretto captures the full action 
     };
 
     export const getInsuranceId = workflow<Input, Output>(
+      "getInsuranceId",
       async (ctx, input): Promise<Output> => {
         const { page } = ctx;
 

--- a/docs/workflow-guides/interactive-script-building.mdx
+++ b/docs/workflow-guides/interactive-script-building.mdx
@@ -1,0 +1,147 @@
+## Interactive script building
+
+> Record your actions in the browser and let your agent turn them into automation code.
+
+Some workflows are too complex to describe in words alone — especially in healthcare software and legacy web apps where the interaction sequence matters and the UI has unusual patterns. Interactive script building lets you perform the workflow yourself, with Libretto recording every click, fill, and navigation. Your agent then reads the action log and translates what you did into a reusable automation script.
+
+### Example prompt
+
+> I'm gonna show you a workflow in the eclinicalworks EHR to get a patient's primary insurance ID. Use libretto skill to turn it into a playwright script that takes patient name and dob as input to get back the insurance ID. URL is ...
+
+You perform the workflow once in the browser. Libretto captures the full action log. The agent reads it and writes a script that can run the same steps programmatically.
+
+### Step-by-step process
+
+<Steps>
+  <Step title="Agent opens a headed browser">
+    ```bash  theme={null}
+    npx libretto open https://your-ehr.example.com --headed
+    ```
+
+    The browser opens on your screen. You're in control from here.
+  </Step>
+
+  <Step title="You perform the workflow manually">
+    Navigate through the application exactly as you would normally. Log in, search for a patient, open their record, find the insurance tab — whatever the workflow requires. Libretto records everything happening in the browser as you go.
+  </Step>
+
+  <Step title="Libretto records your actions">
+    Every click, form fill, and navigation is written to the action log at:
+
+    ```
+    .libretto/sessions/<session>/actions.jsonl
+    ```
+
+    Each entry captures the action type, the element you interacted with, the value you typed (if any), and the URL of the page at that moment.
+  </Step>
+
+  <Step title="Agent reads what you did">
+    ```bash  theme={null}
+    npx libretto actions
+    ```
+
+    The agent reads the action log to reconstruct your workflow step by step. It can also query the log with `jq` to find specific actions or filter by page:
+
+    ```bash  theme={null}
+    # See all fill actions (form inputs you typed into)
+    jq 'select(.action == "fill")' .libretto/sessions/<session>/actions.jsonl
+
+    # See the last 20 actions
+    tail -n 20 .libretto/sessions/<session>/actions.jsonl | jq .
+    ```
+  </Step>
+
+  <Step title="Agent inspects network traffic">
+    ```bash  theme={null}
+    npx libretto network
+    ```
+
+    The agent cross-references your actions with the network requests they triggered. This helps identify the underlying API calls so the workflow can be converted to direct requests if needed.
+  </Step>
+
+  <Step title="Agent writes the workflow file">
+    Using the action log as a blueprint, the agent writes a TypeScript workflow that replicates your steps:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Input = {
+      patientName: string;
+      dob: string; // YYYY-MM-DD
+    };
+
+    type Output = {
+      primaryInsuranceId: string;
+    };
+
+    export const getInsuranceId = workflow<Input, Output>(
+      async (ctx, input): Promise<Output> => {
+        const { page } = ctx;
+
+        await page.goto("https://your-ehr.example.com");
+
+        // Search for the patient by name and DOB
+        await page.locator("#patientSearch").fill(input.patientName);
+        await page.locator("#dobField").fill(input.dob);
+        await page.locator("button[type='submit']").click();
+
+        // Open the patient record
+        await page.locator(".patient-result").first().click();
+
+        // Navigate to insurance tab
+        await page.locator("#insuranceTab").click();
+
+        // Extract the primary insurance ID
+        const insuranceId = await page
+          .locator("[data-field='primaryInsuranceId']").textContent();
+
+        return { primaryInsuranceId: insuranceId?.trim() ?? "" };
+      },
+    );
+    ```
+  </Step>
+
+  <Step title="Agent validates with a headless run">
+    ```bash  theme={null}
+    npx libretto run ./get-insurance-id.ts getInsuranceId --headless \
+      --params '{"patientName": "Jane Smith", "dob": "1985-04-12"}'
+    ```
+
+    The agent confirms the actual returned output matches what you'd expect.
+  </Step>
+</Steps>
+
+### What the action log captures
+
+Each entry in `actions.jsonl` is a JSON object on its own line. User-initiated events include:
+
+* `action` — what happened: `click`, `dblclick`, `fill`, `goto`, etc.
+* `bestSemanticSelector` — the most stable selector for the element you interacted with
+* `value` — the text you typed or option you selected
+* `url` — the page URL at the time of the action
+* `nearbyText` — visible text near the element, for human context
+
+Agent-initiated events include the Playwright locator used and whether the action succeeded.
+
+<Note>
+  The `bestSemanticSelector` field in user action entries is the most reliable selector to use in generated code. It's the canonical identifier Libretto chose for the element based on the DOM structure — prefer it over `targetSelector` or raw CSS paths when writing workflow code.
+</Note>
+
+### When to use this approach
+
+* The workflow involves many steps and is hard to describe concisely
+* You're working with EHR, healthcare, or legacy enterprise software with unusual UI patterns
+* You want to delegate the "figure out the selectors" work entirely to the agent
+* The workflow involves conditional paths that are easier to show than explain
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="One-shot script generation" href="./one-shot-script-generation">
+    Let the agent explore a site and build the workflow without your involvement.
+  </Card>
+
+  <Card title="Debugging workflows" href="./debugging-workflows">
+    Reproduce failures, inspect live page state, and fix broken automations.
+  </Card>
+</CardGroup>

--- a/docs/workflow-guides/one-shot-script-generation.mdx
+++ b/docs/workflow-guides/one-shot-script-generation.mdx
@@ -67,6 +67,7 @@ Your agent opens a browser window for you to log in, then takes over: exploring 
     };
 
     export const linkedInFeedScraper = workflow<{}, Output>(
+      "linkedInFeedScraper",
       async (ctx): Promise<Output> => {
         const { page } = ctx;
 

--- a/docs/workflow-guides/one-shot-script-generation.mdx
+++ b/docs/workflow-guides/one-shot-script-generation.mdx
@@ -19,7 +19,7 @@ Your agent opens a browser window for you to log in, then takes over: exploring 
     The agent starts with:
 
     ```bash  theme={null}
-    npx libretto open https://example.com --headed
+    npx libretto open https://example.com --headed --session one-shot-flow
     ```
 
     Headed mode keeps the browser window visible so you can log in before the agent begins exploring.
@@ -32,6 +32,7 @@ Your agent opens a browser window for you to log in, then takes over: exploring 
   <Step title="Takes a snapshot to understand the page">
     ```bash  theme={null}
     npx libretto snapshot \
+      --session one-shot-flow \
       --objective "Identify feed post elements and their structure" \
       --context "I just loaded the main feed and need the post container selectors."
     ```
@@ -43,7 +44,7 @@ Your agent opens a browser window for you to log in, then takes over: exploring 
     The agent tests selectors and interaction patterns before committing them to code:
 
     ```bash  theme={null}
-    npx libretto exec "return await page.locator('.feed-shared-update-v2').count()"
+    npx libretto exec --session one-shot-flow "return await page.locator('.feed-shared-update-v2').count()"
     ```
 
     Short `exec` calls let the agent validate each step against the live page without writing and re-running a full script each time.

--- a/docs/workflow-guides/one-shot-script-generation.mdx
+++ b/docs/workflow-guides/one-shot-script-generation.mdx
@@ -1,0 +1,131 @@
+## One-shot script generation
+
+> Ask your agent to explore a site and generate a complete browser automation script.
+
+One-shot generation means you give your agent a goal and a URL, and it does the rest. The agent opens a live browser, explores the site, figures out the page structure, and writes a complete workflow file — without you needing to record actions or hand-hold the process.
+
+This is the fastest path from idea to working automation when you're starting from scratch on a site you haven't automated before.
+
+### Example prompt
+
+> Use the Libretto skill. Go on LinkedIn and scrape the first 10 posts for content, who posted it, the number of reactions, the first 25 comments, and the first 25 reposts.
+
+Your agent opens a browser window for you to log in, then takes over: exploring the feed, identifying selectors, prototyping interactions, and assembling the final workflow file.
+
+### How the agent works
+
+<Steps>
+  <Step title="Opens a headed browser">
+    The agent starts with:
+
+    ```bash  theme={null}
+    npx libretto open https://example.com --headed
+    ```
+
+    Headed mode keeps the browser window visible so you can log in before the agent begins exploring.
+  </Step>
+
+  <Step title="Reviews the site's security posture">
+    Before choosing how to capture data, the agent reads the site-security reference and checks for bot detection, monkey-patched fetch, and challenge pages. This determines whether to use direct `fetch()` calls, passive network interception, or DOM extraction.
+  </Step>
+
+  <Step title="Takes a snapshot to understand the page">
+    ```bash  theme={null}
+    npx libretto snapshot \
+      --objective "Identify feed post elements and their structure" \
+      --context "I just loaded the main feed and need the post container selectors."
+    ```
+
+    Snapshot captures a screenshot and the page HTML, then uses an LLM to analyze it — keeping the heavy visual context out of your coding agent's context window.
+  </Step>
+
+  <Step title="Uses exec to prototype interactions">
+    The agent tests selectors and interaction patterns before committing them to code:
+
+    ```bash  theme={null}
+    npx libretto exec "return await page.locator('.feed-shared-update-v2').count()"
+    ```
+
+    Short `exec` calls let the agent validate each step against the live page without writing and re-running a full script each time.
+  </Step>
+
+  <Step title="Writes the workflow file">
+    Once the agent has a working path, it generates a TypeScript file that exports a `workflow()` instance:
+
+    ```typescript  theme={null}
+    import { workflow } from "libretto";
+
+    type Output = {
+      posts: Array<{
+        author: string;
+        content: string;
+        reactions: number;
+        comments: string[];
+        reposts: string[];
+      }>;
+    };
+
+    export const linkedInFeedScraper = workflow<{}, Output>(
+      async (ctx): Promise<Output> => {
+        const { page } = ctx;
+
+        await page.goto("https://www.linkedin.com/feed/");
+        await page.waitForSelector(".feed-shared-update-v2");
+
+        // Collect first 10 posts
+        const postElements = await page.locator(".feed-shared-update-v2").all();
+        const posts = [];
+
+        for (const post of postElements.slice(0, 10)) {
+          const author = await post.locator(".update-components-actor__name").textContent();
+          const content = await post.locator(".feed-shared-text").textContent();
+          // ... extract reactions, comments, reposts
+        }
+
+        return { posts };
+      },
+    );
+    ```
+  </Step>
+
+  <Step title="Validates with a headless run">
+    ```bash  theme={null}
+    npx libretto run ./linkedin-feed.ts linkedInFeedScraper --headless
+    ```
+
+    The agent confirms actual returned output, not just process exit status. If the run fails, the browser stays open for inspection.
+  </Step>
+</Steps>
+
+### When to use this approach
+
+* You're automating a site for the first time and don't know its structure
+* The task is self-contained and clearly scoped ("get the first 10 posts")
+* You want a working script with minimal back-and-forth
+* You don't need to demonstrate the workflow manually first
+
+### Tips
+
+<Tip>
+  Always use `--headed` when the site requires login. The browser window opens on your screen so you can authenticate, and then the agent takes over. Without `--headed`, the agent has no way to get past a login wall.
+</Tip>
+
+<Tip>
+  Give your agent a specific, measurable objective. "Scrape the first 10 posts" is actionable. "Get some LinkedIn data" is not — the agent will have to guess at scope and structure.
+</Tip>
+
+<Note>
+  Make sure your coding agent has the Libretto skill installed before starting. Run `npx libretto setup` in your project root to set up the workspace and configure snapshot analysis if you haven't already.
+</Note>
+
+### Related guides
+
+<CardGroup cols={2}>
+  <Card title="Interactive script building" href="./interactive-script-building">
+    Show the agent your workflow manually and let it turn your actions into code.
+  </Card>
+
+  <Card title="Convert to network requests" href="./convert-to-network-requests">
+    Speed up an existing browser script by switching to direct API calls.
+  </Card>
+</CardGroup>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   },
   "scripts": {
     "build": "turbo run build",
+    "docs:dev": "cd docs && npx -y mintlify@4.2.473 dev",
+    "docs:validate": "cd docs && npx -y mintlify@4.2.473 validate",
+    "docs:broken-links": "cd docs && npx -y mintlify@4.2.473 broken-links --check-anchors",
     "website:build": "pnpm --dir ./apps/website build",
     "sync:mirrors": "node packages/dev-tools/scripts/sync-mirrors.mjs",
     "check:mirrors": "node packages/dev-tools/scripts/check-mirrors-sync.mjs",


### PR DESCRIPTION
## Summary
- add a Mintlify site under `docs/` with navigation, landing page, and repo-level helper scripts
- migrate the current Libretto docs content into Mintlify MDX pages while leaving the existing website docs code in place but inactive
- fix internal doc links and add `.mintignore`/favicon assets so the Mintlify project can validate and deploy from the `docs` directory

## Validation
- `cd docs && npx -y mintlify@4.2.473 validate`
- `cd docs && npx -y mintlify@4.2.473 broken-links --check-anchors`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
