### PR TITLE
website: proxy Mintlify docs through Vercel

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,25 +1,5 @@
-import { Suspense, lazy } from "react";
-import { useLocation } from "wouter";
 import { HomePage } from "./HomePage";
-import { normalizeDocsPath } from "./docs/content";
-
-const DocsPage = lazy(() =>
-  import("./docs/DocsPage").then((module) => ({ default: module.DocsPage })),
-);
 
 export function App() {
-  const [href] = useLocation();
-  const pathname = normalizeDocsPath(
-    new URL(href, window.location.origin).pathname,
-  );
-
-  if (pathname === "/docs" || pathname === "/docs/index.html" || pathname.startsWith("/docs/")) {
-    return (
-      <Suspense fallback={null}>
-        <DocsPage pathname={pathname} />
-      </Suspense>
-    );
-  }
-
   return <HomePage />;
 }

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -16,12 +16,7 @@ export function normalizeAppPathname(pathname: string): string {
 export function isAppOwnedPathname(pathname: string): boolean {
   const normalizedPathname = normalizeAppPathname(pathname);
 
-  return (
-    normalizedPathname === "/" ||
-    normalizedPathname === "/docs" ||
-    normalizedPathname === "/docs/index.html" ||
-    normalizedPathname.startsWith("/docs/")
-  );
+  return normalizedPathname === "/";
 }
 
 function shouldUseSpaNavigation({

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/_mintlify/:path*",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/_mintlify/:path*"
+    },
+    {
+      "source": "/api/request",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/_mintlify/api/request"
+    },
+    {
+      "source": "/docs/llms.txt",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/llms.txt"
+    },
+    {
+      "source": "/docs/llms-full.txt",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/llms-full.txt"
+    },
+    {
+      "source": "/docs/sitemap.xml",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/sitemap.xml"
+    },
+    {
+      "source": "/docs/robots.txt",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/robots.txt"
+    },
+    {
+      "source": "/docs/mcp",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/mcp"
+    },
+    {
+      "source": "/docs",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/docs"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/docs/:path*"
+    },
+    {
+      "source": "/mintlify-assets/:path+",
+      "destination": "https://saffron-health-libretto-73.mintlify.app/mintlify-assets/:path+"
+    }
+  ]
+}

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -7,10 +7,7 @@ export default defineConfig({
   plugins: [tailwindcss(), react()],
   build: {
     rollupOptions: {
-      input: {
-        main: fileURLToPath(new URL("./index.html", import.meta.url)),
-        docs: fileURLToPath(new URL("./docs/index.html", import.meta.url)),
-      },
+      input: fileURLToPath(new URL("./index.html", import.meta.url)),
     },
   },
   lint: { options: { typeAware: true, typeCheck: true } },


### PR DESCRIPTION
## Summary
- add `apps/website/vercel.json` rewrites to proxy `/docs` requests to the Mintlify site
- stop building and serving the legacy website docs bundle so Vercel rewrites can take effect
- keep the old docs source in `apps/website/src/docs` present but inactive

## Validation
- `pnpm install`
- `pnpm website:build`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
