### PR TITLE
website: proxy /docs to mintlify.dev

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -2,44 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
-      "source": "/_mintlify/:path*",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/_mintlify/:path*"
-    },
-    {
-      "source": "/api/request",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/_mintlify/api/request"
-    },
-    {
-      "source": "/docs/llms.txt",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/llms.txt"
-    },
-    {
-      "source": "/docs/llms-full.txt",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/llms-full.txt"
-    },
-    {
-      "source": "/docs/sitemap.xml",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/sitemap.xml"
-    },
-    {
-      "source": "/docs/robots.txt",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/robots.txt"
-    },
-    {
-      "source": "/docs/mcp",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/mcp"
-    },
-    {
       "source": "/docs",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/docs"
+      "destination": "https://saffron-health-libretto-73.mintlify.dev/docs"
     },
     {
       "source": "/docs/:path*",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/docs/:path*"
-    },
-    {
-      "source": "/mintlify-assets/:path+",
-      "destination": "https://saffron-health-libretto-73.mintlify.app/mintlify-assets/:path+"
+      "destination": "https://saffron-health-libretto-73.mintlify.dev/docs/:path*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point the Vercel `/docs` proxy at Mintlify's `.mintlify.dev` origin instead of `.mintlify.app`
- simplify the rewrites now that Mintlify serves the full `/docs/*` subtree directly from the `.mintlify.dev` origin
- align the Vercel config with Mintlify's Host at `/docs` guidance

## Validation
- `pnpm website:build`
- verified `https://saffron-health-libretto-73.mintlify.dev/docs` returns 200
- verified Mintlify's docs links resolve under `/docs/*` on the `.mintlify.dev` origin

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
