### PR TITLE
feat: shared createTmpWorkspace utility

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -15,6 +15,7 @@
     "benchmarks": "tsx cli.ts"
   },
   "devDependencies": {
+    "@libretto/dev-tools": "workspace:*",
     "libretto": "workspace:*"
   }
 }

--- a/benchmarks/webVoyager/runner.ts
+++ b/benchmarks/webVoyager/runner.ts
@@ -587,6 +587,7 @@ async function prepareRunWorkspace(
     parentDir,
     snapshotModel,
     skipBrowsers: true,
+    skipBuild: true,
     quiet: true,
   });
 

--- a/benchmarks/webVoyager/runner.ts
+++ b/benchmarks/webVoyager/runner.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { createWriteStream, readFileSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { createTmpWorkspace } from "@libretto/dev-tools/tmp-workspace";
 import { finished } from "node:stream/promises";
 import { GoogleAuth } from "google-auth-library";
 import {
@@ -571,35 +572,26 @@ async function ensureAnthropicApiKey(): Promise<string> {
 async function prepareRunWorkspace(
   row: WebVoyagerRow,
 ): Promise<{ runDir: string; prompt: string; sessionName: string }> {
-  const runDir = resolve(
-    repoRoot,
-    "benchmarks",
-    BENCHMARK_NAME,
-    "runs",
-    getRunName(row),
-  );
+  const runName = getRunName(row);
+  const parentDir = resolve(repoRoot, "benchmarks", BENCHMARK_NAME, "runs");
+  const runDir = resolve(parentDir, runName);
   const { text: prompt, sessionName } = buildWebVoyagerPrompt(row);
   const snapshotModel = resolveSnapshotModelForBenchmarkWorkspace();
-  const snapshotProviderInstallSpec = resolveProviderInstallSpec(snapshotModel);
 
+  // Clean any previous run
   await rm(runDir, { recursive: true, force: true });
-  await mkdir(runDir, { recursive: true });
-  await mkdir(join(runDir, ".agents"), { recursive: true });
 
-  await writeFile(
-    join(runDir, "package.json"),
-    JSON.stringify(
-      {
-        name: `libretto-benchmark-${getRunName(row)}`,
-        private: true,
-        type: "module",
-        packageManager: rootPackageManager,
-      },
-      null,
-      2,
-    ),
-    "utf8",
-  );
+  // Core workspace setup via shared utility
+  await createTmpWorkspace({
+    name: runName,
+    parentDir,
+    snapshotModel,
+    skipBrowsers: true,
+    quiet: true,
+  });
+
+  // Benchmark-specific files layered on top
+  await mkdir(join(runDir, ".agents"), { recursive: true });
   await writeFile(
     join(runDir, "AGENTS.md"),
     [
@@ -630,21 +622,6 @@ async function prepareRunWorkspace(
   );
   await writeFile(join(runDir, "prompt.md"), `${prompt}\n`, "utf8");
   await writeBenchmarkWorkspaceEnvFile(runDir);
-
-  runWorkspaceCommand(runDir, "git", ["init", "-q"]);
-  runWorkspaceCommand(runDir, "pnpm", [
-    "add",
-    "--lockfile=false",
-    `file:${librettoPackageRoot}`,
-    ...(snapshotProviderInstallSpec ? [snapshotProviderInstallSpec] : []),
-  ]);
-  runWorkspaceCommand(runDir, "npx", ["libretto", "setup", "--skip-browsers"]);
-  runWorkspaceCommand(runDir, "npx", [
-    "libretto",
-    "ai",
-    "configure",
-    snapshotModel,
-  ]);
 
   return { runDir, prompt, sessionName };
 }

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -85,6 +85,7 @@ export const test = base.extend<EvalFixtures>({
       name: stableHash(`${task.file.filepath}::${task.fullName}`).slice(0, 16),
       parentDir: DETERMINISTIC_WORKSPACE_ROOT,
       skipBrowsers: true,
+      skipBuild: true,
       quiet: true,
     });
     try {

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -1,23 +1,11 @@
-import {
-  cp,
-  mkdir,
-  readFile,
-  rm,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import {
-  dirname,
-  isAbsolute,
-  join,
-  relative,
-  resolve,
-} from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { test as base } from "vitest";
 import { ClaudeEvalHarness, ensureClaudeAuthConfigured } from "./harness.js";
+import { createTmpWorkspace } from "@libretto/dev-tools/tmp-workspace";
 
 type EvalFixtures = {
   harness: ClaudeEvalHarness;
@@ -63,36 +51,27 @@ function stableHash(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
-function workspaceDirForTask(task: Readonly<{ fullName: string; file: { filepath: string } }>): string {
-  const stableId = stableHash(`${task.file.filepath}::${task.fullName}`).slice(0, 16);
+function workspaceDirForTask(
+  task: Readonly<{ fullName: string; file: { filepath: string } }>,
+): string {
+  const stableId = stableHash(`${task.file.filepath}::${task.fullName}`).slice(
+    0,
+    16,
+  );
   return join(DETERMINISTIC_WORKSPACE_ROOT, stableId);
 }
 
-function assertWithinRoot(root: string, candidate: string, label: string): void {
+function assertWithinRoot(
+  root: string,
+  candidate: string,
+  label: string,
+): void {
   const rel = relative(root, candidate);
   if (rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(`${label} must stay within ${root}. Received: ${candidate}`);
+    throw new Error(
+      `${label} must stay within ${root}. Received: ${candidate}`,
+    );
   }
-}
-
-async function setupWorkspacePackage(workspaceDir: string): Promise<void> {
-  const workspacePackagePath = join(workspaceDir, "package.json");
-  const workspacePackageJson = {
-    name: "libretto-eval-workspace",
-    private: true,
-    type: "module",
-  };
-  await writeFile(
-    workspacePackagePath,
-    `${JSON.stringify(workspacePackageJson, null, 2)}\n`,
-    "utf8",
-  );
-
-  const nodeModulesPath = join(workspaceDir, "node_modules");
-  const librettoLinkPath = join(nodeModulesPath, "libretto");
-  await mkdir(nodeModulesPath, { recursive: true });
-  await rm(librettoLinkPath, { recursive: true, force: true });
-  await symlink(librettoPackageRoot, librettoLinkPath, "dir");
 }
 
 export const test = base.extend<EvalFixtures>({
@@ -102,8 +81,12 @@ export const test = base.extend<EvalFixtures>({
   evalWorkspaceDir: async ({ task }, use) => {
     const workspaceDir = workspaceDirForTask(task);
     await rm(workspaceDir, { recursive: true, force: true });
-    await mkdir(workspaceDir, { recursive: true });
-    await setupWorkspacePackage(workspaceDir);
+    await createTmpWorkspace({
+      name: stableHash(`${task.file.filepath}::${task.fullName}`).slice(0, 16),
+      parentDir: DETERMINISTIC_WORKSPACE_ROOT,
+      skipBrowsers: true,
+      quiet: true,
+    });
     try {
       await use(workspaceDir);
     } finally {
@@ -116,21 +99,27 @@ export const test = base.extend<EvalFixtures>({
   },
 
   copyEvalReference: async ({ evalWorkspaceDir }, use) => {
-    await use(async (sourceRelativePath: string, destinationRelativePath?: string) => {
-      const sourcePath = resolve(referencesRoot, sourceRelativePath);
-      assertWithinRoot(referencesRoot, sourcePath, "Reference source path");
+    await use(
+      async (sourceRelativePath: string, destinationRelativePath?: string) => {
+        const sourcePath = resolve(referencesRoot, sourceRelativePath);
+        assertWithinRoot(referencesRoot, sourcePath, "Reference source path");
 
-      const targetRelative = destinationRelativePath ?? sourceRelativePath;
-      const targetPath = resolve(evalWorkspaceDir, targetRelative);
-      assertWithinRoot(evalWorkspaceDir, targetPath, "Workspace destination path");
+        const targetRelative = destinationRelativePath ?? sourceRelativePath;
+        const targetPath = resolve(evalWorkspaceDir, targetRelative);
+        assertWithinRoot(
+          evalWorkspaceDir,
+          targetPath,
+          "Workspace destination path",
+        );
 
-      await mkdir(dirname(targetPath), { recursive: true });
-      await cp(sourcePath, targetPath, {
-        recursive: true,
-        force: true,
-      });
-      return targetPath;
-    });
+        await mkdir(dirname(targetPath), { recursive: true });
+        await cp(sourcePath, targetPath, {
+          recursive: true,
+          force: true,
+        });
+        return targetPath;
+      },
+    );
   },
   harness: async ({ evalWorkspaceDir }, use) => {
     ensureClaudeAuthConfigured();

--- a/evals/package.json
+++ b/evals/package.json
@@ -11,6 +11,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@libretto/dev-tools": "workspace:*",
     "libretto": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "benchmarks": "turbo run benchmarks --filter=libretto-benchmarks --",
     "google-login": "gcloud auth login --update-adc && gcloud auth configure-docker us-central1-docker.pkg.dev --quiet",
     "cli": "pnpm --filter libretto cli",
+    "create-tmp-workspace": "pnpm --filter @libretto/dev-tools create-tmp-workspace",
     "website:dev": "pnpm --dir ./apps/website dev"
   }
 }

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -6,11 +6,19 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "bin": {
-    "wt": "./dist/wt.js"
+    "wt": "./dist/wt.js",
+    "create-tmp-workspace": "./dist/create-tmp-workspace.js"
+  },
+  "exports": {
+    "./tmp-workspace": {
+      "types": "./dist/tmp-workspace.d.ts",
+      "import": "./dist/tmp-workspace.js"
+    }
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "type-check": "tsc --noEmit",
+    "create-tmp-workspace": "node dist/create-tmp-workspace.js",
     "sync:mirrors": "node scripts/sync-mirrors.mjs",
     "check:mirrors": "node scripts/check-mirrors-sync.mjs"
   },

--- a/packages/dev-tools/src/create-tmp-workspace.ts
+++ b/packages/dev-tools/src/create-tmp-workspace.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Creates a temporary workspace for testing the local libretto package.
+ *
+ * The workspace is a minimal git repo with:
+ * - package.json pointing to the local libretto package
+ * - libretto configured with google-vertex/gemini-2.5-flash for snapshots
+ * - Playwright browsers installed
+ *
+ * Usage:
+ *   pnpm create-tmp-workspace <name> [--dir <path>]
+ */
+
+import {
+  createTmpWorkspace,
+  type CreateTmpWorkspaceOptions,
+} from "./tmp-workspace.js";
+
+function printUsage(): void {
+  console.log(`Usage: create-tmp-workspace <name> [--dir <path>]
+
+Creates a temporary workspace for testing the local libretto package.
+
+Arguments:
+  name          Name for the workspace directory
+
+Options:
+  --dir <path>  Parent directory for the workspace (default: ./tmp)
+  --help, -h    Show this help message`);
+}
+
+function parseArgs(argv: string[]): CreateTmpWorkspaceOptions | null {
+  const args = argv.slice(2);
+  let name: string | undefined;
+  let parentDir: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else if (arg === "--dir") {
+      parentDir = args[++i];
+      if (!parentDir) {
+        console.error("Error: --dir requires a value");
+        return null;
+      }
+    } else if (!arg.startsWith("-")) {
+      name = arg;
+    } else {
+      console.error(`Error: unknown option ${arg}`);
+      return null;
+    }
+  }
+
+  if (!name) {
+    console.error("Error: workspace name is required\n");
+    printUsage();
+    return null;
+  }
+
+  return { name, parentDir };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv);
+  if (!options) {
+    process.exit(1);
+  }
+
+  try {
+    const workspaceDir = await createTmpWorkspace(options);
+    console.log(`\n✓ Workspace ready at: ${workspaceDir}`);
+    console.log(`  cd ${workspaceDir}`);
+    console.log(`  npx libretto open <url>`);
+  } catch (error) {
+    console.error(
+      `\nFailed to create workspace: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/dev-tools/src/tmp-workspace.ts
+++ b/packages/dev-tools/src/tmp-workspace.ts
@@ -21,6 +21,10 @@ export type CreateTmpWorkspaceOptions = {
   extraPackages?: string[];
   /** Suppress stdout from sub-commands (default: false). */
   quiet?: boolean;
+  /** Skip building libretto before installing (default: false).
+   *  Use when the caller knows libretto is already built, e.g. in
+   *  parallel eval/benchmark runs where a prior step handles the build. */
+  skipBuild?: boolean;
 };
 
 function findRepoRoot(): string {
@@ -98,8 +102,10 @@ export async function createTmpWorkspace(
   log(`Creating workspace: ${workspaceDir}`);
 
   // Build libretto so the workspace gets the latest CLI
-  log("  Building libretto...");
-  run(librettoPackageRoot, "pnpm", ["build"], quiet);
+  if (!options.skipBuild) {
+    log("  Building libretto...");
+    run(librettoPackageRoot, "pnpm", ["build"], quiet);
+  }
 
   // git init
   log("  Initializing git repo...");

--- a/packages/dev-tools/src/tmp-workspace.ts
+++ b/packages/dev-tools/src/tmp-workspace.ts
@@ -1,0 +1,192 @@
+/**
+ * Utility for creating temporary workspaces that test the local libretto package.
+ *
+ * Shared by the CLI entrypoint, evals, and benchmarks.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export type CreateTmpWorkspaceOptions = {
+  /** Name for the workspace directory. */
+  name: string;
+  /** Parent directory (default: <repoRoot>/tmp). */
+  parentDir?: string;
+  /** Snapshot model (default: vertex/gemini-2.5-flash). */
+  snapshotModel?: string;
+  /** Skip Playwright browser installation (default: false). */
+  skipBrowsers?: boolean;
+  /** Additional npm packages to install. */
+  extraPackages?: string[];
+  /** Suppress stdout from sub-commands (default: false). */
+  quiet?: boolean;
+};
+
+function findRepoRoot(): string {
+  const result = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf-8",
+  });
+  return result.trim();
+}
+
+function run(
+  cwd: string,
+  command: string,
+  args: string[],
+  quiet: boolean,
+): void {
+  execFileSync(command, args, {
+    cwd,
+    env: process.env,
+    stdio: quiet ? ["ignore", "pipe", "pipe"] : ["ignore", "inherit", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+function resolveProviderPackage(model: string): string | null {
+  const provider = model.split("/", 1)[0]?.toLowerCase();
+  switch (provider) {
+    case "anthropic":
+      return "@ai-sdk/anthropic";
+    case "google":
+    case "gemini":
+      return "@ai-sdk/google";
+    case "vertex":
+      return "@ai-sdk/google-vertex";
+    case "openai":
+    case "codex":
+      return "@ai-sdk/openai";
+    default:
+      return null;
+  }
+}
+
+function resolveProviderInstallSpec(
+  model: string,
+  librettoPackageRoot: string,
+): string | null {
+  const packageName = resolveProviderPackage(model);
+  if (!packageName) return null;
+
+  const manifestPath = join(librettoPackageRoot, "package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const version = manifest.peerDependencies?.[packageName];
+  return version ? `${packageName}@${version}` : packageName;
+}
+
+export async function createTmpWorkspace(
+  options: CreateTmpWorkspaceOptions,
+): Promise<string> {
+  const repoRoot = findRepoRoot();
+  const librettoPackageRoot = resolve(repoRoot, "packages", "libretto");
+  const snapshotModel = options.snapshotModel ?? "vertex/gemini-2.5-flash";
+  const quiet = options.quiet ?? false;
+  const parentDir = options.parentDir
+    ? resolve(options.parentDir)
+    : resolve(repoRoot, "tmp");
+  const workspaceDir = resolve(parentDir, options.name);
+
+  if (existsSync(workspaceDir)) {
+    throw new Error(`Workspace already exists: ${workspaceDir}`);
+  }
+
+  mkdirSync(workspaceDir, { recursive: true });
+
+  const log = quiet ? () => {} : (msg: string) => console.log(msg);
+
+  log(`Creating workspace: ${workspaceDir}`);
+
+  // Build libretto so the workspace gets the latest CLI
+  log("  Building libretto...");
+  run(librettoPackageRoot, "pnpm", ["build"], quiet);
+
+  // git init
+  log("  Initializing git repo...");
+  run(workspaceDir, "git", ["init", "-q"], quiet);
+
+  // .gitignore
+  writeFileSync(
+    join(workspaceDir, ".gitignore"),
+    [
+      "node_modules/",
+      ".env",
+      ".libretto/sessions/",
+      ".libretto/profiles/",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  // package.json
+  log("  Writing package.json...");
+  writeFileSync(
+    join(workspaceDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `libretto-workspace-${options.name}`,
+        private: true,
+        type: "module",
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+
+  // Install local libretto + provider package
+  const providerSpec = resolveProviderInstallSpec(
+    snapshotModel,
+    librettoPackageRoot,
+  );
+  const installArgs = [
+    "add",
+    "--lockfile=false",
+    `file:${librettoPackageRoot}`,
+    ...(providerSpec ? [providerSpec] : []),
+    ...(options.extraPackages ?? []),
+  ];
+  log(`  Installing packages: pnpm ${installArgs.join(" ")}`);
+  run(workspaceDir, "pnpm", installArgs, quiet);
+
+  // Create .agents/ and .claude/ so `libretto setup` copies skills into them
+  mkdirSync(join(workspaceDir, ".agents"), { recursive: true });
+  mkdirSync(join(workspaceDir, ".claude"), { recursive: true });
+
+  // Run libretto setup (creates .libretto/ dirs, .gitignore, copies skills, installs browsers)
+  const setupArgs = ["libretto", "setup"];
+  if (options.skipBrowsers) {
+    setupArgs.push("--skip-browsers");
+  }
+  log(`  Running npx ${setupArgs.join(" ")}...`);
+  run(workspaceDir, "npx", setupArgs, quiet);
+
+  // Configure snapshot model
+  log(`  Configuring snapshot model: ${snapshotModel}`);
+  run(
+    workspaceDir,
+    "npx",
+    ["libretto", "ai", "configure", snapshotModel],
+    quiet,
+  );
+
+  // Write .env with GCP project if available
+  const projectId =
+    process.env.GOOGLE_CLOUD_PROJECT?.trim() ||
+    process.env.GCLOUD_PROJECT?.trim();
+  if (projectId) {
+    log(`  Writing .env with GOOGLE_CLOUD_PROJECT=${projectId}`);
+    writeFileSync(
+      join(workspaceDir, ".env"),
+      [
+        "# Workspace runtime configuration",
+        `GOOGLE_CLOUD_PROJECT=${projectId}`,
+        `GCLOUD_PROJECT=${projectId}`,
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+  }
+
+  return workspaceDir;
+}

--- a/packages/dev-tools/tsup.config.ts
+++ b/packages/dev-tools/tsup.config.ts
@@ -1,26 +1,29 @@
 import { defineConfig } from "tsup";
 import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 
-function ensureShebang(): void {
-  const entryPath = "dist/wt.js";
-  const content = readFileSync(entryPath, "utf-8");
+const CLI_ENTRIES = ["dist/wt.js", "dist/create-tmp-workspace.js"];
 
-  if (!content.startsWith("#!/")) {
-    writeFileSync(entryPath, `#!/usr/bin/env node\n${content}`);
+function ensureShebangs(): void {
+  for (const entryPath of CLI_ENTRIES) {
+    const content = readFileSync(entryPath, "utf-8");
+
+    if (!content.startsWith("#!/")) {
+      writeFileSync(entryPath, `#!/usr/bin/env node\n${content}`);
+    }
+
+    chmodSync(entryPath, 0o755);
   }
-
-  chmodSync(entryPath, 0o755);
 }
 
 export default defineConfig({
-  entry: ["src/wt.ts"],
+  entry: ["src/wt.ts", "src/create-tmp-workspace.ts", "src/tmp-workspace.ts"],
   format: ["esm"],
-  dts: false,
+  dts: true,
   bundle: false,
   minify: false,
   clean: true,
   outDir: "dist",
   onSuccess: async () => {
-    ensureShebang();
+    ensureShebangs();
   },
 });

--- a/packages/libretto/src/cli/core/ai-model.ts
+++ b/packages/libretto/src/cli/core/ai-model.ts
@@ -14,7 +14,7 @@ export const DEFAULT_SNAPSHOT_MODELS = {
   openai: "openai/gpt-5.4",
   anthropic: "anthropic/claude-sonnet-4-6",
   google: "google/gemini-3-flash-preview",
-  vertex: "vertex/gemini-2.5-pro",
+  vertex: "vertex/gemini-2.5-flash",
 } as const satisfies Record<Provider, string>;
 
 // ── Source detection ────────────────────────────────────────────────────────

--- a/packages/libretto/test/snapshot-api-config.spec.ts
+++ b/packages/libretto/test/snapshot-api-config.spec.ts
@@ -99,7 +99,7 @@ describe("snapshot API model resolution", () => {
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "test-project");
 
     expect(resolveSnapshotApiModel(null)).toMatchObject({
-      model: "vertex/gemini-2.5-pro",
+      model: "vertex/gemini-2.5-flash",
       provider: "vertex",
       source: "env:GOOGLE_CLOUD_PROJECT",
     });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -85,7 +85,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(configure.stdout).toContain("AI config saved.");
 
     const show = await librettoCli("ai configure");
-    expect(show.stdout).toContain("Model: vertex/gemini-2.5-pro");
+    expect(show.stdout).toContain("Model: vertex/gemini-2.5-flash");
   });
 
   test("configures custom model string", async ({ librettoCli }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@libretto/dev-tools':
+        specifier: workspace:*
+        version: link:../packages/dev-tools
       libretto:
         specifier: workspace:*
         version: link:../packages/libretto
@@ -143,6 +146,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@libretto/dev-tools':
+        specifier: workspace:*
+        version: link:../packages/dev-tools
       libretto:
         specifier: workspace:*
         version: link:../packages/libretto


### PR DESCRIPTION
## Summary

Extracts the duplicated workspace-creation logic (used by benchmarks, evals, and ad-hoc testing) into a shared `createTmpWorkspace()` utility in `@libretto/dev-tools`.

### Changes

- **New `packages/dev-tools/src/tmp-workspace.ts`** — shared `createTmpWorkspace(options)` function that handles git init, package.json, pnpm install of local libretto + provider, `libretto setup`, and `libretto ai configure`
- **New `packages/dev-tools/src/create-tmp-workspace.ts`** — CLI entrypoint (`pnpm create-tmp-workspace <name> [--dir <path>]`)
- **`benchmarks/webVoyager/runner.ts`** — refactored `prepareRunWorkspace` to use the shared utility instead of inline workspace setup
- **`evals/fixtures.ts`** — refactored `evalWorkspaceDir` fixture to use the shared utility instead of manual symlinks and package.json creation
- **`packages/dev-tools/tsup.config.ts`** — added new entry points, enabled `.d.ts` generation, generalized shebang logic
- **`packages/libretto/src/cli/core/ai-model.ts`** — changed default vertex model from `gemini-2.5-pro` to `gemini-2.5-flash`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
