### PR TITLE
Fix docs navigation and shared dev-tools utility

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -89,10 +89,7 @@ function Navbar() {
               <span className="text-sm font-medium">{formatStars(stars)}</span>
             )}
           </a>
-          <Button
-            href="/docs/"
-            size="sm"
-          >
+          <Button href="/docs/get-started/introduction" size="sm">
             Go to docs
           </Button>
         </div>
@@ -157,11 +154,7 @@ function Hero() {
           style={{ opacity: 0 }}
           className="mb-16 flex items-center justify-center gap-6"
         >
-          <Button
-            href="/docs/"
-          >
-            Go to docs
-          </Button>
+          <Button href="/docs/get-started/introduction">Go to docs</Button>
         </div>
         <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
           <TerminalDemo />

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,6 +9,11 @@
     "dark": "#1e1d1a"
   },
   "favicon": "/favicon.svg",
+  "logo": {
+    "light": "/favicon.svg",
+    "dark": "/favicon.svg",
+    "href": "https://libretto.sh"
+  },
   "fonts": {
     "heading": {
       "family": "PP Editorial New",


### PR DESCRIPTION
## Summary

### Docs navigation fixes
- Add `logo` config to `docs.json` so the top-left logo in Mintlify docs links back to `https://libretto.sh`
- Fix "Go to docs" buttons on the homepage (`HomePage.tsx`) — changed href from `/docs/` (404) to `/docs/get-started/introduction`

### Shared `createTmpWorkspace` utility (#173)
- New `packages/dev-tools` utility for creating temporary workspaces in tests, benchmarks, and evals
- Refactored `benchmarks/`, `evals/`, and test files to use the shared utility

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
