### PR TITLE
Move pnpm config from .npmrc to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-enable-pre-post-scripts=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
   - "packages/*"
 
 minimumReleaseAge: 10080
+
+enablePrePostScripts: false


### PR DESCRIPTION
## Summary

Move `enable-pre-post-scripts=false` from `.npmrc` to `pnpm-workspace.yaml` (`enablePrePostScripts: false`).

npm warns on unknown config keys in `.npmrc`, causing noise whenever `npx` is used:
```
npm warn Unknown project config "enable-pre-post-scripts"
```

Since this is a pnpm-only setting and we're on pnpm v10 (which reads settings from `pnpm-workspace.yaml`), moving it there eliminates the warning while preserving the behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
