### PR TITLE
feat: readonly-exec docs, sessionMode config, --write-access flag

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Libretto stores read-only vs write-access on the session itself.
 - The primary inspection tools are `snapshot` and `readonly-exec`.
 - `readonly-exec` reuses Libretto's normal execution pipeline, but it only exposes read-only helpers and denies mutating Playwright methods.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
 
 ## Working Rules
 
@@ -60,14 +61,29 @@ npx libretto snapshot \
 ### `readonly-exec`
 
 - Use `readonly-exec` for narrow inspection code only.
-- Available helpers: `page`, `state`, `snapshot`, `get`.
-- Allowed browser reads are limited to page URL/title/HTML, locator text reads, locator count, visibility checks, snapshots, and GET requests.
 - Denied operations fail with `ReadonlyExecDenied: ...`.
+
+#### Helpers
+
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `state` — the current Libretto session state object.
+- `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
+- `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
+
+Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` are also available.
+
+#### Examples
 
 ```bash
 npx libretto readonly-exec "return page.url()" --session failed-job-debug
 npx libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
-echo "return await snapshot()" | npx libretto readonly-exec - --session failed-job-debug
+
+# HTTP GET inspection
+echo "const r = await get('https://api.example.com/status'); return await r.json()" \
+  | npx libretto readonly-exec - --session failed-job-debug
+
+# Scroll down to inspect below-the-fold content
+npx libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 ```
 
 ### `close`

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -38,7 +38,6 @@ metadata:
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
-- Use `session-mode` to inspect or change a session between `write-access` and `read-only`.
 
 ## Commands
 
@@ -60,7 +59,6 @@ npx libretto open https://example.com --headless --session debug-example
 - Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
 - After connecting, `exec`, `snapshot`, `pages`, and the rest of the session commands follow that session's stored mode.
 - Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
-- Session mode is enforced only through Libretto. A separate tool that connects directly to the raw CDP endpoint bypasses it.
 - Pass `--read-only` if the connected session must stay inspection-only from the start.
 
 ```bash
@@ -71,8 +69,10 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ### `session-mode`
 
-- Use `session-mode` to inspect or update whether an existing session is `write-access` or `read-only`.
-- `open`, `run`, and `connect` default new sessions to `write-access`.
+- Use `session-mode` to inspect whether an existing session is `write-access` or `read-only`.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
+- `open`, `run`, and `connect` default new sessions to `write-access` unless the config sets `sessionMode` to `read-only`.
+- Pass `--read-only` or `--write-access` to override the config default for a single command.
 
 ```bash
 npx libretto session-mode --session my-session

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -76,8 +76,6 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ```bash
 npx libretto session-mode --session my-session
-npx libretto session-mode read-only --session my-session
-npx libretto session-mode write-access --session my-session
 ```
 
 ### `snapshot`

--- a/.agents/skills/libretto/references/configuration-file-reference.md
+++ b/.agents/skills/libretto/references/configuration-file-reference.md
@@ -22,6 +22,7 @@ Libretto reads workspace config from `.libretto/config.json`.
 - `ai.model` selects the configured analysis model for `snapshot`.
 - `viewport` is an optional top-level setting used by `open` and `run` when you do not pass `--viewport`.
 - Viewport precedence is: CLI `--viewport`, then `.libretto/config.json`, then the default `1366x768`.
+- `sessionMode` sets the default session access mode for new sessions created by `open`, `connect`, and `run`. Must be `"read-only"` or `"write-access"`. When omitted, defaults to `"write-access"`. Pass `--read-only` or `--write-access` to `open`, `connect`, or `run` to override when creating a session.
 
 Example:
 
@@ -35,7 +36,8 @@ Example:
   "viewport": {
     "width": 1280,
     "height": 800
-  }
+  },
+  "sessionMode": "write-access"
 }
 ```
 

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Libretto stores read-only vs write-access on the session itself.
 - The primary inspection tools are `snapshot` and `readonly-exec`.
 - `readonly-exec` reuses Libretto's normal execution pipeline, but it only exposes read-only helpers and denies mutating Playwright methods.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
 
 ## Working Rules
 
@@ -60,14 +61,29 @@ npx libretto snapshot \
 ### `readonly-exec`
 
 - Use `readonly-exec` for narrow inspection code only.
-- Available helpers: `page`, `state`, `snapshot`, `get`.
-- Allowed browser reads are limited to page URL/title/HTML, locator text reads, locator count, visibility checks, snapshots, and GET requests.
 - Denied operations fail with `ReadonlyExecDenied: ...`.
+
+#### Helpers
+
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `state` — the current Libretto session state object.
+- `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
+- `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
+
+Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` are also available.
+
+#### Examples
 
 ```bash
 npx libretto readonly-exec "return page.url()" --session failed-job-debug
 npx libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
-echo "return await snapshot()" | npx libretto readonly-exec - --session failed-job-debug
+
+# HTTP GET inspection
+echo "const r = await get('https://api.example.com/status'); return await r.json()" \
+  | npx libretto readonly-exec - --session failed-job-debug
+
+# Scroll down to inspect below-the-fold content
+npx libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 ```
 
 ### `close`

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -38,7 +38,6 @@ metadata:
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
-- Use `session-mode` to inspect or change a session between `write-access` and `read-only`.
 
 ## Commands
 
@@ -60,7 +59,6 @@ npx libretto open https://example.com --headless --session debug-example
 - Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
 - After connecting, `exec`, `snapshot`, `pages`, and the rest of the session commands follow that session's stored mode.
 - Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
-- Session mode is enforced only through Libretto. A separate tool that connects directly to the raw CDP endpoint bypasses it.
 - Pass `--read-only` if the connected session must stay inspection-only from the start.
 
 ```bash
@@ -71,8 +69,10 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ### `session-mode`
 
-- Use `session-mode` to inspect or update whether an existing session is `write-access` or `read-only`.
-- `open`, `run`, and `connect` default new sessions to `write-access`.
+- Use `session-mode` to inspect whether an existing session is `write-access` or `read-only`.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
+- `open`, `run`, and `connect` default new sessions to `write-access` unless the config sets `sessionMode` to `read-only`.
+- Pass `--read-only` or `--write-access` to override the config default for a single command.
 
 ```bash
 npx libretto session-mode --session my-session

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -76,8 +76,6 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ```bash
 npx libretto session-mode --session my-session
-npx libretto session-mode read-only --session my-session
-npx libretto session-mode write-access --session my-session
 ```
 
 ### `snapshot`

--- a/.claude/skills/libretto/references/configuration-file-reference.md
+++ b/.claude/skills/libretto/references/configuration-file-reference.md
@@ -22,6 +22,7 @@ Libretto reads workspace config from `.libretto/config.json`.
 - `ai.model` selects the configured analysis model for `snapshot`.
 - `viewport` is an optional top-level setting used by `open` and `run` when you do not pass `--viewport`.
 - Viewport precedence is: CLI `--viewport`, then `.libretto/config.json`, then the default `1366x768`.
+- `sessionMode` sets the default session access mode for new sessions created by `open`, `connect`, and `run`. Must be `"read-only"` or `"write-access"`. When omitted, defaults to `"write-access"`. Pass `--read-only` or `--write-access` to `open`, `connect`, or `run` to override when creating a session.
 
 Example:
 
@@ -35,7 +36,8 @@ Example:
   "viewport": {
     "width": 1280,
     "height": 800
-  }
+  },
+  "sessionMode": "write-access"
 }
 ```
 

--- a/docs/cli-reference/sessions.mdx
+++ b/docs/cli-reference/sessions.mdx
@@ -88,6 +88,17 @@ npx libretto connect ws://localhost:9222 --read-only --session remote-diag
 npx libretto run ./workflow.ts main --read-only --session test-run
 ```
 
+You can also manually set `sessionMode` in `.libretto/config.json` to change the default for all new sessions:
+
+```json theme={null}
+{
+  "version": 1,
+  "sessionMode": "read-only"
+}
+```
+
+Pass `--write-access` to `open`, `connect`, or `run` to override a `read-only` config default when creating a session.
+
 #### Changing session mode
 
 View or change the mode of an existing session with `session-mode`:
@@ -122,7 +133,8 @@ A restricted version of `exec` that only allows read operations on the page. Ava
 - **Locator factories**: `locator()`, `getByRole()`, `getByText()`, `getByLabel()`, `getByPlaceholder()`, `getByAltText()`, `getByTitle()`, `getByTestId()`
 - **Locator reads**: `textContent()`, `innerText()`, `boundingBox()`, `count()`, `getAttribute()`, `inputValue()`, `isVisible()`, `isHidden()`, `isEnabled()`, `isChecked()`
 - **Network**: `get(url)` (GET/HEAD only, no request bodies)
-- **Helpers**: `snapshot()`, `scrollBy()`, `console`, `state`
+- **Viewport**: `scrollBy(deltaX, deltaY)` for scrolling by pixel offset
+- **Other**: `state`, `console`, `URL`, `Buffer`
 
 Any mutating operation (click, fill, goto, reload, etc.) throws a `ReadonlyExecDenied` error.
 

--- a/docs/get-started/configuration.mdx
+++ b/docs/get-started/configuration.mdx
@@ -46,7 +46,8 @@ The config file is at `.libretto/config.json`. You can edit it directly or use t
     "model": "openai/gpt-5.4",
     "updatedAt": "2026-01-01T00:00:00.000Z"
   },
-  "viewport": { "width": 1280, "height": 800 }
+  "viewport": { "width": 1280, "height": 800 },
+  "sessionMode": "write-access"
 }
 ```
 
@@ -59,9 +60,13 @@ The config file is at `.libretto/config.json`. You can edit it directly or use t
 </ParamField>
 
 <ParamField path="viewport" type="object">
-  Optional. Default browser window size (width and height in pixels) used by `open` and `run` when you don't pass `--viewport`. Defaults to `1366x768` if not set.
+  Optional, manually set. Default browser window size (width and height in pixels) used by `open` and `run` when you don't pass `--viewport`. Defaults to `1366x768` if not set.
+</ParamField>
+
+<ParamField path="sessionMode" type="string">
+  Optional, manually set. Default access mode for new sessions created by `open`, `connect`, and `run`. Must be `"read-only"` or `"write-access"`. Defaults to `"write-access"` when omitted. Pass `--read-only` or `--write-access` to `open`, `connect`, or `run` to override when creating a session.
 </ParamField>
 
 <ParamField path="windowPosition" type="object">
-  Optional. Sets the initial position of the headed browser window on screen. Has no effect in headless mode.
+  Optional, manually set. Sets the initial position of the headed browser window on screen. Has no effect in headless mode.
 </ParamField>

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -3,9 +3,9 @@ title: Introduction
 sidebarTitle: Introduction
 ---
 
-> Libretto is the AI toolkit for building and maintaining browser automations.
+> Libretto is a CLI and skill for your coding agent to build and maintain browser automations.
 
-At [Saffron Health](https://saffron.health), we integrate with dozens of healthcare EHRs and payor portals that don't have APIs. That means browser automation: logging into legacy web apps, navigating complex UIs, and extracting data from pages that were never designed for programmatic access. We built Libretto to make that work reliable and maintainable.
+For our prior startup [Saffron Health](https://saffron.health), we spent a lot of time integrating with healthcare EHRs and payor portals that don't have APIs. Building and maintaining those browser automations was painfully slow and ate up engineering time we didn't have. So, we built Libretto to make it easy to create new integrations and quickly fix errors when they pop up.
 
 Libretto gives your coding agent a live browser and a token-efficient CLI to inspect pages, capture network traffic, record user actions, and debug workflows, all without flooding the agent's context window with raw HTML. It's open-source so other teams dealing with similar problems can use it too.
 
@@ -55,9 +55,13 @@ npx libretto run ./integration.ts main
     Configure your AI provider, viewport, and session defaults.
   </Card>
 
-  <Card title="How workflow generation works" icon="sparkles" href="./how-workflow-generation-works">
-    Understand the four-phase flow your agent follows to build automations.
-  </Card>
+<Card
+  title="How workflow generation works"
+  icon="sparkles"
+  href="./how-workflow-generation-works"
+>
+  Understand the four-phase flow your agent follows to build automations.
+</Card>
 
   <Card title="Workflow guides" icon="diagram-project" href="../workflow-guides/one-shot-workflow-generation">
     Build your first automation with step-by-step guides.

--- a/docs/workflow-guides/convert-to-network-requests.mdx
+++ b/docs/workflow-guides/convert-to-network-requests.mdx
@@ -98,11 +98,11 @@ In these cases, stick with your existing Playwright automation or use passive in
 ### Related guides
 
 <CardGroup cols={2}>
-  <Card title="One-shot workflow generation" href="./one-shot-workflow-generation">
+  <Card title="One-shot workflow generation" icon="bolt" href="./one-shot-workflow-generation">
     Start from scratch. Give your agent a goal and let it build the workflow.
   </Card>
 
-  <Card title="Debugging workflows" href="./debugging-workflows">
+  <Card title="Debugging workflows" icon="bug" href="./debugging-workflows">
     Reproduce failures and fix broken automations interactively.
   </Card>
 </CardGroup>

--- a/docs/workflow-guides/debugging-workflows.mdx
+++ b/docs/workflow-guides/debugging-workflows.mdx
@@ -139,11 +139,11 @@ The workflow halts at the `pause()` with the browser open. Inspect the page, the
 ### Related guides
 
 <CardGroup cols={2}>
-  <Card title="One-shot workflow generation" href="./one-shot-workflow-generation">
+  <Card title="One-shot workflow generation" icon="bolt" href="./one-shot-workflow-generation">
     Build a new automation from scratch without any prior knowledge of the site.
   </Card>
 
-  <Card title="Interactive workflow building" href="./interactive-workflow-building">
+  <Card title="Interactive workflow building" icon="hand-pointer" href="./interactive-workflow-building">
     Show the workflow manually and let your agent turn it into reusable code.
   </Card>
 </CardGroup>

--- a/docs/workflow-guides/interactive-workflow-building.mdx
+++ b/docs/workflow-guides/interactive-workflow-building.mdx
@@ -103,11 +103,11 @@ This approach combines your knowledge of the application (you drive the browser 
 ### Related guides
 
 <CardGroup cols={2}>
-  <Card title="One-shot workflow generation" href="./one-shot-workflow-generation">
+  <Card title="One-shot workflow generation" icon="bolt" href="./one-shot-workflow-generation">
     Let the agent explore a site and build the workflow without your involvement.
   </Card>
 
-  <Card title="Debugging workflows" href="./debugging-workflows">
+  <Card title="Debugging workflows" icon="bug" href="./debugging-workflows">
     Reproduce failures, inspect live page state, and fix broken automations.
   </Card>
 </CardGroup>

--- a/docs/workflow-guides/one-shot-workflow-generation.mdx
+++ b/docs/workflow-guides/one-shot-workflow-generation.mdx
@@ -127,11 +127,11 @@ One-shot generation is the fastest way to go from an idea to a working automatio
 ### Related guides
 
 <CardGroup cols={2}>
-  <Card title="Interactive workflow building" href="./interactive-workflow-building">
+  <Card title="Interactive workflow building" icon="hand-pointer" href="./interactive-workflow-building">
     Show the agent your workflow manually and let it turn your actions into code.
   </Card>
 
-  <Card title="Convert to network requests" href="./convert-to-network-requests">
+  <Card title="Convert to network requests" icon="network-wired" href="./convert-to-network-requests">
     Speed up an existing browser script by switching to direct API calls.
   </Card>
 </CardGroup>

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Libretto stores read-only vs write-access on the session itself.
 - The primary inspection tools are `snapshot` and `readonly-exec`.
 - `readonly-exec` reuses Libretto's normal execution pipeline, but it only exposes read-only helpers and denies mutating Playwright methods.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
 
 ## Working Rules
 
@@ -60,14 +61,29 @@ npx libretto snapshot \
 ### `readonly-exec`
 
 - Use `readonly-exec` for narrow inspection code only.
-- Available helpers: `page`, `state`, `snapshot`, `get`.
-- Allowed browser reads are limited to page URL/title/HTML, locator text reads, locator count, visibility checks, snapshots, and GET requests.
 - Denied operations fail with `ReadonlyExecDenied: ...`.
+
+#### Helpers
+
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `state` — the current Libretto session state object.
+- `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
+- `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
+
+Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` are also available.
+
+#### Examples
 
 ```bash
 npx libretto readonly-exec "return page.url()" --session failed-job-debug
 npx libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
-echo "return await snapshot()" | npx libretto readonly-exec - --session failed-job-debug
+
+# HTTP GET inspection
+echo "const r = await get('https://api.example.com/status'); return await r.json()" \
+  | npx libretto readonly-exec - --session failed-job-debug
+
+# Scroll down to inspect below-the-fold content
+npx libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 ```
 
 ### `close`

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -38,7 +38,6 @@ metadata:
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
-- Use `session-mode` to inspect or change a session between `write-access` and `read-only`.
 
 ## Commands
 
@@ -60,7 +59,6 @@ npx libretto open https://example.com --headless --session debug-example
 - Use `connect` to attach to any existing Chrome DevTools Protocol (CDP) endpoint — a browser started with `--remote-debugging-port`, an Electron app, or any other CDP-compatible target.
 - After connecting, `exec`, `snapshot`, `pages`, and the rest of the session commands follow that session's stored mode.
 - Libretto does not manage the connected process's lifecycle. `close` clears the session but does not terminate the remote process.
-- Session mode is enforced only through Libretto. A separate tool that connects directly to the raw CDP endpoint bypasses it.
 - Pass `--read-only` if the connected session must stay inspection-only from the start.
 
 ```bash
@@ -71,8 +69,10 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ### `session-mode`
 
-- Use `session-mode` to inspect or update whether an existing session is `write-access` or `read-only`.
-- `open`, `run`, and `connect` default new sessions to `write-access`.
+- Use `session-mode` to inspect whether an existing session is `write-access` or `read-only`.
+- Only a user can change the session mode for an existing session. Never change a session's mode on your own — the user must change it themselves manually.
+- `open`, `run`, and `connect` default new sessions to `write-access` unless the config sets `sessionMode` to `read-only`.
+- Pass `--read-only` or `--write-access` to override the config default for a single command.
 
 ```bash
 npx libretto session-mode --session my-session

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -76,8 +76,6 @@ npx libretto connect http://127.0.0.1:9223 --session another-session
 
 ```bash
 npx libretto session-mode --session my-session
-npx libretto session-mode read-only --session my-session
-npx libretto session-mode write-access --session my-session
 ```
 
 ### `snapshot`

--- a/packages/libretto/skills/libretto/references/configuration-file-reference.md
+++ b/packages/libretto/skills/libretto/references/configuration-file-reference.md
@@ -22,6 +22,7 @@ Libretto reads workspace config from `.libretto/config.json`.
 - `ai.model` selects the configured analysis model for `snapshot`.
 - `viewport` is an optional top-level setting used by `open` and `run` when you do not pass `--viewport`.
 - Viewport precedence is: CLI `--viewport`, then `.libretto/config.json`, then the default `1366x768`.
+- `sessionMode` sets the default session access mode for new sessions created by `open`, `connect`, and `run`. Must be `"read-only"` or `"write-access"`. When omitted, defaults to `"write-access"`. Pass `--read-only` or `--write-access` to `open`, `connect`, or `run` to override when creating a session.
 
 Example:
 
@@ -35,7 +36,8 @@ Example:
   "viewport": {
     "width": 1280,
     "height": 800
-  }
+  },
+  "sessionMode": "write-access"
 }
 ```
 

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -8,6 +8,7 @@ import {
   runPages,
   runSave,
 } from "../core/browser.js";
+import { readLibrettoConfig } from "../core/config.js";
 import { createLoggerForSession, withSessionLogger } from "../core/context.js";
 import {
   type SessionAccessMode,
@@ -46,8 +47,11 @@ export function parseViewportArg(
   return { width, height };
 }
 
-function resolveRequestedSessionMode(readOnly: boolean | undefined): SessionAccessMode {
-  return readOnly ? "read-only" : "write-access";
+function resolveRequestedSessionMode(readOnly: boolean | undefined, writeAccess: boolean | undefined): SessionAccessMode {
+  if (readOnly) return "read-only";
+  if (writeAccess) return "write-access";
+  const config = readLibrettoConfig();
+  return config.sessionMode ?? "write-access";
 }
 
 export const openInput = SimpleCLI.input({
@@ -64,6 +68,10 @@ export const openInput = SimpleCLI.input({
       name: "read-only",
       help: "Create the session in read-only mode",
     }),
+    writeAccess: SimpleCLI.flag({
+      name: "write-access",
+      help: "Create the session in write-access mode (overrides config default)",
+    }),
     viewport: SimpleCLI.option(z.string().optional(), {
       help: "Viewport size as WIDTHxHEIGHT (e.g. 1920x1080)",
     }),
@@ -71,11 +79,15 @@ export const openInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.url),
-    `Usage: libretto open <url> [--headless] [--read-only] [--viewport WxH] [--session <name>]`,
+    `Usage: libretto open <url> [--headless] [--read-only|--write-access] [--viewport WxH] [--session <name>]`,
   )
   .refine(
     (input) => !(input.headed && input.headless),
     "Cannot pass both --headed and --headless.",
+  )
+  .refine(
+    (input) => !(input.readOnly && input.writeAccess),
+    "Cannot pass both --read-only and --write-access.",
   );
 
 export const openCommand = SimpleCLI.command({
@@ -90,7 +102,7 @@ export const openCommand = SimpleCLI.command({
     const viewport = parseViewportArg(input.viewport);
     await runOpen(input.url!, headed, ctx.session, ctx.logger, {
       viewport,
-      accessMode: resolveRequestedSessionMode(input.readOnly),
+      accessMode: resolveRequestedSessionMode(input.readOnly, input.writeAccess),
     });
   });
 
@@ -106,11 +118,20 @@ export const connectInput = SimpleCLI.input({
       name: "read-only",
       help: "Create the session in read-only mode",
     }),
+    writeAccess: SimpleCLI.flag({
+      name: "write-access",
+      help: "Create the session in write-access mode (overrides config default)",
+    }),
   },
-}).refine(
-  (input) => Boolean(input.cdpUrl),
-  `Usage: libretto connect <cdp-url> [--read-only] --session <name>`,
-);
+})
+  .refine(
+    (input) => Boolean(input.cdpUrl),
+    `Usage: libretto connect <cdp-url> [--read-only|--write-access] --session <name>`,
+  )
+  .refine(
+    (input) => !(input.readOnly && input.writeAccess),
+    "Cannot pass both --read-only and --write-access.",
+  );
 
 export const connectCommand = SimpleCLI.command({
   description: "Connect to an existing Chrome DevTools Protocol (CDP) endpoint",
@@ -123,7 +144,7 @@ export const connectCommand = SimpleCLI.command({
       input.cdpUrl!,
       ctx.session,
       ctx.logger,
-      resolveRequestedSessionMode(input.readOnly),
+      resolveRequestedSessionMode(input.readOnly, input.writeAccess),
     );
   });
 

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -26,6 +26,7 @@ import {
   readNetworkLog,
   wrapPageForActionLogging,
 } from "../core/telemetry.js";
+import { readLibrettoConfig } from "../core/config.js";
 import { createReadonlyExecHelpers } from "../core/readonly-exec.js";
 import type { RunIntegrationWorkerRequest } from "../workers/run-integration-worker-protocol.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
@@ -761,7 +762,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only] [--no-visualize] [--viewport WxH]`;
+const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--viewport WxH]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [
@@ -787,6 +788,10 @@ export const runInput = SimpleCLI.input({
       name: "read-only",
       help: "Create the session in read-only mode",
     }),
+    writeAccess: SimpleCLI.flag({
+      name: "write-access",
+      help: "Create the session in write-access mode (overrides config default)",
+    }),
     noVisualize: SimpleCLI.flag({
       name: "no-visualize",
       help: "Disable ghost cursor + highlight visualization in headed mode",
@@ -811,6 +816,10 @@ export const runInput = SimpleCLI.input({
   .refine(
     (input) => !(input.headed && input.headless),
     "Cannot pass both --headed and --headless.",
+  )
+  .refine(
+    (input) => !(input.readOnly && input.writeAccess),
+    "Cannot pass both --read-only and --write-access.",
   );
 
 function resolveRunParams(
@@ -866,7 +875,7 @@ export const runCommand = SimpleCLI.command({
         visualize,
         authProfileDomain: input.authProfile,
         viewport,
-        accessMode: input.readOnly ? "read-only" : "write-access",
+        accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
       },
       ctx.logger,
     );

--- a/packages/libretto/src/cli/core/config.ts
+++ b/packages/libretto/src/cli/core/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { z } from "zod";
+import { SessionAccessModeSchema } from "../../shared/state/index.js";
 import { LIBRETTO_CONFIG_PATH } from "./context.js";
 
 export const CURRENT_CONFIG_VERSION = 1;
@@ -41,6 +42,7 @@ export const LibrettoConfigSchema = z
     ai: AiConfigSchema.optional(),
     viewport: ViewportConfigSchema.optional(),
     windowPosition: WindowPositionConfigSchema.optional(),
+    sessionMode: SessionAccessModeSchema.optional(),
   })
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;
@@ -67,6 +69,7 @@ function formatExpectedConfigExample(): string {
         x: 1600,
         y: 120,
       },
+      sessionMode: "write-access",
     },
     null,
     2,
@@ -81,7 +84,7 @@ function invalidConfigError(configPath: string, detail?: string): Error {
       "Expected config example:",
       formatExpectedConfigExample(),
       "Notes:",
-      '  - "ai", "viewport", and "windowPosition" are optional.',
+      '  - "ai", "viewport", "windowPosition", and "sessionMode" are optional.',
       '  - "ai.model" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".',
       "Fix the file to match this shape, or delete it and rerun:",
       `  npx libretto ai configure openai | anthropic | gemini | vertex`,

--- a/packages/libretto/src/cli/core/readonly-exec.ts
+++ b/packages/libretto/src/cli/core/readonly-exec.ts
@@ -1,5 +1,4 @@
 import type { Locator, Page } from "playwright";
-import { condenseDom } from "../../shared/condense-dom/condense-dom.js";
 
 const PAGE_READ_METHODS = new Set([
   "url",
@@ -69,16 +68,6 @@ const LOCATOR_ALLOWED_PROPERTIES = new Set<string>([]);
 
 type ReadonlyExecOptions = {
   onActivity?: () => void;
-};
-
-type ReadonlySnapshotPayload = {
-  screenshot: {
-    mimeType: "image/png";
-    bytesBase64: string;
-  };
-  currentUrl: string;
-  pageTitle: string;
-  pageHtml: string;
 };
 
 const readonlyPageCache = new WeakMap<Page, Page>();
@@ -240,28 +229,6 @@ function assertReadonlyRequestBodyAllowed(
   }
 }
 
-async function captureReadonlySnapshot(
-  page: Page,
-  options: ReadonlyExecOptions = {},
-): Promise<ReadonlySnapshotPayload> {
-  const [screenshotBytes, title, html] = await Promise.all([
-    page.screenshot({ type: "png" }),
-    page.title(),
-    page.content(),
-  ]);
-  markActivity(options.onActivity);
-
-  return {
-    screenshot: {
-      mimeType: "image/png",
-      bytesBase64: screenshotBytes.toString("base64"),
-    },
-    currentUrl: page.url(),
-    pageTitle: title,
-    pageHtml: condenseDom(html).html,
-  };
-}
-
 export function createReadonlyExecHelpers(
   page: Page,
   options: ReadonlyExecOptions = {},
@@ -272,7 +239,10 @@ export function createReadonlyExecHelpers(
   return {
     page: readonlyPage,
     state: execState,
-    snapshot: async () => await captureReadonlySnapshot(page, options),
+    // Playwright has no native viewport scroll method — only locator.scrollIntoViewIfNeeded().
+    // Arbitrary scrolling requires page.evaluate(), which is blocked by the readonly proxy
+    // since it can run arbitrary code. This helper calls evaluate on the raw (unwrapped) page,
+    // scoped to just window.scrollBy.
     scrollBy: async (deltaX: number, deltaY: number) => {
       await page.evaluate(
         ([x, y]) => {
@@ -296,6 +266,8 @@ export function createReadonlyExecHelpers(
         method,
       });
     },
+    // Shadows the global Node.js fetch to prevent unrestricted HTTP access.
+    // Without this, agent code would fall through to the global fetch (POST, PUT, DELETE, etc.).
     fetch: () => {
       throw new ReadonlyExecDeniedError(
         "fetch is blocked in readonly-exec; use get() instead",

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -362,7 +362,7 @@ describe("basic CLI subprocess behavior", () => {
   test("fails open with missing url usage error", async ({ librettoCli }) => {
     const result = await librettoCli("open");
     expect(result.stderr).toContain(
-      "Usage: libretto open <url> [--headless] [--read-only] [--viewport WxH] [--session <name>]",
+      "Usage: libretto open <url> [--headless] [--read-only|--write-access] [--viewport WxH] [--session <name>]",
     );
   });
 

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -576,45 +576,6 @@ describe("state-driven CLI subprocess behavior", () => {
     });
   }, 60_000);
 
-  test("readonly-exec snapshot returns diagnostic payload", async ({
-    librettoCli,
-    workspacePath,
-  }) => {
-    const session = "readonly-exec-snapshot";
-    const htmlPath = workspacePath("fixtures", "readonly-snapshot.html");
-    await mkdir(workspacePath("fixtures"), { recursive: true });
-    await writeFile(
-      htmlPath,
-      "<!doctype html><html><head><title>Snapshot Fixture</title></head><body><main><h1>Snapshot Heading</h1></main></body></html>",
-      "utf8",
-    );
-
-    const fileUrl = pathToFileURL(htmlPath).href;
-    await librettoCli(`open "${fileUrl}" --headless --session ${session}`);
-
-    const result = await librettoCli(
-      `readonly-exec - --session ${session}`,
-      undefined,
-      [
-        "const snap = await snapshot();",
-        "return {",
-        "  url: snap.currentUrl,",
-        "  title: snap.pageTitle,",
-        "  htmlContainsHeading: snap.pageHtml.includes('Snapshot Heading'),",
-        "  hasScreenshot: snap.screenshot.bytesBase64.length > 0,",
-        "};",
-      ].join("\n"),
-    );
-
-    expect(result.stderr).toBe("");
-    expect(parseJsonStdout<Record<string, unknown>>(result.stdout)).toEqual({
-      url: fileUrl,
-      title: "Snapshot Fixture",
-      htmlContainsHeading: true,
-      hasScreenshot: true,
-    });
-  }, 60_000);
-
   test("readonly-exec denies mutating Playwright APIs", async ({
     librettoCli,
     workspacePath,


### PR DESCRIPTION
## Summary
- Document `readonly-exec` helpers (`page` proxy, `get`, `scrollBy`, `state`) in both libretto and libretto-readonly skill files
- Remove `snapshot()` helper from `readonly-exec` sandbox — agents should use the standalone `snapshot` CLI command instead
- Add `sessionMode` config option to `.libretto/config.json` for setting default session access mode (`read-only` or `write-access`)
- Add `--write-access` CLI flag to `open`, `connect`, and `run` to override a `read-only` config default
- Update docs: sessions page, configuration page, introduction copy, workflow guide card icons
- Clarify in readonly skill that agents must never change session mode themselves

## Test plan
- [ ] Verify `readonly-exec` works without `snapshot()` helper
- [ ] Verify `sessionMode: "read-only"` in config makes new sessions default to read-only
- [ ] Verify `--write-access` flag overrides a read-only config default
- [ ] Verify `--read-only` and `--write-access` together is rejected
- [ ] Verify docs render correctly on Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
