### PR TITLE
Website and docs polish: terminal demo, styling, and config

### DIFF
--- a/apps/website/src/components/TerminalDemo.tsx
+++ b/apps/website/src/components/TerminalDemo.tsx
@@ -8,7 +8,7 @@ type Line =
   | { type: "agent"; text: string };
 
 const USER_MESSAGE =
-  "Use the Libretto skill. Open LinkedIn and send connection requests to the top 5 people who viewed my profile";
+  'Use the Libretto skill. Go on Craigslist and scrape the first 10 "free stuff" listings for title, location, and link.';
 
 function Cursor({ dark }: { dark?: boolean }) {
   return (
@@ -111,7 +111,7 @@ export function TerminalDemo() {
         ...prev,
         {
           type: "tool",
-          label: "bash: npx libretto open https://linkedin.com --headed",
+          label: "bash: npx libretto open https://craigslist.org --headed",
           done: false,
         },
       ]);
@@ -131,7 +131,7 @@ export function TerminalDemo() {
         {
           type: "tool",
           label:
-            'bash: npx libretto snapshot --objective "Find profile viewers"',
+            'bash: npx libretto snapshot --objective "Find free stuff listings"',
           done: false,
         },
       ]);
@@ -143,7 +143,7 @@ export function TerminalDemo() {
         ),
       );
 
-      // Tool: bash — exec click
+      // Tool: bash — exec click free stuff link
       await sleep(300);
       if (cancelled) return;
       setLines((prev) => [
@@ -162,7 +162,7 @@ export function TerminalDemo() {
         ),
       );
 
-      // Tool: bash — exec count
+      // Tool: bash — exec scrape listings
       await sleep(300);
       if (cancelled) return;
       setLines((prev) => [
@@ -170,7 +170,7 @@ export function TerminalDemo() {
         {
           type: "tool",
           label:
-            "bash: npx libretto exec \"return await page.locator('.profile-card').count()\"",
+            "bash: npx libretto exec \"return await page.locator('.cl-static-search-result').first().textContent()\"",
           done: false,
         },
       ]);
@@ -189,7 +189,7 @@ export function TerminalDemo() {
         ...prev,
         {
           type: "tool",
-          label: "write: linkedin_connections.ts",
+          label: "write: craigslist_free_stuff.ts",
           done: false,
         },
       ]);
@@ -205,7 +205,7 @@ export function TerminalDemo() {
       await sleep(400);
       if (cancelled) return;
       const agentText =
-        "Created linkedin_connections.ts — a workflow that opens LinkedIn, finds your profile viewers, and sends connection requests to the top 5.\n\nRun it anytime:\n  npx libretto run ./linkedin_connections.ts main --headless";
+        "Created craigslist_free_stuff.ts — a workflow that opens Craigslist, navigates to free stuff, and scrapes the first 10 listings for title, location, and link.\n\nRun it anytime:\n  npx libretto run ./craigslist_free_stuff.ts main --headless";
       setIsStreamingAgent(true);
       const words = agentText.split(/(?<=\s)/);
       let so_far = "";

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,7 +27,7 @@
     }
   },
   "appearance": {
-    "default": "light"
+    "default": "system"
   },
   "background": {
     "color": {
@@ -110,10 +110,7 @@
   },
   "navbar": {},
   "contextual": {
-    "options": [
-      "copy",
-      "view"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude"]
   },
   "footer": {}
 }

--- a/docs/global.css
+++ b/docs/global.css
@@ -41,7 +41,6 @@
 .mdx-content h4 {
   font-family: "PP Editorial New", "Newsreader", "Georgia", serif;
   font-weight: 400;
-  letter-spacing: -0.01em;
 }
 
 /* Sidebar group titles — plain sans, lighter */
@@ -90,6 +89,20 @@
   border-color: rgba(30, 29, 26, 0.2);
 }
 
+/* Inline code — match fenced code block background & border */
+.mdx-content :not(pre) > code {
+  background-color: #f0ede7;
+  border: 1px solid rgba(30, 29, 26, 0.1);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875em;
+}
+
+.dark .mdx-content :not(pre) > code {
+  background-color: rgba(245, 242, 236, 0.08);
+  border-color: rgba(245, 242, 236, 0.1);
+}
+
 /* Dark mode overrides */
 /* Dark mode overrides — Mintlify uses a .dark class on <html> */
 .dark #navbar {
@@ -100,4 +113,3 @@
 .dark #sidebar {
   background: var(--ink);
 }
-


### PR DESCRIPTION
## Summary

Minor polish across the website and docs:

- **Terminal demo**: Replace LinkedIn connection-request example with a Craigslist "free stuff" scraper — a more neutral, publicly accessible demo scenario
- **Docs styling**: Add inline code (`<code>`) styling that matches fenced code blocks in both light and dark mode
- **Docs config**: Switch default appearance to `system` (respect OS theme), add `chatgpt` and `claude` to contextual copy options
- **CSS cleanup**: Remove unnecessary letter-spacing on h4, trailing whitespace

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
