### PR TITLE
Fix path to summarize-evals.mjs in evals workflow

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - "package.json"
       - "evals/**"
-      - "scripts/summarize-evals.mjs"
+      - "packages/libretto/scripts/summarize-evals.mjs"
       - ".github/workflows/evals.yml"
   pull_request:
     branches:
@@ -71,7 +71,7 @@ jobs:
       - name: Summarize eval scores
         if: always()
         run: |
-          node scripts/summarize-evals.mjs \
+          node packages/libretto/scripts/summarize-evals.mjs \
             "${RUNNER_TEMP}/eval-scores" \
             "${RUNNER_TEMP}/eval-summary.json" \
             > "${RUNNER_TEMP}/eval-summary.md"


### PR DESCRIPTION
## Summary

The evals workflow referenced `scripts/summarize-evals.mjs` but the file lives at `packages/libretto/scripts/summarize-evals.mjs`. This caused the "Summarize eval scores" step to fail with `MODULE_NOT_FOUND`.

## Changes

- Updated the path trigger and the `node` invocation in `.github/workflows/evals.yml` to use the correct path `packages/libretto/scripts/summarize-evals.mjs`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
