### PR TITLE
Switch AI model to gemini-2.5-flash

### DIFF
--- a/.libretto/config.json
+++ b/.libretto/config.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "ai": {
-    "model": "vertex/gemini-3-flash-preview",
+    "model": "vertex/gemini-2.5-flash",
     "updatedAt": "2026-03-27T00:00:00.000Z"
   }
 }


### PR DESCRIPTION
## Summary

Switch the configured AI model in `.libretto/config.json` from `vertex/gemini-3-flash-preview` to `vertex/gemini-2.5-flash`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
