### PR TITLE
fix: install Playwright chromium in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,10 @@ jobs:
         if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright browsers
+        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        run: npx playwright install chromium
+
       - name: Verify release build
         if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: |


### PR DESCRIPTION
## Summary

- Add `npx playwright install chromium` step to the release workflow's verify job
- The release workflow never ran tests before because `main` always had an already-published version on npm. Now that we bumped to 0.5.6, the verify step actually executes and needs Chromium installed (same as `cli-tests.yml` and `benchmarks.yml` already do).

## Test plan

- [ ] Merge this PR, then re-run the release workflow — it should pass the verify step and publish 0.5.6 to npm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
