### PR TITLE
Improve create-libretto init flow and setup output

### DIFF
--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -2,7 +2,7 @@ import classnames from "classnames";
 import { useState } from "react";
 import { CheckIcon, CopyIcon } from "../icons";
 
-const COMMAND = "npm init libretto@latest";
+const COMMAND = "npm create libretto@latest";
 
 export function InstallSnippet() {
   const [copied, setCopied] = useState(false);

--- a/docs/get-started/new-package-setup.mdx
+++ b/docs/get-started/new-package-setup.mdx
@@ -6,6 +6,12 @@ sidebarTitle: New package setup
 Create a new project with an example workflow, TypeScript config, and everything wired up:
 
 ```bash theme={null}
+npm create libretto@latest
+```
+
+You'll be prompted for a project name (defaults to `my-automations`). You can also pass it directly:
+
+```bash theme={null}
 npm create libretto@latest my-project
 ```
 

--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -18,7 +18,19 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
-// Helpers
+// ANSI helpers
+// ---------------------------------------------------------------------------
+
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+const CLEAR_LINE = "\x1b[2K";
+const RED = "\x1b[31m";
+const GREEN = "\x1b[32m";
+const CYAN = "\x1b[36m";
+
+// ---------------------------------------------------------------------------
+// Package manager detection
 // ---------------------------------------------------------------------------
 
 /**
@@ -76,8 +88,105 @@ function runCommand(pkgManager) {
 }
 
 // ---------------------------------------------------------------------------
+// Interactive prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Interactive prompt with a dim placeholder that disappears while typing
+ * and reappears when the input is empty, like create-next-app.
+ * Shows ✔ in green on completion.
+ */
+function promptProjectName(defaultName) {
+  return new Promise((resolve) => {
+    const label = `${BOLD}What is your project named?${RESET}`;
+    const pendingPrompt = `${CYAN}?${RESET} ${label} `;
+    const donePrompt = `${GREEN}✔${RESET} ${label} `;
+    let value = "";
+
+    function render() {
+      const display = value || `${DIM}${defaultName}${RESET}`;
+      process.stdout.write(`\r${CLEAR_LINE}${pendingPrompt}${display}`);
+      // Place cursor right after the typed text (not after the placeholder)
+      if (!value) {
+        const placeholderLen = defaultName.length;
+        process.stdout.write(`\x1b[${placeholderLen}D`);
+      }
+    }
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+
+    render();
+
+    process.stdin.on("data", (key) => {
+      // Ctrl+C
+      if (key === "\x03") {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdout.write(`\n${RED}Cancelled${RESET}\n`);
+        process.exit(130);
+      }
+      // Enter
+      if (key === "\r" || key === "\n") {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeAllListeners("data");
+        const resolved = value || defaultName;
+        process.stdout.write(`\r${CLEAR_LINE}${donePrompt}${resolved}\n`);
+        resolve(resolved);
+        return;
+      }
+      // Backspace / Delete
+      if (key === "\x7f" || key === "\b") {
+        value = value.slice(0, -1);
+        render();
+        return;
+      }
+      // Ignore other control characters
+      if (key.charCodeAt(0) < 32) return;
+      value += key;
+      render();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Spinner
+// ---------------------------------------------------------------------------
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+function createSpinner(message) {
+  let i = 0;
+  const interval = setInterval(() => {
+    const frame = SPINNER_FRAMES[i++ % SPINNER_FRAMES.length];
+    process.stdout.write(`\r${CLEAR_LINE}${frame} ${message}`);
+  }, 80);
+  return {
+    stop(finalMessage) {
+      clearInterval(interval);
+      process.stdout.write(`\r${CLEAR_LINE}${finalMessage ?? ""}\n`);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Scaffold
 // ---------------------------------------------------------------------------
+
+/**
+ * Read dependencies and devDependencies from the generated package.json.
+ */
+function readDepsFromPackageJson(targetDir) {
+  const pkg = JSON.parse(
+    readFileSync(join(targetDir, "package.json"), "utf-8"),
+  );
+  return {
+    dependencies: Object.keys(pkg.dependencies ?? {}),
+    devDependencies: Object.keys(pkg.devDependencies ?? {}),
+  };
+}
 
 /**
  * Scaffold a new Libretto project into `targetDir`.
@@ -103,10 +212,17 @@ export function scaffoldProject(
   }
 
   // 3. Process package.json.template → package.json
-  const ownPkg = JSON.parse(
-    readFileSync(join(__dirname, "package.json"), "utf-8"),
-  );
-  const librettoVersion = `^${ownPkg.version}`;
+  //    Set LIBRETTO_DEV=1 to use a file: dependency pointing at the local build.
+  const localLibrettoDir = resolve(__dirname, "..", "libretto");
+  let librettoVersion;
+  if (process.env.LIBRETTO_DEV === "1") {
+    librettoVersion = `file:${localLibrettoDir}`;
+  } else {
+    const ownPkg = JSON.parse(
+      readFileSync(join(__dirname, "package.json"), "utf-8"),
+    );
+    librettoVersion = `^${ownPkg.version}`;
+  }
 
   const pkgTemplatePath = join(targetDir, "package.json.template");
   const pkgContents = readFileSync(pkgTemplatePath, "utf-8")
@@ -124,18 +240,64 @@ export function scaffoldProject(
 
   // 5. Install dependencies & run setup
   if (!skipInstall) {
-    console.log(`Installing dependencies with ${pkgManager}...\n`);
-    try {
-      execSync(installCommand(pkgManager), {
-        cwd: targetDir,
-        stdio: "inherit",
-      });
-    } catch {
-      console.error(`\nFailed to install dependencies.`);
-      process.exit(1);
+    const { dependencies, devDependencies } =
+      readDepsFromPackageJson(targetDir);
+
+    if (dependencies.length > 0) {
+      console.log(`Installing dependencies:`);
+      for (const dep of dependencies) {
+        console.log(`- ${dep}`);
+      }
+      if (devDependencies.length > 0) console.log();
     }
 
-    console.log(`Running libretto setup...\n`);
+    if (devDependencies.length > 0) {
+      console.log(`Installing devDependencies:`);
+      for (const dep of devDependencies) {
+        console.log(`- ${dep}`);
+      }
+    }
+    console.log();
+
+    const spinner = createSpinner("Installing packages...");
+    try {
+      const output = execSync(installCommand(pkgManager), {
+        cwd: targetDir,
+        encoding: "utf-8",
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      spinner.stop();
+      // Print just the summary lines (e.g. "added 123 packages...")
+      const lines = output.split("\n");
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        console.log(trimmed);
+      }
+    } catch (err) {
+      spinner.stop();
+      // Print stderr warnings/summary even on "success with warnings"
+      if (err.stderr) {
+        const lines = err.stderr.split("\n");
+        for (const line of lines) {
+          if (line.trim()) console.error(line);
+        }
+      }
+      if (err.status !== 0 && err.status !== null) {
+        console.error(`\nFailed to install dependencies.`);
+        process.exit(1);
+      }
+      // status 0 or null with stderr = warnings, continue
+      if (err.stdout) {
+        const lines = err.stdout.split("\n");
+        for (const line of lines) {
+          if (line.trim()) console.log(line);
+        }
+      }
+    }
+
+    console.log();
+
     try {
       execSync(`${execCommand(pkgManager)} libretto setup`, {
         cwd: targetDir,
@@ -152,12 +314,26 @@ export function scaffoldProject(
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
-  const rawName = process.argv[2] ?? "libretto-automations";
+async function main() {
+  process.on("SIGINT", () => {
+    console.log(`\n${RED}Cancelled${RESET}`);
+    process.exit(130);
+  });
+
+  if (process.env.LIBRETTO_DEV === "1") {
+    const localLibrettoDir = resolve(__dirname, "..", "libretto");
+    console.log(`${DIM}Dev mode: using local libretto from ${localLibrettoDir}${RESET}\n`);
+  }
+
+  const DEFAULT_NAME = "my-automations";
+  let rawName = process.argv[2];
+
+  if (!rawName) {
+    rawName = await promptProjectName(DEFAULT_NAME);
+  }
+
   const targetDir = resolve(rawName);
   const projectName = basename(targetDir);
-  const relPath = relative(process.cwd(), targetDir) || ".";
-  const cdTarget = relPath.startsWith("..") ? targetDir : relPath;
   const pkgManager = detectPackageManager();
 
   // Bail if directory exists and is non-empty
@@ -165,27 +341,22 @@ function main() {
     const entries = readdirSync(targetDir);
     if (entries.length > 0) {
       console.error(
-        `Error: Target directory "${cdTarget}" already exists and is not empty.`,
+        `Error: Target directory "${targetDir}" already exists and is not empty.`,
       );
       process.exit(1);
     }
   }
 
-  console.log(`\nScaffolding Libretto project in ${cdTarget}...\n`);
+  console.log(
+    `\nCreating a new Libretto project in ${BOLD}${targetDir}${RESET}.\n`,
+  );
+  console.log(`Using ${BOLD}${pkgManager}${RESET} and TypeScript.\n`);
 
   scaffoldProject(targetDir, projectName, pkgManager);
 
-  const run = runCommand(pkgManager);
-
-  console.log(`
-Done! Your Libretto project is ready.
-
-Next steps:
-
-  cd ${cdTarget}
-  ${run} libretto open https://example.com --headed   # explore a page interactively
-  ${run} libretto run src/workflows/star-repo.ts       # run the example workflow
-`);
+  console.log(
+    `\n${GREEN}Success!${RESET} Created ${BOLD}${projectName}${RESET} at ${targetDir}\n`,
+  );
 }
 
 // Only run main when this file is executed directly (not imported)
@@ -193,5 +364,8 @@ if (
   process.argv[1] &&
   realpathSync(resolve(process.argv[1])) === fileURLToPath(import.meta.url)
 ) {
-  main();
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -171,6 +171,32 @@ function createSpinner(message) {
   };
 }
 
+/**
+ * Run install command asynchronously so the spinner can animate.
+ * Returns { stdout, stderr, status }.
+ */
+function runInstallAsync(cmd, cwd) {
+  return new Promise((resolve) => {
+    const [bin, ...args] = cmd.split(" ");
+    const child = spawn(bin, args, {
+      cwd,
+      stdio: ["inherit", "pipe", "pipe"],
+      shell: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => {
+      stdout += data;
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data;
+    });
+    child.on("close", (status, signal) => {
+      resolve({ stdout, stderr, status, signal });
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Scaffold
 // ---------------------------------------------------------------------------
@@ -193,7 +219,7 @@ function readDepsFromPackageJson(targetDir) {
  *
  * Exported so tests can call it directly with `skipInstall: true`.
  */
-export function scaffoldProject(
+export async function scaffoldProject(
   targetDir,
   projectName,
   pkgManager,
@@ -260,39 +286,26 @@ export function scaffoldProject(
     console.log();
 
     const spinner = createSpinner("Installing packages...");
-    try {
-      const output = execSync(installCommand(pkgManager), {
-        cwd: targetDir,
-        encoding: "utf-8",
-        stdio: ["inherit", "pipe", "pipe"],
-      });
-      spinner.stop();
-      // Print just the summary lines (e.g. "added 123 packages...")
-      const lines = output.split("\n");
-      for (const line of lines) {
+    const result = await runInstallAsync(installCommand(pkgManager), targetDir);
+    spinner.stop();
+
+    // Print stderr (warnings)
+    if (result.stderr) {
+      for (const line of result.stderr.split("\n")) {
+        if (line.trim()) console.error(line);
+      }
+    }
+
+    if (result.status !== 0) {
+      console.error(`\nFailed to install dependencies.`);
+      process.exit(1);
+    }
+
+    // Print stdout summary lines (e.g. "added 123 packages...")
+    if (result.stdout) {
+      for (const line of result.stdout.split("\n")) {
         const trimmed = line.trim();
-        if (!trimmed) continue;
-        console.log(trimmed);
-      }
-    } catch (err) {
-      spinner.stop();
-      // Print stderr warnings/summary even on "success with warnings"
-      if (err.stderr) {
-        const lines = err.stderr.split("\n");
-        for (const line of lines) {
-          if (line.trim()) console.error(line);
-        }
-      }
-      if (err.status !== 0 && err.status !== null) {
-        console.error(`\nFailed to install dependencies.`);
-        process.exit(1);
-      }
-      // status 0 or null with stderr = warnings, continue
-      if (err.stdout) {
-        const lines = err.stdout.split("\n");
-        for (const line of lines) {
-          if (line.trim()) console.log(line);
-        }
+        if (trimmed) console.log(trimmed);
       }
     }
 
@@ -329,7 +342,11 @@ async function main() {
   let rawName = process.argv[2];
 
   if (!rawName) {
-    rawName = await promptProjectName(DEFAULT_NAME);
+    if (process.stdin.isTTY) {
+      rawName = await promptProjectName(DEFAULT_NAME);
+    } else {
+      rawName = DEFAULT_NAME;
+    }
   }
 
   const targetDir = resolve(rawName);
@@ -352,7 +369,7 @@ async function main() {
   );
   console.log(`Using ${BOLD}${pkgManager}${RESET} and TypeScript.\n`);
 
-  scaffoldProject(targetDir, projectName, pkgManager);
+  await scaffoldProject(targetDir, projectName, pkgManager);
 
   console.log(
     `\n${GREEN}Success!${RESET} Created ${BOLD}${projectName}${RESET} at ${targetDir}\n`,

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -77,6 +77,18 @@ function promptUser(
   });
 }
 
+/** Map provider to a human-readable label for status messages. */
+function providerLabel(provider: Provider): string {
+  const choice = PROVIDER_CHOICES.find((c) => c.provider === provider);
+  return choice?.label ?? provider;
+}
+
+/** Extract the env var name from source like "env:GOOGLE_CLOUD_PROJECT". */
+function sourceEnvVar(source: string): string | null {
+  if (source.startsWith("env:")) return source.slice(4);
+  return null;
+}
+
 /**
  * If the workspace has usable credentials but no pinned model in config,
  * write the resolved default model to `.libretto/config.json`.
@@ -92,18 +104,24 @@ function ensurePinnedDefaultModel(
 }
 
 function printHealthySummary(status: AiSetupStatus & { kind: "ready" }): void {
-  console.log(`  ✓ Model: ${status.model}`);
-  console.log(`  Config: ${LIBRETTO_CONFIG_PATH}`);
+  const envVar = sourceEnvVar(status.source);
+  if (envVar) {
+    console.log(
+      `✓ Detected ${envVar}. Using ${providerLabel(status.provider)}.`,
+    );
+  } else {
+    console.log(`✓ Using ${providerLabel(status.provider)} (${status.model}).`);
+  }
   console.log(
-    "  To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+    "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
   );
 }
 
 function printInvalidAiConfigWarning(status: AiSetupStatus): void {
   if (status.kind !== "invalid-config") return;
-  console.log("  ! Existing AI config is invalid:");
+  console.log("! Existing AI config is invalid:");
   for (const line of status.message.split("\n")) {
-    console.log(`    ${line}`);
+    console.log(`  ${line}`);
   }
 }
 
@@ -152,23 +170,19 @@ export function buildRepairPlan(status: AiSetupStatus): RepairPlan {
 export function formatMissingCredentialsMessage(
   plan: RepairPlan & { kind: "repair-missing-credentials" },
 ): string {
-  return [
-    `  ✗ ${plan.provider} is configured (model: ${plan.model}), but ${plan.envVar} is not set.`,
-  ].join("\n");
+  return `✗ ${plan.provider} is configured (model: ${plan.model}), but ${plan.envVar} is not set.`;
 }
 
 function printSnapshotApiStatus(): boolean {
   const status = resolveAiSetupStatus();
-  const envPath = join(REPO_ROOT, ".env");
 
-  console.log("\nSnapshot analysis:");
   console.log(
-    "  Libretto uses direct API calls for snapshot analysis when supported credentials are available.",
+    "\nLibretto uses a sub-agent to analyze DOM snapshots. The model is determined by environment variables.",
   );
-  console.log(`  Credentials are loaded from process env and ${envPath}.`);
 
   if (status.kind === "ready") {
     const pinned = ensurePinnedDefaultModel(status);
+    console.log();
     printHealthySummary(pinned);
     return true;
   }
@@ -176,32 +190,34 @@ function printSnapshotApiStatus(): boolean {
   // Provider-specific missing-credentials message
   const plan = buildRepairPlan(status);
   if (plan.kind === "repair-missing-credentials") {
+    console.log();
     console.log(formatMissingCredentialsMessage(plan));
     console.log(
-      `    To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
+      `  To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
     );
     return false;
   }
 
   if (plan.kind === "repair-invalid-config") {
     printInvalidAiConfigWarning(status);
-    console.log("    Run `npx libretto setup` interactively to reconfigure.");
+    console.log("  Run `npx libretto setup` interactively to reconfigure.");
     return false;
   }
 
-  console.log("  ✗ No snapshot API credentials detected.");
-  console.log("    Add one provider to .env:");
-  console.log("      OPENAI_API_KEY=...");
-  console.log("      ANTHROPIC_API_KEY=...");
-  console.log("      GEMINI_API_KEY=...  # or GOOGLE_GENERATIVE_AI_API_KEY");
+  console.log();
+  console.log("✗ No snapshot API credentials detected.");
+  console.log("  Add one provider to .env:");
+  console.log("    OPENAI_API_KEY=...");
+  console.log("    ANTHROPIC_API_KEY=...");
+  console.log("    GEMINI_API_KEY=...  # or GOOGLE_GENERATIVE_AI_API_KEY");
   console.log(
-    "      GOOGLE_CLOUD_PROJECT=...  # plus application default credentials for Vertex",
+    "    GOOGLE_CLOUD_PROJECT=...  # plus application default credentials for Vertex",
   );
   console.log(
-    "    Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
+    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
   );
   console.log(
-    "    Run `npx libretto setup` interactively to set up credentials.",
+    "  Run `npx libretto setup` interactively to set up credentials.",
   );
   return false;
 }
@@ -222,11 +238,11 @@ function writeEnvVar(envVar: string, value: string, envPath: string): void {
       () => envLine,
     );
     writeFileSync(envPath, updated);
-    console.log(`\n  ✓ Updated ${envVar} in ${envPath}`);
+    console.log(`\n✓ Updated ${envVar} in ${envPath}`);
   } else {
     const separator = envContent && !envContent.endsWith("\n") ? "\n" : "";
     appendFileSync(envPath, `${separator}${envLine}\n`);
-    console.log(`\n  ✓ Added ${envVar} to ${envPath}`);
+    console.log(`\n✓ Added ${envVar} to ${envPath}`);
   }
 
   process.env[envVar] = value;
@@ -244,13 +260,13 @@ async function promptForCredential(
   envPath: string,
   modelOverride?: string,
 ): Promise<boolean> {
-  console.log(`\n  ${choice.label} selected.`);
-  console.log(`  ${choice.envHint}\n`);
+  console.log(`\n${choice.label} selected.`);
+  console.log(`${choice.envHint}\n`);
 
-  const apiKeyValue = await promptUser(rl, `  Enter your ${choice.envVar}: `);
+  const apiKeyValue = await promptUser(rl, `Enter your ${choice.envVar}: `);
 
   if (!apiKeyValue) {
-    console.log("\n  No value entered. Skipping API key setup.");
+    console.log("\nNo value entered. Skipping API key setup.");
     return false;
   }
 
@@ -259,7 +275,10 @@ async function promptForCredential(
 
   const model = modelOverride ?? DEFAULT_SNAPSHOT_MODELS[choice.provider];
   writeAiConfig(model);
-  console.log(`  ✓ Snapshot API ready: ${model}`);
+  console.log(`✓ Snapshot API ready: ${model}`);
+  console.log(
+    "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+  );
   return true;
 }
 
@@ -272,14 +291,14 @@ async function promptProviderSelection(
   envPath: string,
 ): Promise<boolean> {
   console.log(
-    "  Which API provider would you like to use for snapshot analysis?\n",
+    "Which model provider would you like to use for snapshot analysis?\n",
   );
   for (const choice of PROVIDER_CHOICES) {
-    console.log(`    ${choice.key}) ${choice.label}`);
+    console.log(`  ${choice.key}) ${choice.label}`);
   }
-  console.log("    s) Skip for now\n");
+  console.log("  s) Skip for now\n");
 
-  const answer = await promptUser(rl, "  Choice: ");
+  const answer = await promptUser(rl, "Choice: ");
 
   if (answer.toLowerCase() === "s" || !answer) {
     printSkipMessage();
@@ -288,7 +307,7 @@ async function promptProviderSelection(
 
   const selected = PROVIDER_CHOICES.find((choice) => choice.key === answer);
   if (!selected) {
-    console.log(`\n  Unknown choice "${answer}". Skipping API setup.`);
+    console.log(`\nUnknown choice "${answer}". Skipping API setup.`);
     return false;
   }
 
@@ -297,14 +316,14 @@ async function promptProviderSelection(
 
 function printSkipMessage(): void {
   console.log(
-    "\n  Skipped. You can set up API credentials later by rerunning `npx libretto setup`.",
+    "\nSkipped. You can set up API credentials later by rerunning `npx libretto setup`.",
   );
-  console.log("  Or add credentials directly to your .env file:");
-  console.log("    OPENAI_API_KEY=...");
-  console.log("    ANTHROPIC_API_KEY=...");
-  console.log("    GEMINI_API_KEY=...");
+  console.log("Or add credentials directly to your .env file:");
+  console.log("  OPENAI_API_KEY=...");
+  console.log("  ANTHROPIC_API_KEY=...");
+  console.log("  GEMINI_API_KEY=...");
   console.log(
-    "    Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
+    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex` to set a specific model.",
   );
 }
 
@@ -312,12 +331,13 @@ async function runInteractiveApiSetup(): Promise<void> {
   const status = resolveAiSetupStatus();
   const envPath = join(REPO_ROOT, ".env");
 
-  console.log("\nSnapshot analysis setup:");
-  console.log("  Libretto uses direct API calls for snapshot analysis.");
-  console.log(`  Credentials are loaded from process env and ${envPath}.`);
+  console.log(
+    "\nLibretto uses a sub-agent to analyze DOM snapshots. The model is determined by environment variables.",
+  );
 
   if (status.kind === "ready") {
     const pinned = ensurePinnedDefaultModel(status);
+    console.log();
     printHealthySummary(pinned);
     return;
   }
@@ -334,12 +354,12 @@ async function runInteractiveApiSetup(): Promise<void> {
     if (plan.kind === "repair-missing-credentials") {
       console.log(formatMissingCredentialsMessage(plan));
       console.log("");
-      console.log("  How would you like to fix this?\n");
-      console.log(`    1) Enter ${plan.envVar}`);
-      console.log("    2) Switch to a different provider");
-      console.log("    s) Skip for now\n");
+      console.log("How would you like to fix this?\n");
+      console.log(`  1) Enter ${plan.envVar}`);
+      console.log("  2) Switch to a different provider");
+      console.log("  s) Skip for now\n");
 
-      const answer = await promptUser(rl, "  Choice: ");
+      const answer = await promptUser(rl, "Choice: ");
 
       if (answer === "1") {
         const matchingChoice = PROVIDER_CHOICES.find(
@@ -365,14 +385,14 @@ async function runInteractiveApiSetup(): Promise<void> {
     if (plan.kind === "repair-invalid-config") {
       printInvalidAiConfigWarning(status);
       console.log(
-        "\n  Would you like to reconfigure with a fresh provider selection?\n",
+        "\nWould you like to reconfigure with a fresh provider selection?\n",
       );
       await promptProviderSelection(rl, envPath);
       return;
     }
 
     // ── Unconfigured: standard first-run flow ──
-    console.log("  ✗ No snapshot API credentials detected.\n");
+    console.log("✗ No snapshot API credentials detected.\n");
     await promptProviderSelection(rl, envPath);
   } finally {
     rl.close();
@@ -380,16 +400,16 @@ async function runInteractiveApiSetup(): Promise<void> {
 }
 
 function installBrowsers(): void {
-  console.log("\nInstalling Playwright Chromium...");
+  console.log("Installing Playwright Chromium...");
   const result = spawnSync("npx", ["playwright", "install", "chromium"], {
     stdio: "inherit",
     shell: true,
   });
   if (result.status === 0) {
-    console.log("  ✓ Playwright Chromium installed");
+    console.log("✓ Playwright Chromium installed");
   } else {
     console.error(
-      "  ✗ Failed to install Playwright Chromium. Run manually: npx playwright install chromium",
+      "✗ Failed to install Playwright Chromium. Run manually: npx playwright install chromium",
     );
   }
 }
@@ -421,9 +441,6 @@ function copySkills(): void {
   const agentDirs = detectAgentDirs(REPO_ROOT);
 
   if (agentDirs.length === 0) {
-    console.log(
-      "\nSkills: No .agents/ or .claude/ directory found in repo root — skipping.",
-    );
     return;
   }
 
@@ -431,7 +448,7 @@ function copySkills(): void {
   try {
     skillsRoot = getPackageSkillsRoot();
   } catch (e) {
-    console.error(`  ✗ ${e instanceof Error ? e.message : String(e)}`);
+    console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
     return;
   }
 
@@ -452,7 +469,7 @@ function copySkills(): void {
       cpSync(sourceDir, skillDest, { recursive: true });
       const fileCount = readdirSync(skillDest).length;
       console.log(
-        `  ✓ Copied ${fileCount} skill files to ${agentName}/skills/${skillName}/`,
+        `✓ Copied ${fileCount} skill files to ${agentName}/skills/${skillName}/`,
       );
     }
   }
@@ -473,13 +490,12 @@ export const setupCommand = SimpleCLI.command({
 })
   .input(setupInput)
   .handle(async ({ input }) => {
-    console.log("Setting up libretto...\n");
     ensureLibrettoSetup();
 
     if (!input.skipBrowsers) {
       installBrowsers();
     } else {
-      console.log("\nSkipping browser installation (--skip-browsers)");
+      console.log("Skipping browser installation (--skip-browsers)");
     }
 
     copySkills();
@@ -495,5 +511,6 @@ export const setupCommand = SimpleCLI.command({
       }
     }
 
+    console.log(`\nConfig set up at ${LIBRETTO_CONFIG_PATH}`);
     console.log("\n✓ libretto setup complete");
   });

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -181,9 +181,9 @@ function printSnapshotApiStatus(): boolean {
   );
 
   if (status.kind === "ready") {
-    const pinned = ensurePinnedDefaultModel(status);
     console.log();
-    printHealthySummary(pinned);
+    printHealthySummary(status);
+    ensurePinnedDefaultModel(status);
     return true;
   }
 
@@ -336,9 +336,9 @@ async function runInteractiveApiSetup(): Promise<void> {
   );
 
   if (status.kind === "ready") {
-    const pinned = ensurePinnedDefaultModel(status);
     console.log();
-    printHealthySummary(pinned);
+    printHealthySummary(status);
+    ensurePinnedDefaultModel(status);
     return;
   }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -91,7 +91,7 @@ describe("basic CLI subprocess behavior", () => {
       GCLOUD_PROJECT: "",
     });
 
-    expect(result.stdout).toContain("Snapshot analysis:");
+    expect(result.stdout).toContain("sub-agent to analyze DOM snapshots");
     expect(result.stdout).toContain("No snapshot API credentials detected.");
     expect(result.stdout).toContain("OPENAI_API_KEY=...");
     expect(result.stdout).toContain("ANTHROPIC_API_KEY=...");
@@ -106,9 +106,8 @@ describe("basic CLI subprocess behavior", () => {
       OPENAI_API_KEY: "test-openai-key",
     });
 
-    expect(result.stdout).toContain("Snapshot analysis:");
-    expect(result.stdout).toContain("Model: openai/gpt-5.4");
-    expect(result.stdout).toContain("Config:");
+    expect(result.stdout).toContain("Using OpenAI");
+    expect(result.stdout).toContain("Detected OPENAI_API_KEY");
     expect(result.stdout).toContain("config.json");
     expect(result.stdout).toContain(
       "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
@@ -123,8 +122,8 @@ describe("basic CLI subprocess behavior", () => {
       OPENAI_API_KEY: "test-openai-key",
     });
 
-    expect(result.stdout).toContain("Model: openai/gpt-5.4");
-    expect(result.stdout).toContain("Config:");
+    expect(result.stdout).toContain("Using OpenAI");
+    expect(result.stdout).toContain("config.json");
   });
 
   test("setup rerun shows healthy summary without re-prompting", async ({
@@ -135,15 +134,15 @@ describe("basic CLI subprocess behavior", () => {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "test-openai-key",
     });
-    expect(first.stdout).toContain("Model: openai/gpt-5.4");
+    expect(first.stdout).toContain("Using OpenAI");
 
     // Second run: should show healthy summary, not re-prompt
     const second = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "test-openai-key",
     });
-    expect(second.stdout).toContain("Model: openai/gpt-5.4");
-    expect(second.stdout).toContain("Config:");
+    expect(second.stdout).toContain("Using OpenAI");
+    expect(second.stdout).toContain("config.json");
     expect(second.stdout).toContain(
       "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
     );


### PR DESCRIPTION
## Summary

Overhauls the `create-libretto` init experience to match the polish of `create-next-app`:

### `create-libretto` UX
- **Interactive project name prompt** with dim placeholder that appears/disappears as you type, green `✔` on submit
- **Red "Cancelled"** on Ctrl+C at any point in the flow
- **Animated spinner** during dependency installation
- **Structured output**: lists deps/devDeps before install, shows install summary after
- **`LIBRETTO_DEV=1`** env var to test with local `libretto` build (uses `file:` dependency)

### `libretto setup` output cleanup
- Removed "Setting up libretto..." header and "Snapshot analysis:" title
- Removed 2-space indentation from all setup output
- Rewrote snapshot analysis messaging: "Libretto uses a sub-agent to analyze DOM snapshots. The model is determined by environment variables."
- Shows `✓ Detected <ENV_VAR>. Using <Provider>.` when auto-detected
- Added "Config set up at .libretto/config.json" line
- Changed "API provider" → "model provider" in interactive prompts

### Template
- Added `.agents/skills/` directory to scaffold template so skill installation works on first run

### Docs
- Updated `new-package-setup.mdx` to show no-arg invocation as the primary example

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
