### PR TITLE
Add tabbed workflow examples with interactive terminal demo

### DIFF
--- a/apps/website/src/components/TerminalDemo.tsx
+++ b/apps/website/src/components/TerminalDemo.tsx
@@ -1,14 +1,12 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { RefreshIcon } from "../icons";
+import { workflowExamples, type WorkflowExample } from "./workflowExamples";
 
 type Line =
   | { type: "user"; text: string }
   | { type: "thinking"; done: boolean }
   | { type: "tool"; label: string; done: boolean }
   | { type: "agent"; text: string };
-
-const USER_MESSAGE =
-  'Use the Libretto skill. Go on Craigslist and scrape the first 10 "free stuff" listings for title, location, and link.';
 
 function Cursor({ dark }: { dark?: boolean }) {
   return (
@@ -45,21 +43,13 @@ function ToolLine({ label, done }: { label: string; done: boolean }) {
   );
 }
 
-export function TerminalDemo() {
+function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
   const [lines, setLines] = useState<Line[]>([]);
   const [promptText, setPromptText] = useState("");
   const [promptSubmitted, setPromptSubmitted] = useState(false);
   const [streamingAgent, setStreamingAgent] = useState("");
   const [isStreamingAgent, setIsStreamingAgent] = useState(false);
   const [animationDone, setAnimationDone] = useState(false);
-  const [animationKey, setAnimationKey] = useState(0);
-  const bodyRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (bodyRef.current) {
-      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
-    }
-  }, [lines, promptText, streamingAgent]);
 
   useEffect(() => {
     let cancelled = false;
@@ -74,13 +64,13 @@ export function TerminalDemo() {
     async function run() {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-      await sleep(1000);
+      await sleep(600);
 
       // User types char by char
-      for (let c = 0; c <= USER_MESSAGE.length; c++) {
+      for (let c = 0; c <= example.userMessage.length; c++) {
         if (cancelled) return;
-        setPromptText(USER_MESSAGE.slice(0, c));
-        await sleep(30);
+        setPromptText(example.userMessage.slice(0, c));
+        await sleep(25);
       }
 
       await sleep(500);
@@ -89,14 +79,14 @@ export function TerminalDemo() {
       // Submit
       setPromptSubmitted(true);
       setPromptText("");
-      setLines([{ type: "user", text: USER_MESSAGE }]);
+      setLines([{ type: "user", text: example.userMessage }]);
 
       await sleep(300);
       if (cancelled) return;
 
       // Thinking (spinning)
       setLines((prev) => [...prev, { type: "thinking", done: false }]);
-      await sleep(1800);
+      await sleep(example.thinkDurationMs);
       if (cancelled) return;
 
       // Thinking done
@@ -104,121 +94,44 @@ export function TerminalDemo() {
         prev.map((l) => (l.type === "thinking" ? { ...l, done: true } : l)),
       );
 
-      // Tool: bash — open
-      await sleep(400);
-      if (cancelled) return;
-      setLines((prev) => [
-        ...prev,
-        {
-          type: "tool",
-          label: "bash: npx libretto open https://craigslist.org --headed",
-          done: false,
-        },
-      ]);
-      await sleep(1400);
-      if (cancelled) return;
-      setLines((prev) =>
-        prev.map((l, i) =>
-          i === prev.length - 1 && l.type === "tool" ? { ...l, done: true } : l,
-        ),
-      );
-
-      // Tool: bash — snapshot
-      await sleep(300);
-      if (cancelled) return;
-      setLines((prev) => [
-        ...prev,
-        {
-          type: "tool",
-          label:
-            'bash: npx libretto snapshot --objective "Find free stuff listings"',
-          done: false,
-        },
-      ]);
-      await sleep(1200);
-      if (cancelled) return;
-      setLines((prev) =>
-        prev.map((l, i) =>
-          i === prev.length - 1 && l.type === "tool" ? { ...l, done: true } : l,
-        ),
-      );
-
-      // Tool: bash — exec click free stuff link
-      await sleep(300);
-      if (cancelled) return;
-      setLines((prev) => [
-        ...prev,
-        {
-          type: "tool",
-          label: 'bash: npx libretto exec "await page.locator(…).click()"',
-          done: false,
-        },
-      ]);
-      await sleep(900);
-      if (cancelled) return;
-      setLines((prev) =>
-        prev.map((l, i) =>
-          i === prev.length - 1 && l.type === "tool" ? { ...l, done: true } : l,
-        ),
-      );
-
-      // Tool: bash — exec scrape listings
-      await sleep(300);
-      if (cancelled) return;
-      setLines((prev) => [
-        ...prev,
-        {
-          type: "tool",
-          label:
-            "bash: npx libretto exec \"return await page.locator('.cl-static-search-result').first().textContent()\"",
-          done: false,
-        },
-      ]);
-      await sleep(800);
-      if (cancelled) return;
-      setLines((prev) =>
-        prev.map((l, i) =>
-          i === prev.length - 1 && l.type === "tool" ? { ...l, done: true } : l,
-        ),
-      );
-
-      // Tool: write file
-      await sleep(300);
-      if (cancelled) return;
-      setLines((prev) => [
-        ...prev,
-        {
-          type: "tool",
-          label: "write: craigslist_free_stuff.ts",
-          done: false,
-        },
-      ]);
-      await sleep(1000);
-      if (cancelled) return;
-      setLines((prev) =>
-        prev.map((l, i) =>
-          i === prev.length - 1 && l.type === "tool" ? { ...l, done: true } : l,
-        ),
-      );
+      // Tool steps
+      for (const tool of example.tools) {
+        await sleep(300);
+        if (cancelled) return;
+        setLines((prev) => [
+          ...prev,
+          { type: "tool", label: tool.label, done: false },
+        ]);
+        await sleep(tool.durationMs);
+        if (cancelled) return;
+        setLines((prev) =>
+          prev.map((l, i) =>
+            i === prev.length - 1 && l.type === "tool"
+              ? { ...l, done: true }
+              : l,
+          ),
+        );
+      }
 
       // Agent streams response word by word
       await sleep(400);
       if (cancelled) return;
-      const agentText =
-        "Created craigslist_free_stuff.ts — a workflow that opens Craigslist, navigates to free stuff, and scrapes the first 10 listings for title, location, and link.\n\nRun it anytime:\n  npx libretto run ./craigslist_free_stuff.ts main --headless";
       setIsStreamingAgent(true);
-      const words = agentText.split(/(?<=\s)/);
-      let so_far = "";
+      const words = example.agentResponse.split(/(?<=\s)/);
+      let soFar = "";
       for (const word of words) {
         if (cancelled) return;
-        so_far += word;
-        setStreamingAgent(so_far);
+        soFar += word;
+        setStreamingAgent(soFar);
         await sleep(35 + Math.random() * 30);
       }
       await sleep(200);
       setIsStreamingAgent(false);
       setStreamingAgent("");
-      setLines((prev) => [...prev, { type: "agent", text: agentText }]);
+      setLines((prev) => [
+        ...prev,
+        { type: "agent", text: example.agentResponse },
+      ]);
       setAnimationDone(true);
     }
 
@@ -226,10 +139,69 @@ export function TerminalDemo() {
     return () => {
       cancelled = true;
     };
-  }, [animationKey]);
+  }, [example, animationKey]);
+
+  return {
+    lines,
+    promptText,
+    promptSubmitted,
+    streamingAgent,
+    isStreamingAgent,
+    animationDone,
+  };
+}
+
+export function TerminalDemo() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [animationKey, setAnimationKey] = useState(0);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const example = workflowExamples[activeIndex];
+
+  const {
+    lines,
+    promptText,
+    promptSubmitted,
+    streamingAgent,
+    isStreamingAgent,
+    animationDone,
+  } = useTerminalAnimation(example, animationKey);
+
+  useEffect(() => {
+    if (bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+    }
+  }, [lines, promptText, streamingAgent]);
+
+  const handleTabClick = useCallback(
+    (index: number) => {
+      if (index === activeIndex) return;
+      setActiveIndex(index);
+      setAnimationKey((k) => k + 1);
+    },
+    [activeIndex],
+  );
 
   return (
     <div className="mx-auto max-w-[600px] mt-16">
+      {/* Tabs */}
+      <div className="flex gap-1 mb-2 px-1 overflow-x-auto">
+        {workflowExamples.map((ex, i) => (
+          <button
+            key={ex.id}
+            type="button"
+            onClick={() => handleTabClick(i)}
+            className={`px-3 py-1.5 rounded-t-lg text-[12px] font-medium transition-colors whitespace-nowrap cursor-pointer ${
+              i === activeIndex
+                ? "bg-white text-ink border border-b-0 border-ink/[0.08]"
+                : "text-ink/40 hover:text-ink/60 hover:bg-ink/[0.03]"
+            }`}
+          >
+            {ex.tab}
+          </button>
+        ))}
+      </div>
+
       <div className="rounded-xl border border-ink/[0.08] bg-white shadow-lg overflow-hidden flex flex-col font-mono text-[13px]">
         {/* Title bar */}
         <div className="flex items-center justify-between px-3 py-1.5 border-b border-ink/[0.06] bg-ink/[0.02]">

--- a/apps/website/src/components/TerminalDemo.tsx
+++ b/apps/website/src/components/TerminalDemo.tsx
@@ -204,7 +204,7 @@ export function TerminalDemo() {
   const [extraLines, setExtraLines] = useState<Line[]>([]);
   const [extraStreaming, setExtraStreaming] = useState("");
   const [isExtraStreaming, setIsExtraStreaming] = useState(false);
-  const extraCancelRef = useRef(false);
+  const extraGenRef = useRef(0);
   const extraStreamingRef = useRef("");
   const bodyRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -240,7 +240,7 @@ export function TerminalDemo() {
       setActiveIndex(index);
       setSkipTyping(true);
       setAnimationKey((k) => k + 1);
-      extraCancelRef.current = true;
+      extraGenRef.current++;
       setExtraLines([]);
       setExtraStreaming("");
       setIsExtraStreaming(false);
@@ -251,7 +251,7 @@ export function TerminalDemo() {
 
   const interruptExtraStreaming = useCallback(() => {
     if (!isExtraStreaming) return;
-    extraCancelRef.current = true;
+    extraGenRef.current++;
     const partial = extraStreamingRef.current;
     setIsExtraStreaming(false);
     setExtraStreaming("");
@@ -285,25 +285,26 @@ export function TerminalDemo() {
       setExtraLines((prev) => [...prev, { type: "user", text }]);
 
       // Stream CTA response
-      extraCancelRef.current = false;
+      const gen = ++extraGenRef.current;
       extraStreamingRef.current = "";
 
       async function stream() {
         const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        const isStale = () => extraGenRef.current !== gen;
         await sleep(400);
-        if (extraCancelRef.current) return;
+        if (isStale()) return;
         setIsExtraStreaming(true);
         const words = CTA_RESPONSE.split(/(?<=\s)/);
         let soFar = "";
         for (const word of words) {
-          if (extraCancelRef.current) return;
+          if (isStale()) return;
           soFar += word;
           extraStreamingRef.current = soFar;
           setExtraStreaming(soFar);
           await sleep(35 + Math.random() * 30);
         }
         await sleep(200);
-        if (extraCancelRef.current) return;
+        if (isStale()) return;
         setIsExtraStreaming(false);
         setExtraStreaming("");
         extraStreamingRef.current = "";
@@ -340,7 +341,14 @@ export function TerminalDemo() {
           {/* Reset button */}
           <button
             type="button"
-            onClick={() => setAnimationKey((k) => k + 1)}
+            onClick={() => {
+              extraGenRef.current++;
+              setExtraLines([]);
+              setExtraStreaming("");
+              setIsExtraStreaming(false);
+              setUserInput("");
+              setAnimationKey((k) => k + 1);
+            }}
             className={`p-1 rounded-md text-ink/30 hover:text-ink/60 hover:bg-ink/[0.05] transition-all duration-300 cursor-pointer ${animationDone ? "opacity-100" : "opacity-0 pointer-events-none"}`}
             aria-label="Replay animation"
           >

--- a/apps/website/src/components/TerminalDemo.tsx
+++ b/apps/website/src/components/TerminalDemo.tsx
@@ -6,7 +6,8 @@ type Line =
   | { type: "user"; text: string }
   | { type: "thinking"; done: boolean }
   | { type: "tool"; label: string; done: boolean }
-  | { type: "agent"; text: string };
+  | { type: "agent"; text: string }
+  | { type: "interrupted" };
 
 function Cursor({ dark }: { dark?: boolean }) {
   return (
@@ -43,16 +44,53 @@ function ToolLine({ label, done }: { label: string; done: boolean }) {
   );
 }
 
-function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
+function useTerminalAnimation(
+  example: WorkflowExample,
+  animationKey: number,
+  skipTyping: boolean,
+) {
   const [lines, setLines] = useState<Line[]>([]);
   const [promptText, setPromptText] = useState("");
   const [promptSubmitted, setPromptSubmitted] = useState(false);
   const [streamingAgent, setStreamingAgent] = useState("");
   const [isStreamingAgent, setIsStreamingAgent] = useState(false);
   const [animationDone, setAnimationDone] = useState(false);
+  const cancelledRef = useRef(false);
+  const streamingRef = useRef("");
+
+  const interrupt = useCallback(() => {
+    if (animationDone) return;
+    cancelledRef.current = true;
+
+    // Commit any partial streaming text
+    const partial = streamingRef.current;
+    setIsStreamingAgent(false);
+    setStreamingAgent("");
+    streamingRef.current = "";
+
+    setLines((prev) => {
+      const next = [...prev];
+      // Mark any in-progress thinking/tool as done
+      for (let i = 0; i < next.length; i++) {
+        const l = next[i];
+        if ((l.type === "thinking" || l.type === "tool") && !l.done) {
+          next[i] = { ...l, done: true };
+        }
+      }
+      if (partial) {
+        next.push({ type: "agent", text: partial });
+      }
+      next.push({ type: "interrupted" });
+      return next;
+    });
+
+    setPromptSubmitted(true);
+    setAnimationDone(true);
+  }, [animationDone]);
 
   useEffect(() => {
-    let cancelled = false;
+    cancelledRef.current = false;
+    streamingRef.current = "";
 
     setLines([]);
     setPromptText("");
@@ -63,47 +101,49 @@ function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
 
     async function run() {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const isCancelled = () => cancelledRef.current;
 
-      await sleep(600);
+      if (skipTyping) {
+        setPromptSubmitted(true);
+        setPromptText("");
+        setLines([{ type: "user", text: example.userMessage }]);
+      } else {
+        await sleep(600);
 
-      // User types char by char
-      for (let c = 0; c <= example.userMessage.length; c++) {
-        if (cancelled) return;
-        setPromptText(example.userMessage.slice(0, c));
-        await sleep(25);
+        for (let c = 0; c <= example.userMessage.length; c++) {
+          if (isCancelled()) return;
+          setPromptText(example.userMessage.slice(0, c));
+          await sleep(25);
+        }
+
+        await sleep(500);
+        if (isCancelled()) return;
+
+        setPromptSubmitted(true);
+        setPromptText("");
+        setLines([{ type: "user", text: example.userMessage }]);
       }
 
-      await sleep(500);
-      if (cancelled) return;
-
-      // Submit
-      setPromptSubmitted(true);
-      setPromptText("");
-      setLines([{ type: "user", text: example.userMessage }]);
-
       await sleep(300);
-      if (cancelled) return;
+      if (isCancelled()) return;
 
-      // Thinking (spinning)
       setLines((prev) => [...prev, { type: "thinking", done: false }]);
       await sleep(example.thinkDurationMs);
-      if (cancelled) return;
+      if (isCancelled()) return;
 
-      // Thinking done
       setLines((prev) =>
         prev.map((l) => (l.type === "thinking" ? { ...l, done: true } : l)),
       );
 
-      // Tool steps
       for (const tool of example.tools) {
         await sleep(300);
-        if (cancelled) return;
+        if (isCancelled()) return;
         setLines((prev) => [
           ...prev,
           { type: "tool", label: tool.label, done: false },
         ]);
         await sleep(tool.durationMs);
-        if (cancelled) return;
+        if (isCancelled()) return;
         setLines((prev) =>
           prev.map((l, i) =>
             i === prev.length - 1 && l.type === "tool"
@@ -113,21 +153,23 @@ function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
         );
       }
 
-      // Agent streams response word by word
       await sleep(400);
-      if (cancelled) return;
+      if (isCancelled()) return;
       setIsStreamingAgent(true);
       const words = example.agentResponse.split(/(?<=\s)/);
       let soFar = "";
       for (const word of words) {
-        if (cancelled) return;
+        if (isCancelled()) return;
         soFar += word;
+        streamingRef.current = soFar;
         setStreamingAgent(soFar);
         await sleep(35 + Math.random() * 30);
       }
       await sleep(200);
+      if (isCancelled()) return;
       setIsStreamingAgent(false);
       setStreamingAgent("");
+      streamingRef.current = "";
       setLines((prev) => [
         ...prev,
         { type: "agent", text: example.agentResponse },
@@ -137,9 +179,9 @@ function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
 
     void run();
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
     };
-  }, [example, animationKey]);
+  }, [example, animationKey, skipTyping]);
 
   return {
     lines,
@@ -148,13 +190,24 @@ function useTerminalAnimation(example: WorkflowExample, animationKey: number) {
     streamingAgent,
     isStreamingAgent,
     animationDone,
+    interrupt,
   };
 }
+
+const CTA_RESPONSE = "To try Libretto, run `npm create libretto@latest`";
 
 export function TerminalDemo() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [animationKey, setAnimationKey] = useState(0);
+  const [skipTyping, setSkipTyping] = useState(false);
+  const [userInput, setUserInput] = useState("");
+  const [extraLines, setExtraLines] = useState<Line[]>([]);
+  const [extraStreaming, setExtraStreaming] = useState("");
+  const [isExtraStreaming, setIsExtraStreaming] = useState(false);
+  const extraCancelRef = useRef(false);
+  const extraStreamingRef = useRef("");
   const bodyRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const example = workflowExamples[activeIndex];
 
@@ -165,46 +218,110 @@ export function TerminalDemo() {
     streamingAgent,
     isStreamingAgent,
     animationDone,
-  } = useTerminalAnimation(example, animationKey);
+    interrupt,
+  } = useTerminalAnimation(example, animationKey, skipTyping);
 
   useEffect(() => {
     if (bodyRef.current) {
       bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
     }
-  }, [lines, promptText, streamingAgent]);
+  }, [lines, promptText, streamingAgent, extraLines, extraStreaming]);
+
+  // Focus input when animation finishes
+  useEffect(() => {
+    if (animationDone && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [animationDone]);
 
   const handleTabClick = useCallback(
     (index: number) => {
       if (index === activeIndex) return;
       setActiveIndex(index);
+      setSkipTyping(true);
       setAnimationKey((k) => k + 1);
+      extraCancelRef.current = true;
+      setExtraLines([]);
+      setExtraStreaming("");
+      setIsExtraStreaming(false);
+      setUserInput("");
     },
     [activeIndex],
   );
 
+  const interruptExtraStreaming = useCallback(() => {
+    if (!isExtraStreaming) return;
+    extraCancelRef.current = true;
+    const partial = extraStreamingRef.current;
+    setIsExtraStreaming(false);
+    setExtraStreaming("");
+    extraStreamingRef.current = "";
+    setExtraLines((prev) => {
+      const next = [...prev];
+      if (partial) {
+        next.push({ type: "agent", text: partial });
+      }
+      next.push({ type: "interrupted" });
+      return next;
+    });
+  }, [isExtraStreaming]);
+
+  const handleUserSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const text = userInput.trim();
+      if (!text) return;
+      setUserInput("");
+
+      // Interrupt main animation if still running
+      if (!animationDone) {
+        interrupt();
+      }
+
+      // Interrupt extra streaming if running
+      interruptExtraStreaming();
+
+      // Add user message
+      setExtraLines((prev) => [...prev, { type: "user", text }]);
+
+      // Stream CTA response
+      extraCancelRef.current = false;
+      extraStreamingRef.current = "";
+
+      async function stream() {
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        await sleep(400);
+        if (extraCancelRef.current) return;
+        setIsExtraStreaming(true);
+        const words = CTA_RESPONSE.split(/(?<=\s)/);
+        let soFar = "";
+        for (const word of words) {
+          if (extraCancelRef.current) return;
+          soFar += word;
+          extraStreamingRef.current = soFar;
+          setExtraStreaming(soFar);
+          await sleep(35 + Math.random() * 30);
+        }
+        await sleep(200);
+        if (extraCancelRef.current) return;
+        setIsExtraStreaming(false);
+        setExtraStreaming("");
+        extraStreamingRef.current = "";
+        setExtraLines((prev) => [
+          ...prev,
+          { type: "agent", text: CTA_RESPONSE },
+        ]);
+      }
+      void stream();
+    },
+    [userInput, animationDone, interrupt, interruptExtraStreaming],
+  );
+
   return (
     <div className="mx-auto max-w-[600px] mt-16">
-      {/* Tabs */}
-      <div className="flex gap-1 mb-2 px-1 overflow-x-auto">
-        {workflowExamples.map((ex, i) => (
-          <button
-            key={ex.id}
-            type="button"
-            onClick={() => handleTabClick(i)}
-            className={`px-3 py-1.5 rounded-t-lg text-[12px] font-medium transition-colors whitespace-nowrap cursor-pointer ${
-              i === activeIndex
-                ? "bg-white text-ink border border-b-0 border-ink/[0.08]"
-                : "text-ink/40 hover:text-ink/60 hover:bg-ink/[0.03]"
-            }`}
-          >
-            {ex.tab}
-          </button>
-        ))}
-      </div>
-
       <div className="rounded-xl border border-ink/[0.08] bg-white shadow-lg overflow-hidden flex flex-col font-mono text-[13px]">
         {/* Title bar */}
-        <div className="flex items-center justify-between px-3 py-1.5 border-b border-ink/[0.06] bg-ink/[0.02]">
+        <div className="flex items-center justify-between px-3 py-1.5 bg-ink/[0.02]">
           <div className="flex gap-1.5">
             <div className="size-2.5 rounded-full bg-ink/10" />
             <div className="size-2.5 rounded-full bg-ink/10" />
@@ -229,6 +346,24 @@ export function TerminalDemo() {
           >
             <RefreshIcon className="size-3.5" />
           </button>
+        </div>
+
+        {/* macOS-style tab bar */}
+        <div className="flex border-y border-ink/[0.08] bg-ink/[0.04]">
+          {workflowExamples.map((ex, i) => (
+            <button
+              key={ex.id}
+              type="button"
+              onClick={() => handleTabClick(i)}
+              className={`flex-1 px-3 py-1.5 text-[11.5px] font-sans font-medium transition-colors duration-100 ease-out whitespace-nowrap border-r border-ink/[0.08] last:border-r-0 ${
+                i === activeIndex
+                  ? "bg-white text-ink/70"
+                  : "text-ink/35 hover:text-ink/50 hover:bg-ink/[0.02]"
+              }`}
+            >
+              {ex.tab}
+            </button>
+          ))}
         </div>
 
         {/* Body */}
@@ -260,6 +395,13 @@ export function TerminalDemo() {
                 </div>
               );
             }
+            if (line.type === "interrupted") {
+              return (
+                <div key={i} className="text-red-400 text-[12px] mb-1">
+                  Interrupted
+                </div>
+              );
+            }
             return null;
           })}
 
@@ -270,20 +412,68 @@ export function TerminalDemo() {
               <Cursor />
             </div>
           )}
+
+          {/* Extra lines from user input */}
+          {extraLines.map((line, i) => {
+            if (line.type === "user") {
+              return (
+                <div key={`extra-${i}`} className="flex gap-3 items-start mb-2">
+                  <div className="w-[3px] shrink-0 self-stretch bg-teal-500" />
+                  <span className="text-teal-700">{line.text}</span>
+                </div>
+              );
+            }
+            if (line.type === "agent") {
+              return (
+                <div
+                  key={`extra-${i}`}
+                  className="text-ink/70 whitespace-pre-wrap mt-1"
+                >
+                  {line.text}
+                </div>
+              );
+            }
+            if (line.type === "interrupted") {
+              return (
+                <div
+                  key={`extra-${i}`}
+                  className="text-red-400 text-[12px] mb-1"
+                >
+                  Interrupted
+                </div>
+              );
+            }
+            return null;
+          })}
+
+          {/* Extra streaming */}
+          {isExtraStreaming && (
+            <div className="text-ink/70 whitespace-pre-wrap mt-1">
+              {extraStreaming}
+              <Cursor />
+            </div>
+          )}
         </div>
 
         {/* Prompt box */}
-        <div className="border-t border-ink/[0.1] px-5 py-2.5 text-[12.5px]">
-          <div className="min-h-[24px] flex items-center text-ink/70">
-            {!promptSubmitted ? (
-              <>
-                <span>{promptText}</span>
-                <Cursor />
-              </>
-            ) : (
-              <span className="text-ink/20">Ask a question…</span>
-            )}
-          </div>
+        <div className="border-t border-ink/[0.1] text-[12.5px]">
+          {!promptSubmitted ? (
+            <div className="min-h-[24px] px-5 py-3 text-ink/70 leading-[1.65]">
+              {promptText}
+              <Cursor />
+            </div>
+          ) : (
+            <form onSubmit={handleUserSubmit}>
+              <input
+                ref={inputRef}
+                type="text"
+                value={userInput}
+                onChange={(e) => setUserInput(e.target.value)}
+                placeholder="Ask a question…"
+                className="w-full px-5 py-3 min-h-[24px] bg-transparent text-ink/70 placeholder:text-ink/20 outline-none leading-[1.65]"
+              />
+            </form>
+          )}
         </div>
       </div>
     </div>

--- a/apps/website/src/components/workflowExamples.ts
+++ b/apps/website/src/components/workflowExamples.ts
@@ -1,0 +1,236 @@
+export type ToolStep = {
+  label: string;
+  durationMs: number;
+};
+
+export type WorkflowExample = {
+  id: string;
+  tab: string;
+  userMessage: string;
+  thinkDurationMs: number;
+  tools: ToolStep[];
+  agentResponse: string;
+};
+
+export const workflowExamples: WorkflowExample[] = [
+  {
+    id: "craigslist",
+    tab: "Craigslist",
+    userMessage:
+      "Use the Libretto skill. Go on Craigslist and scrape the first 10 two-bedroom apartment listings for title, price, location, and link.",
+    thinkDurationMs: 1800,
+    tools: [
+      {
+        label: "bash: npx libretto open https://craigslist.org --headed",
+        durationMs: 1400,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Find 2BR apartment listings"',
+        durationMs: 1200,
+      },
+      {
+        label: 'bash: npx libretto exec "await page.locator(…).click()"',
+        durationMs: 900,
+      },
+      {
+        label:
+          "bash: npx libretto exec \"return await page.locator('.cl-static-search-result').first().textContent()\"",
+        durationMs: 800,
+      },
+      {
+        label: "write: craigslist_2br_apartments.ts",
+        durationMs: 1000,
+      },
+    ],
+    agentResponse:
+      "Created craigslist_2br_apartments.ts — a workflow that opens Craigslist, navigates to 2BR apartment listings, and scrapes the first 10 for title, price, location, and link.\n\nRun it anytime:\n  npx libretto run ./craigslist_2br_apartments.ts main --headless",
+  },
+  {
+    id: "linkedin",
+    tab: "LinkedIn",
+    userMessage:
+      "Use the Libretto skill. Go to LinkedIn and triage my pending connection requests — accept requests from people in healthcare or tech, and ignore the rest.",
+    thinkDurationMs: 2000,
+    tools: [
+      {
+        label: "bash: npx libretto open https://linkedin.com --headed",
+        durationMs: 1600,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Find pending connection requests"',
+        durationMs: 1400,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.goto(\'https://www.linkedin.com/mynetwork/invitation-manager/\')"',
+        durationMs: 1100,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "List all pending invitations with name, headline, and mutual connections"',
+        durationMs: 1200,
+      },
+      {
+        label:
+          'bash: npx libretto exec "return await page.locator(\'.invitation-card\').all()"',
+        durationMs: 900,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(…acceptBtn).click()"',
+        durationMs: 800,
+      },
+      {
+        label: "write: linkedin_triage_connections.ts",
+        durationMs: 1000,
+      },
+    ],
+    agentResponse:
+      "Created linkedin_triage_connections.ts — a workflow that opens LinkedIn, reads each pending connection request's headline and industry, accepts healthcare/tech connections, and ignores the rest.\n\nRun it anytime:\n  npx libretto run ./linkedin_triage_connections.ts main --headed",
+  },
+  {
+    id: "eclinicalworks",
+    tab: "eClinicalWorks",
+    userMessage:
+      "Use the Libretto skill. Log into eClinicalWorks, search for a patient by name and date of birth, and pull their insurance information including payer, member ID, group number, and coverage dates.",
+    thinkDurationMs: 2200,
+    tools: [
+      {
+        label: "bash: npx libretto open https://eclinicalworks.com --headed",
+        durationMs: 1800,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Find the login form"',
+        durationMs: 1000,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'#searchPatient\').fill(input.patientName)"',
+        durationMs: 900,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Locate insurance tab in patient chart"',
+        durationMs: 1300,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'[data-tab=insurance]\').click()"',
+        durationMs: 800,
+      },
+      {
+        label:
+          'bash: npx libretto exec "return await page.locator(\'.insurance-detail\').textContent()"',
+        durationMs: 1000,
+      },
+      {
+        label: "write: ecw_patient_insurance.ts",
+        durationMs: 1000,
+      },
+    ],
+    agentResponse:
+      "Created ecw_patient_insurance.ts — a workflow that logs into eClinicalWorks, searches for a patient by name and date of birth, navigates to their insurance tab, and extracts payer name, member ID, group number, and coverage dates.\n\nRun it anytime:\n  npx libretto run ./ecw_patient_insurance.ts main --headed",
+  },
+  {
+    id: "uhc",
+    tab: "UnitedHealthcare",
+    userMessage:
+      "Use the Libretto skill. Log into the UnitedHealthcare provider portal and review a submitted claim by claim number — pull back the status, paid amount, patient responsibility, and any denial codes.",
+    thinkDurationMs: 2000,
+    tools: [
+      {
+        label:
+          "bash: npx libretto open https://uhcprovider.com --headed",
+        durationMs: 1700,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Find the claim search form"',
+        durationMs: 1200,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'#claimNumber\').fill(input.claimNumber)"',
+        durationMs: 800,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'button:has-text(\"Search\")\').click()"',
+        durationMs: 900,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Extract claim status, payment details, and denial codes"',
+        durationMs: 1400,
+      },
+      {
+        label:
+          'bash: npx libretto exec "return await page.locator(\'.claim-summary\').textContent()"',
+        durationMs: 1000,
+      },
+      {
+        label: "write: uhc_claim_review.ts",
+        durationMs: 1000,
+      },
+    ],
+    agentResponse:
+      "Created uhc_claim_review.ts — a workflow that logs into the UHC provider portal, searches for a claim by number, and extracts the status, paid amount, patient responsibility, and any denial codes.\n\nRun it anytime:\n  npx libretto run ./uhc_claim_review.ts main --headed",
+  },
+  {
+    id: "availity",
+    tab: "Availity",
+    userMessage:
+      "Use the Libretto skill. Log into Availity and fill out a prior authorization request for a specialist referral — enter the patient info, referring provider, specialist details, diagnosis codes, and submit.",
+    thinkDurationMs: 2200,
+    tools: [
+      {
+        label: "bash: npx libretto open https://availity.com --headed",
+        durationMs: 1800,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Find the authorizations section"',
+        durationMs: 1200,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'a:has-text(\"Authorizations & Referrals\")\').click()"',
+        durationMs: 900,
+      },
+      {
+        label:
+          'bash: npx libretto snapshot --objective "Map out the prior auth form fields"',
+        durationMs: 1400,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'#memberId\').fill(input.memberId)"',
+        durationMs: 700,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'#diagnosisCode\').fill(input.diagnosisCode)"',
+        durationMs: 700,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'#referringProvider\').fill(input.referringNPI)"',
+        durationMs: 700,
+      },
+      {
+        label:
+          'bash: npx libretto exec "await page.locator(\'button:has-text(\"Submit\")\').click()"',
+        durationMs: 900,
+      },
+      {
+        label: "write: availity_prior_auth.ts",
+        durationMs: 1000,
+      },
+    ],
+    agentResponse:
+      "Created availity_prior_auth.ts — a workflow that logs into Availity, navigates to Authorizations & Referrals, fills out a prior auth form with patient info, provider details, and diagnosis codes, then submits.\n\nRun it anytime:\n  npx libretto run ./availity_prior_auth.ts main --headed",
+  },
+];

--- a/apps/website/src/components/workflowExamples.ts
+++ b/apps/website/src/components/workflowExamples.ts
@@ -136,7 +136,7 @@ export const workflowExamples: WorkflowExample[] = [
   },
   {
     id: "uhc",
-    tab: "UnitedHealthcare",
+    tab: "United Healthcare",
     userMessage:
       "Use the Libretto skill. Log into the UnitedHealthcare provider portal and review a submitted claim by claim number — pull back the status, paid amount, patient responsibility, and any denial codes.",
     thinkDurationMs: 2000,


### PR DESCRIPTION
## Summary

Overhaul the homepage terminal demo with tabbed workflow examples and interactive features:

- **Tabbed interface** — 5 workflow examples (Craigslist, LinkedIn, eClinicalWorks, United Healthcare, Availity) with macOS Terminal-style tab bar
- **Interactive input** — real text input in the prompt box; users can type and submit messages
- **Interruptible animations** — submitting while an animation is running cancels it with a red "Interrupted" indicator, then streams a CTA response
- **Fast tab switching** — skips the typing animation when switching tabs for snappier navigation
- **Data-driven** — extract workflow examples into `workflowExamples.ts` with a `useTerminalAnimation` hook

## Changes

- `TerminalDemo.tsx` — macOS-style integrated tab bar, real input prompt, interrupt support, multi-submit
- `workflowExamples.ts` — new file with 5 workflow example definitions

## Test plan

- [ ] Visit homepage and verify macOS-style tabs render inside the terminal chrome
- [ ] Click each tab — animation should skip typing and start from the submitted prompt
- [ ] Type in the input and press Enter — should show user message and stream CTA response
- [ ] Submit while animation is still running — should show "Interrupted" and then the CTA
- [ ] Submit multiple times — each message should accumulate in the terminal body
- [ ] Replay button still works on each tab
