### PR TITLE
Add Libretto Cloud browser provider (alpha)

### DIFF
--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -632,6 +632,7 @@ async function runIntegrationFromFile(
     viewport: args.viewport,
     accessMode: args.accessMode,
     cdpEndpoint: args.cdpEndpoint,
+    provider: args.provider,
   } satisfies RunIntegrationWorkerRequest);
   const worker = spawn(
     process.execPath,
@@ -873,31 +874,52 @@ export const runCommand = SimpleCLI.command({
 
     const providerName = resolveProviderName(input.provider);
     let cdpEndpoint: string | undefined;
+    let providerInfo: { name: string; sessionId: string } | undefined;
+    let provider: ReturnType<typeof getCloudProviderApi> | undefined;
     if (providerName !== "local") {
-      const provider = getCloudProviderApi(providerName);
+      provider = getCloudProviderApi(providerName);
       console.log(
         `Creating ${providerName} browser session (session: ${ctx.session})...`,
       );
       const providerSession = await provider.createSession();
       console.log(`Connecting to ${providerName} browser...`);
       cdpEndpoint = providerSession.cdpEndpoint;
+      providerInfo = {
+        name: providerName,
+        sessionId: providerSession.sessionId,
+      };
     }
 
-    await runIntegrationFromFile(
-      {
-        integrationPath: input.integrationFile!,
-        session: ctx.session,
-        params,
-        tsconfigPath: input.tsconfig,
-        headless: cdpEndpoint ? true : (headlessMode ?? false),
-        visualize,
-        authProfileDomain: input.authProfile,
-        viewport,
-        accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
-        cdpEndpoint,
-      },
-      ctx.logger,
-    );
+    try {
+      await runIntegrationFromFile(
+        {
+          integrationPath: input.integrationFile!,
+          session: ctx.session,
+          params,
+          tsconfigPath: input.tsconfig,
+          headless: cdpEndpoint ? true : (headlessMode ?? false),
+          visualize,
+          authProfileDomain: input.authProfile,
+          viewport,
+          accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
+          cdpEndpoint,
+          provider: providerInfo,
+        },
+        ctx.logger,
+      );
+    } catch (err) {
+      if (provider && providerInfo) {
+        try {
+          await provider.closeSession(providerInfo.sessionId);
+        } catch (cleanupErr) {
+          console.error(
+            `Failed to clean up ${providerInfo.name} session ${providerInfo.sessionId}:`,
+            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+          );
+        }
+      }
+      throw err;
+    }
   });
 
 export const resumeInput = SimpleCLI.input({

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -27,6 +27,7 @@ import {
   wrapPageForActionLogging,
 } from "../core/telemetry.js";
 import { readLibrettoConfig } from "../core/config.js";
+import { resolveProviderName, getCloudProviderApi } from "../core/providers/index.js";
 import { createReadonlyExecHelpers } from "../core/readonly-exec.js";
 import type { RunIntegrationWorkerRequest } from "../workers/run-integration-worker-protocol.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
@@ -630,6 +631,7 @@ async function runIntegrationFromFile(
     authProfileDomain: args.authProfileDomain,
     viewport: args.viewport,
     accessMode: args.accessMode,
+    cdpEndpoint: args.cdpEndpoint,
   } satisfies RunIntegrationWorkerRequest);
   const worker = spawn(
     process.execPath,
@@ -803,6 +805,10 @@ export const runInput = SimpleCLI.input({
     viewport: SimpleCLI.option(z.string().optional(), {
       help: "Viewport size as WIDTHxHEIGHT (e.g. 1920x1080)",
     }),
+    provider: SimpleCLI.option(z.string().optional(), {
+      help: "Browser provider (local, kernel, browserbase)",
+      aliases: ["-p"],
+    }),
   },
 })
   .refine(
@@ -865,17 +871,30 @@ export const runCommand = SimpleCLI.command({
       ctx.logger,
     );
 
+    const providerName = resolveProviderName(input.provider);
+    let cdpEndpoint: string | undefined;
+    if (providerName !== "local") {
+      const provider = getCloudProviderApi(providerName);
+      console.log(
+        `Creating ${providerName} browser session (session: ${ctx.session})...`,
+      );
+      const providerSession = await provider.createSession();
+      console.log(`Connecting to ${providerName} browser...`);
+      cdpEndpoint = providerSession.cdpEndpoint;
+    }
+
     await runIntegrationFromFile(
       {
         integrationPath: input.integrationFile!,
         session: ctx.session,
         params,
         tsconfigPath: input.tsconfig,
-        headless: headlessMode ?? false,
+        headless: cdpEndpoint ? true : (headlessMode ?? false),
         visualize,
         authProfileDomain: input.authProfile,
         viewport,
         accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
+        cdpEndpoint,
       },
       ctx.logger,
     );

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -890,36 +890,22 @@ export const runCommand = SimpleCLI.command({
       };
     }
 
-    try {
-      await runIntegrationFromFile(
-        {
-          integrationPath: input.integrationFile!,
-          session: ctx.session,
-          params,
-          tsconfigPath: input.tsconfig,
-          headless: cdpEndpoint ? true : (headlessMode ?? false),
-          visualize,
-          authProfileDomain: input.authProfile,
-          viewport,
-          accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
-          cdpEndpoint,
-          provider: providerInfo,
-        },
-        ctx.logger,
-      );
-    } catch (err) {
-      if (provider && providerInfo) {
-        try {
-          await provider.closeSession(providerInfo.sessionId);
-        } catch (cleanupErr) {
-          console.error(
-            `Failed to clean up ${providerInfo.name} session ${providerInfo.sessionId}:`,
-            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
-          );
-        }
-      }
-      throw err;
-    }
+    await runIntegrationFromFile(
+      {
+        integrationPath: input.integrationFile!,
+        session: ctx.session,
+        params,
+        tsconfigPath: input.tsconfig,
+        headless: cdpEndpoint ? true : (headlessMode ?? false),
+        visualize,
+        authProfileDomain: input.authProfile,
+        viewport,
+        accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
+        cdpEndpoint,
+        provider: providerInfo,
+      },
+      ctx.logger,
+    );
   });
 
 export const resumeInput = SimpleCLI.input({

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -890,22 +890,35 @@ export const runCommand = SimpleCLI.command({
       };
     }
 
-    await runIntegrationFromFile(
-      {
-        integrationPath: input.integrationFile!,
-        session: ctx.session,
-        params,
-        tsconfigPath: input.tsconfig,
-        headless: cdpEndpoint ? true : (headlessMode ?? false),
-        visualize,
-        authProfileDomain: input.authProfile,
-        viewport,
-        accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
-        cdpEndpoint,
-        provider: providerInfo,
-      },
-      ctx.logger,
-    );
+    try {
+      await runIntegrationFromFile(
+        {
+          integrationPath: input.integrationFile!,
+          session: ctx.session,
+          params,
+          tsconfigPath: input.tsconfig,
+          headless: cdpEndpoint ? true : (headlessMode ?? false),
+          visualize,
+          authProfileDomain: input.authProfile,
+          viewport,
+          accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
+          cdpEndpoint,
+          provider: providerInfo,
+        },
+        ctx.logger,
+      );
+    } finally {
+      if (provider && providerInfo) {
+        try {
+          await provider.closeSession(providerInfo.sessionId);
+        } catch (cleanupErr) {
+          console.error(
+            `Failed to clean up ${providerInfo.name} session ${providerInfo.sessionId}:`,
+            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+          );
+        }
+      }
+    }
   });
 
 export const resumeInput = SimpleCLI.input({

--- a/packages/libretto/src/cli/core/providers/index.ts
+++ b/packages/libretto/src/cli/core/providers/index.ts
@@ -1,9 +1,10 @@
 import { readLibrettoConfig } from "../config.js";
 import { createBrowserbaseProvider } from "./browserbase.js";
 import { createKernelProvider } from "./kernel.js";
+import { createLibrettoCloudProvider } from "./libretto-cloud.js";
 import type { ProviderApi } from "./types.js";
 
-const VALID_PROVIDERS = new Set(["local", "kernel", "browserbase"] as const);
+const VALID_PROVIDERS = new Set(["local", "kernel", "browserbase", "libretto-cloud"] as const);
 export type ProviderName =
   typeof VALID_PROVIDERS extends Set<infer T> ? T : never;
 
@@ -48,6 +49,11 @@ export function getCloudProviderApi(name: string): ProviderApi {
       return createKernelProvider();
     case "browserbase":
       return createBrowserbaseProvider();
+    case "libretto-cloud":
+      console.warn(
+        "Note: The libretto-cloud provider is in alpha.",
+      );
+      return createLibrettoCloudProvider();
     default:
       throw new Error(
         `Unknown provider "${name}". Valid cloud providers: kernel, browserbase`,

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -1,0 +1,61 @@
+import type { ProviderApi } from "./types.js";
+
+export function createLibrettoCloudProvider(): ProviderApi {
+  const apiKey = process.env.LIBRETTO_API_KEY;
+  if (!apiKey)
+    throw new Error(
+      "LIBRETTO_API_KEY is required for the Libretto Cloud provider.",
+    );
+  const apiUrl = process.env.LIBRETTO_API_URL;
+  if (!apiUrl)
+    throw new Error(
+      "LIBRETTO_API_URL is required for the Libretto Cloud provider.",
+    );
+  const endpoint = apiUrl.replace(/\/$/, "");
+
+  return {
+    async createSession() {
+      const timeoutSeconds = Number(
+        process.env.LIBRETTO_TIMEOUT_SECONDS ?? 7200,
+      );
+      const resp = await fetch(`${endpoint}/v1/sessions/create`, {
+        method: "POST",
+        headers: {
+          "x-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ timeout_seconds: timeoutSeconds }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(
+          `Libretto Cloud API error (${resp.status}): ${body}`,
+        );
+      }
+      const json = (await resp.json()) as {
+        session_id: string;
+        cdp_url: string;
+      };
+      return {
+        sessionId: json.session_id,
+        cdpEndpoint: json.cdp_url,
+      };
+    },
+    async closeSession(sessionId) {
+      const resp = await fetch(`${endpoint}/v1/sessions/close`, {
+        method: "POST",
+        headers: {
+          "x-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ session_id: sessionId }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(
+          `Libretto Cloud API error closing session ${sessionId} (${resp.status}): ${body}`,
+        );
+      }
+    },
+  };
+}

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -240,6 +240,7 @@ async function runIntegrationInternal(
     viewport: args.viewport,
     accessMode: args.accessMode,
     cdpEndpoint: args.cdpEndpoint,
+    provider: args.provider,
   });
   if (!args.headless && args.visualize !== false) {
     await installHeadedWorkflowVisualization({

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -239,6 +239,7 @@ async function runIntegrationInternal(
     storageStatePath,
     viewport: args.viewport,
     accessMode: args.accessMode,
+    cdpEndpoint: args.cdpEndpoint,
   });
   if (!args.headless && args.visualize !== false) {
     await installHeadedWorkflowVisualization({

--- a/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
@@ -11,6 +11,7 @@ export const RunIntegrationWorkerRequestSchema = z.object({
   viewport: z.object({ width: z.number(), height: z.number() }).optional(),
   accessMode: SessionAccessModeSchema.default("write-access"),
   cdpEndpoint: z.string().optional(),
+  provider: z.object({ name: z.string(), sessionId: z.string() }).optional(),
 });
 
 export type RunIntegrationWorkerRequest = z.infer<

--- a/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
+++ b/packages/libretto/src/cli/workers/run-integration-worker-protocol.ts
@@ -10,6 +10,7 @@ export const RunIntegrationWorkerRequestSchema = z.object({
   authProfileDomain: z.string().optional(),
   viewport: z.object({ width: z.number(), height: z.number() }).optional(),
   accessMode: SessionAccessModeSchema.default("write-access"),
+  cdpEndpoint: z.string().optional(),
 });
 
 export type RunIntegrationWorkerRequest = z.infer<

--- a/packages/libretto/src/shared/run/browser.ts
+++ b/packages/libretto/src/shared/run/browser.ts
@@ -37,6 +37,7 @@ export type LaunchBrowserArgs = {
   storageStatePath?: string;
   accessMode?: SessionAccessMode;
   cdpEndpoint?: string;
+  provider?: { name: string; sessionId: string };
 };
 
 export type BrowserSession = {
@@ -102,6 +103,7 @@ export async function launchBrowser({
   storageStatePath,
   accessMode = "write-access",
   cdpEndpoint,
+  provider,
 }: LaunchBrowserArgs): Promise<BrowserSession> {
   // Cloud/remote mode: connect to an existing CDP endpoint instead of launching locally
   if (cdpEndpoint) {
@@ -125,6 +127,7 @@ export async function launchBrowser({
           startedAt: new Date().toISOString(),
           status: "active",
           mode: accessMode,
+          ...(provider ? { provider } : {}),
         },
         null,
         2,

--- a/packages/libretto/src/shared/run/browser.ts
+++ b/packages/libretto/src/shared/run/browser.ts
@@ -36,6 +36,7 @@ export type LaunchBrowserArgs = {
   viewport?: { width: number; height: number };
   storageStatePath?: string;
   accessMode?: SessionAccessMode;
+  cdpEndpoint?: string;
 };
 
 export type BrowserSession = {
@@ -100,7 +101,48 @@ export async function launchBrowser({
   viewport = { width: 1366, height: 768 },
   storageStatePath,
   accessMode = "write-access",
+  cdpEndpoint,
 }: LaunchBrowserArgs): Promise<BrowserSession> {
+  // Cloud/remote mode: connect to an existing CDP endpoint instead of launching locally
+  if (cdpEndpoint) {
+    const browser = await chromium.connectOverCDP(cdpEndpoint);
+    const context =
+      browser.contexts()[0] ?? (await browser.newContext({ viewport }));
+    const page = context.pages()[0] ?? (await context.newPage());
+    page.setDefaultTimeout(30_000);
+    page.setDefaultNavigationTimeout(45_000);
+
+    const metadataPath = ensureLibrettoSessionStatePath(sessionName);
+    writeFileSync(
+      metadataPath,
+      JSON.stringify(
+        {
+          version: SESSION_STATE_VERSION,
+          session: sessionName,
+          port: 0,
+          cdpEndpoint,
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          status: "active",
+          mode: accessMode,
+        },
+        null,
+        2,
+      ),
+    );
+
+    return {
+      browser,
+      context,
+      page,
+      debugPort: 0,
+      metadataPath,
+      close: async () => {
+        await browser.close();
+      },
+    };
+  }
+
   const debugPort = await pickFreePort();
   const windowPosition = headless ? undefined : resolveWindowPosition();
   const browser = await chromium.launch({


### PR DESCRIPTION
## Summary
- Adds `libretto-cloud` as a new browser provider alongside Kernel and Browserbase
- Enables `libretto open <url> --provider libretto-cloud` and `libretto run <file> --provider libretto-cloud` to create browser sessions via the Libretto hosted platform API
- Adds `cdpEndpoint` passthrough in the `run` command worker protocol so cloud sessions work with `launchBrowser`
- Hidden from help text and error messages while in alpha; prints a notice on use
- Requires `LIBRETTO_API_URL` and `LIBRETTO_API_KEY` env vars

## Test plan
- [x] Provider create/close tested against mock API server
- [x] `open` command creates session, connects via CDP, cleans up on failure
- [x] `run` command creates session and passes CDP endpoint to worker
- [x] Alpha warning prints on use
- [x] Provider hidden from `--provider` help text and unknown provider errors
- [ ] End-to-end test against deployed platform API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
