### PR TITLE
revert: undo incomplete v0.6.0 version bump

### DIFF
--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.6.0",
+  "version": "0.5.6",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Reverts #197 which manually bumped version to 0.6.0 without updating SKILL.md files and mirrors
- The correct release process uses `scripts/prepare-release.sh minor` which handles all syncing

## Test plan
- Verify version is back to 0.5.6 in packages/libretto/package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
