### PR TITLE
chore: sync version to 0.6.0 with SKILL.md and mirrors

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Read-Only Works

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Works

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Read-Only Works

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Works

--- a/packages/create-libretto/package.json
+++ b/packages/create-libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-libretto",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Create and set up a Libretto project",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Read-Only Works

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.5.6"
+  version: "0.6.0"
 ---
 
 ## How Libretto Works


### PR DESCRIPTION
## Summary
- Syncs package.json version to 0.6.0 (already published to npm) along with all SKILL.md files, mirrors, and create-libretto version
- Fixes the state left by the revert of #197 so prepare-release.sh can correctly bump to 0.6.1

## Test plan
- `pnpm check:mirrors` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)