### PR TITLE
fix: stage all synced files in prepare-release.sh

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -88,7 +88,17 @@ node packages/dev-tools/scripts/set-libretto-skill-version.mjs "$next_version"
 pnpm sync:mirrors
 pnpm check:mirrors
 
-git add "$package_json_path" "$skill_path" README.md packages/libretto/README.md .agents/skills/libretto .claude/skills/libretto
+git add \
+  "$package_json_path" \
+  packages/libretto/skills/libretto/SKILL.md \
+  packages/libretto/skills/libretto-readonly/SKILL.md \
+  .agents/skills/libretto \
+  .agents/skills/libretto-readonly \
+  .claude/skills/libretto \
+  .claude/skills/libretto-readonly \
+  packages/create-libretto/package.json \
+  README.md \
+  packages/libretto/README.md
 git commit -m "release: v${next_version}"
 git push -u origin "$branch_name"
 


### PR DESCRIPTION
## Summary
- Fixes `scripts/prepare-release.sh` to stage all files updated by `sync:mirrors`
- Previously missing: `libretto-readonly` skills, `create-libretto/package.json`, and readonly mirror directories
- This caused release PRs to be incomplete (see #201 review comments)

## Test plan
- Run `scripts/prepare-release.sh patch` and verify all synced files are included in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
