### PR TITLE
Add libretto to minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,7 @@ packages:
   - "packages/*"
 
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - libretto
 
 enablePrePostScripts: false


### PR DESCRIPTION
## Summary

Adds `libretto` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` so it bypasses the 7-day minimum release age gate and always installs the newest version immediately.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
