### PR TITLE
ci: publish create-libretto in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,10 +160,20 @@ jobs:
       - name: Build publish artifacts
         run: pnpm --filter libretto build
 
-      - name: Publish to npm with trusted publishing
+      - name: Publish libretto to npm
         if: needs.verify.outputs.npm_exists != 'true'
         working-directory: packages/libretto
         run: npm publish --access public
+
+      - name: Publish create-libretto to npm
+        if: needs.verify.outputs.npm_exists != 'true'
+        working-directory: packages/create-libretto
+        run: |
+          if ! npm view "create-libretto@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then
+            npm publish --access public
+          else
+            echo "create-libretto@${{ needs.verify.outputs.version }} already published, skipping."
+          fi
 
       - name: Generate changelog
         if: needs.verify.outputs.release_exists != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,6 @@ jobs:
         run: npm publish --access public
 
       - name: Publish create-libretto to npm
-        if: needs.verify.outputs.npm_exists != 'true'
         working-directory: packages/create-libretto
         run: |
           if ! npm view "create-libretto@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Adds an `npm publish` step for `create-libretto` alongside the existing `libretto` publish in the release workflow
- Checks if the version is already published before attempting to avoid failures
- Enables `pnpm create libretto@latest my-project` once published

## Test plan
- Merge and verify next release publishes both packages to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
