### PR TITLE
Allow `libretto close <session>` as positional argument

### DIFF
--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -242,7 +242,11 @@ export const sessionModeCommand = SimpleCLI.command({
   });
 
 export const closeInput = SimpleCLI.input({
-  positionals: [],
+  positionals: [
+    SimpleCLI.positional("session", z.string().optional(), {
+      help: "Session name to close",
+    }),
+  ],
   named: {
     session: sessionOption(),
     all: SimpleCLI.flag({
@@ -254,7 +258,7 @@ export const closeInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.all || input.session,
-  `Usage: libretto close --session <name>\nUsage: libretto close --all [--force]`,
+  `Usage: libretto close <session>\nUsage: libretto close --all [--force]`,
 );
 
 export const closeCommand = SimpleCLI.command({

--- a/packages/libretto/src/cli/framework/simple-cli.ts
+++ b/packages/libretto/src/cli/framework/simple-cli.ts
@@ -1265,14 +1265,17 @@ function buildInputNormalizer<
         key,
       ].filter((candidate) => candidate.length > 0);
 
-      let value: unknown = undefined;
+      let found = false;
       for (const candidate of normalizedCandidates) {
         if (Object.prototype.hasOwnProperty.call(named, candidate)) {
-          value = named[candidate];
+          output[key] = named[candidate];
+          found = true;
           break;
         }
       }
-      output[key] = value;
+      if (!found && !Object.prototype.hasOwnProperty.call(output, key)) {
+        output[key] = undefined;
+      }
     }
 
     return output as InputObjectFor<TPositionals, TNamed>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,15 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  tmp/test-providers:
+    dependencies:
+      '@ai-sdk/google-vertex':
+        specifier: ^4.0.95
+        version: 4.0.95(zod@4.3.6)
+      libretto:
+        specifier: ^0.6.0
+        version: 0.6.0(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.95(zod@4.3.6))(@ai-sdk/google@3.0.53(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6))
+
 packages:
 
   '@ai-sdk/anthropic@3.0.64':
@@ -3160,6 +3169,24 @@ packages:
 
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
+
+  libretto@0.6.0:
+    resolution: {integrity: sha512-O+UNrdUkn99mGgzeHp2bexM25lq6XgIdMtfmFfQ9DIQ6AxHkwgu5NwQrbGufDvZqPjTyvtWIWXURpLz/USWZuQ==}
+    hasBin: true
+    peerDependencies:
+      '@ai-sdk/anthropic': ^3.0.58
+      '@ai-sdk/google': ^3.0.51
+      '@ai-sdk/google-vertex': ^4.0.80
+      '@ai-sdk/openai': ^3.0.41
+    peerDependenciesMeta:
+      '@ai-sdk/anthropic':
+        optional: true
+      '@ai-sdk/google':
+        optional: true
+      '@ai-sdk/google-vertex':
+        optional: true
+      '@ai-sdk/openai':
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -7077,6 +7104,19 @@ snapshots:
 
   koffi@2.15.2:
     optional: true
+
+  libretto@0.6.0(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.95(zod@4.3.6))(@ai-sdk/google@3.0.53(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6)):
+    dependencies:
+      ai: 6.0.140(zod@4.3.6)
+      esbuild: 0.27.4
+      playwright: 1.58.2
+      tsx: 4.21.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
+      '@ai-sdk/google': 3.0.53(zod@4.3.6)
+      '@ai-sdk/google-vertex': 4.0.95(zod@4.3.6)
+      '@ai-sdk/openai': 3.0.48(zod@4.3.6)
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
## Summary

`libretto close` now accepts the session name as a positional argument in addition to the existing `--session` flag:

```bash
# New (positional)
libretto close my-session

# Still works (named flag)
libretto close --session my-session
```

## Changes

- **`packages/libretto/src/cli/commands/browser.ts`** — Added a positional `session` arg to the `close` command input, updated usage text.
- **`packages/libretto/src/cli/framework/simple-cli.ts`** — Fixed `buildInputNormalizer` so that when a named arg shares a key with a positional, the named arg only overwrites the positional value if it was explicitly provided by the user. Previously it would always overwrite with `undefined`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
