### PR TITLE
fix: poll deployment sync until workflows are populated

### DIFF
--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -61,21 +61,26 @@ async function pollDeployment(
 ): Promise<DeploymentResponse["json"]> {
   const start = Date.now();
   let status: DeploymentStatus = "building";
+  let workflows: string[] | null | undefined = null;
   let deployment: DeploymentResponse["json"] | undefined;
 
-  while (status === "building" && Date.now() - start < maxWaitMs) {
+  while (
+    (status === "building" || (status === "ready" && !workflows?.length)) &&
+    Date.now() - start < maxWaitMs
+  ) {
     await new Promise((r) => setTimeout(r, pollIntervalMs));
 
-    const res = await postJson(apiUrl, apiKey, "/v1/deployments/get", {
+    const res = await postJson(apiUrl, apiKey, "/v1/deployments/sync", {
       id: deploymentId,
     });
     const body = (await res.json()) as DeploymentResponse;
     if (res.status !== 200) {
       throw new Error(
-        `Failed to get deployment status (${res.status}): ${JSON.stringify(body)}`,
+        `Failed to sync deployment status (${res.status}): ${JSON.stringify(body)}`,
       );
     }
     status = body.json.status;
+    workflows = body.json.workflows;
     deployment = body.json;
     process.stdout.write(".");
   }

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -60,14 +60,17 @@ async function pollDeployment(
   maxWaitMs: number,
 ): Promise<DeploymentResponse["json"]> {
   const start = Date.now();
+  const workflowWaitMs = 60_000;
   let status: DeploymentStatus = "building";
   let workflows: string[] | null | undefined = null;
+  let readyAt: number | null = null;
   let deployment: DeploymentResponse["json"] | undefined;
 
-  while (
-    (status === "building" || (status === "ready" && !workflows?.length)) &&
-    Date.now() - start < maxWaitMs
-  ) {
+  while (Date.now() - start < maxWaitMs) {
+    if (status !== "building" && status !== "ready") break;
+    if (status === "ready" && workflows?.length) break;
+    if (status === "ready" && readyAt && Date.now() - readyAt > workflowWaitMs) break;
+
     await new Promise((r) => setTimeout(r, pollIntervalMs));
 
     const res = await postJson(apiUrl, apiKey, "/v1/deployments/sync", {
@@ -82,12 +85,19 @@ async function pollDeployment(
     status = body.json.status;
     workflows = body.json.workflows;
     deployment = body.json;
+    if (status === "ready" && readyAt === null) readyAt = Date.now();
     process.stdout.write(".");
   }
   console.log();
 
   if (!deployment) {
     throw new Error("Deployment timed out before receiving a status update.");
+  }
+
+  if (status === "ready" && !workflows?.length) {
+    throw new Error(
+      "Build completed but workflow discovery failed due to a server-side error. Please redeploy.",
+    );
   }
 
   return deployment;


### PR DESCRIPTION
## Summary
- Update CLI deploy command to use renamed `/v1/deployments/sync` endpoint
- Extend poll loop to continue while status is "ready" but workflows are not yet populated, so the CLI waits for workflow discovery to complete

## Context
Companion to saffron-health/browser-automations branch `fix/deployment-status-stuck-building`, which renames the deployment get route to sync and fixes workflow discovery retry logic.

## Test plan
- [ ] Deploy a workflow and verify the CLI waits for workflows to appear before exiting
- [ ] Verify the CLI still times out gracefully if workflows never populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
