### PR TITLE
Simplify CLI help text and add mirror check to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Verify release build
         if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: |
+          pnpm check:mirrors
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:

--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -1,5 +1,7 @@
+import { resolveAiSetupStatus } from "./core/ai-model.js";
 import { ensureLibrettoSetup } from "./core/context.js";
 import { createCLIApp } from "./router.js";
+import { warnIfInstalledSkillOutOfDate } from "./core/skill-version.js";
 
 function renderUsage(app: ReturnType<typeof createCLIApp>): string {
   return `${app.renderHelp()}
@@ -7,56 +9,34 @@ function renderUsage(app: ReturnType<typeof createCLIApp>): string {
 Options:
   --session <name>        Use a named session (auto-generated for open/run if omitted)
 
-Examples:
-  libretto open https://linkedin.com
-
-  # ... manually log in ...
-  libretto save linkedin.com
-  # Next time you open linkedin.com, you'll be logged in automatically
-
-  libretto exec "await page.locator('button:has-text(\\"Sign in\\")').click()"
-  libretto exec "await page.fill('input[name=\\"email\\"]', 'test@example.com')"
-  libretto readonly-exec "return await page.title()" --session test1
-  libretto connect http://127.0.0.1:9222 --read-only --session test1
-  libretto run ./integration.ts --read-only --session test1
-  libretto status
-  libretto ai configure openai
-  libretto ai configure anthropic
-  libretto ai configure gemini
-  libretto ai configure vertex
-  libretto ai configure openai/gpt-4o
-  libretto snapshot
-  libretto snapshot --objective "Find the submit button" --context "Submitting a referral form, already filled in patient details"
-  libretto resume --session my-session
-  libretto close
-  libretto close --all
-  libretto close --all --force
-
-  # Multiple sessions
-  libretto open https://site1.com --session test1
-  libretto open https://site2.com --session test2
-  libretto exec "return await page.title()" --session test1
-
-Available in exec:
-  page, context, state, browser, networkLog, actionLog
-
-Available in readonly-exec:
-  page, state, snapshot, scrollBy, get
-
-Profiles:
-  Profiles are saved to .libretto/profiles/<domain>.json (git-ignored)
-  They persist cookies, localStorage, and session data across browser launches.
-  Local profiles are machine-local and are not shared with other users/environments.
-  Sessions can expire; if run fails auth, log in again and re-save the profile.
-
-Sessions:
-  Session state is stored in .libretto/sessions/<session>/state.json
-  CLI logs are stored in .libretto/sessions/<session>/logs.jsonl
-  Each session runs an isolated browser instance on a dynamic port.
-  Session mode is stored per session as read-only or write-access.
-  Use --read-only on open, connect, or run to create a read-only session.
-  Session mode is enforced by Libretto commands, not by raw CDP clients outside Libretto.
+Docs (agent-friendly): https://libretto.sh/docs
 `;
+}
+
+function printSetupAudit(): void {
+  warnIfInstalledSkillOutOfDate();
+
+  const status = resolveAiSetupStatus();
+  switch (status.kind) {
+    case "ready":
+      console.log(`✓ AI model: ${status.model}`);
+      break;
+    case "configured-missing-credentials":
+      console.log(
+        `✗ ${status.provider} configured (model: ${status.model}), but credentials are missing. Run \`npx libretto setup\` to repair.`,
+      );
+      break;
+    case "invalid-config":
+      console.log(
+        `✗ AI config is invalid. Run \`npx libretto setup\` to reconfigure.`,
+      );
+      break;
+    case "unconfigured":
+      console.log(
+        `✗ No AI model configured. Run \`npx libretto setup\` or \`npx libretto ai configure\` to set up.`,
+      );
+      break;
+  }
 }
 
 function isRootHelpRequest(rawArgs: readonly string[]): boolean {
@@ -74,6 +54,7 @@ export async function runLibrettoCLI(): Promise<void> {
   try {
     if (isRootHelpRequest(rawArgs)) {
       console.log(renderUsage(app));
+      printSetupAudit();
       return;
     }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -280,8 +280,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("Capture PNG + HTML");
     expect(result.stdout).not.toContain("cloud <subcommand>");
     expect(result.stdout).toContain("experimental <subcommand>");
-    expect(result.stdout).toContain("\nSessions:\n  Session state is stored");
-    expect(result.stdout).toContain("libretto status");
+    expect(result.stdout).toContain("Docs (agent-friendly): https://libretto.sh/docs");
     expect(result.stderr).toBe("");
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,10 +247,10 @@ importers:
     dependencies:
       '@ai-sdk/google-vertex':
         specifier: ^4.0.95
-        version: 4.0.95(zod@4.3.6)
+        version: 4.0.97(zod@4.3.6)
       libretto:
-        specifier: ^0.6.0
-        version: 0.6.0(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.95(zod@4.3.6))(@ai-sdk/google@3.0.53(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6))
+        specifier: ^0.6.2
+        version: 0.6.2(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.97(zod@4.3.6))(@ai-sdk/google@3.0.54(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6))
 
 packages:
 
@@ -266,14 +266,38 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.84':
+    resolution: {integrity: sha512-RnUw6UNvkaw9MEaJU9cIjA+WBP+ZR5+M/9nfbfJHcGKtTbcWXijJuYKx9nYRnm+qU+iiakb0XvQA/vvho6lTsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google-vertex@4.0.95':
     resolution: {integrity: sha512-xL44fHlTtDM7RLkMTgyqMfkfthA38JS91bbMaHItObIhte1PAIY936ZV1PLl/Z9A/oBAXjHWbXo5xDoHzB7LEg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/google-vertex@4.0.97':
+    resolution: {integrity: sha512-++lTUhZ3Ktw9TPfuGOmMi1LlNphmJ4BoyGnlF742YxwFBg8923LqlqjvEADOvM/mlUExz4+n9NsTwlJAddj0ZQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@3.0.53':
     resolution: {integrity: sha512-uz8tIlkDgQJG9Js2Wh9JHzd4kI9+hYJqf9XXJLx60vyN5mRIqhr49iwR5zGP5Gl8odp2PeR3Gh2k+5bh3Z1HHw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.54':
+    resolution: {integrity: sha512-EgYYdA2LpHZefLDU/FIpmeTlL5Hi4WKQZY3nACMh0wVhrS1fAvlfrdwnD1G4ISCOKWMWrMcRZX9ubs3NM/KHfA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.37':
+    resolution: {integrity: sha512-+POSFVcgiu47BK64dhsI6OpcDC0/VAE2ZSaXdXGNNhpC/ava++uSRJYks0k2bpfY0wwCTgpAWZsXn/dG2Yppiw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2456,6 +2480,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ai@6.0.142:
+    resolution: {integrity: sha512-ZoxAsnTL/dFg5WdcwC8QNhKVlLtqwwT3I7p/4i8IJJP+6ZwqF1ljuwMsAsPYYvppZ+RzUxjxxFGb1cbEhNH3dg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -3170,8 +3200,8 @@ packages:
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
 
-  libretto@0.6.0:
-    resolution: {integrity: sha512-O+UNrdUkn99mGgzeHp2bexM25lq6XgIdMtfmFfQ9DIQ6AxHkwgu5NwQrbGufDvZqPjTyvtWIWXURpLz/USWZuQ==}
+  libretto@0.6.2:
+    resolution: {integrity: sha512-fr+4p9bRvsvFvmVx5kJKL7VqZE1nB0ywLkSkL5LNvNAerwMoF/8P1pn0dHjQ+mYiJ00//Bnmnvz3MOdLKmPiRw==}
     hasBin: true
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.58
@@ -4382,6 +4412,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@3.0.84(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/google-vertex@4.0.95(zod@4.3.6)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
@@ -4393,7 +4430,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ai-sdk/google-vertex@4.0.97(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
+      '@ai-sdk/google': 3.0.54(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 2.0.37(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      google-auth-library: 10.6.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@ai-sdk/google@3.0.53(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/google@3.0.54(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/openai-compatible@2.0.37(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
@@ -6346,6 +6407,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ai@6.0.142(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.84(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -7105,17 +7174,17 @@ snapshots:
   koffi@2.15.2:
     optional: true
 
-  libretto@0.6.0(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.95(zod@4.3.6))(@ai-sdk/google@3.0.53(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6)):
+  libretto@0.6.2(@ai-sdk/anthropic@3.0.64(zod@4.3.6))(@ai-sdk/google-vertex@4.0.97(zod@4.3.6))(@ai-sdk/google@3.0.54(zod@4.3.6))(@ai-sdk/openai@3.0.48(zod@4.3.6)):
     dependencies:
-      ai: 6.0.140(zod@4.3.6)
+      ai: 6.0.142(zod@4.3.6)
       esbuild: 0.27.4
       playwright: 1.58.2
       tsx: 4.21.0
       zod: 4.3.6
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
-      '@ai-sdk/google': 3.0.53(zod@4.3.6)
-      '@ai-sdk/google-vertex': 4.0.95(zod@4.3.6)
+      '@ai-sdk/google': 3.0.54(zod@4.3.6)
+      '@ai-sdk/google-vertex': 4.0.97(zod@4.3.6)
       '@ai-sdk/openai': 3.0.48(zod@4.3.6)
 
   lightningcss-android-arm64@1.32.0:


### PR DESCRIPTION
## Summary

- **Simplify CLI help text**: Replace verbose inline examples, profiles docs, and session docs with a link to `https://libretto.sh/docs`. Keeps `--help` concise and agent-friendly.
- **Add setup audit to help output**: When `--help` is printed, also show AI model configuration status so users get immediate feedback on their setup.
- **Add `pnpm check:mirrors` to release workflow**: Ensures mirror files are in sync before publishing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
