### PR TITLE
Fix tab animation race condition in website terminal demo

### DIFF
--- a/apps/website/src/components/TerminalDemo.tsx
+++ b/apps/website/src/components/TerminalDemo.tsx
@@ -55,12 +55,12 @@ function useTerminalAnimation(
   const [streamingAgent, setStreamingAgent] = useState("");
   const [isStreamingAgent, setIsStreamingAgent] = useState(false);
   const [animationDone, setAnimationDone] = useState(false);
-  const cancelledRef = useRef(false);
+  const generationRef = useRef(0);
   const streamingRef = useRef("");
 
   const interrupt = useCallback(() => {
     if (animationDone) return;
-    cancelledRef.current = true;
+    generationRef.current++;
 
     // Commit any partial streaming text
     const partial = streamingRef.current;
@@ -89,7 +89,7 @@ function useTerminalAnimation(
   }, [animationDone]);
 
   useEffect(() => {
-    cancelledRef.current = false;
+    const gen = ++generationRef.current;
     streamingRef.current = "";
 
     setLines([]);
@@ -101,7 +101,7 @@ function useTerminalAnimation(
 
     async function run() {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-      const isCancelled = () => cancelledRef.current;
+      const isCancelled = () => generationRef.current !== gen;
 
       if (skipTyping) {
         setPromptSubmitted(true);
@@ -179,7 +179,7 @@ function useTerminalAnimation(
 
     void run();
     return () => {
-      cancelledRef.current = true;
+      generationRef.current++;
     };
   }, [example, animationKey, skipTyping]);
 


### PR DESCRIPTION
## Summary

Fixes a race condition in the `TerminalDemo` component where switching tabs caused both the old and new tab animations to run simultaneously, mixing their output (e.g., clicking the Availity tab would show Craigslist content interleaved with Availity steps).

## Root cause

`useTerminalAnimation` used a shared `cancelledRef` boolean to cancel in-flight animations. When switching tabs:

1. Effect cleanup set `cancelledRef.current = true`
2. New effect immediately set `cancelledRef.current = false`
3. Old async animation resumed, saw `isCancelled()` returning `false`, and kept running

## Fix

Replaced the boolean `cancelledRef` with a generation counter `generationRef`. Each animation run captures its own generation number (`const gen = ++generationRef.current`), and `isCancelled()` checks `generationRef.current !== gen`. Incrementing the counter permanently invalidates all previous runs regardless of timing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
