### PR TITLE
[NTN-324] Install correct AI SDK package with create-libretto

### DIFF
--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -124,6 +124,20 @@ function installCommand(pkgManager) {
   }
 }
 
+/** Return the command for adding a specific package (e.g. `npm install <pkg>`). */
+function addCommand(pkgManager) {
+  switch (pkgManager) {
+    case "yarn":
+      return "yarn add";
+    case "bun":
+      return "bun add";
+    case "pnpm":
+      return "pnpm add";
+    default:
+      return "npm install";
+  }
+}
+
 /** Return the run command for scripts (used in next-steps messaging). */
 function runCommand(pkgManager) {
   switch (pkgManager) {
@@ -379,17 +393,18 @@ export async function scaffoldProject(
     if (provider) {
       const sdkPackage = PROVIDER_SDK_PACKAGES[provider];
       const spec = resolveSdkVersionSpec(targetDir, sdkPackage);
+      const add = addCommand(pkgManager);
       console.log(`\nInstalling ${spec}...`);
       const sdkSpinner = createSpinner(`Installing ${sdkPackage}...`);
       const sdkResult = await runInstallAsync(
-        `${installCommand(pkgManager)} ${spec}`,
+        `${add} ${spec}`,
         targetDir,
       );
       sdkSpinner.stop();
 
       if (sdkResult.status !== 0) {
         console.error(
-          `\nFailed to install ${sdkPackage}. Install it manually: ${installCommand(pkgManager)} ${spec}`,
+          `\nFailed to install ${sdkPackage}. Install it manually: ${add} ${spec}`,
         );
       } else {
         console.log(`${GREEN}✓${RESET} Installed ${sdkPackage}`);

--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -30,6 +30,59 @@ const GREEN = "\x1b[32m";
 const CYAN = "\x1b[36m";
 
 // ---------------------------------------------------------------------------
+// Provider → AI SDK package mapping
+// ---------------------------------------------------------------------------
+
+const PROVIDER_SDK_PACKAGES = {
+  openai: "@ai-sdk/openai",
+  anthropic: "@ai-sdk/anthropic",
+  google: "@ai-sdk/google",
+  vertex: "@ai-sdk/google-vertex",
+};
+
+/**
+ * Read `.libretto/config.json` and extract the provider prefix from `ai.model`.
+ * Returns null if config is missing or model is not recognized.
+ */
+function detectProviderFromConfig(targetDir) {
+  const configPath = join(targetDir, ".libretto", "config.json");
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const model = config?.ai?.model;
+    if (typeof model !== "string") return null;
+
+    const provider = model.split("/")[0];
+    if (provider in PROVIDER_SDK_PACKAGES) return provider;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the peer-dependency version range for the SDK package from the
+ * installed libretto package.json. Falls back to "latest" if not found.
+ */
+function resolveSdkVersionSpec(targetDir, sdkPackage) {
+  try {
+    const librettoPkgPath = join(
+      targetDir,
+      "node_modules",
+      "libretto",
+      "package.json",
+    );
+    const librettoPkg = JSON.parse(readFileSync(librettoPkgPath, "utf-8"));
+    const range = librettoPkg.peerDependencies?.[sdkPackage];
+    if (range) return `${sdkPackage}@${range}`;
+  } catch {
+    // fall through
+  }
+  return sdkPackage;
+}
+
+// ---------------------------------------------------------------------------
 // Package manager detection
 // ---------------------------------------------------------------------------
 
@@ -319,6 +372,28 @@ export async function scaffoldProject(
     } catch {
       console.error(`\nFailed to run libretto setup.`);
       process.exit(1);
+    }
+
+    // 6. Install the AI SDK package for the selected provider
+    const provider = detectProviderFromConfig(targetDir);
+    if (provider) {
+      const sdkPackage = PROVIDER_SDK_PACKAGES[provider];
+      const spec = resolveSdkVersionSpec(targetDir, sdkPackage);
+      console.log(`\nInstalling ${spec}...`);
+      const sdkSpinner = createSpinner(`Installing ${sdkPackage}...`);
+      const sdkResult = await runInstallAsync(
+        `${installCommand(pkgManager)} ${spec}`,
+        targetDir,
+      );
+      sdkSpinner.stop();
+
+      if (sdkResult.status !== 0) {
+        console.error(
+          `\nFailed to install ${sdkPackage}. Install it manually: ${installCommand(pkgManager)} ${spec}`,
+        );
+      } else {
+        console.log(`${GREEN}✓${RESET} Installed ${sdkPackage}`);
+      }
     }
   }
 }

--- a/packages/create-libretto/template/src/workflows/star-repo.ts
+++ b/packages/create-libretto/template/src/workflows/star-repo.ts
@@ -7,6 +7,14 @@ import { log } from "../shared/utils.js";
 export default workflow("star-repo", async ({ page }) => {
   log("Navigating to Libretto repo...");
   await page.goto("https://github.com/saffron-health/libretto");
-  await page.locator('button:has-text("Star")').click();
-  log("Starred the repo!");
+
+  const description = await page
+    .locator('meta[name="description"]')
+    .getAttribute("content");
+  log(`Repo description: ${description}`);
+
+  const stars = await page.locator("#repo-stars-counter-star").textContent();
+  log(`Stars: ${stars?.trim()}`);
+
+  log("Done! Edit this workflow or create your own in src/workflows/.");
 });


### PR DESCRIPTION
## Summary

When `create-libretto` scaffolds a new project and the user configures a snapshot API provider (OpenAI, Anthropic, Google Gemini, or Vertex), the correct `@ai-sdk/*` peer-dependency package is now automatically installed.

### How it works

1. After `libretto setup` writes `.libretto/config.json` with the selected provider's model (e.g. `openai/gpt-5.4`), `create-libretto` reads the config and extracts the provider prefix.
2. It looks up the matching SDK package from a `PROVIDER_SDK_PACKAGES` map (`openai` → `@ai-sdk/openai`, `anthropic` → `@ai-sdk/anthropic`, `google` → `@ai-sdk/google`, `vertex` → `@ai-sdk/google-vertex`).
3. It reads the version range from the installed `libretto` package's `peerDependencies` to install the correct version.
4. If no provider is configured (user skipped setup), no SDK package is installed — no error.

### Also fixes the example workflow

The template `star-repo.ts` workflow used `button:has-text("Star")` which never matched (GitHub's star element is an `<a>` tag) and required authentication. Replaced with a read-only workflow that reads the repo description via `meta[name="description"]` and star count via `#repo-stars-counter-star` — works headless without login.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
