### PR TITLE
Website: polish npm and community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub Discussions](https://img.shields.io/github/discussions/saffron-health/libretto)](https://github.com/saffron-health/libretto/discussions)
+[![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/NYrG56hVDt)
+
+- Website: [libretto.sh](https://libretto.sh)
+- Repository: [github.com/saffron-health/libretto](https://github.com/saffron-health/libretto)
+- Docs: [libretto.sh/docs](https://libretto.sh/docs)
+- Discord: [discord.gg/NYrG56hVDt](https://discord.gg/NYrG56hVDt)
 
 Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to:
 
@@ -137,7 +143,7 @@ Profiles save browser sessions (cookies, localStorage) so you can reuse authenti
 
 ## Community
 
-Have a question, idea, or want to share what you've built? Join the conversation on [GitHub Discussions](https://github.com/saffron-health/libretto/discussions).
+Have a question, idea, or want to share what you've built? Join the conversation on [Discord](https://discord.gg/NYrG56hVDt) for quick help or [GitHub Discussions](https://github.com/saffron-health/libretto/discussions) for longer-form threads.
 
 - **[Q&A](https://github.com/saffron-health/libretto/discussions/categories/q-a)** — Ask questions and get help
 - **[Ideas](https://github.com/saffron-health/libretto/discussions/categories/ideas)** — Suggest new features or improvements

--- a/apps/website/src/components/CanvasAsciihedron.tsx
+++ b/apps/website/src/components/CanvasAsciihedron.tsx
@@ -638,16 +638,11 @@ export function KonamiOverlay({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.8, y: -4 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
-            style={
+            className={`inline-flex h-5 items-center justify-center rounded border px-1.5 py-0.5 transition-colors duration-200 ${
               completed
-                ? {
-                    color: "rgb(22, 163, 74)",
-                    borderColor: "rgba(22, 163, 74, 0.5)",
-                    transition: "color 0.2s, border-color 0.2s",
-                  }
-                : undefined
-            }
-            className="inline-flex h-5 items-center justify-center rounded border border-stone-300/60 px-1.5 py-0.5 text-stone-400/80"
+                ? "border-green-900/20 bg-green-500/15 text-green-950/80"
+                : "border-ink/[0.08] bg-ink/[0.025] text-ink/55"
+            }`}
           >
             {label}
           </motion.span>

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { Text } from "./Text";
-import { DiscordIcon, GitHubIcon, LinkedInIcon } from "../icons";
-import { DISCORD_URL, REPO_URL } from "../site";
+import { DiscordIcon, GitHubIcon, NpmIcon } from "../icons";
+import { DISCORD_URL, NPM_URL, REPO_URL } from "../site";
 
 export function Footer() {
   return (
@@ -12,13 +12,13 @@ export function Footer() {
         </Text>
         <div className="flex items-center gap-3">
           <a
-            href="https://www.linkedin.com/company/saffron-health"
+            href={NPM_URL}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Saffron Health on LinkedIn"
+            aria-label="Libretto on npm"
             className="text-muted/50 transition-colors hover:text-muted"
           >
-            <LinkedInIcon width={14} height={14} />
+            <NpmIcon width={28} height={12} />
           </a>
           <a
             href={DISCORD_URL}

--- a/apps/website/src/components/MaintainingFeatures.tsx
+++ b/apps/website/src/components/MaintainingFeatures.tsx
@@ -117,7 +117,7 @@ const features: MaintainFeature[] = [
     icon: <LayersIcon className="text-ink/40" />,
   },
   {
-    title: "Read-only mode for sensitive workflows",
+    title: "Read-only mode",
     description:
       "Enable read-only mode to restrict the agent to only observing the page. It won't fill out incorrect information or submit something unexpected.",
     icon: <LogInIcon className="text-ink/40" />,

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -7,8 +7,8 @@ import {
   Button as AriaButton,
 } from "react-aria-components";
 import { motion } from "motion/react";
-import { GitHubStarIcon } from "../icons";
-import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "../site";
+import { GitHubStarIcon, NpmIcon } from "../icons";
+import { DISCUSSIONS_URL, NPM_URL, RELEASES_URL, REPO_URL } from "../site";
 import { CrossfadeIcon } from "./CrossfadeIcon";
 
 type AnimationState = "unmounted" | "hidden" | "visible";
@@ -130,6 +130,15 @@ export function MobileMenu({ stars }: { stars: string | null }) {
               className={itemClass}
             >
               Changelog
+            </MenuItem>
+            <MenuItem
+              href={NPM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={itemClass}
+            >
+              <NpmIcon width={28} height={12} />
+              npm
             </MenuItem>
             <MenuItem
               href={REPO_URL}

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { Text } from "./Text";
 import { Button } from "./Button";
-import { GitHubStarIcon } from "../icons";
+import { GitHubStarIcon, NpmIcon } from "../icons";
 import { AnimationTarget } from "./AnimationOrchestration";
-import { DISCUSSIONS_URL, RELEASES_URL, REPO_URL } from "../site";
+import { DISCUSSIONS_URL, NPM_URL, RELEASES_URL, REPO_URL } from "../site";
 import { AppLink } from "../routing";
 import { MobileMenu } from "./MobileMenu";
 
@@ -73,6 +73,15 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
         </div>
         <div className="flex items-center gap-4">
           <a
+            href={NPM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Libretto on npm"
+            className="hidden text-ink/70 transition-colors hover:text-ink md:flex"
+          >
+            <NpmIcon width={36} height={14} />
+          </a>
+          <a
             href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
@@ -87,9 +96,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             Go to docs
           </Button>
           <div className="md:hidden">
-            <MobileMenu
-              stars={stars !== null ? formatStars(stars) : null}
-            />
+            <MobileMenu stars={stars !== null ? formatStars(stars) : null} />
           </div>
         </div>
       </div>

--- a/apps/website/src/components/SecurityScanAnimation.tsx
+++ b/apps/website/src/components/SecurityScanAnimation.tsx
@@ -113,7 +113,10 @@ function StepRow({
 
 function MockWebsitePanel() {
   return (
-    <div className="relative min-w-[76%] self-start flex-1 overflow-visible rounded-lg border border-ink/10 bg-white/60 sm:min-w-0">
+    <div
+      className="relative min-w-[76%] flex-1 overflow-visible rounded-lg border border-ink/10 bg-white/60 sm:min-w-0"
+      style={{ alignSelf: "safe center" }}
+    >
       {/* Placeholder layout lines */}
       <div className="flex flex-col gap-2 p-4 pt-5">
         {/* Nav bar suggestion */}
@@ -267,7 +270,7 @@ export function SecurityScanAnimation() {
   }, []);
 
   return (
-    <div className="flex h-full w-full flex-row items-start gap-3 overflow-hidden p-4 sm:items-center">
+    <div className="flex h-full w-full flex-row items-start gap-3 overflow-visible p-4 sm:items-center">
       {/* Left: checklist */}
       <motion.div
         layout

--- a/apps/website/src/components/VersionBadge.tsx
+++ b/apps/website/src/components/VersionBadge.tsx
@@ -1,34 +1,48 @@
 import { useEffect, useState } from "react";
+import { RELEASES_URL } from "../site";
 
-function useNpmVersion(pkg: string) {
-  const [version, setVersion] = useState<string | null>(null);
+interface ReleaseInfo {
+  tagName: string;
+  url: string;
+}
+
+function useLatestRelease(repo: string) {
+  const [release, setRelease] = useState<ReleaseInfo | null>(null);
 
   useEffect(() => {
-    fetch(`https://registry.npmjs.org/${pkg}/latest`)
+    fetch(`https://api.github.com/repos/${repo}/releases/latest`)
       .then((r) => r.json())
       .then((data) => {
-        if (typeof data.version === "string") {
-          setVersion(data.version);
+        if (typeof data.tag_name === "string" && typeof data.html_url === "string") {
+          setRelease({
+            tagName: data.tag_name,
+            url: data.html_url,
+          });
         }
       })
       .catch(() => {});
-  }, [pkg]);
+  }, [repo]);
 
-  return version;
+  return release;
 }
 
 export function VersionBadge() {
-  const version = useNpmVersion("libretto");
+  const release = useLatestRelease("saffron-health/libretto");
 
-  if (version === null) {
+  if (release === null) {
     return null;
   }
 
   return (
     <div className="mb-8 flex items-center justify-center">
-      <div className="inline-flex items-center gap-2 rounded-full border border-ink/12 bg-ink/[0.06] px-3 py-1 font-mono text-[11px] backdrop-blur-sm">
-        <span className="tabular-nums text-ink/50">v{version}</span>
-      </div>
+      <a
+        href={release.url || RELEASES_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 rounded-full border border-ink/12 bg-ink/[0.06] px-3 py-1 font-mono text-[11px] text-ink/50 backdrop-blur-sm transition-colors hover:text-ink"
+      >
+        <span className="tabular-nums">{release.tagName}</span>
+      </a>
     </div>
   );
 }

--- a/apps/website/src/components/VersionBadge.tsx
+++ b/apps/website/src/components/VersionBadge.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { RELEASES_URL } from "../site";
 
 interface ReleaseInfo {
   tagName: string;
@@ -36,7 +35,7 @@ export function VersionBadge() {
   return (
     <div className="mb-8 flex items-center justify-center">
       <a
-        href={release.url || RELEASES_URL}
+        href={release.url}
         target="_blank"
         rel="noopener noreferrer"
         className="inline-flex items-center gap-2 rounded-full border border-ink/12 bg-ink/[0.06] px-3 py-1 font-mono text-[11px] text-ink/50 backdrop-blur-sm transition-colors hover:text-ink"

--- a/apps/website/src/icons/NpmIcon.tsx
+++ b/apps/website/src/icons/NpmIcon.tsx
@@ -1,0 +1,18 @@
+export function NpmIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 18 7"
+      fill="none"
+      width="36"
+      height="14"
+      aria-hidden="true"
+      {...props}
+    >
+      <path fill="currentColor" d="M0,0v6h5v1h4v-1h9v-6" />
+      <path
+        fill="#FFFFFF"
+        d="M1,1v4h2v-3h1v3h1v-4h1v5h2v-4h1v2h-1v1h2v-4h1v4h2v-3h1v3h1v-3h1v3h1v-4"
+      />
+    </svg>
+  );
+}

--- a/apps/website/src/icons/index.ts
+++ b/apps/website/src/icons/index.ts
@@ -8,4 +8,5 @@ export { GitHubIcon } from "./GitHubIcon";
 export { GitHubStarIcon } from "./GitHubStarIcon";
 export { KernelLogo } from "./KernelLogo";
 export { LinkedInIcon } from "./LinkedInIcon";
+export { NpmIcon } from "./NpmIcon";
 export { RefreshIcon } from "./RefreshIcon";

--- a/apps/website/src/main.tsx
+++ b/apps/website/src/main.tsx
@@ -4,11 +4,12 @@ import "./index.css";
 import { App } from "./App";
 import { IcosahedronDebug } from "./IcosahedronDebug";
 
-if (import.meta.env.DEV) {
-  void import("cssstudio").then(({ startStudio }) => {
-    startStudio();
-  });
-}
+// Temporarily disabled.
+// if (import.meta.env.DEV) {
+//   void import("cssstudio").then(({ startStudio }) => {
+//     startStudio();
+//   });
+// }
 
 const path = window.location.pathname;
 const DevAgentation = import.meta.env.DEV

--- a/apps/website/src/site.ts
+++ b/apps/website/src/site.ts
@@ -2,3 +2,4 @@ export const REPO_URL = "https://github.com/saffron-health/libretto";
 export const DISCUSSIONS_URL = `${REPO_URL}/discussions`;
 export const RELEASES_URL = `${REPO_URL}/releases`;
 export const DISCORD_URL = "https://discord.gg/NYrG56hVDt";
+export const NPM_URL = "https://www.npmjs.com/package/libretto";

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -5,6 +5,12 @@
 [![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub Discussions](https://img.shields.io/github/discussions/saffron-health/libretto)](https://github.com/saffron-health/libretto/discussions)
+[![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/NYrG56hVDt)
+
+- Website: [libretto.sh](https://libretto.sh)
+- Repository: [github.com/saffron-health/libretto](https://github.com/saffron-health/libretto)
+- Docs: [libretto.sh/docs](https://libretto.sh/docs)
+- Discord: [discord.gg/NYrG56hVDt](https://discord.gg/NYrG56hVDt)
 
 Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to:
 
@@ -137,7 +143,7 @@ Profiles save browser sessions (cookies, localStorage) so you can reuse authenti
 
 ## Community
 
-Have a question, idea, or want to share what you've built? Join the conversation on [GitHub Discussions](https://github.com/saffron-health/libretto/discussions).
+Have a question, idea, or want to share what you've built? Join the conversation on [Discord](https://discord.gg/NYrG56hVDt) for quick help or [GitHub Discussions](https://github.com/saffron-health/libretto/discussions) for longer-form threads.
 
 - **[Q&A](https://github.com/saffron-health/libretto/discussions/categories/q-a)** — Ask questions and get help
 - **[Ideas](https://github.com/saffron-health/libretto/discussions/categories/ideas)** — Suggest new features or improvements

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -3,6 +3,12 @@
 [![npm version](https://img.shields.io/npm/v/libretto)](https://www.npmjs.com/package/libretto)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub Discussions](https://img.shields.io/github/discussions/saffron-health/libretto)](https://github.com/saffron-health/libretto/discussions)
+[![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/NYrG56hVDt)
+
+- Website: [libretto.sh](https://libretto.sh)
+- Repository: [github.com/saffron-health/libretto](https://github.com/saffron-health/libretto)
+- Docs: [libretto.sh/docs](https://libretto.sh/docs)
+- Discord: [discord.gg/NYrG56hVDt](https://discord.gg/NYrG56hVDt)
 
 Libretto is a toolkit for building robust web integrations. It gives your coding agent a live browser and a token-efficient CLI to:
 
@@ -135,7 +141,7 @@ Profiles save browser sessions (cookies, localStorage) so you can reuse authenti
 
 ## Community
 
-Have a question, idea, or want to share what you've built? Join the conversation on [GitHub Discussions](https://github.com/saffron-health/libretto/discussions).
+Have a question, idea, or want to share what you've built? Join the conversation on [Discord](https://discord.gg/NYrG56hVDt) for quick help or [GitHub Discussions](https://github.com/saffron-health/libretto/discussions) for longer-form threads.
 
 - **[Q&A](https://github.com/saffron-health/libretto/discussions/categories/q-a)** — Ask questions and get help
 - **[Ideas](https://github.com/saffron-health/libretto/discussions/categories/ideas)** — Suggest new features or improvements


### PR DESCRIPTION
## Summary
- add npm entry points across the website nav, mobile menu, and footer, plus a shared npm icon/url constant
- switch the homepage version badge to the latest GitHub release and refresh README/community links to point at the website, docs, and Discord
- apply small website polish tweaks, including animation styling/copy updates and temporarily disabling CSS Studio boot in `main.tsx`

## Testing
- pnpm -s --filter @libretto/website build

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
