### PR TITLE
Fix __name ReferenceError in page.evaluate for tsx-compiled workflows

### DIFF
--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -196,6 +196,7 @@ const __NAME_SHIM = [
  */
 const EVALUATE_METHOD_NAMES = [
   "evaluate",
+  "evaluateAll",
   "evaluateHandle",
   "waitForFunction",
   "$eval",

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -235,8 +235,16 @@ function shimCallback<T>(fn: T): T {
 }
 
 /**
+ * $eval and $$eval take (selector, pageFunction, arg?) — callback is at index 1.
+ * All other evaluate methods take (pageFunction, arg?) — callback is at index 0.
+ */
+function callbackIndex(methodName: string): number {
+  return methodName === "$eval" || methodName === "$$eval" ? 1 : 0;
+}
+
+/**
  * Return a proxied Page where evaluate-family methods automatically shim
- * their first (callback) argument with a __name polyfill.
+ * their callback argument with a __name polyfill.
  */
 function shimPageEvaluateMethods(page: Page): Page {
   return new Proxy(page, {
@@ -248,9 +256,10 @@ function shimPageEvaluateMethods(page: Page): Page {
         (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
         typeof value === "function"
       ) {
+        const cbIdx = callbackIndex(prop);
         return function (this: unknown, ...args: unknown[]) {
-          if (args.length > 0) {
-            args[0] = shimCallback(args[0]);
+          if (args.length > cbIdx) {
+            args[cbIdx] = shimCallback(args[cbIdx]);
           }
           return (value as Function).apply(target, args);
         };
@@ -289,9 +298,10 @@ function shimEvaluateMethods<T extends object>(obj: T): T {
         (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
         typeof value === "function"
       ) {
+        const cbIdx = callbackIndex(prop);
         return function (this: unknown, ...args: unknown[]) {
-          if (args.length > 0) {
-            args[0] = shimCallback(args[0]);
+          if (args.length > cbIdx) {
+            args[cbIdx] = shimCallback(args[cbIdx]);
           }
           return (value as Function).apply(target, args);
         };

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Page } from "playwright";
+import type { BrowserContext } from "playwright";
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
@@ -176,142 +176,6 @@ async function loadDefaultWorkflow(
   );
 }
 
-// ---------------------------------------------------------------------------
-// tsx/esbuild __name shim for page.evaluate and similar Playwright APIs
-// ---------------------------------------------------------------------------
-// When tsx compiles TypeScript with keepNames: true, it wraps functions with
-// __name(...) calls. Playwright serializes callback arguments to these APIs
-// via Function#toString() and evaluates them in the browser context, which
-// does not have __name defined. We intercept these methods and prepend a
-// no-op __name polyfill so the serialized source executes correctly.
-// ---------------------------------------------------------------------------
-
-const __NAME_SHIM = [
-  "const __name = (target, value) =>",
-  "  Object.defineProperty(target, 'name', { value, configurable: true });",
-].join(" ");
-
-/**
- * Methods on Page/Frame that serialize a JS callback into the browser context.
- */
-const EVALUATE_METHOD_NAMES = [
-  "evaluate",
-  "evaluateAll",
-  "evaluateHandle",
-  "waitForFunction",
-  "$eval",
-  "$$eval",
-] as const;
-
-/**
- * Wrap a function so that when Playwright serializes it, the source includes
- * a __name shim. We create a wrapper whose toString() output prepends the shim
- * before the original function body.
- */
-function shimCallback<T>(fn: T): T {
-  if (typeof fn !== "function") return fn;
-
-  const original = fn as Function;
-  const originalSource = original.toString();
-
-  // Only shim if the source actually references __name
-  if (!originalSource.includes("__name")) return fn;
-
-  // Build a wrapper that Playwright will serialize via toString().
-  // The wrapper source includes the __name shim followed by the original
-  // function invocation.
-  const shimmedSource = `${__NAME_SHIM}\nreturn (${originalSource}).apply(this, arguments);`;
-
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const shimmed = new Function(shimmedSource) as T & Function;
-
-  // Preserve arity information for Playwright's serializer
-  Object.defineProperty(shimmed, "length", {
-    value: original.length,
-    configurable: true,
-  });
-
-  return shimmed as T;
-}
-
-/**
- * $eval and $$eval take (selector, pageFunction, arg?) — callback is at index 1.
- * All other evaluate methods take (pageFunction, arg?) — callback is at index 0.
- */
-function callbackIndex(methodName: string): number {
-  return methodName === "$eval" || methodName === "$$eval" ? 1 : 0;
-}
-
-/**
- * Return a proxied Page where evaluate-family methods automatically shim
- * their callback argument with a __name polyfill.
- */
-function shimPageEvaluateMethods(page: Page): Page {
-  return new Proxy(page, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-
-      if (
-        typeof prop === "string" &&
-        (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
-        typeof value === "function"
-      ) {
-        const cbIdx = callbackIndex(prop);
-        return function (this: unknown, ...args: unknown[]) {
-          if (args.length > cbIdx) {
-            args[cbIdx] = shimCallback(args[cbIdx]);
-          }
-          return (value as Function).apply(target, args);
-        };
-      }
-
-      // Also proxy mainFrame() and locator() so their evaluate methods are shimmed
-      if (prop === "mainFrame" && typeof value === "function") {
-        return function (this: unknown, ...args: unknown[]) {
-          const frame = (value as Function).apply(target, args);
-          return shimEvaluateMethods(frame);
-        };
-      }
-
-      if (prop === "locator" && typeof value === "function") {
-        return function (this: unknown, ...args: unknown[]) {
-          const locator = (value as Function).apply(target, args);
-          return shimEvaluateMethods(locator);
-        };
-      }
-
-      return value;
-    },
-  });
-}
-
-/**
- * Generic evaluate-method shim for Frame, Locator, ElementHandle, etc.
- */
-function shimEvaluateMethods<T extends object>(obj: T): T {
-  return new Proxy(obj, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-
-      if (
-        typeof prop === "string" &&
-        (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
-        typeof value === "function"
-      ) {
-        const cbIdx = callbackIndex(prop);
-        return function (this: unknown, ...args: unknown[]) {
-          if (args.length > cbIdx) {
-            args[cbIdx] = shimCallback(args[cbIdx]);
-          }
-          return (value as Function).apply(target, args);
-        };
-      }
-
-      return value;
-    },
-  });
-}
-
 export async function installHeadedWorkflowVisualization(args: {
   context: BrowserContext;
   logger: LoggerApi;
@@ -405,9 +269,19 @@ async function runIntegrationInternal(
     },
   });
 
+  // tsx/esbuild injects __name() wrappers when keepNames is true. Playwright
+  // serializes callbacks via Function#toString() into the browser context which
+  // lacks __name, causing ReferenceError. Inject a no-op polyfill into every page.
+  await browserSession.context.addInitScript(() => {
+    (globalThis as Record<string, unknown>).__name = (
+      target: unknown,
+      value: string,
+    ) => Object.defineProperty(target as object, "name", { value, configurable: true });
+  });
+
   const workflowContext: LibrettoWorkflowContext = {
     session: args.session,
-    page: shimPageEvaluateMethods(browserSession.page),
+    page: browserSession.page,
   };
 
   try {

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext } from "playwright";
+import type { BrowserContext, Page } from "playwright";
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
@@ -176,6 +176,131 @@ async function loadDefaultWorkflow(
   );
 }
 
+// ---------------------------------------------------------------------------
+// tsx/esbuild __name shim for page.evaluate and similar Playwright APIs
+// ---------------------------------------------------------------------------
+// When tsx compiles TypeScript with keepNames: true, it wraps functions with
+// __name(...) calls. Playwright serializes callback arguments to these APIs
+// via Function#toString() and evaluates them in the browser context, which
+// does not have __name defined. We intercept these methods and prepend a
+// no-op __name polyfill so the serialized source executes correctly.
+// ---------------------------------------------------------------------------
+
+const __NAME_SHIM = [
+  "const __name = (target, value) =>",
+  "  Object.defineProperty(target, 'name', { value, configurable: true });",
+].join(" ");
+
+/**
+ * Methods on Page/Frame that serialize a JS callback into the browser context.
+ */
+const EVALUATE_METHOD_NAMES = [
+  "evaluate",
+  "evaluateHandle",
+  "waitForFunction",
+  "$eval",
+  "$$eval",
+] as const;
+
+/**
+ * Wrap a function so that when Playwright serializes it, the source includes
+ * a __name shim. We create a wrapper whose toString() output prepends the shim
+ * before the original function body.
+ */
+function shimCallback<T>(fn: T): T {
+  if (typeof fn !== "function") return fn;
+
+  const original = fn as Function;
+  const originalSource = original.toString();
+
+  // Only shim if the source actually references __name
+  if (!originalSource.includes("__name")) return fn;
+
+  // Build a wrapper that Playwright will serialize via toString().
+  // The wrapper source includes the __name shim followed by the original
+  // function invocation.
+  const shimmedSource = `${__NAME_SHIM}\nreturn (${originalSource}).apply(this, arguments);`;
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const shimmed = new Function(shimmedSource) as T & Function;
+
+  // Preserve arity information for Playwright's serializer
+  Object.defineProperty(shimmed, "length", {
+    value: original.length,
+    configurable: true,
+  });
+
+  return shimmed as T;
+}
+
+/**
+ * Return a proxied Page where evaluate-family methods automatically shim
+ * their first (callback) argument with a __name polyfill.
+ */
+function shimPageEvaluateMethods(page: Page): Page {
+  return new Proxy(page, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (
+        typeof prop === "string" &&
+        (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
+        typeof value === "function"
+      ) {
+        return function (this: unknown, ...args: unknown[]) {
+          if (args.length > 0) {
+            args[0] = shimCallback(args[0]);
+          }
+          return (value as Function).apply(target, args);
+        };
+      }
+
+      // Also proxy mainFrame() and locator() so their evaluate methods are shimmed
+      if (prop === "mainFrame" && typeof value === "function") {
+        return function (this: unknown, ...args: unknown[]) {
+          const frame = (value as Function).apply(target, args);
+          return shimEvaluateMethods(frame);
+        };
+      }
+
+      if (prop === "locator" && typeof value === "function") {
+        return function (this: unknown, ...args: unknown[]) {
+          const locator = (value as Function).apply(target, args);
+          return shimEvaluateMethods(locator);
+        };
+      }
+
+      return value;
+    },
+  });
+}
+
+/**
+ * Generic evaluate-method shim for Frame, Locator, ElementHandle, etc.
+ */
+function shimEvaluateMethods<T extends object>(obj: T): T {
+  return new Proxy(obj, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (
+        typeof prop === "string" &&
+        (EVALUATE_METHOD_NAMES as readonly string[]).includes(prop) &&
+        typeof value === "function"
+      ) {
+        return function (this: unknown, ...args: unknown[]) {
+          if (args.length > 0) {
+            args[0] = shimCallback(args[0]);
+          }
+          return (value as Function).apply(target, args);
+        };
+      }
+
+      return value;
+    },
+  });
+}
+
 export async function installHeadedWorkflowVisualization(args: {
   context: BrowserContext;
   logger: LoggerApi;
@@ -271,7 +396,7 @@ async function runIntegrationInternal(
 
   const workflowContext: LibrettoWorkflowContext = {
     session: args.session,
-    page: browserSession.page,
+    page: shimPageEvaluateMethods(browserSession.page),
   };
 
   try {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1018,6 +1018,36 @@ export default workflow("main", async () => {
     expect(result.stdout).not.toContain("Workflow paused.");
   }, 45_000);
 
+  test("run succeeds with page.evaluate callbacks containing nested helpers (tsx __name shim)", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const integrationFilePath = await writeWorkflow(
+      "integration-evaluate-nested.ts",
+      `
+export default workflow("main", async ({ page }) => {
+  await page.goto("https://example.com");
+  const value = await page.evaluate(async () => {
+    const normalize = (input: string | null | undefined) => input?.trim() ?? null;
+    const parseNumberLike = (input: unknown) =>
+      Number(String(input).replace(/[^\\d.]/g, ""));
+    return { text: normalize(" x "), num: parseNumberLike("12") };
+  });
+  console.log("EVAL_RESULT", JSON.stringify(value));
+});
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session evaluate-nested-test --headless`,
+    );
+    expect(result.stderr).not.toContain("__name is not defined");
+    expect(result.stdout).toContain("EVAL_RESULT");
+    expect(result.stdout).toContain('"text":"x"');
+    expect(result.stdout).toContain('"num":12');
+    expect(result.stdout).toContain("Integration completed.");
+  }, 45_000);
+
   test("run prints failure guidance and keeps browser open for exec inspection", async ({
     librettoCli,
     writeWorkflow,


### PR DESCRIPTION
## Summary

Fix `ReferenceError: __name is not defined` when tsx-compiled TypeScript workflows pass callbacks to Playwright's `page.evaluate()` and similar methods during `libretto run`.

## Root cause

tsx/esbuild compiles with `keepNames: true`, injecting `__name()` wrapper calls into function bodies. Playwright serializes callbacks via `Function#toString()` into the browser context, which lacks `__name`, causing a `ReferenceError`.

## Fix

Use `context.addInitScript()` to inject a no-op `__name` polyfill into every browser page before any workflow code runs. This is a 5-line fix that covers all Playwright APIs that serialize JS into the browser — `evaluate`, `evaluateHandle`, `waitForFunction`, `$eval`, `$$eval`, `addInitScript`, etc.

## Test

Added a regression test with a `.ts` workflow that uses nested arrow helpers inside `page.evaluate`, verifying the workflow completes without error.
