### PR TITLE
skill: present a concrete test-run command after workflow validation

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -34,7 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
+- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -218,7 +218,9 @@ Assistant: [Reads `references/code-generation-rules.md` before writing productio
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
-Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+Assistant: Validation passed. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 ```
@@ -239,7 +241,9 @@ Assistant: [Reads `references/code-generation-rules.md` before patching the work
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
-Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+Assistant: Fix verified. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./integration.ts --headed
 ```

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -34,6 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
+- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -214,7 +215,13 @@ Assistant: [Reads `references/site-security-review.md` before choosing between p
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page and need the first meaningful step."`]
 Assistant: [Uses `snapshot` and `exec` as needed to understand the site and decide the implementation path]
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
-Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
+Assistant: I found the working path. I'll now create the workflow file and verify it.
+Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+```
+npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+```
 </example>
 ```
 
@@ -229,7 +236,13 @@ Assistant: The workflow failed and Libretto kept the browser open. I'll inspect 
 Assistant: [Runs `npx libretto snapshot --session debug-flow --objective "Find the blocking error or broken selector target" --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
-Assistant: I found the issue. I'll patch the workflow code, then rerun `npx libretto run ...` to verify the fix.
+Assistant: I found the issue. I'll patch the workflow code and verify.
+Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+```
+npx libretto run ./integration.ts --headed
+```
 </example>
 ```
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -220,10 +220,7 @@ Assistant: [Creates or edits `target-workflow.ts` following `references/code-gen
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
-```
+To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 </example>
 ```
 
@@ -243,10 +240,7 @@ Assistant: [Edits `integration.ts` following `references/code-generation-rules.m
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
 Assistant: Fix verified. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./integration.ts --headed
-```
+To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
 </example>
 ```
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -34,7 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
+- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -218,7 +218,9 @@ Assistant: [Reads `references/code-generation-rules.md` before writing productio
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
-Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+Assistant: Validation passed. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 ```
@@ -239,7 +241,9 @@ Assistant: [Reads `references/code-generation-rules.md` before patching the work
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
-Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+Assistant: Fix verified. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./integration.ts --headed
 ```

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -34,6 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
+- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -214,7 +215,13 @@ Assistant: [Reads `references/site-security-review.md` before choosing between p
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page and need the first meaningful step."`]
 Assistant: [Uses `snapshot` and `exec` as needed to understand the site and decide the implementation path]
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
-Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
+Assistant: I found the working path. I'll now create the workflow file and verify it.
+Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+```
+npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+```
 </example>
 ```
 
@@ -229,7 +236,13 @@ Assistant: The workflow failed and Libretto kept the browser open. I'll inspect 
 Assistant: [Runs `npx libretto snapshot --session debug-flow --objective "Find the blocking error or broken selector target" --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
-Assistant: I found the issue. I'll patch the workflow code, then rerun `npx libretto run ...` to verify the fix.
+Assistant: I found the issue. I'll patch the workflow code and verify.
+Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+```
+npx libretto run ./integration.ts --headed
+```
 </example>
 ```
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -220,10 +220,7 @@ Assistant: [Creates or edits `target-workflow.ts` following `references/code-gen
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
-```
+To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 </example>
 ```
 
@@ -243,10 +240,7 @@ Assistant: [Edits `integration.ts` following `references/code-generation-rules.m
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
 Assistant: Fix verified. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./integration.ts --headed
-```
+To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
 </example>
 ```
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -34,7 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
+- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -218,7 +218,9 @@ Assistant: [Reads `references/code-generation-rules.md` before writing productio
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
-Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+Assistant: Validation passed. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 ```
@@ -239,7 +241,9 @@ Assistant: [Reads `references/code-generation-rules.md` before patching the work
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
-Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+Assistant: Fix verified. Here are the results:
+[Shows the output/results from the headless run]
+To watch it yourself in a browser:
 ```
 npx libretto run ./integration.ts --headed
 ```

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -34,6 +34,7 @@ metadata:
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
 - Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
+- After validation, always present the user with a ready-to-run command they can copy-paste to test the workflow themselves (e.g. `npx libretto run ./workflow.ts --headed --params '{"key":"value"}'`). Include `--headed` so they can watch the browser, and include any `--params` or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -214,7 +215,13 @@ Assistant: [Reads `references/site-security-review.md` before choosing between p
 Assistant: [Runs `npx libretto snapshot --objective "Find the next required action" --context "We are starting the workflow from the landing page and need the first meaningful step."`]
 Assistant: [Uses `snapshot` and `exec` as needed to understand the site and decide the implementation path]
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
-Assistant: I found the working path. I'll now update the workflow file outside Libretto and verify it with `npx libretto run ...`.
+Assistant: I found the working path. I'll now create the workflow file and verify it.
+Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: Headless validation passed. Here is the command to test-run the workflow yourself in a visible browser:
+```
+npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+```
 </example>
 ```
 
@@ -229,7 +236,13 @@ Assistant: The workflow failed and Libretto kept the browser open. I'll inspect 
 Assistant: [Runs `npx libretto snapshot --session debug-flow --objective "Find the blocking error or broken selector target" --context "The workflow just failed after trying to continue from the review step, and I need to identify the visible blocker on the current page."`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
-Assistant: I found the issue. I'll patch the workflow code, then rerun `npx libretto run ...` to verify the fix.
+Assistant: I found the issue. I'll patch the workflow code and verify.
+Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
+Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: Fix verified. Here is the command to test-run the workflow yourself:
+```
+npx libretto run ./integration.ts --headed
+```
 </example>
 ```
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -220,10 +220,7 @@ Assistant: [Creates or edits `target-workflow.ts` following `references/code-gen
 Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
-```
+To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
 </example>
 ```
 
@@ -243,10 +240,7 @@ Assistant: [Edits `integration.ts` following `references/code-generation-rules.m
 Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
 Assistant: Fix verified. Here are the results:
 [Shows the output/results from the headless run]
-To watch it yourself in a browser:
-```
-npx libretto run ./integration.ts --headed
-```
+To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
 </example>
 ```
 


### PR DESCRIPTION
## Summary

Makes test runs more clear in the Libretto skill by ensuring agents always show validation results and a ready-to-run command after building or fixing a workflow.

### Changes

- **New working rule**: after headless validation, always show the user (1) the output/results from the validation run, and (2) a headed version of the same command so they can re-run it and watch the browser.
- **Interactive building example**: replaced the vague `npx libretto run ...` ending with a concrete flow — headless validation, results shown, then a headed command for the user.
- **Debugging example**: same treatment — validation results shown, then a headed test-run command.

Closes NTN-359.
