### PR TITLE
fix: remove shared /tmp symlink from deploy-artifact test

### DIFF
--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -92,17 +92,8 @@ describe("createHostedDeployPackage", () => {
   > {
     const nodeModulesDir = join(dirname(args.outfile), "node_modules");
     mkdirSync(nodeModulesDir, { recursive: true });
-    const linkedPackageDirs = [
-      join(nodeModulesDir, "libretto"),
-      join(tmpdir(), "node_modules", "libretto"),
-    ];
-    for (const linkedPackageDir of linkedPackageDirs) {
-      if (existsSync(linkedPackageDir)) {
-        continue;
-      }
-      mkdirSync(dirname(linkedPackageDir), { recursive: true });
-      symlinkSync(currentLibrettoPackageDir, linkedPackageDir, "dir");
-    }
+    const linkedPackageDir = join(nodeModulesDir, "libretto");
+    symlinkSync(currentLibrettoPackageDir, linkedPackageDir, "dir");
 
     await build({
       bundle: true,


### PR DESCRIPTION
## Summary

The `deploy-artifact.spec.ts` test created a symlink at `/tmp/node_modules/libretto` that persisted across test runs and git worktrees. This caused `EEXIST` errors on subsequent runs when `symlinkSync` tried to create a symlink that already existed (possibly pointing to a different worktree).

## Changes

- Removed the shared `/tmp/node_modules/libretto` symlink from `rebundleDeployEntrypointToCjs`
- The per-test local `node_modules` symlink next to the `outfile` is sufficient for Node's module resolution

This also includes pre-existing doc changes on the branch (hosting guides, website authentication docs, core concepts cleanup).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
