### PR TITLE
fix: wrap libretto-cloud provider requests in oRPC { json } envelope

### DIFF
--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -13,6 +13,8 @@ export function createLibrettoCloudProvider(): ProviderApi {
     );
   const endpoint = apiUrl.replace(/\/$/, "");
 
+  // The Libretto Cloud API is an oRPC RPCHandler, not plain REST, so inputs
+  // must be wrapped as { json: ... } and outputs arrive the same way.
   return {
     async createSession() {
       const timeoutSeconds = Number(
@@ -24,7 +26,9 @@ export function createLibrettoCloudProvider(): ProviderApi {
           "x-api-key": apiKey,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ timeout_seconds: timeoutSeconds }),
+        body: JSON.stringify({
+          json: { timeout_seconds: timeoutSeconds },
+        }),
       });
       if (!resp.ok) {
         const body = await resp.text();
@@ -32,9 +36,8 @@ export function createLibrettoCloudProvider(): ProviderApi {
           `Libretto Cloud API error (${resp.status}): ${body}`,
         );
       }
-      const json = (await resp.json()) as {
-        session_id: string;
-        cdp_url: string;
+      const { json } = (await resp.json()) as {
+        json: { session_id: string; cdp_url: string };
       };
       return {
         sessionId: json.session_id,
@@ -48,7 +51,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
           "x-api-key": apiKey,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ session_id: sessionId }),
+        body: JSON.stringify({ json: { session_id: sessionId } }),
       });
       if (!resp.ok) {
         const body = await resp.text();


### PR DESCRIPTION
## Summary
- `libretto open --provider libretto-cloud` currently fails with a 400 `Input validation failed` — the Libretto Cloud API is served by `@orpc/server`'s `RPCHandler`, which expects the RPC wire format (`{ json: <input> }`), not a bare REST body. The provider was POSTing `{ timeout_seconds }` / `{ session_id }` directly, so oRPC's deserializer saw `undefined` at the root and rejected the request.
- Wrap both `createSession` and `closeSession` request bodies in `{ json: ... }`, and unwrap the `createSession` response the same way (the server returns `{ json: { session_id, cdp_url } }`).
- `kernel.ts` and `browserbase.ts` are unaffected — they talk to third-party REST APIs (`api.onkernel.com`, `api.browserbase.com`), not the Saffron oRPC server.

## Test plan
- [x] `pnpm --filter libretto type-check` passes
- [x] `pnpm --filter libretto build` passes
- [x] `libretto open https://example.com --provider libretto-cloud` creates a session, connects over CDP, and loads the page (verified against the production `browser-automations` API with a real `LIBRETTO_API_KEY`)
- [x] `libretto close` tears the remote session down (server returns `{ success: true, message: "Browser session closed" }`)
- [ ] Consider a follow-up to switch this provider over to `@orpc/client`'s `RPCLink` so the wire format stays in lockstep with the server automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
