### PR TITLE
fix: prevent create-libretto publish failure from blocking GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,7 @@ jobs:
         run: npm publish --access public
 
       - name: Publish create-libretto to npm
+        continue-on-error: true
         working-directory: packages/create-libretto
         run: |
           if ! npm view "create-libretto@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

The release workflow has been failing since v0.6.7 because the `create-libretto` npm publish step fails with a 404 error (the CI npm token likely lacks publish permissions for the `create-libretto` package). This failure blocks the subsequent changelog generation and GitHub release creation steps.

**Fix:** Add `continue-on-error: true` to the `create-libretto` publish step so the workflow continues to create the GitHub release even if that secondary publish fails.

**Additionally:** Created missing GitHub releases and tags for v0.6.7 and v0.6.8 manually.

## Root cause

The `create-libretto` package on npm is owned by `sh_michael`, and the CI npm token doesn't have publish access to it. The npm publish returns a 404, which causes the workflow step to fail and prevents all subsequent steps (changelog, GitHub release) from running.

## Longer-term fix

The `create-libretto` npm token permissions should be fixed so the package publishes correctly. This PR just unblocks the GitHub release creation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
