### PR TITLE
feat(cli): surface live-view and replay URLs on libretto-cloud sessions

### DIFF
--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -882,6 +882,15 @@ export const runCommand = SimpleCLI.command({
         `Creating ${providerName} browser session (session: ${ctx.session})...`,
       );
       const providerSession = await provider.createSession();
+      ctx.logger.info("run-provider-session-created", {
+        provider: providerName,
+        sessionId: providerSession.sessionId,
+        cdpEndpoint: providerSession.cdpEndpoint,
+        liveViewUrl: providerSession.liveViewUrl,
+      });
+      if (providerSession.liveViewUrl) {
+        console.log(`View live session: ${providerSession.liveViewUrl}`);
+      }
       console.log(`Connecting to ${providerName} browser...`);
       cdpEndpoint = providerSession.cdpEndpoint;
       providerInfo = {
@@ -910,7 +919,10 @@ export const runCommand = SimpleCLI.command({
     } finally {
       if (provider && providerInfo) {
         try {
-          await provider.closeSession(providerInfo.sessionId);
+          const result = await provider.closeSession(providerInfo.sessionId);
+          if (result.replayUrl) {
+            console.log(`View recording: ${result.replayUrl}`);
+          }
         } catch (cleanupErr) {
           console.error(
             `Failed to clean up ${providerInfo.name} session ${providerInfo.sessionId}:`,

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -590,7 +590,12 @@ export async function runOpenWithProvider(
     provider: providerName,
     sessionId: providerSession.sessionId,
     cdpEndpoint: providerSession.cdpEndpoint,
+    liveViewUrl: providerSession.liveViewUrl,
   });
+
+  if (providerSession.liveViewUrl) {
+    console.log(`View live session: ${providerSession.liveViewUrl}`);
+  }
 
   console.log(`Connecting to ${providerName} browser...`);
 
@@ -763,6 +768,7 @@ export async function runClose(
     return;
   }
 
+  let replayUrl: string | undefined;
   if (state.provider) {
     // Cloud provider session — close via provider API, no local pid to kill
     logger.info("close-provider", {
@@ -772,7 +778,8 @@ export async function runClose(
     });
     try {
       const provider = getCloudProviderApi(state.provider.name);
-      await provider.closeSession(state.provider.sessionId);
+      const result = await provider.closeSession(state.provider.sessionId);
+      replayUrl = result.replayUrl;
     } catch (err) {
       logger.warn("close-provider-error", {
         session,
@@ -797,8 +804,11 @@ export async function runClose(
   }
 
   clearSessionState(session, logger);
-  logger.info("close-success", { session });
+  logger.info("close-success", { session, replayUrl });
   console.log(`Browser closed (session: ${session}).`);
+  if (replayUrl) {
+    console.log(`View recording: ${replayUrl}`);
+  }
 }
 
 type ClosableSession = {

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -910,6 +910,7 @@ export async function runCloseAll(
 
   // Close provider sessions via their APIs
   const failedProviderSessions = new Set<string>();
+  const replayUrls: Array<{ session: string; replayUrl: string }> = [];
   for (const target of closable) {
     if (target.provider) {
       logger.info("close-all-provider", {
@@ -919,7 +920,13 @@ export async function runCloseAll(
       });
       try {
         const provider = getCloudProviderApi(target.provider.name);
-        await provider.closeSession(target.provider.sessionId);
+        const result = await provider.closeSession(target.provider.sessionId);
+        if (result.replayUrl) {
+          replayUrls.push({
+            session: target.session,
+            replayUrl: result.replayUrl,
+          });
+        }
       } catch (err) {
         logger.warn("close-all-provider-error", {
           session: target.session,
@@ -1029,6 +1036,9 @@ export async function runCloseAll(
   console.log(`Closed ${closedCount} session(s).`);
   if (forceKilled > 0) {
     console.log(`Force-killed ${forceKilled} session(s).`);
+  }
+  for (const { session, replayUrl } of replayUrls) {
+    console.log(`View recording (${session}): ${replayUrl}`);
   }
 }
 

--- a/packages/libretto/src/cli/core/providers/browserbase.ts
+++ b/packages/libretto/src/cli/core/providers/browserbase.ts
@@ -52,6 +52,7 @@ export function createBrowserbaseProvider(): ProviderApi {
           `Browserbase API error closing session ${sessionId} (${resp.status}): ${body}`,
         );
       }
+      return {};
     },
   };
 }

--- a/packages/libretto/src/cli/core/providers/kernel.ts
+++ b/packages/libretto/src/cli/core/providers/kernel.ts
@@ -44,6 +44,7 @@ export function createKernelProvider(): ProviderApi {
           `Kernel API error closing session ${sessionId} (${resp.status}): ${body}`,
         );
       }
+      return {};
     },
   };
 }

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -37,11 +37,17 @@ export function createLibrettoCloudProvider(): ProviderApi {
         );
       }
       const { json } = (await resp.json()) as {
-        json: { session_id: string; cdp_url: string };
+        json: {
+          session_id: string;
+          cdp_url: string;
+          live_view_url: string | null;
+          recording_url: string | null;
+        };
       };
       return {
         sessionId: json.session_id,
         cdpEndpoint: json.cdp_url,
+        liveViewUrl: json.live_view_url ?? undefined,
       };
     },
     async closeSession(sessionId) {
@@ -59,6 +65,10 @@ export function createLibrettoCloudProvider(): ProviderApi {
           `Libretto Cloud API error closing session ${sessionId} (${resp.status}): ${body}`,
         );
       }
+      const { json } = (await resp.json()) as {
+        json: { replay_url: string | null };
+      };
+      return { replayUrl: json.replay_url ?? undefined };
     },
   };
 }

--- a/packages/libretto/src/cli/core/providers/types.ts
+++ b/packages/libretto/src/cli/core/providers/types.ts
@@ -1,9 +1,20 @@
 export type ProviderSession = {
   sessionId: string; // remote session id for cleanup
   cdpEndpoint: string; // CDP WebSocket URL
+  // Provider-hosted URL for watching the session live while it's running.
+  // Only libretto-cloud surfaces this today; direct-SDK providers leave it
+  // undefined.
+  liveViewUrl?: string;
+};
+
+export type ProviderCloseResult = {
+  // Provider-hosted URL for playback of the session recording, surfaced on
+  // successful close. Undefined when the provider didn't capture a
+  // recording or doesn't return one on close.
+  replayUrl?: string;
 };
 
 export type ProviderApi = {
   createSession(): Promise<ProviderSession>;
-  closeSession(sessionId: string): Promise<void>;
+  closeSession(sessionId: string): Promise<ProviderCloseResult>;
 };


### PR DESCRIPTION
## Summary
- `libretto open` / `libretto run` now print `View live session: <url>` after the session is created — a URL for watching the browser in real time while it runs.
- `libretto close` now prints `View recording: <url>` after the session is released — a URL for replaying the recording.
- Previously neither URL was surfaced from the libretto-cloud provider, so there was no way to open the active session in a browser from the CLI.

## Context
Paired with [saffron-health/browser-automations#71](https://github.com/saffron-health/browser-automations/pull/71) (merged + deployed), which added `live_view_url` to the `POST /v1/sessions/create` response and `replay_url` to the `POST /v1/sessions/close` response.

The two URLs are distinct because:
- Kernel returns a dedicated `browser_live_view_url` on `browsers.create` (live view while the session runs).
- Kernel returns a separate `replay_view_url` on `replays.start` (playback, available during or after).
- Steel's `sessionViewerUrl` serves both roles — backend populates both fields with the same string.

## Changes
- `ProviderSession` gains optional `liveViewUrl`.
- `ProviderApi.closeSession` now returns `ProviderCloseResult` (`{ replayUrl?: string }`) instead of `void`, so the caller can surface the replay URL on successful close.
- `kernel` and `browserbase` direct-SDK providers' `closeSession` now returns `{}` — they don't round-trip through our backend, so no viewer URL is available from them.
- `libretto-cloud` provider reads the new `live_view_url` and `replay_url` fields from the backend.
- CLI print sites: `runOpenWithProvider` (open), `runCommand` cloud branch (run — both create and finally-close), and `runClose` (close).

## Test plan
- [x] `pnpm --filter libretto run type-check` passes
- [x] `pnpm --filter libretto run test` passes (195 passed, 5 skipped)
- [x] End-to-end against production:
  - `libretto open https://example.com --session user-view-test --provider libretto-cloud` → printed `View live session: https://proxy.yul-funny-austin.onkernel.com:8443/browser/live/ivYQvulUwP63`
  - Verified the live URL opened in browser and streamed the running session.
  - `libretto close user-view-test` → printed `Browser closed (session: user-view-test).` followed by `View recording: https://.../browser/replays?jwt=...&replay_id=q8qcb7g43uat572nlyun74iv`
  - Confirmed the replay URL plays back the session recording.
- [x] Tested against `BROWSER_PROVIDER=kernel` in prod (currently active provider). Steel path is provider-agnostic on the CLI side — both providers flow through the same response fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
