### PR TITLE
Add Codex OAuth support for OpenAI snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npx libretto status
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
-`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
+`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`, Codex OAuth from `codex login`, or `CODEX_OAUTH_TOKEN` with `CODEX_ACCOUNT_ID`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
 
 Use `ai configure` when you want to explicitly switch providers or set a custom model string.
 

--- a/docs/get-started/configuration.mdx
+++ b/docs/get-started/configuration.mdx
@@ -38,12 +38,12 @@ Both `npm create libretto@latest` and `npx libretto setup` handle initial config
 
 #### AI Provider Reference
 
-| Provider    | Default model                   | Environment variable   | SDK package              |
-| ----------- | ------------------------------- | ---------------------- | ------------------------ |
-| `openai`    | `openai/gpt-5.4`               | `OPENAI_API_KEY`       | `@ai-sdk/openai`        |
-| `anthropic` | `anthropic/claude-sonnet-4-6`   | `ANTHROPIC_API_KEY`    | `@ai-sdk/anthropic`     |
-| `gemini`    | `google/gemini-3-flash-preview` | `GEMINI_API_KEY`       | `@ai-sdk/google`        |
-| `vertex`    | `vertex/gemini-2.5-flash`       | `GOOGLE_CLOUD_PROJECT` | `@ai-sdk/google-vertex`  |
+| Provider    | Default model                   | Credentials                                      | SDK package             |
+| ----------- | ------------------------------- | ------------------------------------------------ | ----------------------- |
+| `openai`    | `openai/gpt-5.4`                | `OPENAI_API_KEY`, Codex OAuth from `codex login`, or `CODEX_OAUTH_TOKEN` with `CODEX_ACCOUNT_ID` | `@ai-sdk/openai` |
+| `anthropic` | `anthropic/claude-sonnet-4-6`   | `ANTHROPIC_API_KEY`                              | `@ai-sdk/anthropic`    |
+| `gemini`    | `google/gemini-3-flash-preview` | `GEMINI_API_KEY`                                 | `@ai-sdk/google`       |
+| `vertex`    | `vertex/gemini-2.5-flash`       | `GOOGLE_CLOUD_PROJECT`                           | `@ai-sdk/google-vertex` |
 
 To view the current configuration, run `npx libretto ai configure` with no arguments. To clear it, pass `--clear`.
 

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -30,12 +30,15 @@ Use this if you want Libretto to scaffold a new package with directory structure
 
   </Step>
 
-  <Step title="Set your API key">
-    Libretto uses an AI model to analyze page snapshots during workflow generation. Add the API key for your chosen provider to a `.env` file in your project root:
+  <Step title="Set your AI credentials">
+    Libretto uses an AI model to analyze page snapshots during workflow generation. Add credentials for your chosen provider to a `.env` file in your project root, or use Codex OAuth from `codex login` for OpenAI models:
 
     ```bash theme={null}
     # .env
     OPENAI_API_KEY=sk-...
+    # or
+    CODEX_OAUTH_TOKEN=...
+    CODEX_ACCOUNT_ID=...
     ```
 
     See the [AI Provider Reference](/get-started/configuration#ai-provider-reference) for the full list of supported providers and their environment variables.
@@ -76,12 +79,15 @@ If you already have a Node.js package that you plan to use for Libretto automati
 
   </Step>
 
-  <Step title="Set your API key">
-    Libretto uses an AI model to analyze page snapshots during workflow generation. Add the API key for your chosen provider to a `.env` file in your project root:
+  <Step title="Set your AI credentials">
+    Libretto uses an AI model to analyze page snapshots during workflow generation. Add credentials for your chosen provider to a `.env` file in your project root, or use Codex OAuth from `codex login` for OpenAI models:
 
     ```bash theme={null}
     # .env
     OPENAI_API_KEY=sk-...
+    # or
+    CODEX_OAUTH_TOKEN=...
+    CODEX_ACCOUNT_ID=...
     ```
 
     See the [AI Provider Reference](/get-started/configuration#ai-provider-reference) for the full list of supported providers and their environment variables.

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -40,7 +40,7 @@ npx libretto status
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
-`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
+`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`, Codex OAuth from `codex login`, or `CODEX_OAUTH_TOKEN` with `CODEX_ACCOUNT_ID`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
 
 Use `ai configure` when you want to explicitly switch providers or set a custom model string.
 

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -38,7 +38,7 @@ npx libretto status
 npx libretto ai configure <openai | anthropic | gemini | vertex>
 ```
 
-`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
+`setup` detects available provider credentials (e.g. `OPENAI_API_KEY`, Codex OAuth from `codex login`, or `CODEX_OAUTH_TOKEN` with `CODEX_ACCOUNT_ID`) and automatically pins the default model to `.libretto/config.json`. Re-running `setup` on a healthy workspace shows the current configuration instead of re-prompting. If credentials are missing for a previously configured provider, `setup` offers an interactive repair flow.
 
 Use `ai configure` when you want to explicitly switch providers or set a custom model string.
 

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -97,7 +97,8 @@ export const PROVIDER_CHOICES: ProviderChoice[] = [
     label: "OpenAI",
     provider: "openai",
     envVar: "OPENAI_API_KEY",
-    envHint: "Get your key at https://platform.openai.com/api-keys",
+    envHint:
+      "Get an API key at https://platform.openai.com/api-keys, or use Codex OAuth via `codex login`",
   },
   {
     key: "2",
@@ -173,6 +174,10 @@ function printHealthySummary(status: AiSetupStatus & { kind: "ready" }): void {
     console.log(
       `✓ Detected ${envVar}. Using ${providerLabel(status.provider)}.`,
     );
+  } else if (status.source === "codex-auth-json-api-key") {
+    console.log("✓ Detected Codex auth.json API key. Using OpenAI.");
+  } else if (status.source === "codex-auth-json-oauth") {
+    console.log("✓ Detected Codex OAuth credentials. Using OpenAI.");
   } else {
     console.log(`✓ Using ${providerLabel(status.provider)} (${status.model}).`);
   }
@@ -231,6 +236,9 @@ export function buildRepairPlan(status: AiSetupStatus): RepairPlan {
 export function formatMissingCredentialsMessage(
   plan: RepairPlan & { kind: "repair-missing-credentials" },
 ): string {
+  if (plan.provider === "openai") {
+    return `✗ ${plan.provider} is configured (model: ${plan.model}), but OpenAI API key and Codex OAuth credentials are missing.`;
+  }
   return `✗ ${plan.provider} is configured (model: ${plan.model}), but ${plan.envVar} is not set.`;
 }
 
@@ -253,9 +261,15 @@ function printSnapshotApiStatus(): boolean {
   if (plan.kind === "repair-missing-credentials") {
     console.log();
     console.log(formatMissingCredentialsMessage(plan));
-    console.log(
-      `  To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
-    );
+    if (plan.provider === "openai") {
+      console.log(
+        "  To fix: add OPENAI_API_KEY to .env, add CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, use `codex login`, or run `npx libretto setup` interactively to repair.",
+      );
+    } else {
+      console.log(
+        `  To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
+      );
+    }
     return false;
   }
 
@@ -269,6 +283,7 @@ function printSnapshotApiStatus(): boolean {
   console.log("✗ No snapshot API credentials detected.");
   console.log("  Add one provider to .env:");
   console.log("    OPENAI_API_KEY=...");
+  console.log("    CODEX_OAUTH_TOKEN=...  # plus CODEX_ACCOUNT_ID");
   console.log("    ANTHROPIC_API_KEY=...");
   console.log("    GEMINI_API_KEY=...  # or GOOGLE_GENERATIVE_AI_API_KEY");
   console.log(
@@ -328,6 +343,7 @@ function printSkipMessage(): void {
   );
   console.log("Or add credentials directly to your .env file:");
   console.log("  OPENAI_API_KEY=...");
+  console.log("  CODEX_OAUTH_TOKEN=...  # plus CODEX_ACCOUNT_ID");
   console.log("  ANTHROPIC_API_KEY=...");
   console.log("  GEMINI_API_KEY=...");
   console.log(
@@ -360,7 +376,13 @@ async function runInteractiveApiSetup(): Promise<void> {
     // ── Repair: configured provider with missing credentials ──
     if (plan.kind === "repair-missing-credentials") {
       console.log(formatMissingCredentialsMessage(plan));
-      console.log(`\nAdd ${plan.envVar} to your .env file to fix this.`);
+      if (plan.provider === "openai") {
+        console.log(
+          "\nAdd OPENAI_API_KEY to your .env file, add CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, or use `codex login` to fix this.",
+        );
+      } else {
+        console.log(`\nAdd ${plan.envVar} to your .env file to fix this.`);
+      }
       console.log("");
       console.log("Or switch to a different provider:\n");
       console.log("  1) Switch to a different provider");

--- a/packages/libretto/src/cli/core/ai-model.ts
+++ b/packages/libretto/src/cli/core/ai-model.ts
@@ -5,6 +5,7 @@ import {
   parseModel,
   type Provider,
 } from "./resolve-model.js";
+import { resolveOpenAiCredentials } from "./openai-credentials.js";
 
 // Re-export so existing consumers (e.g. tests) don't break.
 export { parseDotEnvAssignment } from "../../shared/env/load-env.js";
@@ -26,13 +27,13 @@ export const DEFAULT_SNAPSHOT_MODELS = {
  * Returns the env var name (e.g. "OPENAI_API_KEY", "GEMINI_API_KEY"),
  * or null if no credential is found.
  */
-function detectProviderEnvVar(
+function detectProviderCredentialSource(
   provider: Provider,
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
   switch (provider) {
     case "openai":
-      return env.OPENAI_API_KEY?.trim() ? "OPENAI_API_KEY" : null;
+      return resolveOpenAiCredentials(env)?.source ?? null;
     case "anthropic":
       return env.ANTHROPIC_API_KEY?.trim() ? "ANTHROPIC_API_KEY" : null;
     case "google":
@@ -54,7 +55,11 @@ function detectProviderEnvVar(
 export type SnapshotApiModelSelection = {
   model: string;
   provider: Provider;
-  source: "config" | `env:${string}`;
+  source:
+    | "config"
+    | `env:${string}`
+    | "codex-auth-json-api-key"
+    | "codex-auth-json-oauth";
 };
 
 export class SnapshotApiUnavailableError extends Error {
@@ -67,7 +72,7 @@ export class SnapshotApiUnavailableError extends Error {
 function providerSetupSentence(provider: Provider): string {
   switch (provider) {
     case "openai":
-      return "Add OPENAI_API_KEY to .env or as a shell environment variable.";
+      return "Add OPENAI_API_KEY to .env or as a shell environment variable, set CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, or use a Codex login.";
     case "anthropic":
       return "Add ANTHROPIC_API_KEY to .env or as a shell environment variable.";
     case "google":
@@ -86,7 +91,7 @@ function defaultModelCommandLine(): string {
 function providerMissingCredentialSummary(provider: Provider): string {
   switch (provider) {
     case "openai":
-      return "OPENAI_API_KEY is missing";
+      return "OpenAI API key and Codex OAuth credentials are missing";
     case "anthropic":
       return "ANTHROPIC_API_KEY is missing";
     case "google":
@@ -101,7 +106,7 @@ function providerMissingCredentialSummary(provider: Provider): string {
 function noSnapshotApiConfiguredMessage(): string {
   return [
     "Failed to analyze snapshot because no snapshot analyzer is configured.",
-    `Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with \`${defaultModelCommandLine()}\`.`,
+    `Add OPENAI_API_KEY, CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, use a Codex login, or choose a default model with \`${defaultModelCommandLine()}\`.`,
     "For more info, run `npx libretto setup`.",
   ].join(" ");
 }
@@ -132,12 +137,16 @@ function inferAutoSnapshotModel(): SnapshotApiModelSelection | null {
   ];
 
   for (const provider of providersInPriorityOrder) {
-    const envVar = detectProviderEnvVar(provider);
-    if (!envVar) continue;
+    const credentialSource = detectProviderCredentialSource(provider);
+    if (!credentialSource) continue;
     return {
       model: DEFAULT_SNAPSHOT_MODELS[provider],
       provider,
-      source: `env:${envVar}`,
+      source:
+        credentialSource === "codex-auth-json-api-key" ||
+        credentialSource === "codex-auth-json-oauth"
+          ? credentialSource
+          : `env:${credentialSource}`,
     };
   }
 
@@ -206,7 +215,11 @@ export type AiSetupStatus =
       kind: "ready";
       model: string;
       provider: Provider;
-      source: "config" | `env:${string}`;
+      source:
+        | "config"
+        | `env:${string}`
+        | "codex-auth-json-api-key"
+        | "codex-auth-json-oauth";
     }
   | {
       kind: "configured-missing-credentials";

--- a/packages/libretto/src/cli/core/api-snapshot-analyzer.ts
+++ b/packages/libretto/src/cli/core/api-snapshot-analyzer.ts
@@ -9,7 +9,9 @@
 import { readFileSync } from "node:fs";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { generateObject } from "ai";
+import { z } from "zod";
 import { resolveModel } from "./resolve-model.js";
+import { resolveOpenAiCredentials } from "./openai-credentials.js";
 import {
   InterpretResultSchema,
   buildInlinePromptSelection,
@@ -20,6 +22,102 @@ import {
 } from "./snapshot-analyzer.js";
 import { readSnapshotModel } from "./config.js";
 import { resolveSnapshotApiModelOrThrow } from "./ai-model.js";
+
+const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+
+export function parseCodexResponsesSse(responseText: string): InterpretResult {
+  let outputText = "";
+  for (const line of responseText.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const payload = line.slice("data: ".length).trim();
+    if (!payload || payload === "[DONE]") continue;
+
+    let event: {
+      type?: string;
+      delta?: string;
+      text?: string;
+      error?: { message?: string };
+      response?: { error?: { message?: string } };
+    };
+    try {
+      event = JSON.parse(payload) as typeof event;
+    } catch {
+      continue;
+    }
+
+    if (event.type === "response.output_text.delta" && event.delta) {
+      outputText += event.delta;
+    } else if (event.type === "response.output_text.done" && event.text) {
+      outputText = event.text;
+    } else if (event.type === "error") {
+      throw new Error(event.error?.message || responseText);
+    } else if (event.type === "response.completed" && event.response?.error) {
+      throw new Error(event.response.error.message || responseText);
+    }
+  }
+
+  if (!outputText.trim()) {
+    throw new Error("Codex OAuth response did not include output text.");
+  }
+
+  return InterpretResultSchema.parse(JSON.parse(outputText));
+}
+
+async function runCodexOAuthInterpretObject(args: {
+  token: string;
+  accountId: string;
+  modelId: string;
+  prompt: string;
+  imageBase64: string;
+  imageMimeType: string;
+}): Promise<InterpretResult> {
+  const response = await fetch(CODEX_RESPONSES_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.token}`,
+      "chatgpt-account-id": args.accountId,
+      "OpenAI-Beta": "responses=experimental",
+      originator: "libretto",
+      accept: "text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: args.modelId,
+      store: false,
+      stream: true,
+      instructions:
+        "Analyze the DOM snapshot and screenshot. Return only an object that matches the requested JSON schema.",
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: args.prompt },
+            {
+              type: "input_image",
+              image_url: `data:${args.imageMimeType};base64,${args.imageBase64}`,
+            },
+          ],
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "snapshot_analysis",
+          schema: z.toJSONSchema(InterpretResultSchema),
+          strict: true,
+        },
+      },
+      include: ["reasoning.encrypted_content"],
+    }),
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(responseText || response.statusText);
+  }
+
+  return parseCodexResponsesSse(responseText);
+}
 
 export async function runApiInterpret(
   args: InterpretArgs,
@@ -65,28 +163,40 @@ export async function runApiInterpret(
   const imageMimeType = getMimeType(args.pngPath);
   const imageBytes = Buffer.from(imageBase64, "base64");
 
-  const model = await resolveModel(selection.model);
-
-  const { object: result } = await generateObject({
-    model,
-    schema: InterpretResultSchema,
-    messages: [
-      {
-        role: "user",
-        content: [
-          { type: "text", text: promptSelection.prompt },
-          {
-            type: "image",
-            image: imageBytes,
-            mediaType: imageMimeType,
-          },
-        ],
-      },
-    ],
-    temperature: 0.1,
-  });
-
-  const parsed: InterpretResult = InterpretResultSchema.parse(result);
+  const openAiCredentials = resolveOpenAiCredentials();
+  const parsed: InterpretResult =
+    selection.provider === "openai" &&
+    openAiCredentials?.kind === "codex-oauth"
+      ? await runCodexOAuthInterpretObject({
+          token: openAiCredentials.token,
+          accountId: openAiCredentials.accountId,
+          modelId: selection.model.slice(selection.model.indexOf("/") + 1),
+          prompt: promptSelection.prompt,
+          imageBase64,
+          imageMimeType,
+        })
+      : InterpretResultSchema.parse(
+          (
+            await generateObject({
+              model: await resolveModel(selection.model),
+              schema: InterpretResultSchema,
+              messages: [
+                {
+                  role: "user",
+                  content: [
+                    { type: "text", text: promptSelection.prompt },
+                    {
+                      type: "image",
+                      image: imageBytes,
+                      mediaType: imageMimeType,
+                    },
+                  ],
+                },
+              ],
+              temperature: 0.1,
+            })
+          ).object,
+        );
 
   logger.info("api-interpret-success", {
     selectorCount: parsed.selectors.length,

--- a/packages/libretto/src/cli/core/openai-credentials.ts
+++ b/packages/libretto/src/cli/core/openai-credentials.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type OpenAiCredentialSource =
+  | "OPENAI_API_KEY"
+  | "CODEX_OAUTH_TOKEN"
+  | "codex-auth-json-api-key"
+  | "codex-auth-json-oauth";
+
+export type OpenAiCredentials =
+  | {
+      kind: "api-key";
+      token: string;
+      source: Extract<
+        OpenAiCredentialSource,
+        "OPENAI_API_KEY" | "codex-auth-json-api-key"
+      >;
+    }
+  | {
+      kind: "codex-oauth";
+      token: string;
+      accountId: string;
+      source: Extract<
+        OpenAiCredentialSource,
+        "CODEX_OAUTH_TOKEN" | "codex-auth-json-oauth"
+      >;
+    };
+
+type CodexAuthJson = {
+  OPENAI_API_KEY?: unknown;
+  tokens?: {
+    access_token?: unknown;
+    account_id?: unknown;
+  };
+};
+
+const CODEX_ACCOUNT_CLAIM = "https://api.openai.com/auth";
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function extractAccountIdFromAccessToken(token: string): string | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf-8"),
+    ) as {
+      [CODEX_ACCOUNT_CLAIM]?: {
+        chatgpt_account_id?: unknown;
+      };
+    };
+    return readString(decoded[CODEX_ACCOUNT_CLAIM]?.chatgpt_account_id);
+  } catch {
+    return null;
+  }
+}
+
+function readCodexAuthJson(env: NodeJS.ProcessEnv): CodexAuthJson | null {
+  const codexHome = env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+  const authPath = join(codexHome, "auth.json");
+  if (!existsSync(authPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(authPath, "utf-8")) as CodexAuthJson;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveOpenAiCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): OpenAiCredentials | null {
+  const openAiApiKey = env.OPENAI_API_KEY?.trim();
+  if (openAiApiKey) {
+    return { kind: "api-key", token: openAiApiKey, source: "OPENAI_API_KEY" };
+  }
+
+  const codexOAuthToken = env.CODEX_OAUTH_TOKEN?.trim();
+  if (codexOAuthToken) {
+    const accountId =
+      env.CODEX_ACCOUNT_ID?.trim() ||
+      env.CHATGPT_ACCOUNT_ID?.trim() ||
+      extractAccountIdFromAccessToken(codexOAuthToken);
+    if (accountId) {
+      return {
+        kind: "codex-oauth",
+        token: codexOAuthToken,
+        accountId,
+        source: "CODEX_OAUTH_TOKEN",
+      };
+    }
+  }
+
+  const codexAuthJson = readCodexAuthJson(env);
+  const codexAuthJsonApiKey = readString(codexAuthJson?.OPENAI_API_KEY);
+  if (codexAuthJsonApiKey) {
+    return {
+      kind: "api-key",
+      token: codexAuthJsonApiKey,
+      source: "codex-auth-json-api-key",
+    };
+  }
+
+  const codexAuthJsonOAuthToken = readString(
+    codexAuthJson?.tokens?.access_token,
+  );
+  const codexAuthJsonAccountId = readString(codexAuthJson?.tokens?.account_id);
+  if (codexAuthJsonOAuthToken) {
+    const accountId =
+      codexAuthJsonAccountId ||
+      extractAccountIdFromAccessToken(codexAuthJsonOAuthToken);
+    if (!accountId) return null;
+    return {
+      kind: "codex-oauth",
+      token: codexAuthJsonOAuthToken,
+      accountId,
+      source: "codex-auth-json-oauth",
+    };
+  }
+
+  return null;
+}
+
+export function hasOpenAiCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return resolveOpenAiCredentials(env) !== null;
+}

--- a/packages/libretto/src/cli/core/resolve-model.ts
+++ b/packages/libretto/src/cli/core/resolve-model.ts
@@ -1,4 +1,9 @@
 import type { LanguageModel } from "ai";
+import {
+  type OpenAiCredentials,
+  hasOpenAiCredentials,
+  resolveOpenAiCredentials,
+} from "./openai-credentials.js";
 
 export type Provider = "google" | "vertex" | "anthropic" | "openai" | "openrouter";
 
@@ -21,6 +26,14 @@ const SUPPORTED_PROVIDER_ALIASES = {
   openai: "openai",
   openrouter: "openrouter",
 } as const satisfies Record<string, Provider>;
+
+const CODEX_OPENAI_BASE_URL = "https://chatgpt.com/backend-api/codex";
+
+type OpenAiProviderSettings = {
+  apiKey: string;
+  baseURL?: string;
+  headers?: Record<string, string>;
+};
 
 function readFirstEnvValue(
   env: NodeJS.ProcessEnv,
@@ -71,7 +84,7 @@ export function hasProviderCredentials(
     case "anthropic":
       return Boolean(env.ANTHROPIC_API_KEY?.trim());
     case "openai":
-      return Boolean(env.OPENAI_API_KEY?.trim());
+      return hasOpenAiCredentials(env);
     case "openrouter":
       return Boolean(env.OPENROUTER_API_KEY?.trim());
   }
@@ -87,12 +100,30 @@ export function missingProviderCredentialsMessage(provider: Provider): string {
       return "Anthropic API key is missing. Set ANTHROPIC_API_KEY.";
     }
     case "openai": {
-      return "OpenAI API key is missing. Set OPENAI_API_KEY.";
+      return "OpenAI credentials are missing. Set OPENAI_API_KEY, set CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, or use a Codex login.";
     }
     case "openrouter": {
       return "OpenRouter API key is missing. Set OPENROUTER_API_KEY.";
     }
   }
+}
+
+export function buildOpenAiProviderSettings(
+  credentials: OpenAiCredentials,
+): OpenAiProviderSettings {
+  if (credentials.kind === "api-key") {
+    return { apiKey: credentials.token };
+  }
+
+  return {
+    apiKey: credentials.token,
+    baseURL: CODEX_OPENAI_BASE_URL,
+    headers: {
+      "chatgpt-account-id": credentials.accountId,
+      "OpenAI-Beta": "responses=experimental",
+      originator: "libretto",
+    },
+  };
 }
 
 async function getProviderModel(
@@ -131,12 +162,12 @@ async function getProviderModel(
       return anthropic(modelId);
     }
     case "openai": {
-      const apiKey = process.env.OPENAI_API_KEY?.trim();
-      if (!apiKey) {
+      const credentials = resolveOpenAiCredentials();
+      if (!credentials) {
         throw new Error(missingProviderCredentialsMessage(provider));
       }
       const { createOpenAI } = await import("@ai-sdk/openai");
-      const openai = createOpenAI({ apiKey });
+      const openai = createOpenAI(buildOpenAiProviderSettings(credentials));
       return openai(modelId);
     }
     case "openrouter": {

--- a/packages/libretto/test/ai-setup-status.spec.ts
+++ b/packages/libretto/test/ai-setup-status.spec.ts
@@ -6,6 +6,10 @@ import { resolveAiSetupStatus } from "../src/cli/core/ai-model.js";
 
 function clearProviderEnv(): void {
   vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("CODEX_OAUTH_TOKEN", "");
+  vi.stubEnv("CODEX_ACCOUNT_ID", "");
+  vi.stubEnv("CHATGPT_ACCOUNT_ID", "");
+  vi.stubEnv("CODEX_HOME", join(tmpdir(), "libretto-test-missing-codex-home"));
   vi.stubEnv("ANTHROPIC_API_KEY", "");
   vi.stubEnv("GEMINI_API_KEY", "");
   vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "");
@@ -49,6 +53,58 @@ describe("resolveAiSetupStatus", () => {
         model: "openai/gpt-5.4",
         provider: "openai",
         source: "env:OPENAI_API_KEY",
+      });
+    });
+
+    it("resolves ready from Codex auth.json API key when no config exists", () => {
+      const codexHome = join(testDir, "codex-home");
+      mkdirSync(codexHome, { recursive: true });
+      writeFileSync(
+        join(codexHome, "auth.json"),
+        JSON.stringify({ OPENAI_API_KEY: "sk-codex-api-key" }),
+        "utf-8",
+      );
+      vi.stubEnv("CODEX_HOME", codexHome);
+
+      expect(resolveAiSetupStatus(configPath)).toEqual({
+        kind: "ready",
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        source: "codex-auth-json-api-key",
+      });
+    });
+
+    it("resolves ready from Codex OAuth env when no config exists", () => {
+      vi.stubEnv("CODEX_OAUTH_TOKEN", "test-token");
+      vi.stubEnv("CODEX_ACCOUNT_ID", "test-account");
+      expect(resolveAiSetupStatus(configPath)).toEqual({
+        kind: "ready",
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        source: "env:CODEX_OAUTH_TOKEN",
+      });
+    });
+
+    it("resolves ready from Codex auth.json OAuth when no config exists", () => {
+      const codexHome = join(testDir, "codex-home");
+      mkdirSync(codexHome, { recursive: true });
+      writeFileSync(
+        join(codexHome, "auth.json"),
+        JSON.stringify({
+          tokens: {
+            access_token: "test-token",
+            account_id: "test-account",
+          },
+        }),
+        "utf-8",
+      );
+      vi.stubEnv("CODEX_HOME", codexHome);
+
+      expect(resolveAiSetupStatus(configPath)).toEqual({
+        kind: "ready",
+        model: "openai/gpt-5.4",
+        provider: "openai",
+        source: "codex-auth-json-oauth",
       });
     });
 

--- a/packages/libretto/test/api-snapshot-analyzer.spec.ts
+++ b/packages/libretto/test/api-snapshot-analyzer.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexResponsesSse } from "../src/cli/core/api-snapshot-analyzer.js";
+
+describe("parseCodexResponsesSse", () => {
+  it("ignores SSE terminators and malformed frames after valid output", () => {
+    const output = JSON.stringify({
+      answer: "Example Domain",
+      selectors: [
+        {
+          label: "Page heading",
+          selector: "h1",
+          rationale: "The heading contains the page title.",
+        },
+      ],
+      notes: "Ready.",
+    });
+
+    expect(
+      parseCodexResponsesSse(
+        [
+          "event: response.output_text.delta",
+          `data: ${JSON.stringify({
+            type: "response.output_text.delta",
+            delta: output.slice(0, 10),
+          })}`,
+          "",
+          "event: response.output_text.delta",
+          `data: ${JSON.stringify({
+            type: "response.output_text.delta",
+            delta: output.slice(10),
+          })}`,
+          "",
+          "event: response.completed",
+          'data: {"type":"response.completed","response":{"error":null}}',
+          "",
+          "data: [DONE]",
+          "data: ",
+          "data: {not json",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      answer: "Example Domain",
+      selectors: [
+        {
+          label: "Page heading",
+          selector: "h1",
+          rationale: "The heading contains the page title.",
+        },
+      ],
+      notes: "Ready.",
+    });
+  });
+});

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -84,6 +84,10 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
+      CODEX_OAUTH_TOKEN: "",
+      CODEX_ACCOUNT_ID: "",
+      CHATGPT_ACCOUNT_ID: "",
+      CODEX_HOME: "/tmp/libretto-test-missing-codex-home",
       ANTHROPIC_API_KEY: "",
       GEMINI_API_KEY: "",
       GOOGLE_GENERATIVE_AI_API_KEY: "",
@@ -94,6 +98,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("sub-agent to analyze DOM snapshots");
     expect(result.stdout).toContain("No snapshot API credentials detected.");
     expect(result.stdout).toContain("OPENAI_API_KEY=...");
+    expect(result.stdout).toContain("CODEX_OAUTH_TOKEN=...");
     expect(result.stdout).toContain("ANTHROPIC_API_KEY=...");
     expect(result.stdout).toContain("GEMINI_API_KEY=...");
   });
@@ -189,12 +194,18 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
+      CODEX_OAUTH_TOKEN: "",
+      CODEX_ACCOUNT_ID: "",
+      CHATGPT_ACCOUNT_ID: "",
+      CODEX_HOME: workspacePath(".codex-missing"),
       ANTHROPIC_API_KEY: "test-anthropic-key",
     });
 
     // Should name the configured provider and missing env var
     expect(result.stdout).toContain("openai is configured");
-    expect(result.stdout).toContain("OPENAI_API_KEY is not set");
+    expect(result.stdout).toContain(
+      "OpenAI API key and Codex OAuth credentials are missing",
+    );
     // Should NOT show the generic unconfigured message
     expect(result.stdout).not.toContain("No snapshot API credentials detected");
   });
@@ -244,6 +255,10 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("setup --skip-browsers", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
+      CODEX_OAUTH_TOKEN: "",
+      CODEX_ACCOUNT_ID: "",
+      CHATGPT_ACCOUNT_ID: "",
+      CODEX_HOME: workspacePath(".codex-missing"),
       ANTHROPIC_API_KEY: "",
       GEMINI_API_KEY: "",
       GOOGLE_GENERATIVE_AI_API_KEY: "",

--- a/packages/libretto/test/setup-repair.spec.ts
+++ b/packages/libretto/test/setup-repair.spec.ts
@@ -11,6 +11,10 @@ import type { AiSetupStatus } from "../src/cli/core/ai-model.js";
 
 function clearProviderEnv(): void {
   vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("CODEX_OAUTH_TOKEN", "");
+  vi.stubEnv("CODEX_ACCOUNT_ID", "");
+  vi.stubEnv("CHATGPT_ACCOUNT_ID", "");
+  vi.stubEnv("CODEX_HOME", join(tmpdir(), "libretto-test-missing-codex-home"));
   vi.stubEnv("ANTHROPIC_API_KEY", "");
   vi.stubEnv("GEMINI_API_KEY", "");
   vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "");
@@ -151,7 +155,8 @@ describe("formatMissingCredentialsMessage", () => {
     }
     const msg = formatMissingCredentialsMessage(plan);
     expect(msg).toContain("openai");
-    expect(msg).toContain("OPENAI_API_KEY");
+    expect(msg).toContain("OpenAI API key");
+    expect(msg).toContain("Codex OAuth");
     expect(msg).toContain("openai/gpt-5.4");
     expect(msg).not.toContain("No snapshot API credentials detected");
   });

--- a/packages/libretto/test/snapshot-api-config.spec.ts
+++ b/packages/libretto/test/snapshot-api-config.spec.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { buildInlinePromptSelection } from "../src/cli/core/snapshot-analyzer.js";
 import {
   parseDotEnvAssignment,
@@ -6,6 +9,8 @@ import {
   resolveSnapshotApiModel,
 } from "../src/cli/core/ai-model.js";
 import { LIBRETTO_CONFIG_PATH } from "../src/cli/core/context.js";
+import { resolveOpenAiCredentials } from "../src/cli/core/openai-credentials.js";
+import { buildOpenAiProviderSettings } from "../src/cli/core/resolve-model.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -13,6 +18,10 @@ afterEach(() => {
 
 function clearProviderEnv(): void {
   vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("CODEX_OAUTH_TOKEN", "");
+  vi.stubEnv("CODEX_ACCOUNT_ID", "");
+  vi.stubEnv("CHATGPT_ACCOUNT_ID", "");
+  vi.stubEnv("CODEX_HOME", join(tmpdir(), "libretto-test-missing-codex-home"));
   vi.stubEnv("ANTHROPIC_API_KEY", "");
   vi.stubEnv("GEMINI_API_KEY", "");
   vi.stubEnv("GOOGLE_GENERATIVE_AI_API_KEY", "");
@@ -31,6 +40,127 @@ describe("snapshot API model resolution", () => {
       model: "openai/gpt-5.4",
       provider: "openai",
       source: "env:OPENAI_API_KEY",
+    });
+  });
+
+  it("uses Codex auth.json API key as OpenAI credentials", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+    const codexHome = join(
+      tmpdir(),
+      `libretto-test-codex-home-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(
+      join(codexHome, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: "sk-codex-api-key" }),
+      "utf-8",
+    );
+    vi.stubEnv("CODEX_HOME", codexHome);
+
+    expect(resolveSnapshotApiModel(null)).toMatchObject({
+      model: "openai/gpt-5.4",
+      provider: "openai",
+      source: "codex-auth-json-api-key",
+    });
+  });
+
+  it("uses CODEX_OAUTH_TOKEN as OpenAI credentials", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+    vi.stubEnv("CODEX_OAUTH_TOKEN", "test-codex-access-token");
+    vi.stubEnv("CODEX_ACCOUNT_ID", "test-account-id");
+
+    expect(resolveSnapshotApiModel(null)).toMatchObject({
+      model: "openai/gpt-5.4",
+      provider: "openai",
+      source: "env:CODEX_OAUTH_TOKEN",
+    });
+
+    expect(resolveOpenAiCredentials()).toEqual({
+      kind: "codex-oauth",
+      token: "test-codex-access-token",
+      accountId: "test-account-id",
+      source: "CODEX_OAUTH_TOKEN",
+    });
+  });
+
+  it("uses Codex auth.json OAuth tokens as OpenAI credentials", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+    const codexHome = join(
+      tmpdir(),
+      `libretto-test-codex-home-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(
+      join(codexHome, "auth.json"),
+      JSON.stringify({
+        tokens: {
+          access_token: "test-codex-access-token",
+          account_id: "test-account-id",
+        },
+      }),
+      "utf-8",
+    );
+    vi.stubEnv("CODEX_HOME", codexHome);
+
+    expect(resolveSnapshotApiModel(null)).toMatchObject({
+      model: "openai/gpt-5.4",
+      provider: "openai",
+      source: "codex-auth-json-oauth",
+    });
+
+    expect(resolveOpenAiCredentials()).toEqual({
+      kind: "codex-oauth",
+      token: "test-codex-access-token",
+      accountId: "test-account-id",
+      source: "codex-auth-json-oauth",
+    });
+  });
+
+  it("ignores CODEX_OAUTH_TOKEN without an account id", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+    vi.stubEnv("CODEX_OAUTH_TOKEN", "test-codex-access-token");
+
+    expect(resolveSnapshotApiModel(null)).toBeNull();
+  });
+
+  it("ignores Codex auth.json OAuth tokens without an account id", () => {
+    vi.stubEnv("LIBRETTO_DISABLE_DOTENV", "1");
+    clearProviderEnv();
+    const codexHome = join(
+      tmpdir(),
+      `libretto-test-codex-home-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(
+      join(codexHome, "auth.json"),
+      JSON.stringify({ tokens: { access_token: "test-codex-access-token" } }),
+      "utf-8",
+    );
+    vi.stubEnv("CODEX_HOME", codexHome);
+
+    expect(resolveSnapshotApiModel(null)).toBeNull();
+  });
+
+  it("builds Codex OAuth OpenAI provider settings for the Codex backend", () => {
+    expect(
+      buildOpenAiProviderSettings({
+        kind: "codex-oauth",
+        token: "test-codex-access-token",
+        accountId: "test-account-id",
+        source: "codex-auth-json-oauth",
+      }),
+    ).toEqual({
+      apiKey: "test-codex-access-token",
+      baseURL: "https://chatgpt.com/backend-api/codex",
+      headers: {
+        "chatgpt-account-id": "test-account-id",
+        "OpenAI-Beta": "responses=experimental",
+        originator: "libretto",
+      },
     });
   });
 
@@ -112,7 +242,7 @@ describe("snapshot API model resolution", () => {
     clearProviderEnv();
 
     expect(() => resolveSnapshotApiModelOrThrow(null)).toThrowError(
-      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`. For more info, run `npx libretto setup`.",
+      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, use a Codex login, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`. For more info, run `npx libretto setup`.",
     );
   });
 
@@ -158,7 +288,7 @@ describe("snapshot API model resolution", () => {
     expect(() =>
       resolveSnapshotApiModelOrThrow("openai/gpt-5.4"),
     ).toThrowError(
-      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto setup\`.`,
+      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OpenAI API key and Codex OAuth credentials are missing. Add OPENAI_API_KEY to .env or as a shell environment variable, set CODEX_OAUTH_TOKEN with CODEX_ACCOUNT_ID, or use a Codex login. For more info, run \`npx libretto setup\`.`,
     );
   });
 });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -130,6 +130,10 @@ describe("state-driven CLI subprocess behavior", () => {
       {
         LIBRETTO_DISABLE_DOTENV: "1",
         OPENAI_API_KEY: "",
+        CODEX_OAUTH_TOKEN: "",
+        CODEX_ACCOUNT_ID: "",
+        CHATGPT_ACCOUNT_ID: "",
+        CODEX_HOME: workspacePath(".codex-missing"),
         ANTHROPIC_API_KEY: "",
         GEMINI_API_KEY: "",
         GOOGLE_GENERATIVE_AI_API_KEY: "",
@@ -285,6 +289,10 @@ describe("state-driven CLI subprocess behavior", () => {
     const status = await librettoCli("status", {
       LIBRETTO_DISABLE_DOTENV: "1",
       OPENAI_API_KEY: "",
+      CODEX_OAUTH_TOKEN: "",
+      CODEX_ACCOUNT_ID: "",
+      CHATGPT_ACCOUNT_ID: "",
+      CODEX_HOME: "/tmp/libretto-test-missing-codex-home",
       ANTHROPIC_API_KEY: "",
       GEMINI_API_KEY: "",
       GOOGLE_GENERATIVE_AI_API_KEY: "",


### PR DESCRIPTION
## Summary
- add first-class OpenAI credential resolution for `OPENAI_API_KEY`, Codex OAuth env vars, and Codex `auth.json`
- route Codex OAuth snapshot analysis through the ChatGPT Codex Responses endpoint with streaming SSE parsing
- update setup/status/docs and tests for Codex OAuth detection and snapshot behavior

## Verification
- `corepack pnpm check:mirrors`
- `corepack pnpm --filter libretto type-check`
- `corepack pnpm --dir packages/libretto exec vitest run`
- `corepack pnpm --dir packages/libretto run build`
- local `npx libretto snapshot` smoke test with `OPENAI_API_KEY=` and Codex OAuth credentials
