### PR TITLE
Initialize Git in create-libretto projects

### DIFF
--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -265,6 +265,45 @@ function runInstallAsync(cmd, cwd) {
 }
 
 // ---------------------------------------------------------------------------
+// Git
+// ---------------------------------------------------------------------------
+
+function isGitAvailable() {
+  try {
+    execSync("git --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isInsideGitWorkTree(targetDir) {
+  try {
+    const output = execSync("git rev-parse --is-inside-work-tree", {
+      cwd: targetDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+function initializeGitRepository(targetDir) {
+  if (!isGitAvailable()) return false;
+  if (existsSync(join(targetDir, ".git"))) return false;
+  if (isInsideGitWorkTree(targetDir)) return false;
+
+  try {
+    execSync("git init", { cwd: targetDir, stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Scaffold
 // ---------------------------------------------------------------------------
 
@@ -411,6 +450,11 @@ export async function scaffoldProject(
       }
     }
   }
+
+  // 6. Initialize a git repository for standalone projects.
+  if (initializeGitRepository(targetDir)) {
+    console.log(`${GREEN}✓${RESET} Initialized git repository`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -461,9 +505,16 @@ async function main() {
 
   await scaffoldProject(targetDir, projectName, pkgManager);
 
+  const run = runCommand(pkgManager);
+  const relDir = relative(process.cwd(), targetDir) || projectName;
+
   console.log(
     `\n${GREEN}Success!${RESET} Created ${BOLD}${projectName}${RESET} at ${targetDir}\n`,
   );
+  console.log(`Next steps:`);
+  console.log(`  cd ${relDir}`);
+  console.log(`  ${run} libretto run src/workflows/star-repo.ts`);
+  console.log();
 }
 
 // Only run main when this file is executed directly (not imported)


### PR DESCRIPTION
## Summary
- initialize a Git repository for standalone projects generated by `create-libretto`
- skip Git initialization when `git` is unavailable, the target already has `.git`, or the target is inside an existing worktree
- preserve the scaffold success output with next-step commands for running the example workflow

## Validation
- `node --check packages/create-libretto/index.mjs`
- smoke-tested `scaffoldProject(..., { skipInstall: true })` creates `.git/` for a standalone temp project
- smoke-tested nested scaffolding inside an existing Git worktree skips creating nested `.git/`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
