### PR TITLE
Add Fathom analytics

### DIFF
--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -36,6 +36,10 @@
 
     <!-- LinkedIn -->
     <meta property="og:site_name" content="Libretto" />
+
+    <!-- Fathom - beautiful, simple website analytics -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="OSJVKIKF" defer></script>
+    <!-- / Fathom -->
   </head>
   <body>
     <div id="app"></div>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -137,5 +137,10 @@
       "discord": "https://discord.gg/NYrG56hVDt",
       "linkedin": "https://www.linkedin.com/company/saffron-health"
     }
+  },
+  "integrations": {
+    "fathom": {
+      "siteId": "OSJVKIKF"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add the Fathom analytics embed to the marketing site head
- configure the Mintlify docs site to use Fathom site ID `OSJVKIKF`

## Verification
- `pnpm --dir ./apps/website build`
- `pnpm docs:validate`
- Verified with Playwriter against the local website that the Fathom script is present

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
