### PR TITLE
config: switch snapshotModel to vertex/gemini-2.5-flash

### DIFF
--- a/.libretto/config.json
+++ b/.libretto/config.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "snapshotModel": "openai/gpt-5.4",
+  "snapshotModel": "vertex/gemini-2.5-flash",
   "ai": {
     "model": "openai/gpt-5.4",
     "updatedAt": "2026-04-14T00:16:50.626Z"


### PR DESCRIPTION
## Summary

Switches the `snapshotModel` in `.libretto/config.json` from `openai/gpt-5.4` to `vertex/gemini-2.5-flash`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
