### PR TITLE
feat: add `--auth-profile` option to `open` command

### DIFF
--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -80,6 +80,10 @@ export const openInput = SimpleCLI.input({
       name: "write-access",
       help: "Create the session in write-access mode (overrides config default)",
     }),
+    authProfile: SimpleCLI.option(z.string().optional(), {
+      name: "auth-profile",
+      help: "Domain for local auth profile (e.g. apps.example.com)",
+    }),
     viewport: SimpleCLI.option(z.string().optional(), {
       help: "Viewport size as WIDTHxHEIGHT (e.g. 1920x1080)",
     }),
@@ -91,7 +95,7 @@ export const openInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.url),
-    `Usage: libretto open <url> [--headless] [--read-only|--write-access] [--viewport WxH] [--session <name>]`,
+    `Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]`,
   )
   .refine(
     (input) => !(input.headed && input.headless),
@@ -120,6 +124,7 @@ export const openCommand = SimpleCLI.command({
           input.readOnly,
           input.writeAccess,
         ),
+        authProfileDomain: input.authProfile,
       });
     } else {
       const provider = getCloudProviderApi(providerName);

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -82,7 +82,7 @@ export const openInput = SimpleCLI.input({
     }),
     authProfile: SimpleCLI.option(z.string().optional(), {
       name: "auth-profile",
-      help: "Domain for local auth profile (e.g. apps.example.com)",
+      help: "Override the domain used for auth profile lookup (e.g. use login.example.com's profile when opening app.example.com)",
     }),
     viewport: SimpleCLI.option(z.string().optional(), {
       help: "Viewport size as WIDTHxHEIGHT (e.g. 1920x1080)",
@@ -107,7 +107,8 @@ export const openInput = SimpleCLI.input({
   );
 
 export const openCommand = SimpleCLI.command({
-  description: "Launch browser and open URL (headed by default)",
+  description:
+    "Launch browser and open URL (headed by default). Automatically loads a saved auth profile for the URL's domain if one exists.",
 })
   .input(openInput)
   .use(withAutoSession())

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -402,6 +402,7 @@ export async function runOpen(
   options?: {
     viewport?: { width: number; height: number };
     accessMode?: SessionAccessMode;
+    authProfileDomain?: string;
   },
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
@@ -423,9 +424,26 @@ export async function runOpen(
   const runLogPath = logFileForSession(session);
 
   const browserMode = headed ? "headed" : "headless";
+
+  // When --auth-profile is provided, use that domain for profile lookup
+  // instead of deriving it from the URL.
+  const authDomain = options?.authProfileDomain
+    ? normalizeDomain(normalizeUrl(options.authProfileDomain))
+    : undefined;
+  if (authDomain) {
+    const authProfilePath = getProfilePath(authDomain);
+    if (!existsSync(authProfilePath)) {
+      throw new Error(
+        `No saved auth profile for "${authDomain}". ` +
+          `Save one first: libretto open https://${authDomain} --session <name>, ` +
+          `log in, then run: libretto auth save ${authDomain}`,
+      );
+    }
+  }
+
   const supportsSavedProfile =
     parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
-  const domain = supportsSavedProfile ? normalizeDomain(parsedUrl) : undefined;
+  const domain = authDomain ?? (supportsSavedProfile ? normalizeDomain(parsedUrl) : undefined);
   const profilePath = domain ? getProfilePath(domain) : undefined;
   const useProfile = domain ? hasProfile(domain) : false;
 

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -435,8 +435,8 @@ export async function runOpen(
     if (!existsSync(authProfilePath)) {
       throw new Error(
         `No saved auth profile for "${authDomain}". ` +
-          `Save one first: libretto open https://${authDomain} --session <name>, ` +
-          `log in, then run: libretto auth save ${authDomain}`,
+          `Save one first: libretto open https://${authDomain} --headed --session <name>, ` +
+          `log in, then run: libretto save ${authDomain} --session <name>`,
       );
     }
   }

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -360,7 +360,7 @@ describe("basic CLI subprocess behavior", () => {
   test("fails open with missing url usage error", async ({ librettoCli }) => {
     const result = await librettoCli("open");
     expect(result.stderr).toContain(
-      "Usage: libretto open <url> [--headless] [--read-only|--write-access] [--viewport WxH] [--session <name>]",
+      "Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]",
     );
   });
 


### PR DESCRIPTION
## Summary

The `--auth-profile` flag was only available on the `run` command. This PR adds it to `open` as well, so you can launch a browser with a saved auth profile for a domain different from the target URL. It also documents the existing auto-load behavior in the help text.

### Example

```bash
libretto open https://app.example.com --auth-profile login.example.com
```

This loads the saved profile for `login.example.com` even though the target URL is `app.example.com`.

## Changes

- **`packages/libretto/src/cli/commands/browser.ts`**: Added `--auth-profile <domain>` option to `openInput`, passed it through to `runOpen()`, and improved help text — the command description now mentions auto-loading of saved profiles, and `--auth-profile` explains it overrides the domain used for profile lookup.
- **`packages/libretto/src/cli/core/browser.ts`**: Extended `runOpen()` options with `authProfileDomain`. When provided, it overrides the URL-derived domain for profile lookup and validates the profile exists with a clear error message if not.
- **`packages/libretto/test/basic.spec.ts`**: Updated test assertion to match the new usage string.
