### PR TITLE
docs: update glimpse-changes skill with new features (v1.9.3)

### DIFF
--- a/.agents/skills/glimpse-changes/SKILL.md
+++ b/.agents/skills/glimpse-changes/SKILL.md
@@ -3,7 +3,7 @@ name: glimpse-changes
 description: Create a visual explanation of the current session diff as a single HTML page and show it in a native Glimpse window. Use when the user wants a visual walkthrough of local code changes instead of a plain text diff.
 metadata:
   author: tanishqkancharla
-  version: "1.4.0"
+  version: "1.9.3"
 ---
 
 # Glimpse Changes
@@ -19,7 +19,18 @@ cat report.md | npx glimpse-changes
 npx glimpse-changes "# Title\n\nContent"
 ```
 
-The CLI opens a Glimpse window and exits immediately.
+Use `-` to force reading from stdin:
+
+```bash
+npx glimpse-changes -
+```
+
+### Options
+
+- `--dry-run` — Render to file only, don't open Glimpse. Prints `{ dryRun: true, htmlPath, title }` as JSON.
+- `--background` — Open the window in the background, print the output file path, and exit immediately. The output file contains `__PENDING__` until the user closes the window, then it contains the review output.
+
+By default the CLI blocks until the window is closed and prints review output to stdout.
 
 ## Diff blocks
 
@@ -57,6 +68,19 @@ Every non-empty line must start with `+`, `-`, or a space. Invalid lines cause a
 
 For added-file snippets, you can start with `+++ path/to/file.ext` and keep the remaining lines prefixed with `+`. The renderer will synthesize a proper new-file diff so the filename and syntax highlighting are preserved.
 
+## Changes blocks
+
+Use a `changes` fenced block to show expandable file-level diffs with full syntax highlighting. Each line is a file path, optionally with a line range to focus on:
+
+````
+```changes
+src/cli/run.ts
+src/utils/parse.ts:10-50
+```
+````
+
+The renderer reads the file from the working tree and compares it against `HEAD` via `git show`, producing a rich interactive diff with collapsible hunks, add/remove stats, and syntax highlighting inferred from the file extension.
+
 ## Code blocks
 
 Fenced code blocks with a language tag get syntax highlighting via `@pierre/diffs`:
@@ -67,10 +91,38 @@ const x = 1;
 ```
 ````
 
+## Markdown support
+
+Beyond code and diff blocks, the renderer supports:
+
+- Headings (`# H1` through `###### H6`) — H1–H3 appear in a table of contents
+- Bold (`**text**`), italic (`*text*`), inline code (`` `code` ``), links (`[label](url)`)
+- Blockquotes (`> text`)
+- Unordered lists (`- item`)
+- Ordered lists (`1. item`)
+- Tables (GFM pipe syntax with alignment)
+- Horizontal rules (`---`)
+- Bare URLs are auto-linked
+
+## Annotations (user review)
+
+When the window is open, the user can select text and leave inline comments. On close, the CLI outputs all annotations in a structured format:
+
+```
+User review:
+
+> selected text (file:line)
+
+User's comment here
+```
+
+If the user closes without annotating, the output is:
+`Window closed. User marked done without review.`
+
 ## Typical workflow
 
 1. Inspect changes with `git diff`, `git status`, etc.
 2. Write a markdown explanation of the changes.
 3. Pipe it to `npx glimpse-changes`.
 
-Prefer command diffs (`!`git diff ...``) over pasting raw diff content — they always reflect the current working tree.
+Prefer command diffs (`` !`git diff ...` ``) over pasting raw diff content — they always reflect the current working tree. Use `changes` blocks for interactive file-level diffs with expand/collapse.


### PR DESCRIPTION
Updates the glimpse-changes skill documentation to reflect new features:

- `--dry-run` and `--background` CLI options
- Stdin mode with `-`
- `changes` fenced blocks for interactive file-level diffs
- Extended markdown support (tables, blockquotes, ordered lists, etc.)
- Annotation/review workflow documentation
- Version bump to 1.9.3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
