### PR TITLE
feat(cli): experimental billing portal + status commands

### DIFF
--- a/packages/libretto/src/cli/commands/billing.ts
+++ b/packages/libretto/src/cli/commands/billing.ts
@@ -1,0 +1,133 @@
+/**
+ * Hosted-platform billing commands. Stripe is the source of truth
+ * for the plan catalog and is also where every tenant — including
+ * Free — has a live Subscription. The Stripe Customer Portal is the
+ * single management UI: it shows the user's current plan and lets
+ * them switch between any of the configured Subscription Update
+ * products (Free / Pro / Team).
+ *
+ *   libretto experimental billing portal   → Stripe Customer Portal
+ *   libretto experimental billing status   → plan + usage + period end
+ *
+ * `libretto init` is unchanged. New tenants start on Free automatically
+ * (with a real Stripe Customer + Free Subscription created at signup).
+ *
+ * Auth: requires a session cookie (or LIBRETTO_API_KEY).
+ */
+
+import { SimpleCLI } from "../framework/simple-cli.js";
+import {
+  NOT_AUTHENTICATED_MESSAGE,
+  orpcCall,
+  pickCredential,
+  resolveApiUrl,
+} from "../core/auth-fetch.js";
+import { readAuthState } from "../core/auth-storage.js";
+
+// Marketing-site URL — used for BAA requests and Enterprise contact.
+const CONTACT_URL = "https://libretto.sh";
+
+// ---------------------------------------------------------------------------
+// Types — mirrored from api/src/routes/billing/subscription.ts
+// ---------------------------------------------------------------------------
+
+type SubscriptionResponse = {
+  plan: string;
+  status: string;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  browserHoursUsedThisPeriod: number;
+  browserHoursLimit: number | null;
+};
+
+type OpenPlansPageResponse = {
+  url: string;
+};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function requireAuth(): Promise<{ apiUrl: string; credential: ReturnType<typeof pickCredential> }> {
+  const stored = await readAuthState();
+  const apiUrl = resolveApiUrl(stored);
+  const credential = pickCredential(stored);
+  if (credential.source === "none") {
+    throw new Error(NOT_AUTHENTICATED_MESSAGE);
+  }
+  return { apiUrl, credential };
+}
+
+function formatLimit(limit: number | null): string {
+  return limit === null ? "∞" : String(limit);
+}
+
+// ---------------------------------------------------------------------------
+// portal: always opens the Stripe Customer Portal — every tenant has a
+// live Stripe Subscription (Free or paid) so the portal always has
+// something to show. It's where users see their current plan and switch
+// to another. We DON'T branch on plan / status here.
+// ---------------------------------------------------------------------------
+
+export const billingPortalCommand = SimpleCLI.command({
+  description: "Open the libretto plans page (current plan + switch options)",
+  experimental: true,
+})
+  .handle(async () => {
+    const { apiUrl, credential } = await requireAuth();
+    const { url } = await orpcCall<OpenPlansPageResponse>({
+      apiUrl,
+      path: "/v1/billing/openPlansPage",
+      credential,
+    });
+    console.log("Open this URL in your browser to choose or change your plan:");
+    console.log(`  ${url}`);
+    console.log();
+    console.log(
+      "(Shows all tiers with features, your current plan, and a Manage payment / invoices link.)",
+    );
+    console.log(
+      `For a BAA or Enterprise pricing, contact us at ${CONTACT_URL}.`,
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+export const billingStatusCommand = SimpleCLI.command({
+  description: "Print the current plan, status, and browser-hour usage",
+  experimental: true,
+})
+  .handle(async () => {
+    const { apiUrl, credential } = await requireAuth();
+    const sub = await orpcCall<SubscriptionResponse>({
+      apiUrl,
+      path: "/v1/billing/subscription",
+      credential,
+    });
+
+    const used = sub.browserHoursUsedThisPeriod.toFixed(2);
+    const limit = formatLimit(sub.browserHoursLimit);
+
+    console.log(`Plan:    ${sub.plan} (${sub.status})`);
+    console.log(`Usage:   ${used} / ${limit} browser hours this period`);
+    if (sub.currentPeriodEnd) {
+      console.log(`Period:  ends ${sub.currentPeriodEnd.slice(0, 10)}`);
+    }
+    if (sub.cancelAtPeriodEnd) {
+      console.log("Note:    cancellation scheduled at period end.");
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Group export
+// ---------------------------------------------------------------------------
+
+export const billingCommands = SimpleCLI.group({
+  description: "Hosted-platform subscription + usage commands",
+  routes: {
+    portal: billingPortalCommand,
+    status: billingStatusCommand,
+  },
+});

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -1,5 +1,6 @@
 import { aiCommands } from "./commands/ai.js";
 import { authCommands } from "./commands/auth.js";
+import { billingCommands } from "./commands/billing.js";
 import { browserCommands } from "./commands/browser.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
@@ -14,6 +15,7 @@ export const cliRoutes = {
   ...executionCommands,
   ai: aiCommands,
   auth: authCommands,
+  billing: billingCommands,
   setup: setupCommand,
   status: statusCommand,
   snapshot: snapshotCommand,


### PR DESCRIPTION
## Summary

Adds two `experimental` CLI commands surfacing the hosted-platform billing flow:

- `libretto experimental billing portal` — calls `/v1/billing/openPlansPage` on the API and prints the URL of a custom plans page (current plan + switch options + Manage payment & invoices link).
- `libretto experimental billing status` — prints plan, status, period end, and browser-hour usage from `auth.billing`.

Both commands require a hosted-platform session cookie (or `LIBRETTO_API_KEY`). The API gates them to organization owners only.

`libretto init` is unchanged: tenants are auto-provisioned on Free at signup; users come back here later to upgrade.

## Companion PR

Server-side billing infrastructure (schema, ORPC routes, Stripe webhook, custom plans page, owner-gate, etc.) lives in saffron-health/browser-automations: https://github.com/saffron-health/browser-automations (parent PR opens next — link to follow).

## Test plan

- [x] `libretto experimental billing portal` returns a working plans-page URL
- [x] `libretto experimental billing status` reflects current `auth.billing` state
- [x] Member-role users get FORBIDDEN; owner-role users succeed
- [x] Build + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
