### PR TITLE
Load .env before CLI command dispatch

### DIFF
--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -2,6 +2,7 @@ import { resolveAiSetupStatus } from "./core/ai-model.js";
 import { ensureLibrettoSetup } from "./core/context.js";
 import { createCLIApp } from "./router.js";
 import { warnIfInstalledSkillOutOfDate } from "./core/skill-version.js";
+import { loadEnv } from "../shared/env/load-env.js";
 
 function renderUsage(app: ReturnType<typeof createCLIApp>): string {
   return `${app.renderHelp()}
@@ -48,6 +49,7 @@ function isRootHelpRequest(rawArgs: readonly string[]): boolean {
 export async function runLibrettoCLI(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   let exitCode = 0;
+  loadEnv();
   ensureLibrettoSetup();
   const app = createCLIApp();
 

--- a/packages/libretto/src/cli/core/ai-model.ts
+++ b/packages/libretto/src/cli/core/ai-model.ts
@@ -5,7 +5,6 @@ import {
   parseModel,
   type Provider,
 } from "./resolve-model.js";
-import { loadEnv } from "../../shared/env/load-env.js";
 
 // Re-export so existing consumers (e.g. tests) don't break.
 export { parseDotEnvAssignment } from "../../shared/env/load-env.js";
@@ -148,6 +147,10 @@ function inferAutoSnapshotModel(): SnapshotApiModelSelection | null {
 /**
  * Resolve which API model to use for snapshot analysis.
  *
+ * Environment variables are loaded by the CLI entrypoint (`runLibrettoCLI` in
+ * `cli.ts`) before this resolver runs. Keep dotenv loading centralized there so
+ * model resolution and browser provider resolution share the same env setup.
+ *
  * Priority:
  * 1. snapshotModel from .libretto/config.json (set via `ai configure`)
  * 2. Auto-detect from available API credentials in env
@@ -155,8 +158,6 @@ function inferAutoSnapshotModel(): SnapshotApiModelSelection | null {
 export function resolveSnapshotApiModel(
   snapshotModel: string | null = readSnapshotModel(),
 ): SnapshotApiModelSelection | null {
-  loadEnv();
-
   if (snapshotModel) {
     const { provider } = parseModel(snapshotModel);
     return {
@@ -246,8 +247,6 @@ function readSnapshotModelSafely(
 export function resolveAiSetupStatus(
   configPath: string = LIBRETTO_CONFIG_PATH,
 ): AiSetupStatus {
-  loadEnv();
-
   const result = readSnapshotModelSafely(configPath);
 
   if (!result.ok) {

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -4,7 +4,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { cwd } from "node:process";
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { loadEnv } from "../../shared/env/load-env.js";
 import {
   getDefaultWorkflowFromModuleExports,
   getWorkflowsFromModuleExports,
@@ -195,11 +194,6 @@ async function runIntegrationInternal(
 ): Promise<RunIntegrationOutcome> {
   const { logger } = options;
   const absolutePath = getAbsoluteIntegrationPath(args.integrationPath);
-
-  const envPath = loadEnv();
-  if (envPath) {
-    logger.info("loaded-env", { path: envPath });
-  }
 
   const workflow = await loadDefaultWorkflow(absolutePath);
   const signalPaths = getPauseSignalPaths(args.session);

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -114,6 +114,24 @@ describe("basic CLI subprocess behavior", () => {
     );
   });
 
+  test("setup loads snapshot API credentials from workspace .env", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    await writeFile(workspacePath(".env"), "OPENAI_API_KEY=test-openai-key\n");
+
+    const result = await librettoCli("setup --skip-browsers", {
+      ANTHROPIC_API_KEY: "",
+      GEMINI_API_KEY: "",
+      GOOGLE_GENERATIVE_AI_API_KEY: "",
+      GOOGLE_CLOUD_PROJECT: "",
+      GCLOUD_PROJECT: "",
+    });
+
+    expect(result.stdout).toContain("Using OpenAI");
+    expect(result.stdout).toContain("Detected OPENAI_API_KEY");
+  });
+
   test("setup auto-pins default model when OPENAI_API_KEY is present", async ({
     librettoCli,
   }) => {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -121,11 +121,12 @@ describe("basic CLI subprocess behavior", () => {
     await writeFile(workspacePath(".env"), "OPENAI_API_KEY=test-openai-key\n");
 
     const result = await librettoCli("setup --skip-browsers", {
-      ANTHROPIC_API_KEY: "",
-      GEMINI_API_KEY: "",
-      GOOGLE_GENERATIVE_AI_API_KEY: "",
-      GOOGLE_CLOUD_PROJECT: "",
-      GCLOUD_PROJECT: "",
+      OPENAI_API_KEY: undefined,
+      ANTHROPIC_API_KEY: undefined,
+      GEMINI_API_KEY: undefined,
+      GOOGLE_GENERATIVE_AI_API_KEY: undefined,
+      GOOGLE_CLOUD_PROJECT: undefined,
+      GCLOUD_PROJECT: undefined,
     });
 
     expect(result.stdout).toContain("Using OpenAI");

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { describe, expect } from "vitest";
 import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
 import { test } from "./fixtures.js";
@@ -78,6 +79,28 @@ describe("provider resolution via CLI", () => {
     expect(result.stderr).not.toContain("Invalid provider");
     // If it got past resolution to actually trying kernel, it won't mention browserbase
     expect(result.stderr).not.toContain("browserbase");
+  });
+
+  test("open loads Browserbase credentials from workspace .env", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    await writeFile(
+      workspacePath(".env"),
+      [
+        "BROWSERBASE_API_KEY=test-key",
+        "BROWSERBASE_PROJECT_ID=test-project",
+        "BROWSERBASE_ENDPOINT=http://127.0.0.1:9",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await librettoCli(
+      "open https://example.com --provider browserbase",
+    );
+
+    expect(result.stderr).not.toContain("BROWSERBASE_API_KEY is required");
+    expect(result.stderr).not.toContain("BROWSERBASE_PROJECT_ID is required");
   });
 });
 

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -97,6 +97,11 @@ describe("provider resolution via CLI", () => {
 
     const result = await librettoCli(
       "open https://example.com --provider browserbase",
+      {
+        BROWSERBASE_API_KEY: undefined,
+        BROWSERBASE_PROJECT_ID: undefined,
+        BROWSERBASE_ENDPOINT: undefined,
+      },
     );
 
     expect(result.stderr).not.toContain("BROWSERBASE_API_KEY is required");

--- a/packages/libretto/test/fixtures.ts
+++ b/packages/libretto/test/fixtures.ts
@@ -24,7 +24,7 @@ type CliFixtures = {
   librettoRuntimePath: string;
   librettoCli: (
     command: string,
-    env?: Record<string, string>,
+    env?: Record<string, string | undefined>,
     stdinText?: string,
   ) => Promise<SpawnResult>;
   writeWorkflow: (
@@ -120,16 +120,25 @@ async function execProcess(
   command: string,
   args: string[],
   cwd: string,
-  env?: Record<string, string>,
+  env?: Record<string, string | undefined>,
   stdinText?: string,
 ): Promise<SpawnResult> {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(env ?? {})) {
+    if (value === undefined) {
+      delete childEnv[key];
+    } else {
+      childEnv[key] = value;
+    }
+  }
+
   return await new Promise<SpawnResult>((resolveResult, reject) => {
     const child = execFile(
       command,
       args,
       {
         cwd,
-        env: { ...process.env, ...env },
+        env: childEnv,
         maxBuffer: 10 * 1024 * 1024,
       },
       (error, stdout, stderr) => {
@@ -295,7 +304,7 @@ export const test = base.extend<CliFixtures>({
     await use(
       async (
         command: string,
-        env?: Record<string, string>,
+        env?: Record<string, string | undefined>,
         stdinText?: string,
       ) => {
         return await execProcess(


### PR DESCRIPTION
## Summary
- load `.env` once at the Libretto CLI entrypoint before command dispatch
- centralize dotenv handling by removing lower-level `loadEnv()` calls from snapshot model resolution and the workflow runtime worker
- add CLI-level regression coverage for Browserbase provider credentials and snapshot setup credentials loaded from workspace `.env`
- allow CLI tests to explicitly remove inherited host env vars so dotenv regressions prove values came from the workspace `.env`

## Why
Commands such as `open --provider browserbase` and `run --provider browserbase` create cloud providers in the parent CLI process. Before this change, that process could read `process.env.BROWSERBASE_API_KEY` before `.env` was loaded, causing false missing-credential errors when keys existed only in `.env`.

The `run` worker now relies on the parent CLI process to load dotenv and passes the hydrated environment through `spawn(..., { env: process.env })`.

## Testing
- CI: `test` passed on the initial push
- Not run locally: dependencies are not installed in this worktree (`node_modules` missing), so `pnpm --filter libretto type-check` failed on unresolved packages.
