### PR TITLE
Fix exec inspection for daemonless failed runs

### DIFF
--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -3,8 +3,13 @@ import { spawn } from "node:child_process";
 import * as moduleBuiltin from "node:module";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
+import { installInstrumentation } from "../../shared/instrumentation/index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
-import { resolveViewport } from "../core/browser.js";
+import {
+  connect,
+  disconnectBrowser,
+  resolveViewport,
+} from "../core/browser.js";
 import { parseViewportArg } from "./browser.js";
 import { getPauseSignalPaths } from "../core/pause-signals.js";
 import {
@@ -19,8 +24,17 @@ import {
 import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { resolveProviderName, getCloudProviderApi } from "../core/providers/index.js";
-import { stripEmptyCatchHandlers } from "../core/exec-compiler.js";
+import {
+  compileExecFunction,
+  stripEmptyCatchHandlers,
+} from "../core/exec-compiler.js";
 import { DaemonClient } from "../core/daemon/index.js";
+import { createReadonlyExecHelpers } from "../core/readonly-exec.js";
+import {
+  readActionLog,
+  readNetworkLog,
+  wrapPageForActionLogging,
+} from "../core/telemetry.js";
 import type { RunIntegrationWorkerRequest } from "../workers/run-integration-worker-protocol.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
@@ -108,6 +122,149 @@ async function execViaDaemon(
   }
 }
 
+async function execViaCdpFallback(
+  code: string,
+  session: string,
+  logger: LoggerApi,
+  options: {
+    visualize?: boolean;
+    pageId?: string;
+    mode?: ExecMode;
+  },
+): Promise<void> {
+  const visualize = options.visualize ?? false;
+  const pageId = options.pageId;
+  const mode = options.mode ?? "exec";
+  const { cleaned: cleanedCode, strippedCount } = stripEmptyCatchHandlers(code);
+  if (strippedCount > 0) {
+    console.log("(Stripped `.catch(() => {})` — letting errors bubble up)");
+  }
+  logger.info(`${mode}-start`, {
+    session,
+    codeLength: cleanedCode.length,
+    codePreview: cleanedCode.slice(0, 200),
+    visualize,
+    pageId,
+    via: "cdp-fallback",
+  });
+
+  const {
+    browser,
+    context,
+    page,
+    pageId: resolvedPageId,
+  } = await connect(session, logger, 10000, {
+    pageId,
+    requireSinglePage: true,
+  });
+
+  const STALL_THRESHOLD_MS = 60_000;
+  let lastActivityTs = Date.now();
+  const onActivity = () => {
+    lastActivityTs = Date.now();
+  };
+
+  const stallInterval = setInterval(() => {
+    const silenceMs = Date.now() - lastActivityTs;
+    if (silenceMs >= STALL_THRESHOLD_MS) {
+      logger.warn(`${mode}-stall-warning`, {
+        session,
+        silenceMs,
+        codePreview: cleanedCode.slice(0, 200),
+        via: "cdp-fallback",
+      });
+      console.warn(
+        `[stall-warning] No Playwright activity for ${Math.round(silenceMs / 1000)}s — ${mode} may be hung (code: ${cleanedCode.slice(0, 100)}...)`,
+      );
+    }
+  }, STALL_THRESHOLD_MS);
+
+  const execStartTs = Date.now();
+  const sigintHandler = () => {
+    logger.info(`${mode}-interrupted`, {
+      session,
+      duration: Date.now() - execStartTs,
+      codePreview: cleanedCode.slice(0, 200),
+      via: "cdp-fallback",
+    });
+  };
+  process.on("SIGINT", sigintHandler);
+
+  if (mode === "exec") {
+    wrapPageForActionLogging(page, session, resolvedPageId, onActivity);
+  }
+
+  if (visualize && mode === "exec") {
+    await installInstrumentation(page, { visualize: true, logger });
+  }
+
+  try {
+    const execState: Record<string, unknown> = {};
+    const helpers =
+      mode === "readonly-exec"
+        ? createReadonlyExecHelpers(page, { onActivity })
+        : {
+            page,
+            context,
+            state: execState,
+            browser,
+            networkLog: (
+              opts: {
+                last?: number;
+                filter?: string;
+                method?: string;
+                pageId?: string;
+              } = {},
+            ) => readNetworkLog(session, opts),
+            actionLog: (
+              opts: {
+                last?: number;
+                filter?: string;
+                action?: string;
+                source?: string;
+                pageId?: string;
+              } = {},
+            ) => readActionLog(session, opts),
+            console,
+            setTimeout,
+            setInterval,
+            clearTimeout,
+            clearInterval,
+            fetch,
+            URL,
+            Buffer,
+          };
+
+    const helperNames = Object.keys(helpers);
+    const fn = compileExecFunction(cleanedCode, helperNames);
+    const result = await fn(...Object.values(helpers));
+    logger.info(`${mode}-success`, {
+      session,
+      hasResult: result !== undefined,
+      via: "cdp-fallback",
+    });
+    if (result !== undefined) {
+      console.log(
+        typeof result === "string" ? result : JSON.stringify(result, null, 2),
+      );
+    } else {
+      console.log("Executed successfully");
+    }
+  } catch (err) {
+    logger.error(`${mode}-error`, {
+      error: err,
+      session,
+      codePreview: cleanedCode.slice(0, 200),
+      via: "cdp-fallback",
+    });
+    throw err;
+  } finally {
+    clearInterval(stallInterval);
+    process.removeListener("SIGINT", sigintHandler);
+    disconnectBrowser(browser, logger, session);
+  }
+}
+
 async function runExec(
   code: string,
   session: string,
@@ -120,10 +277,16 @@ async function runExec(
 ): Promise<void> {
   const state = readSessionStateOrThrow(session);
   if (!state.daemonSocketPath) {
-    throw new Error(
-      `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
-    );
+    // Compatibility fallback for failed runs created before `run` became
+    // daemon-backed: those session states can have a live CDP endpoint/port but
+    // no daemon socket. Keep `exec` inspection working until such sessions are
+    // gone. Context: https://www.notion.so/Make-libretto-run-daemon-backed-for-failed-workflow-inspection-352ac9fb35f181c1b7d3f08c0a735e9d
+    logger.warn(`${options.mode ?? "exec"}-daemon-socket-missing-cdp-fallback`, {
+      session,
+      hasCdpEndpoint: Boolean(state.cdpEndpoint),
+      port: state.port,
+    });
+    return execViaCdpFallback(code, session, logger, options);
   }
   return execViaDaemon(code, session, state.daemonSocketPath, logger, options);
 }

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -155,7 +155,6 @@ async function execViaCdpFallback(
     pageId: resolvedPageId,
   } = await connect(session, logger, 10000, {
     pageId,
-    requireSinglePage: true,
   });
 
   const STALL_THRESHOLD_MS = 60_000;

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1074,6 +1074,8 @@ export default workflow("main", async ({ page }) => {
       `
 export default workflow("main", async (ctx) => {
   await ctx.page.goto("https://example.com");
+  const debugPage = await ctx.page.context().newPage();
+  await debugPage.goto("data:text/html,<title>Debug Target</title>");
   await ctx.page.locator("[").click();
 });
 `,
@@ -1090,7 +1092,7 @@ export default workflow("main", async (ctx) => {
     const execResult = await librettoCli(
       `exec "return await page.title()" --session ${session}`,
     );
-    expect(execResult.stdout).toContain("Example Domain");
+    expect(execResult.stdout).toMatch(/Example Domain|Debug Target/);
 
     const rerunResult = await librettoCli(
       `run "${integrationFilePath}" --session ${session} --headless`,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1087,6 +1087,11 @@ export default workflow("main", async (ctx) => {
     expect(runResult.stderr).toContain("use `exec` to inspect it");
     expect(runResult.stderr).toContain("Call `run` to re-run the workflow.");
 
+    const execResult = await librettoCli(
+      `exec "return await page.title()" --session ${session}`,
+    );
+    expect(execResult.stdout).toContain("Example Domain");
+
     const rerunResult = await librettoCli(
       `run "${integrationFilePath}" --session ${session} --headless`,
     );


### PR DESCRIPTION
## Summary
- restore a CDP-backed compatibility fallback when `exec` sees a live session without a daemon socket
- keep fallback inspection usable for failed runs with multiple open pages
- document why the fallback exists and link to the Notion task
- extend the failed workflow guidance test to actually run `exec` against the preserved browser

## Verification
- `pnpm -s type-check --filter=libretto`
- `pnpm -s test --filter=libretto`
- `pnpm -s test --filter=libretto -- basic.spec.ts`
- `pnpm -s test --filter=libretto -- basic.spec.ts -t "run prints failure guidance and keeps browser open for exec inspection"`
- verified the new targeted assertion fails without the fallback and passes with it
