### PR TITLE
Quiet successful Turbo test logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "sync-skills": "pnpm run sync:mirrors",
     "check:skills": "pnpm run check:mirrors",
     "type-check": "turbo run type-check",
-    "test": "turbo run test",
+    "test": "turbo run test --log-order=grouped",
     "prepare-release": "bash ./scripts/prepare-release.sh",
     "evals": "turbo run evals --filter=@libretto/evals --",
     "benchmarks": "turbo run benchmarks --filter=@libretto/benchmarks --",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "outputLogs": "errors-only"
     },
     "type-check": {
       "dependsOn": ["build"],
@@ -11,7 +12,8 @@
     },
     "test": {
       "dependsOn": ["build"],
-      "cache": false
+      "cache": false,
+      "outputLogs": "errors-only"
     },
     "benchmarks": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- configure Turbo `build` and `test` tasks to only emit task logs on failures
- run root `pnpm test` with grouped Turbo log output for easier failure inspection

## Testing
- `pnpm -s test` *(fails: existing `test/basic.spec.ts` expectation failure in `fails run when local auth profile is declared but missing`)*
