### PR TITLE
ci: build before release verification tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
         if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: |
           pnpm check:mirrors
+          pnpm --filter libretto build
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:


### PR DESCRIPTION
## Summary

- build libretto before running release verification tests so tests that need packages/libretto/dist can pass

## Verification

- not run (workflow-only change)