### PR TITLE
Use package-manager-aware Libretto command guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,4 +8,4 @@ A page's URL prefix must match its `docs.json` group name, lowercased and hyphen
 
 ## Testing
 
-You can test the docs site with Libretto itself. Start the dev server, then use `libretto open` to open the local URL and verify pages render correctly.
+You can test the docs site with Libretto itself. Start the dev server, then use `npx libretto open` to open the local URL and verify pages render correctly.

--- a/docs/library-api/workflow.mdx
+++ b/docs/library-api/workflow.mdx
@@ -63,7 +63,7 @@ export default workflow<{ query: string }, string[]>(
 
 #### Running with the CLI
 
-Pass the file path to `libretto run`. The file must have a default-exported `workflow()`:
+Pass the file path to `npx libretto run`. The file must have a default-exported `workflow()`:
 
 ```bash theme={null}
 npx libretto run ./my-workflow.ts

--- a/docs/libretto-cloud/deployments.mdx
+++ b/docs/libretto-cloud/deployments.mdx
@@ -15,7 +15,7 @@ export LIBRETTO_API_KEY=<issued-api-key>
 
 ### Expected deploy directory
 
-`libretto experimental deploy` uploads one package directory at a time. That directory must contain:
+`npx libretto experimental deploy` uploads one package directory at a time. That directory must contain:
 
 - A `package.json`
 - An entry file for workflow discovery

--- a/packages/create-libretto/index.mjs
+++ b/packages/create-libretto/index.mjs
@@ -138,20 +138,9 @@ function addCommand(pkgManager) {
   }
 }
 
-/** Return the run command for scripts (used in next-steps messaging). */
+/** Return the run command for scripts (used in generated instructions). */
 function runCommand(pkgManager) {
-  switch (pkgManager) {
-    case "npm":
-      return "npx";
-    case "pnpm":
-      return "pnpm exec";
-    case "yarn":
-      return "yarn";
-    case "bun":
-      return "bunx";
-    default:
-      return "npx";
-  }
+  return execCommand(pkgManager);
 }
 
 // ---------------------------------------------------------------------------
@@ -423,7 +412,7 @@ export async function scaffoldProject(
         stdio: "inherit",
       });
     } catch {
-      console.error(`\nFailed to run libretto setup.`);
+      console.error(`\nFailed to run Libretto setup.`);
       process.exit(1);
     }
 

--- a/packages/create-libretto/template/README.md
+++ b/packages/create-libretto/template/README.md
@@ -18,7 +18,7 @@ Run a workflow:
 
 ## Agent Skills
 
-Libretto ships with agent skills that let AI coding assistants (Claude Code, Codex, etc.) build and maintain workflows for you. After running `libretto setup`, the skill files are installed at the root of your project in `.agents/skills/` and `.claude/skills/`. These root-level skill directories are what your AI assistant reads to understand how to use Libretto.
+Libretto ships with agent skills that let AI coding assistants (Claude Code, Codex, etc.) build and maintain workflows for you. After running `{{runCommand}} libretto setup`, the skill files are installed at the root of your project in `.agents/skills/` and `.claude/skills/`. These root-level skill directories are what your AI assistant reads to understand how to use Libretto.
 
 ## Links
 

--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -2,6 +2,7 @@ import { resolveAiSetupStatus } from "./core/ai-model.js";
 import { ensureLibrettoSetup } from "./core/context.js";
 import { createCLIApp } from "./router.js";
 import { warnIfInstalledSkillOutOfDate } from "./core/skill-version.js";
+import { runCommand } from "./core/run-command.js";
 import { loadEnv } from "../shared/env/load-env.js";
 
 function renderUsage(app: ReturnType<typeof createCLIApp>): string {
@@ -24,17 +25,17 @@ function printSetupAudit(): void {
       break;
     case "configured-missing-credentials":
       console.log(
-        `✗ ${status.provider} configured (model: ${status.model}), but credentials are missing. Run \`npx libretto setup\` to repair.`,
+        `✗ ${status.provider} configured (model: ${status.model}), but credentials are missing. Run \`${runCommand("setup")}\` to repair.`,
       );
       break;
     case "invalid-config":
       console.log(
-        `✗ AI config is invalid. Run \`npx libretto setup\` to reconfigure.`,
+        `✗ AI config is invalid. Run \`${runCommand("setup")}\` to reconfigure.`,
       );
       break;
     case "unconfigured":
       console.log(
-        `✗ No AI model configured. Run \`npx libretto setup\` or \`npx libretto ai configure\` to set up.`,
+        `✗ No AI model configured. Run \`${runCommand("setup")}\` or \`${runCommand("ai configure")}\` to set up.`,
       );
       break;
   }

--- a/packages/libretto/src/cli/commands/ai.ts
+++ b/packages/libretto/src/cli/commands/ai.ts
@@ -7,6 +7,7 @@ import {
 } from "../core/config.js";
 import { LIBRETTO_CONFIG_PATH } from "../core/context.js";
 import { DEFAULT_SNAPSHOT_MODELS } from "../core/ai-model.js";
+import { runCommand } from "../core/run-command.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
 const PROVIDER_ALIASES: Record<string, string> = {
@@ -63,7 +64,7 @@ export function runAiConfigure(
   } = {},
 ): void {
   const configureCommandName =
-    options.configureCommandName ?? "npx libretto ai configure";
+    options.configureCommandName ?? runCommand("ai configure");
   const configPath = options.configPath ?? LIBRETTO_CONFIG_PATH;
 
   const presetArg = input.preset?.trim();
@@ -135,7 +136,7 @@ export const aiCommands = SimpleCLI.group({
             preset: input.preset,
           },
           {
-            configureCommandName: `libretto ai configure`,
+            configureCommandName: runCommand("ai configure"),
           },
         );
       }),

--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -1,15 +1,15 @@
 /**
  * Experimental auth commands for the libretto hosted platform.
  *
- *   libretto experimental auth signup
- *   libretto experimental auth login
- *   libretto experimental auth logout
- *   libretto experimental auth invite <email> [--role member|admin|owner]
- *   libretto experimental auth accept-invite <tenantSlug> <invitationId>
- *   libretto experimental auth api-key issue [--label <label>]
- *   libretto experimental auth api-key list
- *   libretto experimental auth api-key revoke <id>
- *   libretto experimental auth whoami
+ *   npx libretto experimental auth signup
+ *   npx libretto experimental auth login
+ *   npx libretto experimental auth logout
+ *   npx libretto experimental auth invite <email> [--role member|admin|owner]
+ *   npx libretto experimental auth accept-invite <tenantSlug> <invitationId>
+ *   npx libretto experimental auth api-key issue [--label <label>]
+ *   npx libretto experimental auth api-key list
+ *   npx libretto experimental auth api-key revoke <id>
+ *   npx libretto experimental auth whoami
  *
  * Credentials live at ~/.libretto/auth.json (mode 0600). The CLI sends either
  * the stored API key or the stored session cookie depending on what's
@@ -36,6 +36,7 @@ import {
   type AuthState,
 } from "../core/auth-storage.js";
 import { prompt, promptPassword, slugify } from "../core/prompt.js";
+import { runCommand } from "../core/run-command.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -215,7 +216,7 @@ export const signupCommand = SimpleCLI.command({
     const name = await prompt("Your name:");
     if (name.toLowerCase() === "q" || name.length === 0) {
       console.log(
-        "OK — ask an existing teammate to run `libretto experimental auth invite <your-email>` and then run `libretto experimental auth accept-invite <slug> <invitation-id>` from this machine.",
+        `OK — ask an existing teammate to run \`${runCommand("experimental auth invite <your-email>")}\` and then run \`${runCommand("experimental auth accept-invite <slug> <invitation-id>")}\` from this machine.`,
       );
       return;
     }
@@ -294,7 +295,7 @@ export const signupCommand = SimpleCLI.command({
     console.log(`Session saved to ${authStatePath()}`);
     console.log();
     console.log("To generate an API key, run:");
-    console.log("  libretto experimental auth api-key issue --label <label>");
+    console.log(`  ${runCommand("experimental auth api-key issue --label <label>")}`);
     console.log("Then add LIBRETTO_API_KEY=<key> to your project's .env file.");
   });
 
@@ -475,7 +476,7 @@ export const inviteCommand = SimpleCLI.command({
     console.log();
     console.log("Tell them to run:");
     console.log(
-      `  libretto experimental auth accept-invite ${orgSlug} ${data.id}`,
+      `  ${runCommand(`experimental auth accept-invite ${orgSlug} ${data.id}`)}`,
     );
   });
 
@@ -611,7 +612,7 @@ export const acceptInviteCommand = SimpleCLI.command({
     console.log();
     console.log("Email verified. You're logged in and a member of the organization.");
     console.log("To generate an API key, run:");
-    console.log("  libretto experimental auth api-key issue --label <label>");
+    console.log(`  ${runCommand("experimental auth api-key issue --label <label>")}`);
     console.log("Then add LIBRETTO_API_KEY=<key> to your project's .env file.");
   });
 
@@ -740,7 +741,7 @@ export const whoamiCommand = SimpleCLI.command({
 
     if (credential.source === "none") {
       console.log(
-        "Not authenticated. Run `libretto experimental auth signup`, `login`, or set LIBRETTO_API_KEY in your env.",
+        `Not authenticated. Run \`${runCommand("experimental auth signup")}\`, \`${runCommand("experimental auth login")}\`, or set LIBRETTO_API_KEY in your env.`,
       );
       return;
     }

--- a/packages/libretto/src/cli/commands/billing.ts
+++ b/packages/libretto/src/cli/commands/billing.ts
@@ -6,8 +6,8 @@
  * them switch between any of the configured Subscription Update
  * products (Free / Pro / Team).
  *
- *   libretto experimental billing portal   → Stripe Customer Portal
- *   libretto experimental billing status   → plan + usage + period end
+ *   npx libretto experimental billing portal   → Stripe Customer Portal
+ *   npx libretto experimental billing status   → plan + usage + period end
  *
  * `libretto init` is unchanged. New tenants start on Free automatically
  * (with a real Stripe Customer + Free Subscription created at signup).

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -15,6 +15,7 @@ import {
 } from "../core/providers/index.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { createLoggerForSession, withSessionLogger } from "../core/context.js";
+import { runCommand } from "../core/run-command.js";
 import {
   type SessionAccessMode,
   assertSessionAvailableForStart,
@@ -95,7 +96,7 @@ export const openInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.url),
-    `Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]`,
+    `Usage: ${runCommand("open <url>")} [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]`,
   )
   .refine(
     (input) => !(input.headed && input.headless),
@@ -160,7 +161,7 @@ export const connectInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.cdpUrl),
-    `Usage: libretto connect <cdp-url> [--read-only|--write-access] --session <name>`,
+    `Usage: ${runCommand("connect <cdp-url>")} [--read-only|--write-access] --session <name>`,
   )
   .refine(
     (input) => !(input.readOnly && input.writeAccess),
@@ -193,7 +194,7 @@ export const saveInput = SimpleCLI.input({
   },
 }).refine(
   (input) => Boolean(input.urlOrDomain),
-  `Usage: libretto save <url|domain> --session <name>`,
+  `Usage: ${runCommand("save <url|domain>")} --session <name>`,
 );
 
 export const saveCommand = SimpleCLI.command({
@@ -264,7 +265,7 @@ export const closeInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.all || input.session,
-  `Usage: libretto close <session>\nUsage: libretto close --all [--force]`,
+  `Usage: ${runCommand("close <session>")}\nUsage: ${runCommand("close --all")} [--force]`,
 );
 
 export const closeCommand = SimpleCLI.command({
@@ -273,7 +274,7 @@ export const closeCommand = SimpleCLI.command({
   .input(closeInput)
   .handle(async ({ input }) => {
     if (input.force && !input.all) {
-      throw new Error(`Usage: libretto close --all [--force]`);
+      throw new Error(`Usage: ${runCommand("close --all")} [--force]`);
     }
     if (input.all) {
       const logger = createLoggerForSession("cli");

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -21,6 +21,7 @@ import { readLibrettoConfig } from "../core/config.js";
 import { resolveProviderName, getCloudProviderApi } from "../core/providers/index.js";
 import { stripEmptyCatchHandlers } from "../core/exec-compiler.js";
 import { DaemonClient } from "../core/daemon/index.js";
+import { runCommand as formatRunCommand } from "../core/run-command.js";
 import type { RunIntegrationWorkerRequest } from "../workers/run-integration-worker-protocol.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
@@ -122,7 +123,7 @@ async function runExec(
   if (!state.daemonSocketPath) {
     throw new Error(
       `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
+        `Close and reopen the session: ${formatRunCommand(`close --session ${session}`)}`,
     );
   }
   return execViaDaemon(code, session, state.daemonSocketPath, logger, options);
@@ -325,7 +326,7 @@ async function runResume(
 
   if (!existsSync(pausedSignalPath)) {
     throw new Error(
-      `Session "${session}" is not paused. Run "libretto run ... --session ${session}" and call pause("${session}") first.`,
+      `Session "${session}" is not paused. Run "${formatRunCommand(`run ... --session ${session}`)}" and call pause("${session}") first.`,
     );
   }
 
@@ -480,7 +481,7 @@ export const execInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.code !== undefined,
-  `Usage: libretto exec <code|-> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec - [--session <name>] [--visualize]`,
+  `Usage: ${formatRunCommand("exec <code|->")} [--session <name>] [--visualize]\n       echo '<code>' | ${formatRunCommand("exec -")} [--session <name>] [--visualize]`,
 );
 
 export const execCommand = SimpleCLI.command({
@@ -521,7 +522,7 @@ export const readonlyExecInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.code !== undefined,
-  `Usage: libretto readonly-exec <code|-> [--session <name>] [--page <id>]\n       echo '<code>' | libretto readonly-exec - [--session <name>] [--page <id>]`,
+  `Usage: ${formatRunCommand("readonly-exec <code|->")} [--session <name>] [--page <id>]\n       echo '<code>' | ${formatRunCommand("readonly-exec -")} [--session <name>] [--page <id>]`,
 );
 
 export const readonlyExecCommand = SimpleCLI.command({
@@ -543,7 +544,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--viewport WxH]`;
+const runUsage = `Usage: ${formatRunCommand("run <integrationFile>")} [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--viewport WxH]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -14,6 +14,7 @@ import {
   LIBRETTO_CONFIG_PATH,
   REPO_ROOT,
 } from "../core/context.js";
+import { runCommand } from "../core/run-command.js";
 import {
   type AiSetupStatus,
   DEFAULT_SNAPSHOT_MODELS,
@@ -177,7 +178,7 @@ function printHealthySummary(status: AiSetupStatus & { kind: "ready" }): void {
     console.log(`✓ Using ${providerLabel(status.provider)} (${status.model}).`);
   }
   console.log(
-    "To change: npx libretto ai configure openai | anthropic | gemini | vertex | openrouter",
+    `To change: ${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
   );
 }
 
@@ -254,14 +255,14 @@ function printSnapshotApiStatus(): boolean {
     console.log();
     console.log(formatMissingCredentialsMessage(plan));
     console.log(
-      `  To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
+      `  To fix: add ${plan.envVar} to .env, or run \`${runCommand("setup")}\` interactively to repair.`,
     );
     return false;
   }
 
   if (plan.kind === "repair-invalid-config") {
     printInvalidAiConfigWarning(status);
-    console.log("  Run `npx libretto setup` interactively to reconfigure.");
+    console.log(`  Run \`${runCommand("setup")}\` interactively to reconfigure.`);
     return false;
   }
 
@@ -275,10 +276,10 @@ function printSnapshotApiStatus(): boolean {
     "    GOOGLE_CLOUD_PROJECT=...  # plus application default credentials for Vertex",
   );
   console.log(
-    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter` to set a specific model.",
+    `  Or run \`${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}\` to set a specific model.`,
   );
   console.log(
-    "  Run `npx libretto setup` interactively to set up credentials.",
+    `  Run \`${runCommand("setup")}\` interactively to set up credentials.`,
   );
   return false;
 }
@@ -324,14 +325,14 @@ async function promptProviderSelection(
 
 function printSkipMessage(): void {
   console.log(
-    "\nSkipped. You can set up API credentials later by rerunning `npx libretto setup`.",
+    `\nSkipped. You can set up API credentials later by rerunning \`${runCommand("setup")}\`.`,
   );
   console.log("Or add credentials directly to your .env file:");
   console.log("  OPENAI_API_KEY=...");
   console.log("  ANTHROPIC_API_KEY=...");
   console.log("  GEMINI_API_KEY=...");
   console.log(
-    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter` to set a specific model.",
+    `  Or run \`${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}\` to set a specific model.`,
   );
 }
 
@@ -442,7 +443,7 @@ function copySkills(): void {
       "\n⚠️ No .agents/ or .claude/ directory found. Libretto skills were not installed.",
     );
     console.log(
-      "  Create one of these directories in your repo root and rerun `npx libretto setup` to install skills:",
+      `  Create one of these directories in your repo root and rerun \`${runCommand("setup")}\` to install skills:`,
     );
     console.log(`    mkdir ${join(REPO_ROOT, ".claude")}`);
     return;
@@ -510,7 +511,7 @@ export const setupCommand = SimpleCLI.command({
       const ready = printSnapshotApiStatus();
       if (!ready) {
         console.log(
-          "\nIf you're an agent, request the user to run `npx libretto setup`.",
+          `\nIf you're an agent, request the user to run \`${runCommand("setup")}\`.`,
         );
       }
     }

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -13,6 +13,7 @@ import { runApiInterpret } from "../core/api-snapshot-analyzer.js";
 import { readSnapshotModel } from "../core/config.js";
 import { resolveSnapshotApiModelOrThrow } from "../core/ai-model.js";
 import { DaemonClient } from "../core/daemon/index.js";
+import { runCommand } from "../core/run-command.js";
 
 export const FALLBACK_SNAPSHOT_VIEWPORT = { width: 1280, height: 800 } as const;
 
@@ -161,7 +162,7 @@ async function runSnapshot(
   if (!state?.daemonSocketPath) {
     throw new Error(
       `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
+        `Close and reopen the session: ${runCommand(`close --session ${session}`)}`,
     );
   }
 

--- a/packages/libretto/src/cli/commands/status.ts
+++ b/packages/libretto/src/cli/commands/status.ts
@@ -1,5 +1,6 @@
 import { LIBRETTO_CONFIG_PATH } from "../core/context.js";
 import { type AiSetupStatus, resolveAiSetupStatus } from "../core/ai-model.js";
+import { runCommand } from "../core/run-command.js";
 import { listRunningSessions, type SessionState } from "../core/session.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
@@ -17,7 +18,7 @@ function printAiStatus(status: AiSetupStatus): void {
         console.log(`  Source: ${status.source}`);
       }
       console.log(
-        "  To change: npx libretto ai configure openai | anthropic | gemini | vertex | openrouter",
+        `  To change: ${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
       );
       break;
 
@@ -25,7 +26,7 @@ function printAiStatus(status: AiSetupStatus): void {
       console.log(
         `  ✗ ${status.provider} is configured (model: ${status.model}), but credentials are missing.`,
       );
-      console.log("  Run `npx libretto setup` to repair.");
+      console.log(`  Run \`${runCommand("setup")}\` to repair.`);
       break;
 
     case "invalid-config":
@@ -33,13 +34,13 @@ function printAiStatus(status: AiSetupStatus): void {
       for (const line of status.message.split("\n")) {
         console.log(`    ${line}`);
       }
-      console.log("  Run `npx libretto setup` to reconfigure.");
+      console.log(`  Run \`${runCommand("setup")}\` to reconfigure.`);
       break;
 
     case "unconfigured":
       console.log("  ✗ No AI model configured.");
       console.log(
-        "  Run `npx libretto setup` or `npx libretto ai configure` to set up.",
+        `  Run \`${runCommand("setup")}\` or \`${runCommand("ai configure")}\` to set up.`,
       );
       break;
   }

--- a/packages/libretto/src/cli/core/ai-model.ts
+++ b/packages/libretto/src/cli/core/ai-model.ts
@@ -5,6 +5,7 @@ import {
   parseModel,
   type Provider,
 } from "./resolve-model.js";
+import { runCommand } from "./run-command.js";
 
 // Re-export so existing consumers (e.g. tests) don't break.
 export { parseDotEnvAssignment } from "../../shared/env/load-env.js";
@@ -80,7 +81,7 @@ function providerSetupSentence(provider: Provider): string {
 }
 
 function defaultModelCommandLine(): string {
-  return "npx libretto ai configure openai | anthropic | gemini | vertex | openrouter";
+  return runCommand("ai configure openai | anthropic | gemini | vertex | openrouter");
 }
 
 function providerMissingCredentialSummary(provider: Provider): string {
@@ -102,7 +103,7 @@ function noSnapshotApiConfiguredMessage(): string {
   return [
     "Failed to analyze snapshot because no snapshot analyzer is configured.",
     `Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with \`${defaultModelCommandLine()}\`.`,
-    "For more info, run `npx libretto setup`.",
+    `For more info, run \`${runCommand("setup")}\`.`,
   ].join(" ");
 }
 
@@ -116,7 +117,7 @@ function missingProviderSnapshotMessage(
   return [
     `Failed to analyze snapshot because ${selection.provider} is configured${configuredSource}, but ${providerMissingCredentialSummary(selection.provider)}.`,
     providerSetupSentence(selection.provider),
-    "For more info, run `npx libretto setup`.",
+    `For more info, run \`${runCommand("setup")}\`.`,
   ].join(" ");
 }
 

--- a/packages/libretto/src/cli/core/auth-fetch.ts
+++ b/packages/libretto/src/cli/core/auth-fetch.ts
@@ -10,6 +10,7 @@
  */
 
 import { readAuthState, writeAuthState, type AuthState } from "./auth-storage.js";
+import { runCommand } from "./run-command.js";
 
 export const HOSTED_API_URL = "https://api.libretto.sh";
 
@@ -19,8 +20,8 @@ export const HOSTED_API_URL = "https://api.libretto.sh";
  */
 export const NOT_AUTHENTICATED_MESSAGE = [
   "Not authenticated.",
-  "  • Cookie expired or never set: run `libretto experimental auth login` to refresh it.",
-  "  • Or set LIBRETTO_API_KEY in your .env (issue one with `libretto experimental auth api-key issue --label <label>` after logging in).",
+  `  • Cookie expired or never set: run \`${runCommand("experimental auth login")}\` to refresh it.`,
+  `  • Or set LIBRETTO_API_KEY in your .env (issue one with \`${runCommand("experimental auth api-key issue --label <label>")}\` after logging in).`,
 ].join("\n");
 
 export type CredentialSource = "env-api-key" | "cookie" | "none";

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -25,6 +25,7 @@ import {
 import type { ProviderApi } from "./providers/types.js";
 import { getCloudProviderApi } from "./providers/index.js";
 import { DaemonClient, spawnSessionDaemon } from "./daemon/index.js";
+import { runCommand } from "./run-command.js";
 
 const CLOSE_WAIT_MS = 1_500;
 const FORCE_CLOSE_WAIT_MS = 300;
@@ -230,14 +231,14 @@ export async function connect(
     if (state.provider) {
       throw new Error(
         `Could not connect to ${state.provider.name} session for "${session}" at ${endpoint}. ` +
-          `The remote session may still be active. Try again, or close with: libretto close --session ${session}`,
+          `The remote session may still be active. Try again, or close with: ${runCommand(`close --session ${session}`)}`,
       );
     }
 
     if (state.pid == null || !isPidRunning(state.pid)) {
       clearSessionState(session, logger);
       throw new Error(
-        `No browser running for session "${session}". Run 'libretto open <url> --session ${session}' first.`,
+        `No browser running for session "${session}". Run '${runCommand(`open <url> --session ${session}`)}' first.`,
       );
     }
 
@@ -273,7 +274,7 @@ export async function connect(
 
   if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
     throw new Error(
-      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto pages --session ${session}" to list ids).`,
+      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "${runCommand(`pages --session ${session}`)}" to list ids).`,
     );
   }
 
@@ -283,7 +284,7 @@ export async function connect(
     : pageRefs[pageRefs.length - 1]!;
   if (!pageRef) {
     throw new Error(
-      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto pages --session ${session}" to list ids.`,
+      `Page "${options?.pageId}" was not found in session "${session}". Run "${runCommand(`pages --session ${session}`)}" to list ids.`,
     );
   }
   const page = pageRef.page;
@@ -325,7 +326,7 @@ export async function runPages(
   if (!state.daemonSocketPath) {
     throw new Error(
       `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
+        `Close and reopen the session: ${runCommand(`close --session ${session}`)}`,
     );
   }
   const client = new DaemonClient(state.daemonSocketPath);
@@ -423,8 +424,8 @@ export async function runOpen(
     if (!existsSync(authProfilePath)) {
       throw new Error(
         `No saved auth profile for "${authDomain}". ` +
-          `Save one first: libretto open https://${authDomain} --headed --session <name>, ` +
-          `log in, then run: libretto save ${authDomain} --session <name>`,
+          `Save one first: ${runCommand(`open https://${authDomain} --headed --session <name>`)}, ` +
+          `log in, then run: ${runCommand(`save ${authDomain} --session <name>`)}`,
       );
     }
   }
@@ -695,7 +696,7 @@ export async function runClose(
       writeSessionState({ ...state, status: "cleanup-failed" }, logger);
       throw new Error(
         `Failed to close remote ${state.provider.name} session "${state.provider.sessionId}" for session "${session}". ` +
-          `State preserved with status "cleanup-failed". Retry with: libretto close --session ${session}`,
+          `State preserved with status "cleanup-failed". Retry with: ${runCommand(`close --session ${session}`)}`,
       );
     }
   }
@@ -896,7 +897,7 @@ export async function runCloseAll(
       [
         `Failed to close ${survivors.length} session(s) gracefully: ${formatSessionList(survivors)}.`,
         `Closed ${closed} session(s).`,
-        `Retry with: libretto close --all --force`,
+        `Retry with: ${runCommand("close --all --force")}`,
       ].join("\n"),
     );
   }
@@ -978,11 +979,11 @@ export async function runConnect(
         `Invalid CDP URL: ${cdpUrl}`,
         ``,
         `Expected an HTTP or WebSocket URL pointing to a Chrome DevTools Protocol endpoint, for example:`,
-        `  libretto connect http://127.0.0.1:9222`,
-        `  libretto connect http://remote-host:9222`,
-        `  libretto connect http://remote-host:9222/devtools/browser/<id>`,
-        `  libretto connect ws://remote-host:9222/devtools/browser/<id>`,
-        `  libretto connect wss://remote-host/cdp-endpoint`,
+        `  ${runCommand("connect http://127.0.0.1:9222")}`,
+        `  ${runCommand("connect http://remote-host:9222")}`,
+        `  ${runCommand("connect http://remote-host:9222/devtools/browser/<id>")}`,
+        `  ${runCommand("connect ws://remote-host:9222/devtools/browser/<id>")}`,
+        `  ${runCommand("connect wss://remote-host/cdp-endpoint")}`,
       ].join("\n"),
     );
   }

--- a/packages/libretto/src/cli/core/config.ts
+++ b/packages/libretto/src/cli/core/config.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { z } from "zod";
 import { SessionAccessModeSchema } from "../../shared/state/index.js";
 import { LIBRETTO_CONFIG_PATH } from "./context.js";
+import { runCommand } from "./run-command.js";
 
 export const CURRENT_CONFIG_VERSION = 1;
 
@@ -67,7 +68,7 @@ function invalidConfigError(configPath: string, detail?: string): Error {
       '  - "snapshotModel", "viewport", "windowPosition", and "sessionMode" are optional.',
       '  - "snapshotModel" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".',
       "Fix the file to match this shape, or delete it and rerun:",
-      `  npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`,
+      `  ${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
     ]
       .filter(Boolean)
       .join("\n"),

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -43,6 +43,7 @@ import { wrapPageForActionLogging } from "../telemetry.js";
 import { handlePages } from "./pages.js";
 import { handleExec, handleReadonlyExec } from "./exec.js";
 import { handleSnapshot } from "./snapshot.js";
+import { runCommand } from "../run-command.js";
 import {
   isConnectConfig,
   type DaemonConfig,
@@ -309,7 +310,7 @@ class BrowserDaemon {
     if (!pageId) {
       if (this.pageById.size > 1) {
         throw new Error(
-          `Multiple pages are open in session "${this.session}". Pass --page <id> to target a page (run "libretto pages --session ${this.session}" to list ids).`,
+          `Multiple pages are open in session "${this.session}". Pass --page <id> to target a page (run "${runCommand(`pages --session ${this.session}`)}" to list ids).`,
         );
       }
       // Return the single tracked page rather than `this.page` — the
@@ -322,7 +323,7 @@ class BrowserDaemon {
     const page = this.pageById.get(pageId);
     if (!page) {
       throw new Error(
-        `Page "${pageId}" was not found in session "${this.session}". Run "libretto pages --session ${this.session}" to list ids.`,
+        `Page "${pageId}" was not found in session "${this.session}". Run "${runCommand(`pages --session ${this.session}`)}" to list ids.`,
       );
     }
     return page;

--- a/packages/libretto/src/cli/core/run-command.ts
+++ b/packages/libretto/src/cli/core/run-command.ts
@@ -1,0 +1,58 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { resolveLibrettoRepoRoot } from "../../shared/paths/repo-root.js";
+
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+type Environment = Record<string, string | undefined>;
+
+type RunCommandOptions = {
+  cwd?: string;
+  env?: Environment;
+};
+
+export function detectPackageManager(
+  cwd: string = process.cwd(),
+  env: Environment = process.env,
+): PackageManager {
+  const userAgent = env.npm_config_user_agent ?? "";
+  if (userAgent.startsWith("pnpm")) return "pnpm";
+  if (userAgent.startsWith("yarn")) return "yarn";
+  if (userAgent.startsWith("bun")) return "bun";
+  if (userAgent.startsWith("npm")) return "npm";
+
+  const root = resolveLibrettoRepoRoot(cwd);
+  if (existsSync(join(root, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(root, "yarn.lock"))) return "yarn";
+  if (existsSync(join(root, "bun.lockb")) || existsSync(join(root, "bun.lock"))) {
+    return "bun";
+  }
+  return "npm";
+}
+
+export function packageManagerRunCommand(
+  packageManager: PackageManager = detectPackageManager(),
+): string {
+  switch (packageManager) {
+    case "pnpm":
+      return "pnpm exec";
+    case "yarn":
+      return "yarn";
+    case "bun":
+      return "bunx";
+    case "npm":
+      return "npx";
+  }
+}
+
+export function runCommand(
+  args?: string,
+  options: RunCommandOptions = {},
+): string {
+  const trimmed = args?.trim();
+  const packageManager = detectPackageManager(
+    options.cwd ?? process.cwd(),
+    options.env ?? process.env,
+  );
+  const base = `${packageManagerRunCommand(packageManager)} libretto`;
+  return trimmed ? `${base} ${trimmed}` : base;
+}

--- a/packages/libretto/src/cli/core/session.ts
+++ b/packages/libretto/src/cli/core/session.ts
@@ -22,6 +22,7 @@ import {
   type SessionStatus,
   type SessionState,
 } from "../../shared/state/index.js";
+import { runCommand } from "./run-command.js";
 
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
@@ -154,7 +155,7 @@ function throwSessionNotFoundError(session: string): never {
   }
   lines.push("");
   lines.push("Start one with:");
-  lines.push(`  libretto open <url> --session ${session}`);
+  lines.push(`  ${runCommand(`open <url> --session ${session}`)}`);
   throw new Error(lines.join("\n"));
 }
 
@@ -230,7 +231,7 @@ export function assertSessionAllowsCommand(
 
   const supportedModes = [...allowedModes].join(", ");
   throw new Error(
-    `Command "${commandName}" is blocked for session "${state.session}" because it is in ${mode} mode. Allowed modes for this command: ${supportedModes}. Run \`libretto session-mode write-access --session ${state.session}\` to unlock the session.`,
+    `Command "${commandName}" is blocked for session "${state.session}" because it is in ${mode} mode. Allowed modes for this command: ${supportedModes}. Run \`${runCommand(`session-mode write-access --session ${state.session}`)}\` to unlock the session.`,
   );
 }
 
@@ -281,7 +282,7 @@ export function assertSessionAvailableForStart(
   // if they have a provider field with a cdpEndpoint.
   if (existingState.provider && existingState.cdpEndpoint) {
     throw new Error(
-      `Session "${session}" is already open via ${existingState.provider.name} provider. Close it first with: libretto close --session ${session}`,
+      `Session "${session}" is already open via ${existingState.provider.name} provider. Close it first with: ${runCommand(`close --session ${session}`)}`,
     );
   }
 
@@ -291,6 +292,6 @@ export function assertSessionAvailableForStart(
   }
   const endpoint = `http://127.0.0.1:${existingState.port}`;
   throw new Error(
-    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto close --session ${session}`,
+    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: ${runCommand(`close --session ${session}`)}`,
   );
 }

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { REPO_ROOT } from "./context.js";
+import { runCommand } from "./run-command.js";
 
 type PackageManifest = {
   version?: string;
@@ -85,7 +86,7 @@ export function warnIfInstalledSkillOutOfDate(): void {
     }
 
     console.error(
-      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`,
+      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`${runCommand("setup")}\` to update your skills to the correct version.`,
     );
   } catch {
     // Never block command execution on a best-effort skill version check.

--- a/packages/libretto/src/cli/core/snapshot-analyzer.ts
+++ b/packages/libretto/src/cli/core/snapshot-analyzer.ts
@@ -17,6 +17,7 @@ import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import type { LoggerApi } from "../../shared/logger/index.js";
+import { runCommand } from "./run-command.js";
 // Used by the legacy CLI-agent path (UserCodingAgent) which is preserved but
 // not wired into the snapshot command. The active config schema (ai-config.ts)
 // no longer has preset/commandPrefix — this type is kept for the legacy code.
@@ -297,7 +298,7 @@ async function runExternalCommand(
       if (error.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: ${command}. Configure AI with 'libretto ai configure'.`,
+            `Command not found: ${command}. Configure AI with '${runCommand("ai configure")}'.`,
           ),
         );
         return;
@@ -830,7 +831,7 @@ export async function runInterpret(
   const configuredAgent = UserCodingAgent.getConfigured();
   if (!configuredAgent) {
     throw new Error(
-      "No AI config set. Run 'npx libretto ai configure codex' (or claude/gemini), or set API credentials in your .env file for direct API analysis.",
+      `No AI config set. Run '${runCommand("ai configure codex")}' (or claude/gemini), or set API credentials in your .env file for direct API analysis.`,
     );
   }
 
@@ -840,7 +841,7 @@ export async function runInterpret(
   // re-enabled, the caller must supply a valid provider/model-id string.
   throw new Error(
     "The CLI-agent snapshot analysis path is not active. " +
-      "Update your config to the current format with `npx libretto ai configure <provider>`, " +
+      `Update your config to the current format with \`${runCommand("ai configure <provider>")}\`, ` +
       "or set API credentials in .env for direct API analysis.",
   );
 

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -7,6 +7,7 @@ import { executionCommands } from "./commands/execution.js";
 import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
+import { runCommand } from "./core/run-command.js";
 import { SimpleCLI } from "./framework/simple-cli.js";
 
 export const cliRoutes = {
@@ -22,5 +23,5 @@ export const cliRoutes = {
 };
 
 export function createCLIApp() {
-  return SimpleCLI.define("libretto", cliRoutes);
+  return SimpleCLI.define(runCommand(), cliRoutes);
 }

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -29,6 +29,7 @@ import {
   getPauseSignalPaths,
   removeSignalIfExists,
 } from "../core/pause-signals.js";
+import { runCommand } from "../core/run-command.js";
 import { installSessionTelemetry } from "../core/session-telemetry.js";
 import type { RunIntegrationWorkerRequest } from "./run-integration-worker-protocol.js";
 
@@ -122,9 +123,9 @@ function getMissingLocalAuthProfileError(args: {
     `Local auth profile not found for domain "${args.normalizedDomain}".`,
     `Expected profile file: ${args.profilePath}`,
     "To create it:",
-    `  1. libretto open https://${args.normalizedDomain} --headed --session ${args.session}`,
+    `  1. ${runCommand(`open https://${args.normalizedDomain} --headed --session ${args.session}`)}`,
     "  2. Log in manually in the browser window.",
-    `  3. libretto save ${args.normalizedDomain} --session ${args.session}`,
+    `  3. ${runCommand(`save ${args.normalizedDomain} --session ${args.session}`)}`,
   ].join("\n");
 }
 
@@ -171,7 +172,7 @@ async function loadDefaultWorkflow(
   }
 
   throw new Error(
-    `No default-exported workflow found in ${absolutePath}. libretto run only uses the file's default export. Available named workflows: ${availableWorkflowNames.join(", ")}`,
+    `No default-exported workflow found in ${absolutePath}. ${runCommand("run")} only uses the file's default export. Available named workflows: ${availableWorkflowNames.join(", ")}`,
   );
 }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
+import { runCommand } from "../src/cli/core/run-command.js";
 
 const packageJsonUrl = new URL("../package.json", import.meta.url);
 
@@ -40,7 +41,7 @@ function expectMissingSessionError(output: string, session: string): void {
   expect(output).toContain(`No session "${session}" found.`);
   expect(output).toContain("No active sessions.");
   expect(output).toContain("Start one with:");
-  expect(output).toContain(`libretto open <url> --session ${session}`);
+  expect(output).toContain(runCommand(`open <url> --session ${session}`));
 }
 
 async function readCliVersion(): Promise<string> {
@@ -74,7 +75,7 @@ function expectedSkillVersionWarning(
   skillVersion: string,
   cliVersion: string,
 ): string {
-  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`;
+  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}). Please run \`${runCommand("setup")}\` to update your skills to the correct version.`;
 }
 
 describe("basic CLI subprocess behavior", () => {
@@ -110,7 +111,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("Detected OPENAI_API_KEY");
     expect(result.stdout).toContain("config.json");
     expect(result.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      `To change: ${runCommand("ai configure openai | anthropic | gemini | vertex")}`,
     );
   });
 
@@ -163,7 +164,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(second.stdout).toContain("Using OpenAI");
     expect(second.stdout).toContain("config.json");
     expect(second.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      `To change: ${runCommand("ai configure openai | anthropic | gemini | vertex")}`,
     );
     // Should NOT contain the unconfigured prompts
     expect(second.stdout).not.toContain(
@@ -293,7 +294,7 @@ describe("basic CLI subprocess behavior", () => {
 
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain(`Usage: ${runCommand()} <command>`);
     expect(result.stdout).toContain("readonly-exec");
     expect(result.stdout).toContain("snapshot");
     expect(result.stdout).toContain("Capture PNG + HTML");
@@ -305,7 +306,7 @@ describe("basic CLI subprocess behavior", () => {
 
   test("prints usage for help command", async ({ librettoCli }) => {
     const result = await librettoCli("help");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain(`Usage: ${runCommand()} <command>`);
     expect(result.stdout).toContain("Commands:");
     expect(result.stdout).toContain("open");
     expect(result.stdout).toContain("ai");
@@ -326,7 +327,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help ai configure");
     expect(result.stdout).toContain("Configure AI runtime");
     expect(result.stdout).toContain(
-      "Usage: libretto ai configure [preset] [options]",
+      `Usage: ${runCommand("ai configure")} [preset] [options]`,
     );
     expect(result.stderr).toBe("");
   });
@@ -337,7 +338,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help experimental");
     expect(result.stdout).toContain("Experimental commands");
     expect(result.stdout).toContain(
-      "Usage: libretto experimental <subcommand>",
+      `Usage: ${runCommand("experimental")} <subcommand>`,
     );
     expect(result.stdout).toContain("deploy");
     expect(result.stderr).toBe("");
@@ -351,7 +352,7 @@ describe("basic CLI subprocess behavior", () => {
       "Run the default-exported Libretto workflow from a file",
     );
     expect(result.stdout).toContain(
-      "Usage: libretto run [integrationFile] [options]",
+      `Usage: ${runCommand("run")} [integrationFile] [options]`,
     );
     expect(result.stdout).toContain("--read-only");
     expect(result.stdout).toContain("--no-visualize");
@@ -365,7 +366,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help session-mode");
     expect(result.stdout).toContain("View or set the session access mode");
     expect(result.stdout).toContain(
-      "Usage: libretto session-mode [mode] [options]",
+      `Usage: ${runCommand("session-mode")} [mode] [options]`,
     );
     expect(result.stderr).toBe("");
   });
@@ -373,13 +374,13 @@ describe("basic CLI subprocess behavior", () => {
   test("fails unknown command with a clear error", async ({ librettoCli }) => {
     const result = await librettoCli("nope-command");
     expect(result.stderr).toContain("Unknown command: nope-command");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain(`Usage: ${runCommand()} <command>`);
   });
 
   test("fails open with missing url usage error", async ({ librettoCli }) => {
     const result = await librettoCli("open");
     expect(result.stderr).toContain(
-      "Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]",
+      `Usage: ${runCommand("open <url>")} [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]`,
     );
   });
 
@@ -501,7 +502,7 @@ describe("basic CLI subprocess behavior", () => {
   test("fails exec with missing code usage error", async ({ librettoCli }) => {
     const result = await librettoCli("exec --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
+      `Usage: ${runCommand("exec <code|->")} [--session <name>] [--visualize]`,
     );
   });
 
@@ -510,7 +511,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("exec --visualize --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
+      `Usage: ${runCommand("exec <code|->")} [--session <name>] [--visualize]`,
     );
     expect(result.stderr).not.toContain(
       `Missing required --session for "exec".`,
@@ -522,7 +523,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("readonly-exec --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto readonly-exec <code|-> [--session <name>] [--page <id>]",
+      `Usage: ${runCommand("readonly-exec <code|->")} [--session <name>] [--page <id>]`,
     );
   });
 
@@ -902,9 +903,9 @@ export default workflow("main", async () => {
       'Local auth profile not found for domain "app.example.com".',
     );
     expect(result.stderr).toContain(
-      "libretto open https://app.example.com --headed --session",
+      runCommand("open https://app.example.com --headed --session"),
     );
-    expect(result.stderr).toContain("libretto save app.example.com --session");
+    expect(result.stderr).toContain(runCommand("save app.example.com --session"));
   });
 
   test("does not require local auth profile when auth metadata is absent", async ({
@@ -1104,7 +1105,7 @@ export default workflow("main", async (ctx) => {
   }) => {
     const result = await librettoCli("save --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto save <url|domain> --session <name>",
+      `Usage: ${runCommand("save <url|domain>")} --session <name>`,
     );
   });
 

--- a/packages/libretto/test/multi-page.spec.ts
+++ b/packages/libretto/test/multi-page.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
+import { runCommand } from "../src/cli/core/run-command.js";
 
 describe("multi-page CLI behavior", () => {
   test("pages lists open pages with ids and urls", async ({ librettoCli }) => {
@@ -83,7 +84,7 @@ describe("multi-page CLI behavior", () => {
     expect(execResult.stderr).toContain(
       `Page "${missingPageId}" was not found in session "${session}".`,
     );
-    expect(execResult.stderr).toContain(`libretto pages --session ${session}`);
+    expect(execResult.stderr).toContain(runCommand(`pages --session ${session}`));
 
   }, 45_000);
 });

--- a/packages/libretto/test/multi-session.spec.ts
+++ b/packages/libretto/test/multi-session.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "vitest";
 import { test } from "./fixtures";
+import { runCommand } from "../src/cli/core/run-command.js";
 
 function extractReturnedSessionId(output: string): string | null {
   const patterns = [
@@ -178,6 +179,6 @@ export default workflow("main", async () => {
     expect(secondOpen.stderr).toContain(
       `Session "${session}" is already open and connected to`,
     );
-    expect(secondOpen.stderr).toContain(`libretto close --session ${session}`);
+    expect(secondOpen.stderr).toContain(runCommand(`close --session ${session}`));
   }, 60_000);
 });

--- a/packages/libretto/test/run-command.spec.ts
+++ b/packages/libretto/test/run-command.spec.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { test } from "./fixtures";
+import {
+  detectPackageManager,
+  packageManagerRunCommand,
+  runCommand,
+} from "../src/cli/core/run-command.js";
+
+const tempDirs: string[] = [];
+
+async function tempWorkspace(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "libretto-run-command-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("run command formatting", () => {
+  it("maps package managers to their binary runners", () => {
+    expect(packageManagerRunCommand("npm")).toBe("npx");
+    expect(packageManagerRunCommand("pnpm")).toBe("pnpm exec");
+    expect(packageManagerRunCommand("yarn")).toBe("yarn");
+    expect(packageManagerRunCommand("bun")).toBe("bunx");
+  });
+
+  it("detects the package manager from npm_config_user_agent", () => {
+    expect(
+      detectPackageManager(process.cwd(), {
+        npm_config_user_agent: "npm/10.0.0 node/v20.0.0",
+      }),
+    ).toBe("npm");
+    expect(
+      detectPackageManager(process.cwd(), {
+        npm_config_user_agent: "pnpm/10.33.0 npm/? node/v20.0.0",
+      }),
+    ).toBe("pnpm");
+    expect(
+      detectPackageManager(process.cwd(), {
+        npm_config_user_agent: "yarn/1.22.22 npm/? node/v20.0.0",
+      }),
+    ).toBe("yarn");
+    expect(
+      detectPackageManager(process.cwd(), {
+        npm_config_user_agent: "bun/1.2.0 npm/? node/v20.0.0",
+      }),
+    ).toBe("bun");
+  });
+
+  it("falls back to workspace lockfiles when no user agent is present", async () => {
+    const pnpmWorkspace = await tempWorkspace();
+    await writeFile(join(pnpmWorkspace, "pnpm-lock.yaml"), "");
+    expect(detectPackageManager(pnpmWorkspace, {})).toBe("pnpm");
+
+    const yarnWorkspace = await tempWorkspace();
+    await writeFile(join(yarnWorkspace, "yarn.lock"), "");
+    expect(detectPackageManager(yarnWorkspace, {})).toBe("yarn");
+
+    const bunWorkspace = await tempWorkspace();
+    await writeFile(join(bunWorkspace, "bun.lock"), "");
+    expect(detectPackageManager(bunWorkspace, {})).toBe("bun");
+  });
+
+  it("formats a complete libretto command", () => {
+    expect(runCommand("setup")).toContain(" libretto setup");
+  });
+});
+
+test("CLI help and usage use the invoker package manager command", async ({
+  librettoCli,
+}) => {
+  const cases = [
+    ["npm/10.0.0 node/v20.0.0", "npx libretto"],
+    ["pnpm/10.33.0 npm/? node/v20.0.0", "pnpm exec libretto"],
+    ["yarn/1.22.22 npm/? node/v20.0.0", "yarn libretto"],
+    ["bun/1.2.0 npm/? node/v20.0.0", "bunx libretto"],
+  ] as const;
+
+  for (const [userAgent, command] of cases) {
+    const env = { npm_config_user_agent: userAgent };
+
+    const help = await librettoCli("help", env);
+    expect(help.stdout).toContain(`Usage: ${command} <command>`);
+
+    const openUsage = await librettoCli("open", env);
+    expect(openUsage.stderr).toContain(`Usage: ${command} open <url>`);
+
+    const runUsage = await librettoCli("run", env);
+    expect(runUsage.stderr).toContain(`Usage: ${command} run <integrationFile>`);
+
+    const setup = await librettoCli("setup --skip-browsers", {
+      ...env,
+      LIBRETTO_DISABLE_DOTENV: "1",
+      OPENAI_API_KEY: "test-openai-key",
+    });
+    expect(setup.stdout).toContain(
+      `To change: ${command} ai configure openai | anthropic | gemini | vertex`,
+    );
+  }
+});

--- a/packages/libretto/test/snapshot-api-config.spec.ts
+++ b/packages/libretto/test/snapshot-api-config.spec.ts
@@ -6,6 +6,7 @@ import {
   resolveSnapshotApiModel,
 } from "../src/cli/core/ai-model.js";
 import { LIBRETTO_CONFIG_PATH } from "../src/cli/core/context.js";
+import { runCommand } from "../src/cli/core/run-command.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -112,7 +113,7 @@ describe("snapshot API model resolution", () => {
     clearProviderEnv();
 
     expect(() => resolveSnapshotApiModelOrThrow(null)).toThrowError(
-      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`. For more info, run `npx libretto setup`.",
+      `Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with \`${runCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}\`. For more info, run \`${runCommand("setup")}\`.`,
     );
   });
 
@@ -158,7 +159,7 @@ describe("snapshot API model resolution", () => {
     expect(() =>
       resolveSnapshotApiModelOrThrow("openai/gpt-5.4"),
     ).toThrowError(
-      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto setup\`.`,
+      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`${runCommand("setup")}\`.`,
     );
   });
 });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import { pathToFileURL } from "node:url";
 import { describe, expect, onTestFinished } from "vitest";
 import { test } from "./fixtures";
+import { runCommand } from "../src/cli/core/run-command.js";
 
 function extractReturnedSessionId(output: string): string | null {
   const patterns = [
@@ -39,7 +40,7 @@ function expectMissingSessionError(output: string, session: string): void {
   expect(output).toContain(`No session "${session}" found.`);
   expect(output).toContain("No active sessions.");
   expect(output).toContain("Start one with:");
-  expect(output).toContain(`libretto open <url> --session ${session}`);
+  expect(output).toContain(runCommand(`open <url> --session ${session}`));
 }
 
 function parseJsonStdout<T>(stdout: string): T {
@@ -142,7 +143,7 @@ describe("state-driven CLI subprocess behavior", () => {
       "Failed to analyze snapshot because no snapshot analyzer is configured.",
     );
     expect(snapshot.stderr).toContain(
-      "For more info, run `npx libretto setup`.",
+      `For more info, run \`${runCommand("setup")}\`.`,
     );
     expect(
       existsSync(workspacePath(".libretto", "sessions", session, "snapshots")),
@@ -191,7 +192,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(secondOpen.stderr).toContain(
       `Session "${session}" is already open and connected to`,
     );
-    expect(secondOpen.stderr).toContain(`libretto close --session ${session}`);
+    expect(secondOpen.stderr).toContain(runCommand(`close --session ${session}`));
   }, 45_000);
 
   test("shows recovery guidance when a session-backed command targets a missing session", async ({
@@ -223,7 +224,7 @@ describe("state-driven CLI subprocess behavior", () => {
 
   test("rejects close --force without --all", async ({ librettoCli }) => {
     const result = await librettoCli("close --force");
-    expect(result.stderr).toContain("Usage: libretto close --all [--force]");
+    expect(result.stderr).toContain(`Usage: ${runCommand("close --all")} [--force]`);
   });
 
   test("close --all closes active sessions", async ({ librettoCli }) => {
@@ -293,7 +294,7 @@ describe("state-driven CLI subprocess behavior", () => {
     });
     expect(status.stdout).toContain("AI configuration:");
     expect(status.stdout).toContain("No AI model configured");
-    expect(status.stdout).toContain("npx libretto setup");
+    expect(status.stdout).toContain(runCommand("setup"));
   });
 
   test("status shows configured model after setup pins it", async ({
@@ -313,7 +314,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(status.stdout).toContain("AI configuration:");
     expect(status.stdout).toContain("openai/gpt-5.4");
     expect(status.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      `To change: ${runCommand("ai configure openai | anthropic | gemini | vertex")}`,
     );
   });
 
@@ -402,7 +403,7 @@ describe("state-driven CLI subprocess behavior", () => {
       `Command "exec" is blocked for session "${session}" because it is in read-only mode.`,
     );
     expect(blockedExec.stderr).toContain(
-      `libretto session-mode write-access --session ${session}`,
+      runCommand(`session-mode write-access --session ${session}`),
     );
 
     const readonlyExec = await librettoCli(


### PR DESCRIPTION
## Summary
- Update CLI help, usage errors, auth/billing guidance, and docs to show `npx libretto ...` commands.
- Update tests for the revised help and error output.
- Keep internal hosted-agent validation on the bundled `libretto` executable in browser-automations because those staged workspaces do not provide an `npx` bin shim.

## Verification
- `pnpm --filter libretto build`
- `pnpm --filter libretto test -- test/basic.spec.ts test/stateful.spec.ts test/multi-session.spec.ts test/multi-page.spec.ts`
- `pnpm --filter libretto type-check`