### PR TITLE
Use package manager-aware Libretto command guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,4 +8,4 @@ A page's URL prefix must match its `docs.json` group name, lowercased and hyphen
 
 ## Testing
 
-You can test the docs site with Libretto itself. Start the dev server, then use `libretto open` to open the local URL and verify pages render correctly.
+You can test the docs site with Libretto itself. Start the dev server, then use `npx libretto open` to open the local URL and verify pages render correctly.

--- a/docs/library-api/workflow.mdx
+++ b/docs/library-api/workflow.mdx
@@ -63,7 +63,7 @@ export default workflow<{ query: string }, string[]>(
 
 #### Running with the CLI
 
-Pass the file path to `libretto run`. The file must have a default-exported `workflow()`:
+Pass the file path to `npx libretto run`. The file must have a default-exported `workflow()`:
 
 ```bash theme={null}
 npx libretto run ./my-workflow.ts

--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -1,5 +1,6 @@
 import { resolveAiSetupStatus } from "./core/ai-model.js";
 import { ensureLibrettoSetup } from "./core/context.js";
+import { librettoCommand } from "./core/package-manager.js";
 import { createCLIApp } from "./router.js";
 import { warnIfInstalledSkillOutOfDate } from "./core/skill-version.js";
 import { loadEnv } from "../shared/env/load-env.js";
@@ -24,17 +25,17 @@ function printSetupAudit(): void {
       break;
     case "configured-missing-credentials":
       console.log(
-        `✗ ${status.provider} configured (model: ${status.model}), but credentials are missing. Run \`npx libretto setup\` to repair.`,
+        `✗ ${status.provider} configured (model: ${status.model}), but credentials are missing. Run \`${librettoCommand("setup")}\` to repair.`,
       );
       break;
     case "invalid-config":
       console.log(
-        `✗ AI config is invalid. Run \`npx libretto setup\` to reconfigure.`,
+        `✗ AI config is invalid. Run \`${librettoCommand("setup")}\` to reconfigure.`,
       );
       break;
     case "unconfigured":
       console.log(
-        `✗ No AI model configured. Run \`npx libretto setup\` or \`npx libretto ai configure\` to set up.`,
+        `✗ No AI model configured. Run \`${librettoCommand("setup")}\` or \`${librettoCommand("ai configure")}\` to set up.`,
       );
       break;
   }

--- a/packages/libretto/src/cli/commands/ai.ts
+++ b/packages/libretto/src/cli/commands/ai.ts
@@ -7,6 +7,7 @@ import {
 } from "../core/config.js";
 import { LIBRETTO_CONFIG_PATH } from "../core/context.js";
 import { DEFAULT_SNAPSHOT_MODELS } from "../core/ai-model.js";
+import { librettoCommand } from "../core/package-manager.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
 const PROVIDER_ALIASES: Record<string, string> = {
@@ -63,7 +64,7 @@ export function runAiConfigure(
   } = {},
 ): void {
   const configureCommandName =
-    options.configureCommandName ?? "npx libretto ai configure";
+    options.configureCommandName ?? librettoCommand("ai configure");
   const configPath = options.configPath ?? LIBRETTO_CONFIG_PATH;
 
   const presetArg = input.preset?.trim();
@@ -135,7 +136,7 @@ export const aiCommands = SimpleCLI.group({
             preset: input.preset,
           },
           {
-            configureCommandName: `libretto ai configure`,
+            configureCommandName: librettoCommand("ai configure"),
           },
         );
       }),

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -15,6 +15,7 @@ import {
 } from "../core/providers/index.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { createLoggerForSession, withSessionLogger } from "../core/context.js";
+import { librettoCommand } from "../core/package-manager.js";
 import {
   type SessionAccessMode,
   assertSessionAvailableForStart,
@@ -95,7 +96,7 @@ export const openInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.url),
-    `Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]`,
+    `Usage: ${librettoCommand("open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]")}`,
   )
   .refine(
     (input) => !(input.headed && input.headless),
@@ -160,7 +161,7 @@ export const connectInput = SimpleCLI.input({
 })
   .refine(
     (input) => Boolean(input.cdpUrl),
-    `Usage: libretto connect <cdp-url> [--read-only|--write-access] --session <name>`,
+    `Usage: ${librettoCommand("connect <cdp-url> [--read-only|--write-access] --session <name>")}`,
   )
   .refine(
     (input) => !(input.readOnly && input.writeAccess),
@@ -193,7 +194,7 @@ export const saveInput = SimpleCLI.input({
   },
 }).refine(
   (input) => Boolean(input.urlOrDomain),
-  `Usage: libretto save <url|domain> --session <name>`,
+  `Usage: ${librettoCommand("save <url|domain> --session <name>")}`,
 );
 
 export const saveCommand = SimpleCLI.command({
@@ -264,7 +265,7 @@ export const closeInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.all || input.session,
-  `Usage: libretto close <session>\nUsage: libretto close --all [--force]`,
+  `Usage: ${librettoCommand("close <session>")}\nUsage: ${librettoCommand("close --all [--force]")}`,
 );
 
 export const closeCommand = SimpleCLI.command({
@@ -273,7 +274,7 @@ export const closeCommand = SimpleCLI.command({
   .input(closeInput)
   .handle(async ({ input }) => {
     if (input.force && !input.all) {
-      throw new Error(`Usage: libretto close --all [--force]`);
+      throw new Error(`Usage: ${librettoCommand("close --all [--force]")}`);
     }
     if (input.all) {
       const logger = createLoggerForSession("cli");

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -23,7 +23,11 @@ import {
 } from "../core/session.js";
 import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import { readLibrettoConfig } from "../core/config.js";
-import { resolveProviderName, getCloudProviderApi } from "../core/providers/index.js";
+import { librettoCommand } from "../core/package-manager.js";
+import {
+  resolveProviderName,
+  getCloudProviderApi,
+} from "../core/providers/index.js";
 import {
   compileExecFunction,
   stripEmptyCatchHandlers,
@@ -487,7 +491,7 @@ async function runResume(
 
   if (!existsSync(pausedSignalPath)) {
     throw new Error(
-      `Session "${session}" is not paused. Run "libretto run ... --session ${session}" and call pause("${session}") first.`,
+      `Session "${session}" is not paused. Run "${librettoCommand(`run ... --session ${session}`)}" and call pause("${session}") first.`,
     );
   }
 
@@ -642,7 +646,7 @@ export const execInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.code !== undefined,
-  `Usage: libretto exec <code|-> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec - [--session <name>] [--visualize]`,
+  `Usage: ${librettoCommand("exec <code|-> [--session <name>] [--visualize]")}\n       echo '<code>' | ${librettoCommand("exec - [--session <name>] [--visualize]")}`,
 );
 
 export const execCommand = SimpleCLI.command({
@@ -683,7 +687,7 @@ export const readonlyExecInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.code !== undefined,
-  `Usage: libretto readonly-exec <code|-> [--session <name>] [--page <id>]\n       echo '<code>' | libretto readonly-exec - [--session <name>] [--page <id>]`,
+  `Usage: ${librettoCommand("readonly-exec <code|-> [--session <name>] [--page <id>]")}\n       echo '<code>' | ${librettoCommand("readonly-exec - [--session <name>] [--page <id>]")}`,
 );
 
 export const readonlyExecCommand = SimpleCLI.command({
@@ -705,7 +709,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--viewport WxH]`;
+const runUsage = `Usage: ${librettoCommand("run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--viewport WxH]")}`;
 
 export const runInput = SimpleCLI.input({
   positionals: [

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -1,10 +1,5 @@
 import { createInterface } from "node:readline";
-import {
-  cpSync,
-  existsSync,
-  readdirSync,
-  rmSync,
-} from "node:fs";
+import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +14,11 @@ import {
   DEFAULT_SNAPSHOT_MODELS,
   resolveAiSetupStatus,
 } from "../core/ai-model.js";
+import {
+  detectProjectPackageManager,
+  installCommand,
+  librettoCommand,
+} from "../core/package-manager.js";
 import type { Provider } from "../core/resolve-model.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
@@ -29,26 +29,6 @@ const PROVIDER_SDK_PACKAGES: Record<Provider, string> = {
   vertex: "@ai-sdk/google-vertex",
   openrouter: "@ai-sdk/openai",
 };
-
-function detectPackageManager(): string {
-  if (existsSync(join(REPO_ROOT, "pnpm-lock.yaml"))) return "pnpm";
-  if (existsSync(join(REPO_ROOT, "yarn.lock"))) return "yarn";
-  if (existsSync(join(REPO_ROOT, "bun.lockb"))) return "bun";
-  return "npm";
-}
-
-function installCommand(pkgManager: string): string {
-  switch (pkgManager) {
-    case "yarn":
-      return "yarn add";
-    case "bun":
-      return "bun add";
-    case "pnpm":
-      return "pnpm add";
-    default:
-      return "npm install";
-  }
-}
 
 function isSdkInstalled(sdkPackage: string): boolean {
   try {
@@ -66,7 +46,7 @@ function installSdkIfNeeded(provider: Provider): void {
   const sdkPackage = PROVIDER_SDK_PACKAGES[provider];
   if (isSdkInstalled(sdkPackage)) return;
 
-  const pkgManager = detectPackageManager();
+  const pkgManager = detectProjectPackageManager();
   const cmd = installCommand(pkgManager);
   console.log(`\nInstalling ${sdkPackage}...`);
   const result = spawnSync(cmd, [sdkPackage], {
@@ -177,7 +157,7 @@ function printHealthySummary(status: AiSetupStatus & { kind: "ready" }): void {
     console.log(`✓ Using ${providerLabel(status.provider)} (${status.model}).`);
   }
   console.log(
-    "To change: npx libretto ai configure openai | anthropic | gemini | vertex | openrouter",
+    `To change: ${librettoCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
   );
 }
 
@@ -254,14 +234,16 @@ function printSnapshotApiStatus(): boolean {
     console.log();
     console.log(formatMissingCredentialsMessage(plan));
     console.log(
-      `  To fix: add ${plan.envVar} to .env, or run \`npx libretto setup\` interactively to repair.`,
+      `  To fix: add ${plan.envVar} to .env, or run \`${librettoCommand("setup")}\` interactively to repair.`,
     );
     return false;
   }
 
   if (plan.kind === "repair-invalid-config") {
     printInvalidAiConfigWarning(status);
-    console.log("  Run `npx libretto setup` interactively to reconfigure.");
+    console.log(
+      `  Run \`${librettoCommand("setup")}\` interactively to reconfigure.`,
+    );
     return false;
   }
 
@@ -275,10 +257,10 @@ function printSnapshotApiStatus(): boolean {
     "    GOOGLE_CLOUD_PROJECT=...  # plus application default credentials for Vertex",
   );
   console.log(
-    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter` to set a specific model.",
+    `  Or run \`${librettoCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}\` to set a specific model.`,
   );
   console.log(
-    "  Run `npx libretto setup` interactively to set up credentials.",
+    `  Run \`${librettoCommand("setup")}\` interactively to set up credentials.`,
   );
   return false;
 }
@@ -324,14 +306,14 @@ async function promptProviderSelection(
 
 function printSkipMessage(): void {
   console.log(
-    "\nSkipped. You can set up API credentials later by rerunning `npx libretto setup`.",
+    `\nSkipped. You can set up API credentials later by rerunning \`${librettoCommand("setup")}\`.`,
   );
   console.log("Or add credentials directly to your .env file:");
   console.log("  OPENAI_API_KEY=...");
   console.log("  ANTHROPIC_API_KEY=...");
   console.log("  GEMINI_API_KEY=...");
   console.log(
-    "  Or run `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter` to set a specific model.",
+    `  Or run \`${librettoCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}\` to set a specific model.`,
   );
 }
 
@@ -442,7 +424,7 @@ function copySkills(): void {
       "\n⚠️ No .agents/ or .claude/ directory found. Libretto skills were not installed.",
     );
     console.log(
-      "  Create one of these directories in your repo root and rerun `npx libretto setup` to install skills:",
+      `  Create one of these directories in your repo root and rerun \`${librettoCommand("setup")}\` to install skills:`,
     );
     console.log(`    mkdir ${join(REPO_ROOT, ".claude")}`);
     return;
@@ -510,7 +492,7 @@ export const setupCommand = SimpleCLI.command({
       const ready = printSnapshotApiStatus();
       if (!ready) {
         console.log(
-          "\nIf you're an agent, request the user to run `npx libretto setup`.",
+          `\nIf you're an agent, request the user to run \`${librettoCommand("setup")}\`.`,
         );
       }
     }

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -13,6 +13,7 @@ import { runApiInterpret } from "../core/api-snapshot-analyzer.js";
 import { readSnapshotModel } from "../core/config.js";
 import { resolveSnapshotApiModelOrThrow } from "../core/ai-model.js";
 import { DaemonClient } from "../core/daemon/index.js";
+import { librettoCommand } from "../core/package-manager.js";
 
 export const FALLBACK_SNAPSHOT_VIEWPORT = { width: 1280, height: 800 } as const;
 
@@ -161,7 +162,7 @@ async function runSnapshot(
   if (!state?.daemonSocketPath) {
     throw new Error(
       `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
+        `Close and reopen the session: ${librettoCommand(`close --session ${session}`)}`,
     );
   }
 

--- a/packages/libretto/src/cli/commands/status.ts
+++ b/packages/libretto/src/cli/commands/status.ts
@@ -1,5 +1,6 @@
 import { LIBRETTO_CONFIG_PATH } from "../core/context.js";
 import { type AiSetupStatus, resolveAiSetupStatus } from "../core/ai-model.js";
+import { librettoCommand } from "../core/package-manager.js";
 import { listRunningSessions, type SessionState } from "../core/session.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
@@ -17,7 +18,7 @@ function printAiStatus(status: AiSetupStatus): void {
         console.log(`  Source: ${status.source}`);
       }
       console.log(
-        "  To change: npx libretto ai configure openai | anthropic | gemini | vertex | openrouter",
+        `  To change: ${librettoCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
       );
       break;
 
@@ -25,7 +26,7 @@ function printAiStatus(status: AiSetupStatus): void {
       console.log(
         `  ✗ ${status.provider} is configured (model: ${status.model}), but credentials are missing.`,
       );
-      console.log("  Run `npx libretto setup` to repair.");
+      console.log(`  Run \`${librettoCommand("setup")}\` to repair.`);
       break;
 
     case "invalid-config":
@@ -33,13 +34,13 @@ function printAiStatus(status: AiSetupStatus): void {
       for (const line of status.message.split("\n")) {
         console.log(`    ${line}`);
       }
-      console.log("  Run `npx libretto setup` to reconfigure.");
+      console.log(`  Run \`${librettoCommand("setup")}\` to reconfigure.`);
       break;
 
     case "unconfigured":
       console.log("  ✗ No AI model configured.");
       console.log(
-        "  Run `npx libretto setup` or `npx libretto ai configure` to set up.",
+        `  Run \`${librettoCommand("setup")}\` or \`${librettoCommand("ai configure")}\` to set up.`,
       );
       break;
   }

--- a/packages/libretto/src/cli/core/ai-model.ts
+++ b/packages/libretto/src/cli/core/ai-model.ts
@@ -1,5 +1,6 @@
 import { readSnapshotModel } from "./config.js";
 import { LIBRETTO_CONFIG_PATH } from "./context.js";
+import { librettoCommand } from "./package-manager.js";
 import {
   hasProviderCredentials,
   parseModel,
@@ -80,7 +81,9 @@ function providerSetupSentence(provider: Provider): string {
 }
 
 function defaultModelCommandLine(): string {
-  return "npx libretto ai configure openai | anthropic | gemini | vertex | openrouter";
+  return librettoCommand(
+    "ai configure openai | anthropic | gemini | vertex | openrouter",
+  );
 }
 
 function providerMissingCredentialSummary(provider: Provider): string {
@@ -102,7 +105,7 @@ function noSnapshotApiConfiguredMessage(): string {
   return [
     "Failed to analyze snapshot because no snapshot analyzer is configured.",
     `Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with \`${defaultModelCommandLine()}\`.`,
-    "For more info, run `npx libretto setup`.",
+    `For more info, run \`${librettoCommand("setup")}\`.`,
   ].join(" ");
 }
 
@@ -116,7 +119,7 @@ function missingProviderSnapshotMessage(
   return [
     `Failed to analyze snapshot because ${selection.provider} is configured${configuredSource}, but ${providerMissingCredentialSummary(selection.provider)}.`,
     providerSetupSentence(selection.provider),
-    "For more info, run `npx libretto setup`.",
+    `For more info, run \`${librettoCommand("setup")}\`.`,
   ].join(" ");
 }
 

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -12,6 +12,7 @@ import type { LoggerApi } from "../../shared/logger/index.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import { PROFILES_DIR } from "./context.js";
 import { readLibrettoConfig } from "./config.js";
+import { librettoCommand } from "./package-manager.js";
 import {
   assertSessionAvailableForStart,
   clearSessionState,
@@ -230,14 +231,14 @@ export async function connect(
     if (state.provider) {
       throw new Error(
         `Could not connect to ${state.provider.name} session for "${session}" at ${endpoint}. ` +
-          `The remote session may still be active. Try again, or close with: libretto close --session ${session}`,
+          `The remote session may still be active. Try again, or close with: ${librettoCommand(`close --session ${session}`)}`,
       );
     }
 
     if (state.pid == null || !isPidRunning(state.pid)) {
       clearSessionState(session, logger);
       throw new Error(
-        `No browser running for session "${session}". Run 'libretto open <url> --session ${session}' first.`,
+        `No browser running for session "${session}". Run '${librettoCommand(`open <url> --session ${session}`)}' first.`,
       );
     }
 
@@ -273,7 +274,7 @@ export async function connect(
 
   if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
     throw new Error(
-      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto pages --session ${session}" to list ids).`,
+      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "${librettoCommand(`pages --session ${session}`)}" to list ids).`,
     );
   }
 
@@ -283,7 +284,7 @@ export async function connect(
     : pageRefs[pageRefs.length - 1]!;
   if (!pageRef) {
     throw new Error(
-      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto pages --session ${session}" to list ids.`,
+      `Page "${options?.pageId}" was not found in session "${session}". Run "${librettoCommand(`pages --session ${session}`)}" to list ids.`,
     );
   }
   const page = pageRef.page;
@@ -325,7 +326,7 @@ export async function runPages(
   if (!state.daemonSocketPath) {
     throw new Error(
       `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
-        `Close and reopen the session: libretto close --session ${session}`,
+        `Close and reopen the session: ${librettoCommand(`close --session ${session}`)}`,
     );
   }
   const client = new DaemonClient(state.daemonSocketPath);
@@ -423,8 +424,8 @@ export async function runOpen(
     if (!existsSync(authProfilePath)) {
       throw new Error(
         `No saved auth profile for "${authDomain}". ` +
-          `Save one first: libretto open https://${authDomain} --headed --session <name>, ` +
-          `log in, then run: libretto save ${authDomain} --session <name>`,
+          `Save one first: ${librettoCommand(`open https://${authDomain} --headed --session <name>`)}, ` +
+          `log in, then run: ${librettoCommand(`save ${authDomain} --session <name>`)}`,
       );
     }
   }
@@ -695,7 +696,7 @@ export async function runClose(
       writeSessionState({ ...state, status: "cleanup-failed" }, logger);
       throw new Error(
         `Failed to close remote ${state.provider.name} session "${state.provider.sessionId}" for session "${session}". ` +
-          `State preserved with status "cleanup-failed". Retry with: libretto close --session ${session}`,
+          `State preserved with status "cleanup-failed". Retry with: ${librettoCommand(`close --session ${session}`)}`,
       );
     }
   }
@@ -896,7 +897,7 @@ export async function runCloseAll(
       [
         `Failed to close ${survivors.length} session(s) gracefully: ${formatSessionList(survivors)}.`,
         `Closed ${closed} session(s).`,
-        `Retry with: libretto close --all --force`,
+        `Retry with: ${librettoCommand("close --all --force")}`,
       ].join("\n"),
     );
   }
@@ -978,11 +979,11 @@ export async function runConnect(
         `Invalid CDP URL: ${cdpUrl}`,
         ``,
         `Expected an HTTP or WebSocket URL pointing to a Chrome DevTools Protocol endpoint, for example:`,
-        `  libretto connect http://127.0.0.1:9222`,
-        `  libretto connect http://remote-host:9222`,
-        `  libretto connect http://remote-host:9222/devtools/browser/<id>`,
-        `  libretto connect ws://remote-host:9222/devtools/browser/<id>`,
-        `  libretto connect wss://remote-host/cdp-endpoint`,
+        `  ${librettoCommand("connect http://127.0.0.1:9222")}`,
+        `  ${librettoCommand("connect http://remote-host:9222")}`,
+        `  ${librettoCommand("connect http://remote-host:9222/devtools/browser/<id>")}`,
+        `  ${librettoCommand("connect ws://remote-host:9222/devtools/browser/<id>")}`,
+        `  ${librettoCommand("connect wss://remote-host/cdp-endpoint")}`,
       ].join("\n"),
     );
   }

--- a/packages/libretto/src/cli/core/config.ts
+++ b/packages/libretto/src/cli/core/config.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { z } from "zod";
 import { SessionAccessModeSchema } from "../../shared/state/index.js";
 import { LIBRETTO_CONFIG_PATH } from "./context.js";
+import { librettoCommand } from "./package-manager.js";
 
 export const CURRENT_CONFIG_VERSION = 1;
 
@@ -67,7 +68,7 @@ function invalidConfigError(configPath: string, detail?: string): Error {
       '  - "snapshotModel", "viewport", "windowPosition", and "sessionMode" are optional.',
       '  - "snapshotModel" must be a provider/model string like "openai/gpt-5.4" or "anthropic/claude-sonnet-4-6".',
       "Fix the file to match this shape, or delete it and rerun:",
-      `  npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`,
+      `  ${librettoCommand("ai configure openai | anthropic | gemini | vertex | openrouter")}`,
     ]
       .filter(Boolean)
       .join("\n"),

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -43,6 +43,7 @@ import { wrapPageForActionLogging } from "../telemetry.js";
 import { handlePages } from "./pages.js";
 import { handleExec, handleReadonlyExec } from "./exec.js";
 import { handleSnapshot } from "./snapshot.js";
+import { librettoCommand } from "../package-manager.js";
 import {
   isConnectConfig,
   type DaemonConfig,
@@ -309,7 +310,7 @@ class BrowserDaemon {
     if (!pageId) {
       if (this.pageById.size > 1) {
         throw new Error(
-          `Multiple pages are open in session "${this.session}". Pass --page <id> to target a page (run "libretto pages --session ${this.session}" to list ids).`,
+          `Multiple pages are open in session "${this.session}". Pass --page <id> to target a page (run "${librettoCommand(`pages --session ${this.session}`)}" to list ids).`,
         );
       }
       // Return the single tracked page rather than `this.page` — the
@@ -322,7 +323,7 @@ class BrowserDaemon {
     const page = this.pageById.get(pageId);
     if (!page) {
       throw new Error(
-        `Page "${pageId}" was not found in session "${this.session}". Run "libretto pages --session ${this.session}" to list ids.`,
+        `Page "${pageId}" was not found in session "${this.session}". Run "${librettoCommand(`pages --session ${this.session}`)}" to list ids.`,
       );
     }
     return page;

--- a/packages/libretto/src/cli/core/package-manager.ts
+++ b/packages/libretto/src/cli/core/package-manager.ts
@@ -1,0 +1,76 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { resolveLibrettoRepoRoot } from "../../shared/paths/repo-root.js";
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+function packageManagerFromUserAgent(
+  env: NodeJS.ProcessEnv = process.env,
+): PackageManager | null {
+  const userAgent = env.npm_config_user_agent ?? "";
+  if (userAgent.startsWith("pnpm")) return "pnpm";
+  if (userAgent.startsWith("yarn")) return "yarn";
+  if (userAgent.startsWith("bun")) return "bun";
+  if (userAgent.startsWith("npm")) return "npm";
+  return null;
+}
+
+function packageManagerFromLockfile(root: string): PackageManager | null {
+  if (existsSync(join(root, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(root, "yarn.lock"))) return "yarn";
+  if (existsSync(join(root, "bun.lockb")) || existsSync(join(root, "bun.lock")))
+    return "bun";
+  return null;
+}
+
+export function detectPackageManager(
+  root = resolveLibrettoRepoRoot(),
+  env: NodeJS.ProcessEnv = process.env,
+): PackageManager {
+  const fromUserAgent = packageManagerFromUserAgent(env);
+  if (fromUserAgent) return fromUserAgent;
+
+  return packageManagerFromLockfile(root) ?? "npm";
+}
+
+export function detectProjectPackageManager(
+  root = resolveLibrettoRepoRoot(),
+): PackageManager {
+  return packageManagerFromLockfile(root) ?? "npm";
+}
+
+export function installCommand(
+  packageManager = detectProjectPackageManager(),
+): string {
+  switch (packageManager) {
+    case "yarn":
+      return "yarn add";
+    case "bun":
+      return "bun add";
+    case "pnpm":
+      return "pnpm add";
+    default:
+      return "npm install";
+  }
+}
+
+function librettoRunner(packageManager = detectPackageManager()): string {
+  switch (packageManager) {
+    case "pnpm":
+      return "pnpm exec";
+    case "yarn":
+      return "yarn";
+    case "bun":
+      return "bunx";
+    default:
+      return "npx";
+  }
+}
+
+export function librettoCommand(
+  args = "",
+  packageManager = detectPackageManager(),
+): string {
+  const suffix = args.trim();
+  return `${librettoRunner(packageManager)} libretto${suffix ? ` ${suffix}` : ""}`;
+}

--- a/packages/libretto/src/cli/core/session.ts
+++ b/packages/libretto/src/cli/core/session.ts
@@ -22,6 +22,7 @@ import {
   type SessionStatus,
   type SessionState,
 } from "../../shared/state/index.js";
+import { librettoCommand } from "./package-manager.js";
 
 const SESSION_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
@@ -154,7 +155,7 @@ function throwSessionNotFoundError(session: string): never {
   }
   lines.push("");
   lines.push("Start one with:");
-  lines.push(`  libretto open <url> --session ${session}`);
+  lines.push(`  ${librettoCommand(`open <url> --session ${session}`)}`);
   throw new Error(lines.join("\n"));
 }
 
@@ -230,7 +231,7 @@ export function assertSessionAllowsCommand(
 
   const supportedModes = [...allowedModes].join(", ");
   throw new Error(
-    `Command "${commandName}" is blocked for session "${state.session}" because it is in ${mode} mode. Allowed modes for this command: ${supportedModes}. Run \`libretto session-mode write-access --session ${state.session}\` to unlock the session.`,
+    `Command "${commandName}" is blocked for session "${state.session}" because it is in ${mode} mode. Allowed modes for this command: ${supportedModes}. Run \`${librettoCommand(`session-mode write-access --session ${state.session}`)}\` to unlock the session.`,
   );
 }
 
@@ -281,7 +282,7 @@ export function assertSessionAvailableForStart(
   // if they have a provider field with a cdpEndpoint.
   if (existingState.provider && existingState.cdpEndpoint) {
     throw new Error(
-      `Session "${session}" is already open via ${existingState.provider.name} provider. Close it first with: libretto close --session ${session}`,
+      `Session "${session}" is already open via ${existingState.provider.name} provider. Close it first with: ${librettoCommand(`close --session ${session}`)}`,
     );
   }
 
@@ -291,6 +292,6 @@ export function assertSessionAvailableForStart(
   }
   const endpoint = `http://127.0.0.1:${existingState.port}`;
   throw new Error(
-    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: libretto close --session ${session}`,
+    `Session "${session}" is already open and connected to ${endpoint} (pid ${existingState.pid}). Create a new session or close the current one with: ${librettoCommand(`close --session ${session}`)}`,
   );
 }

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { REPO_ROOT } from "./context.js";
+import { librettoCommand } from "./package-manager.js";
 
 type PackageManifest = {
   version?: string;
@@ -85,7 +86,7 @@ export function warnIfInstalledSkillOutOfDate(): void {
     }
 
     console.error(
-      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`,
+      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`${librettoCommand("setup")}\` to update your skills to the correct version.`,
     );
   } catch {
     // Never block command execution on a best-effort skill version check.

--- a/packages/libretto/src/cli/core/snapshot-analyzer.ts
+++ b/packages/libretto/src/cli/core/snapshot-analyzer.ts
@@ -17,6 +17,7 @@ import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import type { LoggerApi } from "../../shared/logger/index.js";
+import { librettoCommand } from "./package-manager.js";
 // Used by the legacy CLI-agent path (UserCodingAgent) which is preserved but
 // not wired into the snapshot command. The active config schema (ai-config.ts)
 // no longer has preset/commandPrefix — this type is kept for the legacy code.
@@ -297,7 +298,7 @@ async function runExternalCommand(
       if (error.code === "ENOENT") {
         reject(
           new Error(
-            `Command not found: ${command}. Configure AI with 'libretto ai configure'.`,
+            `Command not found: ${command}. Configure AI with '${librettoCommand("ai configure")}'.`,
           ),
         );
         return;
@@ -830,7 +831,7 @@ export async function runInterpret(
   const configuredAgent = UserCodingAgent.getConfigured();
   if (!configuredAgent) {
     throw new Error(
-      "No AI config set. Run 'npx libretto ai configure codex' (or claude/gemini), or set API credentials in your .env file for direct API analysis.",
+      `No AI config set. Run '${librettoCommand("ai configure codex")}' (or claude/gemini), or set API credentials in your .env file for direct API analysis.`,
     );
   }
 
@@ -840,7 +841,7 @@ export async function runInterpret(
   // re-enabled, the caller must supply a valid provider/model-id string.
   throw new Error(
     "The CLI-agent snapshot analysis path is not active. " +
-      "Update your config to the current format with `npx libretto ai configure <provider>`, " +
+      `Update your config to the current format with \`${librettoCommand("ai configure <provider>")}\`, ` +
       "or set API credentials in .env for direct API analysis.",
   );
 

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -7,6 +7,7 @@ import { executionCommands } from "./commands/execution.js";
 import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
+import { librettoCommand } from "./core/package-manager.js";
 import { SimpleCLI } from "./framework/simple-cli.js";
 
 export const cliRoutes = {
@@ -22,5 +23,5 @@ export const cliRoutes = {
 };
 
 export function createCLIApp() {
-  return SimpleCLI.define("libretto", cliRoutes);
+  return SimpleCLI.define(librettoCommand(), cliRoutes);
 }

--- a/packages/libretto/src/cli/workers/run-integration-runtime.ts
+++ b/packages/libretto/src/cli/workers/run-integration-runtime.ts
@@ -25,6 +25,7 @@ import {
   getSessionNetworkLogPath,
   getSessionStatePath,
 } from "../core/context.js";
+import { librettoCommand } from "../core/package-manager.js";
 import {
   getPauseSignalPaths,
   removeSignalIfExists,
@@ -122,9 +123,9 @@ function getMissingLocalAuthProfileError(args: {
     `Local auth profile not found for domain "${args.normalizedDomain}".`,
     `Expected profile file: ${args.profilePath}`,
     "To create it:",
-    `  1. libretto open https://${args.normalizedDomain} --headed --session ${args.session}`,
+    `  1. ${librettoCommand(`open https://${args.normalizedDomain} --headed --session ${args.session}`)}`,
     "  2. Log in manually in the browser window.",
-    `  3. libretto save ${args.normalizedDomain} --session ${args.session}`,
+    `  3. ${librettoCommand(`save ${args.normalizedDomain} --session ${args.session}`)}`,
   ].join("\n");
 }
 
@@ -171,7 +172,7 @@ async function loadDefaultWorkflow(
   }
 
   throw new Error(
-    `No default-exported workflow found in ${absolutePath}. libretto run only uses the file's default export. Available named workflows: ${availableWorkflowNames.join(", ")}`,
+    `No default-exported workflow found in ${absolutePath}. ${librettoCommand("run")} only uses the file's default export. Available named workflows: ${availableWorkflowNames.join(", ")}`,
   );
 }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -74,7 +74,7 @@ function expectedSkillVersionWarning(
   skillVersion: string,
   cliVersion: string,
 ): string {
-  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}). Please run \`npx libretto setup\` to update your skills to the correct version.`;
+  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}).`;
 }
 
 describe("basic CLI subprocess behavior", () => {
@@ -110,7 +110,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("Detected OPENAI_API_KEY");
     expect(result.stdout).toContain("config.json");
     expect(result.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      "libretto ai configure openai | anthropic | gemini | vertex",
     );
   });
 
@@ -163,7 +163,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(second.stdout).toContain("Using OpenAI");
     expect(second.stdout).toContain("config.json");
     expect(second.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      "libretto ai configure openai | anthropic | gemini | vertex",
     );
     // Should NOT contain the unconfigured prompts
     expect(second.stdout).not.toContain(
@@ -293,7 +293,7 @@ describe("basic CLI subprocess behavior", () => {
 
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain("libretto <command>");
     expect(result.stdout).toContain("readonly-exec");
     expect(result.stdout).toContain("snapshot");
     expect(result.stdout).toContain("Capture PNG + HTML");
@@ -303,9 +303,20 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("prints CLI guidance with the invoking package manager", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("--help", {
+      npm_config_user_agent: "bun/1.0.0",
+    });
+
+    expect(result.stdout).toContain("Usage: bunx libretto <command>");
+    expect(result.stdout).toContain("bunx libretto setup");
+  });
+
   test("prints usage for help command", async ({ librettoCli }) => {
     const result = await librettoCli("help");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain("libretto <command>");
     expect(result.stdout).toContain("Commands:");
     expect(result.stdout).toContain("open");
     expect(result.stdout).toContain("ai");
@@ -326,7 +337,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help ai configure");
     expect(result.stdout).toContain("Configure AI runtime");
     expect(result.stdout).toContain(
-      "Usage: libretto ai configure [preset] [options]",
+      "libretto ai configure [preset] [options]",
     );
     expect(result.stderr).toBe("");
   });
@@ -337,7 +348,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help experimental");
     expect(result.stdout).toContain("Experimental commands");
     expect(result.stdout).toContain(
-      "Usage: libretto experimental <subcommand>",
+      "libretto experimental <subcommand>",
     );
     expect(result.stdout).toContain("deploy");
     expect(result.stderr).toBe("");
@@ -351,7 +362,7 @@ describe("basic CLI subprocess behavior", () => {
       "Run the default-exported Libretto workflow from a file",
     );
     expect(result.stdout).toContain(
-      "Usage: libretto run [integrationFile] [options]",
+      "libretto run [integrationFile] [options]",
     );
     expect(result.stdout).toContain("--read-only");
     expect(result.stdout).toContain("--no-visualize");
@@ -365,7 +376,7 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help session-mode");
     expect(result.stdout).toContain("View or set the session access mode");
     expect(result.stdout).toContain(
-      "Usage: libretto session-mode [mode] [options]",
+      "libretto session-mode [mode] [options]",
     );
     expect(result.stderr).toBe("");
   });
@@ -373,13 +384,13 @@ describe("basic CLI subprocess behavior", () => {
   test("fails unknown command with a clear error", async ({ librettoCli }) => {
     const result = await librettoCli("nope-command");
     expect(result.stderr).toContain("Unknown command: nope-command");
-    expect(result.stdout).toContain("Usage: libretto <command>");
+    expect(result.stdout).toContain("libretto <command>");
   });
 
   test("fails open with missing url usage error", async ({ librettoCli }) => {
     const result = await librettoCli("open");
     expect(result.stderr).toContain(
-      "Usage: libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]",
+      "libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]",
     );
   });
 
@@ -466,11 +477,15 @@ describe("basic CLI subprocess behavior", () => {
     await seedInstalledSkillVersion(workspacePath, ".agents", "0.0.0");
 
     const result = await librettoCli("open https://example.com", {
+      npm_config_user_agent: "bun/1.0.0",
       PLAYWRIGHT_BROWSERS_PATH: "/definitely-not-real",
     });
 
     expect(result.stderr).toContain(
       expectedSkillVersionWarning("0.0.0", cliVersion),
+    );
+    expect(result.stderr).toContain(
+      `Please run \`bunx libretto setup\` to update your skills to the correct version.`,
     );
     expect(result.stderr).toContain("Daemon exited before startup");
   });
@@ -501,7 +516,7 @@ describe("basic CLI subprocess behavior", () => {
   test("fails exec with missing code usage error", async ({ librettoCli }) => {
     const result = await librettoCli("exec --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
+      "libretto exec <code|-> [--session <name>] [--visualize]",
     );
   });
 
@@ -510,7 +525,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("exec --visualize --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto exec <code|-> [--session <name>] [--visualize]",
+      "libretto exec <code|-> [--session <name>] [--visualize]",
     );
     expect(result.stderr).not.toContain(
       `Missing required --session for "exec".`,
@@ -522,7 +537,7 @@ describe("basic CLI subprocess behavior", () => {
   }) => {
     const result = await librettoCli("readonly-exec --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto readonly-exec <code|-> [--session <name>] [--page <id>]",
+      "libretto readonly-exec <code|-> [--session <name>] [--page <id>]",
     );
   });
 
@@ -1111,7 +1126,7 @@ export default workflow("main", async (ctx) => {
   }) => {
     const result = await librettoCli("save --session test");
     expect(result.stderr).toContain(
-      "Usage: libretto save <url|domain> --session <name>",
+      "libretto save <url|domain> --session <name>",
     );
   });
 

--- a/packages/libretto/test/package-manager.spec.ts
+++ b/packages/libretto/test/package-manager.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  detectProjectPackageManager,
+  detectPackageManager,
+  installCommand,
+  librettoCommand,
+} from "../src/cli/core/package-manager.js";
+
+describe("package manager command rendering", () => {
+  it("renders libretto commands for supported package managers", () => {
+    expect(librettoCommand("setup", "npm")).toBe("npx libretto setup");
+    expect(librettoCommand("setup", "pnpm")).toBe("pnpm exec libretto setup");
+    expect(librettoCommand("setup", "yarn")).toBe("yarn libretto setup");
+    expect(librettoCommand("setup", "bun")).toBe("bunx libretto setup");
+  });
+
+  it("detects the package manager from npm_config_user_agent", () => {
+    expect(
+      detectPackageManager("/tmp/no-lockfiles", {
+        npm_config_user_agent: "bun/1.0.0",
+      }),
+    ).toBe("bun");
+  });
+
+  it("uses lockfiles, not the invoking command, for project installs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "libretto-pm-"));
+    try {
+      writeFileSync(join(dir, "pnpm-lock.yaml"), "");
+
+      expect(
+        detectProjectPackageManager(dir),
+      ).toBe("pnpm");
+      expect(installCommand(detectProjectPackageManager(dir))).toBe("pnpm add");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/libretto/test/snapshot-api-config.spec.ts
+++ b/packages/libretto/test/snapshot-api-config.spec.ts
@@ -112,7 +112,7 @@ describe("snapshot API model resolution", () => {
     clearProviderEnv();
 
     expect(() => resolveSnapshotApiModelOrThrow(null)).toThrowError(
-      "Failed to analyze snapshot because no snapshot analyzer is configured. Add OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_CLOUD_PROJECT, or OPENROUTER_API_KEY to .env or as a shell environment variable, or choose a default model with `npx libretto ai configure openai | anthropic | gemini | vertex | openrouter`. For more info, run `npx libretto setup`.",
+      /choose a default model with `.*libretto ai configure openai \| anthropic \| gemini \| vertex \| openrouter`\. For more info, run `.*libretto setup`\./,
     );
   });
 
@@ -158,7 +158,9 @@ describe("snapshot API model resolution", () => {
     expect(() =>
       resolveSnapshotApiModelOrThrow("openai/gpt-5.4"),
     ).toThrowError(
-      `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH}, but OPENAI_API_KEY is missing. Add OPENAI_API_KEY to .env or as a shell environment variable. For more info, run \`npx libretto setup\`.`,
+      new RegExp(
+        `Failed to analyze snapshot because openai is configured in ${LIBRETTO_CONFIG_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}, but OPENAI_API_KEY is missing\\. Add OPENAI_API_KEY to \\.env or as a shell environment variable\\. For more info, run \`.*libretto setup\`\\.`,
+      ),
     );
   });
 });

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -142,8 +142,9 @@ describe("state-driven CLI subprocess behavior", () => {
       "Failed to analyze snapshot because no snapshot analyzer is configured.",
     );
     expect(snapshot.stderr).toContain(
-      "For more info, run `npx libretto setup`.",
+      "For more info, run",
     );
+    expect(snapshot.stderr).toContain("libretto setup");
     expect(
       existsSync(workspacePath(".libretto", "sessions", session, "snapshots")),
     ).toBe(false);
@@ -223,7 +224,7 @@ describe("state-driven CLI subprocess behavior", () => {
 
   test("rejects close --force without --all", async ({ librettoCli }) => {
     const result = await librettoCli("close --force");
-    expect(result.stderr).toContain("Usage: libretto close --all [--force]");
+    expect(result.stderr).toContain("libretto close --all [--force]");
   });
 
   test("close --all closes active sessions", async ({ librettoCli }) => {
@@ -293,7 +294,7 @@ describe("state-driven CLI subprocess behavior", () => {
     });
     expect(status.stdout).toContain("AI configuration:");
     expect(status.stdout).toContain("No AI model configured");
-    expect(status.stdout).toContain("npx libretto setup");
+    expect(status.stdout).toContain("libretto setup");
   });
 
   test("status shows configured model after setup pins it", async ({
@@ -313,7 +314,7 @@ describe("state-driven CLI subprocess behavior", () => {
     expect(status.stdout).toContain("AI configuration:");
     expect(status.stdout).toContain("openai/gpt-5.4");
     expect(status.stdout).toContain(
-      "To change: npx libretto ai configure openai | anthropic | gemini | vertex",
+      "libretto ai configure openai | anthropic | gemini | vertex",
     );
   });
 


### PR DESCRIPTION
## Summary
- Add a shared package-manager helper for rendering Libretto CLI commands as `npx`, `pnpm exec`, `yarn`, or `bunx` based on the invoking package manager.
- Update CLI help, status, setup, config, snapshot, session, and browser recovery guidance to use package-manager-aware command strings.
- Keep project dependency installation lockfile-based so `setup` still installs SDK packages with the project package manager.
- Normalize docs command examples to `npx libretto`.

## Testing
- `pnpm -s type-check --filter=libretto`
- `pnpm -s --filter libretto build`
- `pnpm --dir packages/libretto exec vitest run --root ../.. --environment node --testTimeout 30000 packages/libretto/test/basic.spec.ts packages/libretto/test/stateful.spec.ts packages/libretto/test/snapshot-api-config.spec.ts packages/libretto/test/package-manager.spec.ts`
- `pnpm --dir packages/libretto exec vitest run --root ../.. --environment node --testTimeout 30000 packages/libretto/test`
