### PR TITLE
Clarify hosted credential usage

### DIFF
--- a/docs/libretto-cloud-api/credentials.mdx
+++ b/docs/libretto-cloud-api/credentials.mdx
@@ -7,6 +7,53 @@ hidden: true
 
 All routes on this page require `x-api-key`.
 
+### Using stored credentials in jobs
+
+The credentials API stores encrypted credential JSON for your tenant. To use a
+stored credential in a hosted workflow, read it from the credentials API in your
+server-side caller, then pass the needed fields in the `params` object when you
+create the job. The workflow receives those fields as normal input parameters.
+
+```typescript
+const apiKey = process.env.LIBRETTO_API_KEY;
+if (!apiKey) throw new Error("LIBRETTO_API_KEY is required");
+
+const credentialResponse = await fetch(
+  "https://api.libretto.sh/v1/credentials/get",
+  {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      json: { name: "portal-production" },
+    }),
+  },
+);
+
+const credentialBody = await credentialResponse.json();
+const credential = credentialBody.json.value;
+
+await fetch("https://api.libretto.sh/v1/jobs/create", {
+  method: "POST",
+  headers: {
+    "x-api-key": apiKey,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    json: {
+      workflow: "portal-login",
+      params: {
+        memberId: "12345",
+        username: credential.username,
+        password: credential.password,
+      },
+    },
+  }),
+});
+```
+
 ### POST `/v1/credentials/create`
 
 Store a new credential object.


### PR DESCRIPTION
## Summary
- Add a short note to hidden credentials API docs explaining that stored credentials should be read by the server-side caller and passed to hosted workflows through job params.

## Testing
- Not run; docs-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/saffron-health/libretto/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->