### PR TITLE
Update default session timeout to 5400s

### DIFF
--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -14,7 +14,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
   return {
     async createSession() {
       const timeoutSeconds = Number(
-        process.env.LIBRETTO_TIMEOUT_SECONDS ?? 7200,
+        process.env.LIBRETTO_TIMEOUT_SECONDS ?? 5400,
       );
       const resp = await fetch(`${endpoint}/v1/sessions/create`, {
         method: "POST",
@@ -28,9 +28,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
       });
       if (!resp.ok) {
         const body = await resp.text();
-        throw new Error(
-          `Libretto Cloud API error (${resp.status}): ${body}`,
-        );
+        throw new Error(`Libretto Cloud API error (${resp.status}): ${body}`);
       }
       const { json } = (await resp.json()) as {
         json: {


### PR DESCRIPTION
## Summary
- Update default `LIBRETTO_TIMEOUT_SECONDS` from 7200 to 5400 to match the hosted execution API's `JOB_BROWSER_SESSION_TIMEOUT_SECONDS` cap

## Context
The browser-automations API now enforces a 5400s (90 min) max on browser sessions as part of the capacity-gated hosted execution architecture. This aligns the CLI default so sessions don't get rejected for exceeding the server-side limit.

## Test plan
- [ ] Verify `libretto open` creates sessions successfully with the new default
- [ ] Verify custom `LIBRETTO_TIMEOUT_SECONDS` values still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)