### PR TITLE
Add experiments CLI framework

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -42,7 +42,7 @@ jobs:
           tests=false
           while IFS= read -r file; do
             case "$file" in
-              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json|.github/workflows/cli-tests.yml|packages/libretto/package.json|packages/libretto/tsconfig.json|packages/libretto/vitest.config.*|packages/libretto/tsup.config.*|packages/libretto/src/*|packages/libretto/test/*|packages/libretto/scripts/*)
+              package.json|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json|tsconfig.base.json|.github/workflows/cli-tests.yml|packages/libretto/package.json|packages/libretto/tsconfig.json|packages/libretto/vitest.config.*|packages/libretto/tsup.config.*|packages/libretto/src/*|packages/libretto/test/*|packages/libretto/scripts/*)
                 tests=true
                 break
                 ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ This is a pnpm monorepo.
   - CLI source: `packages/libretto/src/cli/`
   - Tests: `packages/libretto/test/*.spec.ts`
 - `apps/website` — marketing site (Vite / vite-plus)
-- `docs/` — Mintlify documentation site
+- `docs/` — user-facing Mintlify documentation site
+- `packages/libretto/docs/` — internal package documentation for implementation notes and maintainer references
 - `benchmarks/` — benchmark suite (imports from `packages/libretto/src/`)
 - `evals/` — eval suite
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,7 @@
 # Documentation Site (Mintlify)
 
+This top-level `docs/` directory is the user-facing Mintlify documentation site. Put internal implementation notes and maintainer references under the relevant package instead, such as `packages/libretto/docs/`.
+
 Config in `docs.json`. Preview with `pnpm docs:dev` (runs on `localhost:3000`).
 
 ## Sidebar group name must match the URL

--- a/packages/libretto/docs/experiments.md
+++ b/packages/libretto/docs/experiments.md
@@ -1,0 +1,66 @@
+# Experiments Framework
+
+Use this reference when adding or changing Libretto experiment flags, wiring experiment checks through CLI or daemon internals, or debugging `libretto experiments` behavior.
+
+## Purpose and Scope
+
+Experiments are boolean feature flags for Libretto internal machinery. They let maintainers enable in-progress CLI or daemon behavior in a workspace without exposing those flags to user workflow code.
+
+Do not add experiments to `LibrettoWorkflowContext` in `packages/libretto/src/shared/workflow/workflow.ts`. User workflows should not branch on Libretto experiment flags.
+
+## Registry and Workspace State
+
+The experiment registry lives in `packages/libretto/src/cli/core/experiments.ts`.
+
+- Add each flag to `EXPERIMENTS` with a stable name, title, description, and `defaultValue`.
+- Use the exported `ExperimentName` and `Experiments` types instead of duplicating flag shapes.
+- Use `resolveExperiments()` to read the resolved boolean snapshot.
+- Use `setExperimentEnabled()` to persist an override and reject unknown flag names.
+
+Workspace overrides are stored in `.libretto/config.json` under the optional `experiments` record. The config schema is defined in `packages/libretto/src/cli/core/config.ts`; unknown config fields are still passed through.
+
+Example workspace state:
+
+```json
+{
+  "version": 1,
+  "experiments": {
+    "exampleExperiment": true
+  }
+}
+```
+
+## CLI Behavior
+
+`libretto experiments` is the CLI surface for inspecting and changing workspace experiment overrides.
+
+```bash
+npx libretto experiments
+npx libretto experiments enable <experiment>
+npx libretto experiments disable <experiment>
+```
+
+The command is implemented in `packages/libretto/src/cli/commands/experiments.ts` and registered as a top-level command. Listing prints registered experiments in registry order with their enabled/disabled state and description. Enable/disable persists the override to `.libretto/config.json` and prints deterministic success text.
+
+Invalid actions, missing experiment names, and unknown experiment names should fail with actionable usage that includes the available experiment names.
+
+## CLI and Daemon Plumbing
+
+Use `withExperiments()` from `packages/libretto/src/cli/commands/shared.ts` when a command needs experiment values. It resolves one experiment snapshot for the CLI invocation and adds it to command context as `ctx.experiments`.
+
+Daemon-backed startup paths must serialize that snapshot into `DaemonConfig.experiments` in `packages/libretto/src/cli/core/daemon/config.ts`. This currently applies to:
+
+- daemon-backed `open`
+- `connect`
+- provider-backed `open`
+- `run`
+
+The daemon receives experiments at startup only. Changes made with `libretto experiments enable|disable` apply to new daemon sessions, not already-running sessions.
+
+Inside the daemon, experiments are for Libretto machinery only. Keep them in daemon/controller internals; do not pass them into public workflow context objects.
+
+## Testing Notes
+
+Before adding or changing tests, read `docs/tests-guide.md`.
+
+Prefer user-level CLI behavior tests for `libretto experiments` listing and enable/disable flows. Keep a regression test that an enabled experiment is not visible on `LibrettoWorkflowContext` during `run`.

--- a/packages/libretto/src/cli/AGENTS.md
+++ b/packages/libretto/src/cli/AGENTS.md
@@ -1,0 +1,7 @@
+# CLI Source
+
+## Experiments
+
+When adding or changing Libretto experiment flags, read `../../docs/experiments.md` for the registry, CLI command, config, and daemon plumbing conventions.
+
+Experiments are internal Libretto machinery. Do not expose them on `LibrettoWorkflowContext` or user workflow APIs.

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -24,6 +24,7 @@ import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   sessionOption,
   withAutoSession,
+  withExperiments,
   withRequiredSession,
 } from "./shared.js";
 
@@ -110,6 +111,7 @@ export const openCommand = SimpleCLI.command({
 })
   .input(openInput)
   .use(withAutoSession())
+  .use(withExperiments())
   .handle(async ({ input, ctx }) => {
     warnIfInstalledSkillOutOfDate();
     assertSessionAvailableForStart(ctx.session, ctx.logger);
@@ -124,6 +126,7 @@ export const openCommand = SimpleCLI.command({
           input.writeAccess,
         ),
         authProfileDomain: input.authProfile,
+        experiments: ctx.experiments,
       });
     } else {
       await runOpenWithProvider(
@@ -132,6 +135,7 @@ export const openCommand = SimpleCLI.command({
         ctx.session,
         ctx.logger,
         resolveRequestedSessionMode(input.readOnly, input.writeAccess),
+        ctx.experiments,
       );
     }
   });
@@ -168,6 +172,7 @@ export const connectCommand = SimpleCLI.command({
 })
   .input(connectInput)
   .use(withAutoSession())
+  .use(withExperiments())
   .handle(async ({ input, ctx }) => {
     warnIfInstalledSkillOutOfDate();
     await runConnectWithLogger(
@@ -175,6 +180,7 @@ export const connectCommand = SimpleCLI.command({
       ctx.session,
       ctx.logger,
       resolveRequestedSessionMode(input.readOnly, input.writeAccess),
+      ctx.experiments,
     );
   });
 

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -577,6 +577,7 @@ async function runIntegrationFromFile(
   } = await DaemonClient.spawn({
     config: {
       session: args.session,
+      experiments: args.experiments,
       browser: args.providerName
         ? { kind: "provider", providerName: args.providerName }
         : {

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -46,11 +46,13 @@ import {
   wrapPageForActionLogging,
 } from "../core/telemetry.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
+import type { Experiments } from "../core/experiments.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   pageOption,
   sessionOption,
   withAutoSession,
+  withExperiments,
   withRequiredSession,
 } from "./shared.js";
 
@@ -66,6 +68,7 @@ type RunIntegrationCommandRequest = {
   providerName?: string;
   stayOpenOnSuccess: boolean;
   tsconfigPath?: string;
+  experiments: Experiments;
 };
 type ExecMode = "exec" | "readonly-exec";
 
@@ -839,6 +842,7 @@ export const runCommand = SimpleCLI.command({
 })
   .input(runInput)
   .use(withAutoSession())
+  .use(withExperiments())
   .handle(async ({ input, ctx }) => {
     warnIfInstalledSkillOutOfDate();
     await stopExistingFailedRunSession(ctx.session, ctx.logger);
@@ -881,6 +885,7 @@ export const runCommand = SimpleCLI.command({
         accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
         providerName: daemonProviderName,
         stayOpenOnSuccess: input.stayOpenOnSuccess,
+        experiments: ctx.experiments,
       },
       ctx.logger,
     );

--- a/packages/libretto/src/cli/commands/experiments.ts
+++ b/packages/libretto/src/cli/commands/experiments.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { librettoCommand } from "../../shared/package-manager.js";
+import {
+  EXPERIMENTS,
+  isExperimentName,
+  resolveExperiments,
+  setExperimentEnabled,
+  type ExperimentName,
+  type Experiments,
+} from "../core/experiments.js";
+import { SimpleCLI } from "../framework/simple-cli.js";
+
+const experimentNames = Object.keys(EXPERIMENTS) as ExperimentName[];
+
+const experimentsUsage = [
+  "Usage:",
+  `  ${librettoCommand("experiments")}`,
+  `  ${librettoCommand("experiments enable <experiment>")}`,
+  `  ${librettoCommand("experiments disable <experiment>")}`,
+].join("\n");
+
+export const experimentsInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("action", z.string().optional(), {
+      help: "Action to apply",
+    }),
+    SimpleCLI.positional("experiment", z.string().optional(), {
+      help: "Experiment name",
+    }),
+  ],
+  named: {},
+});
+
+function formatAvailableExperiments(): string {
+  return [
+    "Available experiments:",
+    ...experimentNames.map((name) => `  ${name}`),
+  ].join("\n");
+}
+
+function experimentUsageError(message: string): Error {
+  return new Error(
+    [message, "", experimentsUsage, "", formatAvailableExperiments()].join(
+      "\n",
+    ),
+  );
+}
+
+function printExperiments(experiments: Experiments): void {
+  console.log("Libretto experiments:");
+  for (const name of experimentNames) {
+    const metadata = EXPERIMENTS[name];
+    console.log(
+      `- ${name}: ${experiments[name] ? "enabled" : "disabled"} — ${metadata.title}`,
+    );
+    console.log(`  ${metadata.description}`);
+  }
+}
+
+export const experimentsCommand = SimpleCLI.command({
+  description: "List or update Libretto experiment flags",
+})
+  .input(experimentsInput)
+  .handle(async ({ input }) => {
+    if (!input.action) {
+      printExperiments(resolveExperiments());
+      return;
+    }
+
+    if (input.action !== "enable" && input.action !== "disable") {
+      throw experimentUsageError(`Unknown experiments action "${input.action}".`);
+    }
+
+    if (!input.experiment) {
+      throw experimentUsageError(
+        `Missing experiment name for ${input.action}.`,
+      );
+    }
+
+    if (!isExperimentName(input.experiment)) {
+      throw experimentUsageError(`Unknown experiment "${input.experiment}".`);
+    }
+
+    setExperimentEnabled(input.experiment, input.action === "enable");
+    console.log(`Experiment "${input.experiment}" ${input.action}d.`);
+  });

--- a/packages/libretto/src/cli/commands/shared.ts
+++ b/packages/libretto/src/cli/commands/shared.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import type { LoggerApi } from "../../shared/logger/index.js";
+import type { Experiments } from "../core/experiments.js";
+import { resolveExperiments } from "../core/experiments.js";
 import { createLoggerForSession } from "../core/context.js";
 import {
   generateSessionName,
@@ -9,6 +11,8 @@ import {
 } from "../core/session.js";
 import {
   SimpleCLI,
+  type SimpleCLIMiddlewareArgs,
+  type SimpleCLIContext,
   type SimpleCLIMiddleware,
 } from "../framework/simple-cli.js";
 
@@ -32,6 +36,22 @@ export type SessionContext = {
 export type SessionStateContext = SessionContext & {
   sessionState: SessionState;
 };
+
+export type ExperimentsContext = {
+  experiments: Experiments;
+};
+
+export function withExperiments() {
+  return async <TInput, TContext extends SimpleCLIContext>({
+    ctx,
+  }: SimpleCLIMiddlewareArgs<
+    TInput,
+    TContext
+  >): Promise<TContext & ExperimentsContext> => ({
+    ...ctx,
+    experiments: resolveExperiments(),
+  });
+}
 
 export function withRequiredSession(): SimpleCLIMiddleware<
   { session?: string },

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -11,6 +11,7 @@ import { createServer } from "node:net";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import type { Experiments } from "./experiments.js";
+import { resolveExperiments } from "./experiments.js";
 import { getSessionProviderClosePath, PROFILES_DIR } from "./context.js";
 import { readLibrettoConfig } from "./config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
@@ -406,6 +407,7 @@ export async function runOpen(
   const url = parsedUrl.href;
   const viewport = resolveViewport(options?.viewport, logger);
   const accessMode = options?.accessMode ?? "write-access";
+  const experiments = options?.experiments ?? resolveExperiments();
   const windowPosition = headed ? resolveWindowPosition(logger) : undefined;
   logger.info("open-start", {
     url,
@@ -466,6 +468,7 @@ export async function runOpen(
     await DaemonClient.spawn({
       config: {
         session,
+        experiments,
         browser: {
           kind: "launch",
           headed,
@@ -520,6 +523,7 @@ export async function runOpenWithProvider(
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
   const url = parsedUrl.href;
+  const resolvedExperiments = experiments ?? resolveExperiments();
   logger.info("open-provider-start", { url, provider: providerName, session });
 
   console.log(
@@ -537,6 +541,7 @@ export async function runOpenWithProvider(
   } = await DaemonClient.spawn({
     config: {
       session,
+      experiments: resolvedExperiments,
       browser: {
         kind: "provider",
         providerName,
@@ -1178,6 +1183,7 @@ export async function runConnect(
   accessMode: SessionAccessMode = "write-access",
   experiments?: Experiments,
 ): Promise<void> {
+  const resolvedExperiments = experiments ?? resolveExperiments();
   logger.info("connect-start", { cdpUrl, session, accessMode });
   assertSessionAvailableForStart(session, logger);
 
@@ -1239,6 +1245,7 @@ export async function runConnect(
     await DaemonClient.spawn({
       config: {
         session,
+        experiments: resolvedExperiments,
         browser: { kind: "connect", cdpEndpoint: endpoint },
       },
       logger,

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -11,7 +11,6 @@ import { createServer } from "node:net";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import type { Experiments } from "./experiments.js";
-import { resolveExperiments } from "./experiments.js";
 import { getSessionProviderClosePath, PROFILES_DIR } from "./context.js";
 import { readLibrettoConfig } from "./config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
@@ -396,18 +395,17 @@ export async function runOpen(
   headed: boolean,
   session: string,
   logger: LoggerApi,
-  options?: {
+  options: {
     viewport?: { width: number; height: number };
     accessMode?: SessionAccessMode;
     authProfileDomain?: string;
-    experiments?: Experiments;
+    experiments: Experiments;
   },
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
   const url = parsedUrl.href;
   const viewport = resolveViewport(options?.viewport, logger);
   const accessMode = options?.accessMode ?? "write-access";
-  const experiments = options?.experiments ?? resolveExperiments();
   const windowPosition = headed ? resolveWindowPosition(logger) : undefined;
   logger.info("open-start", {
     url,
@@ -468,7 +466,7 @@ export async function runOpen(
     await DaemonClient.spawn({
       config: {
         session,
-        experiments,
+        experiments: options.experiments,
         browser: {
           kind: "launch",
           headed,
@@ -518,12 +516,11 @@ export async function runOpenWithProvider(
   providerName: string,
   session: string,
   logger: LoggerApi,
-  accessMode: SessionAccessMode = "write-access",
-  experiments?: Experiments,
+  accessMode: SessionAccessMode,
+  experiments: Experiments,
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
   const url = parsedUrl.href;
-  const resolvedExperiments = experiments ?? resolveExperiments();
   logger.info("open-provider-start", { url, provider: providerName, session });
 
   console.log(
@@ -541,7 +538,7 @@ export async function runOpenWithProvider(
   } = await DaemonClient.spawn({
     config: {
       session,
-      experiments: resolvedExperiments,
+      experiments,
       browser: {
         kind: "provider",
         providerName,
@@ -1180,10 +1177,9 @@ export async function runConnect(
   cdpUrl: string,
   session: string,
   logger: LoggerApi,
-  accessMode: SessionAccessMode = "write-access",
-  experiments?: Experiments,
+  accessMode: SessionAccessMode,
+  experiments: Experiments,
 ): Promise<void> {
-  const resolvedExperiments = experiments ?? resolveExperiments();
   logger.info("connect-start", { cdpUrl, session, accessMode });
   assertSessionAvailableForStart(session, logger);
 
@@ -1245,7 +1241,7 @@ export async function runConnect(
     await DaemonClient.spawn({
       config: {
         session,
-        experiments: resolvedExperiments,
+        experiments,
         browser: { kind: "connect", cdpEndpoint: endpoint },
       },
       logger,

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -10,6 +10,7 @@ import { dirname, join } from "node:path";
 import { createServer } from "node:net";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
+import type { Experiments } from "./experiments.js";
 import { getSessionProviderClosePath, PROFILES_DIR } from "./context.js";
 import { readLibrettoConfig } from "./config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
@@ -398,6 +399,7 @@ export async function runOpen(
     viewport?: { width: number; height: number };
     accessMode?: SessionAccessMode;
     authProfileDomain?: string;
+    experiments?: Experiments;
   },
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
@@ -514,6 +516,7 @@ export async function runOpenWithProvider(
   session: string,
   logger: LoggerApi,
   accessMode: SessionAccessMode = "write-access",
+  experiments?: Experiments,
 ): Promise<void> {
   const parsedUrl = normalizeUrl(rawUrl);
   const url = parsedUrl.href;
@@ -1173,6 +1176,7 @@ export async function runConnect(
   session: string,
   logger: LoggerApi,
   accessMode: SessionAccessMode = "write-access",
+  experiments?: Experiments,
 ): Promise<void> {
   logger.info("connect-start", { cdpUrl, session, accessMode });
   assertSessionAvailableForStart(session, logger);

--- a/packages/libretto/src/cli/core/config.ts
+++ b/packages/libretto/src/cli/core/config.ts
@@ -27,6 +27,7 @@ export const LibrettoConfigSchema = z
     windowPosition: WindowPositionConfigSchema.optional(),
     provider: z.string().optional(),
     sessionMode: SessionAccessModeSchema.optional(),
+    experiments: z.record(z.string(), z.boolean()).optional(),
   })
   .passthrough();
 export type LibrettoConfig = z.infer<typeof LibrettoConfigSchema>;

--- a/packages/libretto/src/cli/core/daemon/config.ts
+++ b/packages/libretto/src/cli/core/daemon/config.ts
@@ -4,6 +4,8 @@
  * Serialized as JSON in `process.argv[2]` when spawning the daemon.
  */
 
+import type { Experiments } from "../experiments.js";
+
 /**
  * Config for daemon-managed browser launch (`libretto open`).
  * The daemon owns the browser lifecycle and will close it on shutdown.
@@ -51,6 +53,7 @@ export type DaemonWorkflowConfig = {
 
 export type DaemonConfig = {
   session: string;
+  experiments: Experiments;
   browser:
     | DaemonBrowserLaunchConfig
     | DaemonBrowserConnectConfig

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -72,6 +72,7 @@ import {
   type DaemonBrowserProviderConfig,
   type DaemonWorkflowConfig,
 } from "./config.js";
+import type { Experiments } from "../experiments.js";
 import { getCloudProviderApi } from "../providers/index.js";
 import type { ProviderApi } from "../providers/types.js";
 import {
@@ -160,6 +161,7 @@ class BrowserDaemon {
 
   private constructor(
     private readonly session: string,
+    private readonly experiments: Experiments,
     private readonly externallyManaged: boolean,
     private readonly browser: Browser,
     private readonly context: BrowserContext,
@@ -190,6 +192,7 @@ class BrowserDaemon {
    */
   private static async initialize(args: {
     session: string;
+    experiments: Experiments;
     externallyManaged: boolean;
     browser: Browser;
     context: BrowserContext;
@@ -211,6 +214,7 @@ class BrowserDaemon {
   }): Promise<BrowserDaemon> {
     const {
       session,
+      experiments,
       externallyManaged,
       browser,
       context,
@@ -253,6 +257,7 @@ class BrowserDaemon {
     const socketPath = getDaemonSocketPath(session);
     const daemon = new BrowserDaemon(
       session,
+      experiments,
       externallyManaged,
       browser,
       context,
@@ -328,6 +333,7 @@ class BrowserDaemon {
 
   static async launchBrowser(args: {
     session: string;
+    experiments: Experiments;
     browser: DaemonBrowserLaunchConfig;
     workflow?: DaemonWorkflowConfig;
   }): Promise<BrowserDaemon> {
@@ -372,6 +378,7 @@ class BrowserDaemon {
 
     const daemon = await BrowserDaemon.initialize({
       session,
+      experiments: args.experiments,
       externallyManaged: false,
       browser,
       context,
@@ -393,6 +400,7 @@ class BrowserDaemon {
 
   static async connectToEndpoint(args: {
     session: string;
+    experiments: Experiments;
     browser: DaemonBrowserConnectConfig;
   }): Promise<BrowserDaemon> {
     const { session, browser: config } = args;
@@ -410,6 +418,7 @@ class BrowserDaemon {
 
     const daemon = await BrowserDaemon.initialize({
       session,
+      experiments: args.experiments,
       externallyManaged: true,
       browser,
       context,
@@ -430,6 +439,7 @@ class BrowserDaemon {
 
   static async connectToProvider(args: {
     session: string;
+    experiments: Experiments;
     browser: DaemonBrowserProviderConfig;
   }): Promise<BrowserDaemon> {
     const { session, browser: config } = args;
@@ -451,6 +461,7 @@ class BrowserDaemon {
 
       const daemon = await BrowserDaemon.initialize({
         session,
+        experiments: args.experiments,
         externallyManaged: true,
         browser,
         context,
@@ -792,15 +803,18 @@ async function main(): Promise<void> {
     config.browser.kind === "provider"
       ? await BrowserDaemon.connectToProvider({
           session: config.session,
+          experiments: config.experiments,
           browser: config.browser,
         })
       : config.browser.kind === "connect"
         ? await BrowserDaemon.connectToEndpoint({
             session: config.session,
+            experiments: config.experiments,
             browser: config.browser,
           })
         : await BrowserDaemon.launchBrowser({
             session: config.session,
+            experiments: config.experiments,
             browser: config.browser,
             workflow: config.workflow,
           });

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -1,0 +1,62 @@
+import {
+  readLibrettoConfig,
+  type LibrettoConfig,
+  writeLibrettoConfig,
+} from "./config.js";
+
+export const EXPERIMENTS = {
+  exampleExperiment: {
+    title: "Example experiment",
+    description: "Example experiment flag for validating experiment plumbing.",
+    defaultValue: false,
+  },
+} as const satisfies Record<
+  string,
+  {
+    title: string;
+    description: string;
+    defaultValue: boolean;
+  }
+>;
+
+export type ExperimentName = keyof typeof EXPERIMENTS;
+export type Experiments = Record<ExperimentName, boolean>;
+
+export function isExperimentName(name: string): name is ExperimentName {
+  return Object.hasOwn(EXPERIMENTS, name);
+}
+
+export function resolveExperiments(
+  config: LibrettoConfig = readLibrettoConfig(),
+): Experiments {
+  return Object.fromEntries(
+    Object.entries(EXPERIMENTS).map(([name, metadata]) => [
+      name,
+      config.experiments?.[name] ?? metadata.defaultValue,
+    ]),
+  ) as Experiments;
+}
+
+export function setExperimentEnabled(
+  name: string,
+  enabled: boolean,
+  configPath?: string,
+): Experiments {
+  if (!isExperimentName(name)) {
+    throw new Error(`Unknown experiment "${name}".`);
+  }
+
+  const config = readLibrettoConfig(configPath);
+  const writtenConfig = writeLibrettoConfig(
+    {
+      ...config,
+      experiments: {
+        ...config.experiments,
+        [name]: enabled,
+      },
+    },
+    configPath,
+  );
+
+  return resolveExperiments(writtenConfig);
+}

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -4,6 +4,7 @@ import { billingCommands } from "./commands/billing.js";
 import { browserCommands } from "./commands/browser.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
+import { experimentsCommand } from "./commands/experiments.js";
 import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
@@ -13,6 +14,7 @@ import { SimpleCLI } from "./framework/simple-cli.js";
 export const cliRoutes = {
   ...browserCommands,
   deploy: deployCommand,
+  experiments: experimentsCommand,
   ...executionCommands,
   ai: aiCommands,
   auth: authCommands,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -294,6 +294,8 @@ describe("basic CLI subprocess behavior", () => {
   test("prints usage for --help", async ({ librettoCli }) => {
     const result = await librettoCli("--help");
     expect(result.stdout).toContain("libretto <command>");
+    expect(result.stdout).toContain("experiments");
+    expect(result.stdout).toContain("List or update Libretto experiment flags");
     expect(result.stdout).toContain("readonly-exec");
     expect(result.stdout).toContain("snapshot");
     expect(result.stdout).toContain("Capture PNG + HTML");
@@ -380,6 +382,78 @@ describe("basic CLI subprocess behavior", () => {
       "libretto session-mode [mode] [options]",
     );
     expect(result.stderr).toBe("");
+  });
+
+  test("prints experiments help", async ({ librettoCli }) => {
+    const result = await librettoCli("help experiments");
+    expect(result.stdout).toContain("List or update Libretto experiment flags");
+    expect(result.stdout).toContain(
+      "libretto experiments [action] [experiment]",
+    );
+    expect(result.stdout).toContain("Action to apply");
+    expect(result.stdout).toContain("Experiment name");
+    expect(result.stderr).toBe("");
+  });
+
+  test("experiments lists registered experiments and updates state", async ({
+    librettoCli,
+  }) => {
+    const initial = await librettoCli("experiments");
+    expect(initial.stdout).toContain("Libretto experiments:");
+    expect(initial.stdout).toContain("exampleExperiment");
+    expect(initial.stdout).toContain("Example experiment");
+    expect(initial.stdout).toContain(
+      "Example experiment flag for validating experiment plumbing.",
+    );
+    expect(initial.stdout).toContain("disabled");
+    expect(initial.stderr).toBe("");
+
+    const enabled = await librettoCli("experiments enable exampleExperiment");
+    expect(enabled.stdout).toContain('Experiment "exampleExperiment" enabled.');
+    expect(enabled.stderr).toBe("");
+
+    const afterEnable = await librettoCli("experiments");
+    expect(afterEnable.stdout).toContain("exampleExperiment");
+    expect(afterEnable.stdout).toContain("enabled");
+    expect(afterEnable.stderr).toBe("");
+
+    const disabled = await librettoCli("experiments disable exampleExperiment");
+    expect(disabled.stdout).toContain(
+      'Experiment "exampleExperiment" disabled.',
+    );
+    expect(disabled.stderr).toBe("");
+
+    const afterDisable = await librettoCli("experiments");
+    expect(afterDisable.stdout).toContain("exampleExperiment");
+    expect(afterDisable.stdout).toContain("disabled");
+    expect(afterDisable.stderr).toBe("");
+  });
+
+  test("experiments rejects missing and unknown experiment names with usage", async ({
+    librettoCli,
+  }) => {
+    const missing = await librettoCli("experiments enable");
+    expect(missing.stderr).toContain("Missing experiment name for enable.");
+    expect(missing.stderr).toContain("libretto experiments");
+    expect(missing.stderr).toContain("libretto experiments enable <experiment>");
+    expect(missing.stderr).toContain("exampleExperiment");
+
+    const unknownAction = await librettoCli(
+      "experiments toggle exampleExperiment",
+    );
+    expect(unknownAction.stderr).toContain(
+      'Unknown experiments action "toggle".',
+    );
+    expect(unknownAction.stderr).toContain("libretto experiments");
+    expect(unknownAction.stderr).toContain(
+      "libretto experiments enable <experiment>",
+    );
+
+    const unknown = await librettoCli("experiments enable nopeExperiment");
+    expect(unknown.stderr).toContain('Unknown experiment "nopeExperiment".');
+    expect(unknown.stderr).toContain("libretto experiments");
+    expect(unknown.stderr).toContain("libretto experiments enable <experiment>");
+    expect(unknown.stderr).toContain("exampleExperiment");
   });
 
   test("fails unknown command with a clear error", async ({ librettoCli }) => {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -456,6 +456,28 @@ describe("basic CLI subprocess behavior", () => {
     expect(unknown.stderr).toContain("exampleExperiment");
   });
 
+  test("run does not expose enabled experiments to workflow context", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    await librettoCli("experiments enable exampleExperiment");
+    const integrationFilePath = await writeWorkflow(
+      "integration-experiment-context.mjs",
+      `
+export default workflow("main", async (ctx) => {
+  console.log("EXPERIMENTS_CONTEXT_TYPE", typeof ctx.experiments);
+});
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session experiment-context-test --headless`,
+    );
+    expect(result.stdout).toContain("EXPERIMENTS_CONTEXT_TYPE undefined");
+    expect(result.stdout).toContain("Integration completed.");
+    expect(result.stderr).toBe("");
+  }, 45_000);
+
   test("fails unknown command with a clear error", async ({ librettoCli }) => {
     const result = await librettoCli("nope-command");
     expect(result.stderr).toContain("Unknown command: nope-command");

--- a/specs/experiments-framework-spec.md
+++ b/specs/experiments-framework-spec.md
@@ -96,13 +96,13 @@ export const experimentsCommand = SimpleCLI.command({
   });
 ```
 
-- [ ] Add `packages/libretto/src/cli/commands/experiments.ts` with list, enable, and disable behavior.
-- [ ] Register `experiments: experimentsCommand` in `packages/libretto/src/cli/router.ts`.
-- [ ] Make `libretto experiments` print each registered experiment in stable registry order with its state and description.
-- [ ] Make enable/disable output deterministic success text, for example `Experiment "x" enabled.`.
-- [ ] Make missing or unknown experiment names fail with actionable usage that includes `libretto experiments` and `libretto experiments enable <experiment>`.
-- [ ] Add user-level CLI tests in `packages/libretto/test/basic.spec.ts` for help visibility, listing, enabling, disabling, and unknown experiment failure.
-- [ ] Verify `pnpm -s test --filter=libretto -- basic.spec.ts` passes.
+- [x] Add `packages/libretto/src/cli/commands/experiments.ts` with list, enable, and disable behavior.
+- [x] Register `experiments: experimentsCommand` in `packages/libretto/src/cli/router.ts`.
+- [x] Make `libretto experiments` print each registered experiment in stable registry order with its state and description.
+- [x] Make enable/disable output deterministic success text, for example `Experiment "x" enabled.`.
+- [x] Make missing or unknown experiment names fail with actionable usage that includes `libretto experiments` and `libretto experiments enable <experiment>`.
+- [x] Add user-level CLI tests in `packages/libretto/test/basic.spec.ts` for help visibility, listing, enabling, disabling, and unknown experiment failure.
+- [x] Verify `pnpm -s test --filter=libretto -- basic.spec.ts` passes.
 
 ### Phase 3: Add experiments middleware to CLI context
 

--- a/specs/experiments-framework-spec.md
+++ b/specs/experiments-framework-spec.md
@@ -1,0 +1,161 @@
+## Problem overview
+
+Libretto needs a small experiments framework for feature flags. Users should be able to see known experiments, enable or disable them in workspace state, and have CLI and daemon code receive the resolved flag values.
+
+## Solution overview
+
+Add a typed experiment registry and store per-workspace flag overrides in `.libretto/config.json`. Add a top-level `libretto experiments` command that lists registered experiments and supports `enable` and `disable` actions, then add CLI middleware that reads the resolved experiment map and passes the same snapshot into daemon startup config for new sessions.
+
+## Goals
+
+- Users can run `npx libretto experiments` to list every registered experiment and its enabled or disabled state.
+- Users can run `npx libretto experiments enable <experiment>` and `npx libretto experiments disable <experiment>` to persist a flag override in Libretto workspace state.
+- CLI command handlers can read a typed experiments object from middleware as `{ [experimentName]: boolean }`.
+- Daemon-backed flows receive the same resolved experiments object at daemon startup.
+
+## Non-goals
+
+- No migrations or backfills.
+- No remote experiment service, targeting rules, percentages, variants, or non-boolean values.
+- No live propagation of experiment changes into already-running daemon sessions.
+- No public documentation page beyond CLI help and command output in v1.
+
+## Future work
+
+No future work yet.
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto/src/cli/core/config.ts` — Defines the workspace `.libretto/config.json` schema and read/write helpers.
+- `packages/libretto/src/cli/core/context.ts` — Defines the Libretto config path and setup directory helpers.
+- `packages/libretto/src/cli/router.ts` — Registers top-level SimpleCLI command routes.
+- `packages/libretto/src/cli/commands/shared.ts` — Holds reusable CLI options and middleware; this is the natural place for `withExperiments()`.
+- `packages/libretto/src/cli/commands/browser.ts` — Starts daemon-backed `open` and `connect` sessions.
+- `packages/libretto/src/cli/commands/execution.ts` — Starts daemon-backed `run` workflows and should pass experiments into daemon config.
+- `packages/libretto/src/cli/core/daemon/config.ts` — Defines serialized daemon startup config.
+- `packages/libretto/src/cli/core/daemon/daemon.ts` — Reads daemon config and starts browser/workflow controllers.
+- `packages/libretto/src/cli/core/workflow-runner/runner.ts` — Builds the workflow context passed to user workflows.
+- `packages/libretto/src/shared/workflow/workflow.ts` — Defines the public `LibrettoWorkflowContext` type.
+- `packages/libretto/test/basic.spec.ts` — Existing user-level CLI help and behavior tests.
+- `docs/tests-guide.md` — Test guidance: prefer user-level CLI behavior assertions and avoid testing internal `.libretto` file structure.
+
+## Implementation
+
+### Phase 1: Add a typed experiment registry and config helpers
+
+Define the flag data model first so commands, middleware, and daemon config share one source of truth. Keep v1 to boolean flags and use a static registry so `libretto experiments` can list all known experiments deterministically.
+
+```ts
+export const EXPERIMENTS = {
+  exampleExperiment: {
+    title: "Example experiment",
+    description: "Short user-facing description",
+    defaultValue: false,
+  },
+} as const;
+
+export type ExperimentName = keyof typeof EXPERIMENTS;
+export type Experiments = Record<ExperimentName, boolean>;
+
+export function resolveExperiments(config = readLibrettoConfig()): Experiments {
+  return Object.fromEntries(
+    Object.entries(EXPERIMENTS).map(([name, metadata]) => [
+      name,
+      config.experiments?.[name] ?? metadata.defaultValue,
+    ]),
+  ) as Experiments;
+}
+```
+
+- [x] Add `packages/libretto/src/cli/core/experiments.ts` with `EXPERIMENTS`, `ExperimentName`, `Experiments`, `isExperimentName`, `resolveExperiments`, and `setExperimentEnabled`; registered experiment metadata includes title, description, and default value.
+- [x] Extend `LibrettoConfigSchema` in `packages/libretto/src/cli/core/config.ts` with optional `experiments: z.record(z.boolean()).optional()` while preserving passthrough behavior.
+- [x] Make `setExperimentEnabled` reject unknown experiment names using the static registry.
+- [x] Skip experiment-specific unit coverage for Phase 1 per user request.
+- [x] Verify `pnpm -s type-check --filter=libretto` passes.
+
+### Phase 2: Add the `libretto experiments` CLI command
+
+Add the user-facing command after the core helpers exist. Use one top-level command with optional action positionals so `libretto experiments` lists experiments directly instead of showing group help.
+
+```ts
+const experimentsInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("action", z.enum(["enable", "disable"]).optional()),
+    SimpleCLI.positional("experiment", z.string().optional()),
+  ],
+  named: {},
+});
+
+export const experimentsCommand = SimpleCLI.command({
+  description: "List or update Libretto experiment flags",
+})
+  .input(experimentsInput)
+  .handle(async ({ input }) => {
+    if (!input.action) return printExperiments(resolveExperiments());
+    setExperimentEnabled(input.experiment, input.action === "enable");
+  });
+```
+
+- [ ] Add `packages/libretto/src/cli/commands/experiments.ts` with list, enable, and disable behavior.
+- [ ] Register `experiments: experimentsCommand` in `packages/libretto/src/cli/router.ts`.
+- [ ] Make `libretto experiments` print each registered experiment in stable registry order with its state and description.
+- [ ] Make enable/disable output deterministic success text, for example `Experiment "x" enabled.`.
+- [ ] Make missing or unknown experiment names fail with actionable usage that includes `libretto experiments` and `libretto experiments enable <experiment>`.
+- [ ] Add user-level CLI tests in `packages/libretto/test/basic.spec.ts` for help visibility, listing, enabling, disabling, and unknown experiment failure.
+- [ ] Verify `pnpm -s test --filter=libretto -- basic.spec.ts` passes.
+
+### Phase 3: Add experiments middleware to CLI context
+
+Expose resolved flags through reusable middleware so future CLI handlers do not need to read config directly. Keep the middleware simple: read workspace config once for the command invocation and add `ctx.experiments`.
+
+```ts
+export type ExperimentsContext = {
+  experiments: Experiments;
+};
+
+export function withExperiments(): SimpleCLIMiddleware<
+  {},
+  {},
+  ExperimentsContext
+> {
+  return async ({ ctx }) => ({
+    ...ctx,
+    experiments: resolveExperiments(),
+  });
+}
+```
+
+- [ ] Add `ExperimentsContext` and `withExperiments()` to `packages/libretto/src/cli/commands/shared.ts`.
+- [ ] Apply `withExperiments()` to daemon-starting commands that need to forward flags, starting with `open`, `connect`, and `run`.
+- [ ] Thread the resolved `ctx.experiments` value through existing command-to-core calls with the smallest signature changes.
+- [ ] Add a focused test or type-level usage check that a command using the middleware can access `ctx.experiments` as a boolean map.
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+
+### Phase 4: Pass experiments into daemon startup and workflow context
+
+Serialize the resolved experiment snapshot in `DaemonConfig` so new daemon sessions receive the same flags as the CLI invocation that created them. Expose the snapshot on workflow context so daemon-hosted workflows can branch on flags.
+
+```ts
+export type DaemonConfig = {
+  session: string;
+  experiments: Experiments;
+  browser:
+    | DaemonBrowserLaunchConfig
+    | DaemonBrowserConnectConfig
+    | DaemonBrowserProviderConfig;
+  workflow?: DaemonWorkflowConfig;
+};
+
+const workflowContext: LibrettoWorkflowContext = {
+  session: this.config.session,
+  page: this.config.page,
+  experiments: this.config.experiments,
+};
+```
+
+- [ ] Add `experiments: Experiments` to `DaemonConfig` in `packages/libretto/src/cli/core/daemon/config.ts`.
+- [ ] Pass experiments in every `DaemonClient.spawn({ config })` call used by `open`, `connect`, provider-backed open, and `run`.
+- [ ] Store experiments on `BrowserDaemon` or `WorkflowControllerConfig`, whichever creates the smallest path to workflow context.
+- [ ] Extend `LibrettoWorkflowContext` in `packages/libretto/src/shared/workflow/workflow.ts` with `experiments: Experiments`.
+- [ ] Add a daemon/workflow test that enables a registered experiment, runs a workflow, and asserts the workflow can observe `ctx.experiments[experimentName] === true`.
+- [ ] Verify `pnpm -s test --filter=libretto` passes.

--- a/specs/experiments-framework-spec.md
+++ b/specs/experiments-framework-spec.md
@@ -131,9 +131,9 @@ export function withExperiments(): SimpleCLIMiddleware<
 - [x] Verify the real `open`, `connect`, and `run` handlers type-check when reading `ctx.experiments` as a boolean map.
 - [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
-### Phase 4: Pass experiments into daemon startup and workflow context
+### Phase 4: Pass experiments into daemon startup
 
-Serialize the resolved experiment snapshot in `DaemonConfig` so new daemon sessions receive the same flags as the CLI invocation that created them. Expose the snapshot on workflow context so daemon-hosted workflows can branch on flags.
+Serialize the resolved experiment snapshot in `DaemonConfig` so new daemon sessions receive the same flags as the CLI invocation that created them. Store the snapshot inside daemon internals for Libretto machinery only; do not expose experiments to user workflows.
 
 ```ts
 export type DaemonConfig = {
@@ -145,17 +145,11 @@ export type DaemonConfig = {
     | DaemonBrowserProviderConfig;
   workflow?: DaemonWorkflowConfig;
 };
-
-const workflowContext: LibrettoWorkflowContext = {
-  session: this.config.session,
-  page: this.config.page,
-  experiments: this.config.experiments,
-};
 ```
 
-- [ ] Add `experiments: Experiments` to `DaemonConfig` in `packages/libretto/src/cli/core/daemon/config.ts`.
-- [ ] Pass experiments in every `DaemonClient.spawn({ config })` call used by `open`, `connect`, provider-backed open, and `run`.
-- [ ] Store experiments on `BrowserDaemon` or `WorkflowControllerConfig`, whichever creates the smallest path to workflow context.
-- [ ] Extend `LibrettoWorkflowContext` in `packages/libretto/src/shared/workflow/workflow.ts` with `experiments: Experiments`.
-- [ ] Add a daemon/workflow test that enables a registered experiment, runs a workflow, and asserts the workflow can observe `ctx.experiments[experimentName] === true`.
-- [ ] Verify `pnpm -s test --filter=libretto` passes.
+- [x] Add `experiments: Experiments` to `DaemonConfig` in `packages/libretto/src/cli/core/daemon/config.ts`.
+- [x] Pass experiments in every `DaemonClient.spawn({ config })` call used by `open`, `connect`, provider-backed open, and `run`.
+- [x] Store experiments on `BrowserDaemon` for internal Libretto daemon machinery.
+- [x] Keep `LibrettoWorkflowContext` free of experiments; workflows should not receive feature flag internals.
+- [x] Add a daemon/workflow regression test that enables a registered experiment, runs a workflow, and asserts the workflow context does not expose experiments.
+- [x] Verify `pnpm -s test --filter=libretto` passes.

--- a/specs/experiments-framework-spec.md
+++ b/specs/experiments-framework-spec.md
@@ -125,11 +125,11 @@ export function withExperiments(): SimpleCLIMiddleware<
 }
 ```
 
-- [ ] Add `ExperimentsContext` and `withExperiments()` to `packages/libretto/src/cli/commands/shared.ts`.
-- [ ] Apply `withExperiments()` to daemon-starting commands that need to forward flags, starting with `open`, `connect`, and `run`.
-- [ ] Thread the resolved `ctx.experiments` value through existing command-to-core calls with the smallest signature changes.
-- [ ] Add a focused test or type-level usage check that a command using the middleware can access `ctx.experiments` as a boolean map.
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+- [x] Add `ExperimentsContext` and `withExperiments()` to `packages/libretto/src/cli/commands/shared.ts`.
+- [x] Apply `withExperiments()` to daemon-starting commands that need to forward flags, starting with `open`, `connect`, and `run`.
+- [x] Thread the resolved `ctx.experiments` value through existing command-to-core calls with the smallest signature changes.
+- [x] Verify the real `open`, `connect`, and `run` handlers type-check when reading `ctx.experiments` as a boolean map.
+- [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 4: Pass experiments into daemon startup and workflow context
 


### PR DESCRIPTION
## Summary
- add an experiment registry and `libretto experiments` commands for listing and inspecting experiments
- pass enabled experiments through browser and execution startup into daemon configuration
- document the experiments framework and add CLI coverage for experiment command behavior

## Testing
- not run locally; awaiting PR checks
