### PR TITLE
Add compact snapshot exec diff experiment

### DIFF
--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -79,6 +79,7 @@
     "glimpseui": "^0.5.1",
     "google-auth-library": "^10.6.1",
     "openai": "^6.29.0",
+    "outdent": "^0.8.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -28,6 +28,7 @@ import {
 import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
+import { renderSnapshotDiff } from "../../shared/snapshot/diff-snapshots.js";
 import { resolveProviderName } from "../core/providers/index.js";
 import { getAbsoluteIntegrationPath } from "../core/workflow-runtime.js";
 import {
@@ -36,6 +37,7 @@ import {
 } from "../core/exec-compiler.js";
 import {
   DaemonClient,
+  type DaemonExecSuccess,
   type DaemonExecResult,
   type DaemonToCliApi,
 } from "../core/daemon/ipc.js";
@@ -81,6 +83,16 @@ function writeDaemonExecOutput(output?: { stdout: string; stderr: string }) {
   if (output?.stderr) {
     process.stderr.write(output.stderr);
   }
+}
+
+function writeDaemonSnapshotDiff(
+  snapshotDiff: DaemonExecSuccess["snapshotDiff"],
+) {
+  if (!snapshotDiff) return;
+  const renderedDiff = renderSnapshotDiff(snapshotDiff);
+  if (!renderedDiff) return;
+  console.log("Page changes:");
+  console.log(renderedDiff);
 }
 
 async function execViaDaemon(
@@ -131,7 +143,7 @@ async function execViaDaemon(
     throw new Error(response.message);
   }
 
-  const { result, output } = response.data;
+  const { result, output, snapshotDiff } = response.data;
   writeDaemonExecOutput(output);
 
   logger.info(`${mode}-success`, {
@@ -146,6 +158,7 @@ async function execViaDaemon(
   } else {
     console.log("Executed successfully");
   }
+  writeDaemonSnapshotDiff(snapshotDiff);
 }
 
 async function execViaCdpFallback(

--- a/packages/libretto/src/cli/commands/experiments.ts
+++ b/packages/libretto/src/cli/commands/experiments.ts
@@ -54,7 +54,7 @@ function printExperiments(experiments: Experiments): void {
     console.log(
       `- ${name}: ${experiments[name] ? "enabled" : "disabled"} — ${metadata.title}`,
     );
-    console.log(`  ${metadata.description}`);
+    console.log(`  ${metadata.oneSentenceDescription}`);
   }
 }
 

--- a/packages/libretto/src/cli/commands/experiments.ts
+++ b/packages/libretto/src/cli/commands/experiments.ts
@@ -15,6 +15,7 @@ const experimentNames = Object.keys(EXPERIMENTS) as ExperimentName[];
 const experimentsUsage = [
   "Usage:",
   `  ${librettoCommand("experiments")}`,
+  `  ${librettoCommand("experiments describe <experiment>")}`,
   `  ${librettoCommand("experiments enable <experiment>")}`,
   `  ${librettoCommand("experiments disable <experiment>")}`,
 ].join("\n");
@@ -57,6 +58,13 @@ function printExperiments(experiments: Experiments): void {
   }
 }
 
+function printExperimentDescription(name: ExperimentName): void {
+  const metadata = EXPERIMENTS[name];
+  console.log(`${metadata.title} (${name})`);
+  console.log("");
+  console.log(metadata.docs);
+}
+
 export const experimentsCommand = SimpleCLI.command({
   description: "List or update Libretto experiment flags",
 })
@@ -67,7 +75,11 @@ export const experimentsCommand = SimpleCLI.command({
       return;
     }
 
-    if (input.action !== "enable" && input.action !== "disable") {
+    if (
+      input.action !== "describe" &&
+      input.action !== "enable" &&
+      input.action !== "disable"
+    ) {
       throw experimentUsageError(`Unknown experiments action "${input.action}".`);
     }
 
@@ -79,6 +91,11 @@ export const experimentsCommand = SimpleCLI.command({
 
     if (!isExperimentName(input.experiment)) {
       throw experimentUsageError(`Unknown experiment "${input.experiment}".`);
+    }
+
+    if (input.action === "describe") {
+      printExperimentDescription(input.experiment);
+      return;
     }
 
     setExperimentEnabled(input.experiment, input.action === "enable");

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -8,12 +8,18 @@ import {
   type ScreenshotPair,
 } from "../core/snapshot-analyzer.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
-import { pageOption, sessionOption, withRequiredSession } from "./shared.js";
+import {
+  pageOption,
+  sessionOption,
+  withExperiments,
+  withRequiredSession,
+} from "./shared.js";
 import { runApiInterpret } from "../core/api-snapshot-analyzer.js";
 import { readSnapshotModel } from "../core/config.js";
 import { resolveSnapshotApiModelOrThrow } from "../core/ai-model.js";
 import { DaemonClient } from "../core/daemon/ipc.js";
 import { librettoCommand } from "../../shared/package-manager.js";
+import { renderSnapshot } from "../../shared/snapshot/render-snapshot.js";
 
 export const FALLBACK_SNAPSHOT_VIEWPORT = { width: 1280, height: 800 } as const;
 
@@ -124,6 +130,9 @@ async function captureSnapshot(
   } finally {
     client.destroy();
   }
+  if (!("htmlPath" in snapshotResult)) {
+    throw new Error("Daemon returned a compact snapshot for a legacy request.");
+  }
   const { pngPath, htmlPath, snapshotRunId, pageUrl, title } = snapshotResult;
 
   // condenseDom runs in the CLI process, not the daemon.
@@ -154,9 +163,16 @@ async function runSnapshot(
   session: string,
   logger: LoggerApi,
   pageId: string | undefined,
-  objective: string,
-  context: string,
+  objective: string | undefined,
+  context: string | undefined,
 ): Promise<void> {
+  if (objective === undefined) {
+    throw new Error("Missing required option --objective.");
+  }
+  if (context === undefined) {
+    throw new Error("Missing required option --context.");
+  }
+
   const normalizedObjective = objective.trim();
   const normalizedContext = context.trim();
 
@@ -195,13 +211,61 @@ async function runSnapshot(
   await runApiInterpret(interpretArgs, logger, snapshotModel);
 }
 
+async function runCompactSnapshot(
+  args: {
+    session: string;
+    daemonSocketPath?: string;
+    logger: LoggerApi;
+    pageId?: string;
+    ref?: string;
+  },
+): Promise<void> {
+  if (!args.daemonSocketPath) {
+    throw new Error(
+      `Session "${args.session}" has no daemon socket. The browser daemon may have crashed. ` +
+        `Close and reopen the session: ${librettoCommand(`close --session ${args.session}`)}`,
+    );
+  }
+
+  args.logger.info("compact-snapshot-via-daemon", {
+    session: args.session,
+    pageId: args.pageId,
+    ref: args.ref,
+  });
+
+  const client = await DaemonClient.connect(args.daemonSocketPath);
+  let result: Awaited<ReturnType<DaemonClient["snapshot"]>>;
+  try {
+    result = await client.snapshot({
+      mode: "compact",
+      pageId: args.pageId,
+      useCachedSnapshot: args.ref !== undefined,
+    });
+  } finally {
+    client.destroy();
+  }
+  if (!("mode" in result) || result.mode !== "compact") {
+    throw new Error("Daemon returned a legacy snapshot for a compact request.");
+  }
+
+  console.log(`Screenshot at ${result.pngPath}`);
+  console.log(renderSnapshot(result.snapshot, args.ref));
+  console.log(
+    `Hint: Use ${librettoCommand(`snapshot <ref> --session ${args.session}`)} to inspect a subtree.`,
+  );
+}
+
 export const snapshotInput = SimpleCLI.input({
-  positionals: [],
+  positionals: [
+    SimpleCLI.positional("ref", z.string().optional(), {
+      help: "Optional element ref to scope output to that subtree (for example, l16 or e16)",
+    }),
+  ],
   named: {
     session: sessionOption(),
     page: pageOption(),
-    objective: SimpleCLI.option(z.string()),
-    context: SimpleCLI.option(z.string()),
+    objective: SimpleCLI.option(z.string().optional()),
+    context: SimpleCLI.option(z.string().optional()),
   },
 });
 
@@ -210,7 +274,25 @@ export const snapshotCommand = SimpleCLI.command({
 })
   .input(snapshotInput)
   .use(withRequiredSession())
+  .use(withExperiments())
   .handle(async ({ input, ctx }) => {
+    if (ctx.experiments.compactSnapshotFormat) {
+      await runCompactSnapshot({
+        session: ctx.session,
+        daemonSocketPath: ctx.sessionState.daemonSocketPath,
+        logger: ctx.logger,
+        pageId: input.page,
+        ref: input.ref,
+      });
+      return;
+    }
+
+    if (input.ref) {
+      throw new Error(
+        `Snapshot refs require the compactSnapshotFormat experiment. Enable it with ${librettoCommand("experiments enable compactSnapshotFormat")}.`,
+      );
+    }
+
     await runSnapshot(
       ctx.session,
       ctx.logger,

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -762,19 +762,29 @@ class BrowserDaemon {
           args.visualize,
         );
 
-        const waitResult = await waitForPageStable(page);
-        if (!waitResult.ok) {
-          this.logger.warn("compact-exec-stability-wait-incomplete", {
+        try {
+          const waitResult = await waitForPageStable(page);
+          if (!waitResult.ok) {
+            this.logger.warn("compact-exec-stability-wait-incomplete", {
+              session: this.session,
+              pageId: args.pageId,
+              diagnostics: waitResult.diagnostics,
+            });
+          }
+
+          const after = await snapshot(page);
+          const snapshotDiff = diffSnapshots(before, after);
+          this.latestCompactSnapshotByPage.set(page, after);
+          return { ...result, snapshotDiff };
+        } catch (error) {
+          this.latestCompactSnapshotByPage.delete(page);
+          this.logger.warn("compact-exec-diff-failed", {
             session: this.session,
             pageId: args.pageId,
-            diagnostics: waitResult.diagnostics,
+            error: error instanceof Error ? error.message : String(error),
           });
+          return result;
         }
-
-        const after = await snapshot(page);
-        const snapshotDiff = diffSnapshots(before, after);
-        this.latestCompactSnapshotByPage.set(page, after);
-        return { ...result, snapshotDiff };
       });
       return { ok: true, data };
     } catch (error) {

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -63,8 +63,9 @@ import {
 } from "../browser.js";
 import { handlePages } from "./pages.js";
 import { handleExec, handleReadonlyExec } from "./exec.js";
-import { handleSnapshot } from "./snapshot.js";
+import { handleCompactSnapshot, handleSnapshot } from "./snapshot.js";
 import { librettoCommand } from "../../../shared/package-manager.js";
+import type { Snapshot } from "../../../shared/snapshot/types.js";
 import {
   type DaemonConfig,
   type DaemonBrowserLaunchConfig,
@@ -158,6 +159,7 @@ class BrowserDaemon {
   private readonly connectedClis = new Set<IpcPeer<DaemonToCliApi>>();
   private workflowController: WorkflowController | undefined;
   private shutdownPromise: Promise<DaemonCloseResult> | undefined;
+  private latestCompactSnapshot: Snapshot | null = null;
 
   private constructor(
     private readonly session: string,
@@ -613,15 +615,7 @@ class BrowserDaemon {
         this.withRequestTimeout(() => handlePages(this.pageById, this.page)),
       exec: (args) => this.runExec(args),
       readonlyExec: (args) => this.runReadonlyExec(args),
-      snapshot: (args) =>
-        this.withRequestTimeout(() =>
-          handleSnapshot(
-            this.resolveTargetPage(args.pageId),
-            this.session,
-            this.logger,
-            args.pageId,
-          ),
-        ),
+      snapshot: (args) => this.runSnapshot(args),
       getWorkflowStatus: () => this.getWorkflowStatus(),
       resumeWorkflow: () => this.resumeWorkflow(),
       close: () =>
@@ -629,6 +623,44 @@ class BrowserDaemon {
           keepIpcClientsAlive: true,
         }),
     };
+  }
+
+  private async runSnapshot(
+    args: Parameters<CliToDaemonApi["snapshot"]>[0],
+  ): Promise<ReturnType<CliToDaemonApi["snapshot"]>> {
+    if (args.mode === "compact") {
+      if (!this.experiments.compactSnapshotFormat) {
+        throw new Error(
+          `The compactSnapshotFormat experiment is not enabled for session "${this.session}". ` +
+            `Close and reopen the session after running ${librettoCommand("experiments enable compactSnapshotFormat")}.`,
+        );
+      }
+      const result = await this.withRequestTimeout(() =>
+        handleCompactSnapshot(
+          this.resolveTargetPage(args.pageId),
+          this.session,
+          this.logger,
+          {
+            pageId: args.pageId,
+            cachedSnapshot: this.latestCompactSnapshot,
+            useCachedSnapshot: args.useCachedSnapshot,
+          },
+        ),
+      );
+      if (!args.useCachedSnapshot) {
+        this.latestCompactSnapshot = result.snapshot;
+      }
+      return result;
+    }
+
+    return this.withRequestTimeout(() =>
+      handleSnapshot(
+        this.resolveTargetPage(args.pageId),
+        this.session,
+        this.logger,
+        args.pageId,
+      ),
+    );
   }
 
   private async withRequestTimeout<T>(

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -166,7 +166,7 @@ class BrowserDaemon {
   private readonly connectedClis = new Set<IpcPeer<DaemonToCliApi>>();
   private workflowController: WorkflowController | undefined;
   private shutdownPromise: Promise<DaemonCloseResult> | undefined;
-  private latestCompactSnapshot: Snapshot | null = null;
+  private readonly latestCompactSnapshotByPage = new WeakMap<Page, Snapshot>();
 
   private constructor(
     private readonly session: string,
@@ -666,20 +666,21 @@ class BrowserDaemon {
             `Close and reopen the session after running ${librettoCommand("experiments enable compactSnapshotFormat")}.`,
         );
       }
+      const targetPage = this.resolveTargetPage(args.pageId);
       const result = await this.withRequestTimeout(() =>
         handleCompactSnapshot(
-          this.resolveTargetPage(args.pageId),
+          targetPage,
           this.session,
           this.logger,
           {
             pageId: args.pageId,
-            cachedSnapshot: this.latestCompactSnapshot,
+            cachedSnapshot: this.latestCompactSnapshotByPage.get(targetPage),
             useCachedSnapshot: args.useCachedSnapshot,
           },
         ),
       );
       if (!args.useCachedSnapshot) {
-        this.latestCompactSnapshot = result.snapshot;
+        this.latestCompactSnapshotByPage.set(targetPage, result.snapshot);
       }
       return result;
     }
@@ -744,12 +745,15 @@ class BrowserDaemon {
   private async runCompactExec(
     args: Parameters<CliToDaemonApi["exec"]>[0],
   ): Promise<DaemonExecResult> {
+    let targetPage: Page | undefined;
     try {
-      const targetPage = this.resolveTargetPage(args.pageId);
+      targetPage = this.resolveTargetPage(args.pageId);
+      const page = targetPage;
       const data = await this.withRequestTimeout(async () => {
-        const before = this.latestCompactSnapshot ?? (await snapshot(targetPage));
+        const before =
+          this.latestCompactSnapshotByPage.get(page) ?? (await snapshot(page));
         const result = await handleExec(
-          targetPage,
+          page,
           args.code,
           this.context,
           this.browser,
@@ -758,7 +762,7 @@ class BrowserDaemon {
           args.visualize,
         );
 
-        const waitResult = await waitForPageStable(targetPage);
+        const waitResult = await waitForPageStable(page);
         if (!waitResult.ok) {
           this.logger.warn("compact-exec-stability-wait-incomplete", {
             session: this.session,
@@ -767,14 +771,14 @@ class BrowserDaemon {
           });
         }
 
-        const after = await snapshot(targetPage);
+        const after = await snapshot(page);
         const snapshotDiff = diffSnapshots(before, after);
-        this.latestCompactSnapshot = after;
+        this.latestCompactSnapshotByPage.set(page, after);
         return { ...result, snapshotDiff };
       });
       return { ok: true, data };
     } catch (error) {
-      this.latestCompactSnapshot = null;
+      if (targetPage) this.latestCompactSnapshotByPage.delete(targetPage);
       return this.createExecErrorResult(error);
     }
   }

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -66,6 +66,9 @@ import { handleExec, handleReadonlyExec } from "./exec.js";
 import { handleCompactSnapshot, handleSnapshot } from "./snapshot.js";
 import { librettoCommand } from "../../../shared/package-manager.js";
 import type { Snapshot } from "../../../shared/snapshot/types.js";
+import { snapshot } from "../../../shared/snapshot/capture-snapshot.js";
+import { diffSnapshots } from "../../../shared/snapshot/diff-snapshots.js";
+import { waitForPageStable } from "../../../shared/snapshot/wait-for-page-stable.js";
 import {
   type DaemonConfig,
   type DaemonBrowserLaunchConfig,
@@ -688,6 +691,10 @@ class BrowserDaemon {
   private async runExec(
     args: Parameters<CliToDaemonApi["exec"]>[0],
   ): Promise<DaemonExecResult> {
+    if (this.experiments.compactSnapshotFormat) {
+      return this.runCompactExec(args);
+    }
+
     try {
       const data = await this.withRequestTimeout(() =>
         handleExec(
@@ -702,6 +709,44 @@ class BrowserDaemon {
       );
       return { ok: true, data };
     } catch (error) {
+      return this.createExecErrorResult(error);
+    }
+  }
+
+  private async runCompactExec(
+    args: Parameters<CliToDaemonApi["exec"]>[0],
+  ): Promise<DaemonExecResult> {
+    try {
+      const targetPage = this.resolveTargetPage(args.pageId);
+      const data = await this.withRequestTimeout(async () => {
+        const before = this.latestCompactSnapshot ?? (await snapshot(targetPage));
+        const result = await handleExec(
+          targetPage,
+          args.code,
+          this.context,
+          this.browser,
+          this.execState,
+          this.session,
+          args.visualize,
+        );
+
+        const waitResult = await waitForPageStable(targetPage);
+        if (!waitResult.ok) {
+          this.logger.warn("compact-exec-stability-wait-incomplete", {
+            session: this.session,
+            pageId: args.pageId,
+            diagnostics: waitResult.diagnostics,
+          });
+        }
+
+        const after = await snapshot(targetPage);
+        const snapshotDiff = diffSnapshots(before, after);
+        this.latestCompactSnapshot = after;
+        return { ...result, snapshotDiff };
+      });
+      return { ok: true, data };
+    } catch (error) {
+      this.latestCompactSnapshot = null;
       return this.createExecErrorResult(error);
     }
   }

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -68,7 +68,11 @@ import { librettoCommand } from "../../../shared/package-manager.js";
 import type { Snapshot } from "../../../shared/snapshot/types.js";
 import { snapshot } from "../../../shared/snapshot/capture-snapshot.js";
 import { diffSnapshots } from "../../../shared/snapshot/diff-snapshots.js";
-import { waitForPageStable } from "../../../shared/snapshot/wait-for-page-stable.js";
+import {
+  installPageStabilityWaiter,
+  preparePageStabilityWait,
+  waitForPageStable,
+} from "../../../shared/snapshot/wait-for-page-stable.js";
 import {
   type DaemonConfig,
   type DaemonBrowserLaunchConfig,
@@ -188,6 +192,16 @@ class BrowserDaemon {
     return id;
   }
 
+  private async installCompactSnapshotWaiter(page: Page): Promise<void> {
+    const result = await preparePageStabilityWait(page, { timeoutMs: 1_000 });
+    if (!result.ok) {
+      this.logger.warn("compact-snapshot-waiter-install-incomplete", {
+        session: this.session,
+        diagnostics: result.diagnostics,
+      });
+    }
+  }
+
   // ── Shared initialization ──────────────────────────────────────────
 
   /**
@@ -257,6 +271,10 @@ class BrowserDaemon {
       });
     }
 
+    if (experiments.compactSnapshotFormat) {
+      await context.addInitScript(installPageStabilityWaiter);
+    }
+
     // IPC server — typed handlers are attached per client connection so one
     // daemon lifetime can serve multiple CLI invocations.
     const socketPath = getDaemonSocketPath(session);
@@ -277,9 +295,19 @@ class BrowserDaemon {
       wrapPageForActionLogging(p, session);
       daemon.trackPage(p);
     }
+    if (experiments.compactSnapshotFormat) {
+      await Promise.all(
+        initialPages.map((initialPage) =>
+          daemon.installCompactSnapshotWaiter(initialPage),
+        ),
+      );
+    }
     context.on("page", (newPage) => {
       wrapPageForActionLogging(newPage, session);
       daemon.trackPage(newPage);
+      if (experiments.compactSnapshotFormat) {
+        void daemon.installCompactSnapshotWaiter(newPage);
+      }
     });
 
     // Navigate after telemetry is installed (so we capture the initial

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { createIpcPeer, type IpcPeer } from "../../../shared/ipc/ipc.js";
 import { connectToIpcSocket } from "../../../shared/ipc/socket-transport.js";
 import type { LoggerApi } from "../../../shared/logger/index.js";
+import type { Snapshot } from "../../../shared/snapshot/types.js";
 import { REPO_ROOT } from "../context.js";
 import type { WorkflowStatus } from "../workflow-runner/runner.js";
 import type { DaemonConfig } from "./config.js";
@@ -23,20 +24,32 @@ export type DaemonExecArgs = {
 
 export type DaemonReadonlyExecArgs = { code: string; pageId?: string };
 
-export type DaemonSnapshotArgs = { pageId?: string };
+export type DaemonSnapshotArgs =
+  | { mode?: "legacy"; pageId?: string; useCachedSnapshot?: false }
+  | { mode: "compact"; pageId?: string; useCachedSnapshot?: boolean };
 
 export type DaemonExecSuccess = {
   result: unknown;
   output?: DaemonExecOutput;
 };
 
-export type DaemonSnapshotResult = {
+export type DaemonLegacySnapshotResult = {
   pngPath: string;
   htmlPath: string;
   snapshotRunId: string;
   pageUrl: string;
   title: string;
 };
+
+export type DaemonCompactSnapshotResult = {
+  mode: "compact";
+  pngPath: string;
+  snapshot: Snapshot;
+};
+
+export type DaemonSnapshotResult =
+  | DaemonLegacySnapshotResult
+  | DaemonCompactSnapshotResult;
 
 export type DaemonCloseResult = { replayUrl?: string };
 

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { createIpcPeer, type IpcPeer } from "../../../shared/ipc/ipc.js";
 import { connectToIpcSocket } from "../../../shared/ipc/socket-transport.js";
 import type { LoggerApi } from "../../../shared/logger/index.js";
+import type { SnapshotDiff } from "../../../shared/snapshot/diff-snapshots.js";
 import type { Snapshot } from "../../../shared/snapshot/types.js";
 import { REPO_ROOT } from "../context.js";
 import type { WorkflowStatus } from "../workflow-runner/runner.js";
@@ -31,6 +32,7 @@ export type DaemonSnapshotArgs =
 export type DaemonExecSuccess = {
   result: unknown;
   output?: DaemonExecOutput;
+  snapshotDiff?: SnapshotDiff;
 };
 
 export type DaemonLegacySnapshotResult = {

--- a/packages/libretto/src/cli/core/daemon/snapshot.ts
+++ b/packages/libretto/src/cli/core/daemon/snapshot.ts
@@ -3,6 +3,12 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import type { LoggerApi } from "../../../shared/logger/index.js";
 import { getSessionSnapshotRunDir } from "../context.js";
 import {
+  snapshot,
+  type Snapshot,
+} from "../../../shared/snapshot/capture-snapshot.js";
+import { waitForPageStable } from "../../../shared/snapshot/wait-for-page-stable.js";
+import { librettoCommand } from "../../../shared/package-manager.js";
+import {
   resolveSnapshotViewport,
   readSnapshotViewportMetrics,
   shouldForceSnapshotViewport,
@@ -11,6 +17,13 @@ import {
 } from "../../commands/snapshot.js";
 
 const RENDER_SETTLE_TIMEOUT_MS = 10_000;
+
+type SnapshotScreenshot = {
+  pngPath: string;
+  snapshotRunId: string;
+  pageUrl: string;
+  title: string;
+};
 
 export async function handleSnapshot(
   targetPage: Page,
@@ -24,6 +37,92 @@ export async function handleSnapshot(
   pageUrl: string;
   title: string;
 }> {
+  const screenshot = await captureSnapshotScreenshot(
+    targetPage,
+    session,
+    logger,
+    pageId,
+  );
+  const htmlPath = `${getSessionSnapshotRunDir(
+    session,
+    screenshot.snapshotRunId,
+  )}/page.html`;
+
+  // Capture HTML content.
+  const htmlContent = await targetPage.content();
+  writeFileSync(htmlPath, htmlContent);
+
+  logger.info("screenshot-success", {
+    session,
+    pageUrl: screenshot.pageUrl,
+    title: screenshot.title,
+    pngPath: screenshot.pngPath,
+    htmlPath,
+    snapshotRunId: screenshot.snapshotRunId,
+  });
+
+  return {
+    ...screenshot,
+    htmlPath,
+  };
+}
+
+export async function handleCompactSnapshot(
+  targetPage: Page,
+  session: string,
+  logger: LoggerApi,
+  options: {
+    pageId?: string;
+    cachedSnapshot?: Snapshot | null;
+    useCachedSnapshot?: boolean;
+  } = {},
+): Promise<{
+  mode: "compact";
+  pngPath: string;
+  snapshot: Snapshot;
+}> {
+  const screenshot = await captureSnapshotScreenshot(
+    targetPage,
+    session,
+    logger,
+    options.pageId,
+  );
+
+  if (options.useCachedSnapshot) {
+    if (!options.cachedSnapshot) {
+      throw new Error(
+        `No compact snapshot is cached for session "${session}". Run ${librettoCommand(`snapshot --session ${session}`)} first.`,
+      );
+    }
+    return {
+      mode: "compact",
+      pngPath: screenshot.pngPath,
+      snapshot: options.cachedSnapshot,
+    };
+  }
+
+  const waitResult = await waitForPageStable(targetPage);
+  if (!waitResult.ok) {
+    logger.warn("compact-snapshot-stability-wait-incomplete", {
+      session,
+      pageId: options.pageId,
+      diagnostics: waitResult.diagnostics,
+    });
+  }
+
+  return {
+    mode: "compact",
+    pngPath: screenshot.pngPath,
+    snapshot: await snapshot(targetPage),
+  };
+}
+
+async function captureSnapshotScreenshot(
+  targetPage: Page,
+  session: string,
+  logger: LoggerApi,
+  pageId?: string,
+): Promise<SnapshotScreenshot> {
   const snapshotRunId = `snapshot-${Date.now()}`;
   const snapshotRunDir = getSessionSnapshotRunDir(session, snapshotRunId);
   mkdirSync(snapshotRunDir, { recursive: true });
@@ -45,7 +144,6 @@ export async function handleSnapshot(
   }
 
   const pngPath = `${snapshotRunDir}/page.png`;
-  const htmlPath = `${snapshotRunDir}/page.html`;
 
   // Wait for network to settle before capturing.
   await Promise.race([
@@ -91,22 +189,16 @@ export async function handleSnapshot(
     await targetPage.screenshot({ path: pngPath });
   }
 
-  // Capture HTML content.
-  const htmlContent = await targetPage.content();
-  writeFileSync(htmlPath, htmlContent);
-
-  logger.info("screenshot-success", {
+  logger.info("screenshot-captured", {
     session,
     pageUrl,
     title,
     pngPath,
-    htmlPath,
     snapshotRunId,
   });
 
   return {
     pngPath,
-    htmlPath,
     snapshotRunId,
     pageUrl: pageUrl ?? "",
     title: title ?? "",

--- a/packages/libretto/src/cli/core/daemon/snapshot.ts
+++ b/packages/libretto/src/cli/core/daemon/snapshot.ts
@@ -81,19 +81,18 @@ export async function handleCompactSnapshot(
   pngPath: string;
   snapshot: Snapshot;
 }> {
-  const screenshot = await captureSnapshotScreenshot(
-    targetPage,
-    session,
-    logger,
-    options.pageId,
-  );
-
   if (options.useCachedSnapshot) {
     if (!options.cachedSnapshot) {
       throw new Error(
         `No compact snapshot is cached for session "${session}". Run ${librettoCommand(`snapshot --session ${session}`)} first.`,
       );
     }
+    const screenshot = await captureSnapshotScreenshot(
+      targetPage,
+      session,
+      logger,
+      options.pageId,
+    );
     return {
       mode: "compact",
       pngPath: screenshot.pngPath,
@@ -109,6 +108,13 @@ export async function handleCompactSnapshot(
       diagnostics: waitResult.diagnostics,
     });
   }
+
+  const screenshot = await captureSnapshotScreenshot(
+    targetPage,
+    session,
+    logger,
+    options.pageId,
+  );
 
   return {
     mode: "compact",

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -8,12 +8,42 @@ export const EXPERIMENTS = {
   exampleExperiment: {
     title: "Example experiment",
     description: "Example experiment flag for validating experiment plumbing.",
+    docs: "Example experiment flag for validating experiment plumbing.",
     defaultValue: false,
   },
   compactSnapshotFormat: {
     title: "Compact snapshot format",
     description:
       "Use compact accessibility snapshots and exec page-change diffs without an AI sub-agent.",
+    docs: [
+      "Compact snapshot format replaces the default snapshot analysis path for daemon-backed sessions while enabled.",
+      "",
+      "How to enable it:",
+      "  1. libretto experiments enable compactSnapshotFormat",
+      "  2. Open a new daemon-backed session after enabling the experiment.",
+      "     Existing sessions keep the experiment settings they started with.",
+      "",
+      "Capture a full compact snapshot:",
+      "  libretto snapshot --session <name>",
+      "",
+      "Output includes:",
+      "  - Screenshot at <path>",
+      "  - A compact accessibility tree with page/frame tags, headings, semantic role tags, and refs such as l16",
+      "  - A hint for scoping follow-up snapshots to a subtree",
+      "",
+      "Inspect a cached subtree:",
+      "  libretto snapshot <ref> --session <name>",
+      "",
+      "Subtree snapshots reuse the latest full compact snapshot cached in the daemon. They capture a fresh screenshot but do not recapture the snapshot tree. Run an unscoped snapshot first; otherwise Libretto reports an error telling you to run libretto snapshot --session <name>.",
+      "",
+      "Default behavior while disabled:",
+      "  libretto snapshot still requires --objective and --context and uses the PNG + HTML + AI analysis path.",
+      "",
+      "Notes:",
+      "  - The experiment is internal CLI/daemon machinery and is not exposed to workflow code.",
+      "  - Use ref forms printed in the tree, such as l16. Numeric-suffix aliases such as e16 also match l16.",
+      "  - The daemon waits for page stability before full compact snapshot capture; timeout diagnostics are logged as warnings rather than failing the command.",
+    ].join("\n"),
     defaultValue: false,
   },
 } as const satisfies Record<
@@ -21,6 +51,7 @@ export const EXPERIMENTS = {
   {
     title: string;
     description: string;
+    docs?: string;
     defaultValue: boolean;
   }
 >;

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -10,6 +10,12 @@ export const EXPERIMENTS = {
     description: "Example experiment flag for validating experiment plumbing.",
     defaultValue: false,
   },
+  compactSnapshotFormat: {
+    title: "Compact snapshot format",
+    description:
+      "Use compact accessibility snapshots and exec page-change diffs without an AI sub-agent.",
+    defaultValue: false,
+  },
 } as const satisfies Record<
   string,
   {

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -7,13 +7,14 @@ import {
 export const EXPERIMENTS = {
   exampleExperiment: {
     title: "Example experiment",
-    description: "Example experiment flag for validating experiment plumbing.",
+    oneSentenceDescription:
+      "Example experiment flag for validating experiment plumbing.",
     docs: "Example experiment flag for validating experiment plumbing.",
     defaultValue: false,
   },
   compactSnapshotFormat: {
     title: "Compact snapshot format",
-    description:
+    oneSentenceDescription:
       "Use compact accessibility snapshots and exec page-change diffs without an AI sub-agent.",
     docs: [
       "Compact snapshot format replaces the default snapshot analysis path for daemon-backed sessions while enabled.",
@@ -50,7 +51,7 @@ export const EXPERIMENTS = {
   string,
   {
     title: string;
-    description: string;
+    oneSentenceDescription: string;
     docs?: string;
     defaultValue: boolean;
   }

--- a/packages/libretto/src/shared/snapshot/capture-snapshot.ts
+++ b/packages/libretto/src/shared/snapshot/capture-snapshot.ts
@@ -1,0 +1,615 @@
+import type { CDPSession, Page } from "playwright";
+import type { Snapshot, SnapshotNode, SnapshotPrimitive } from "./types.js";
+
+export type {
+  Snapshot,
+  SnapshotAvailableFrame,
+  SnapshotFrame,
+  SnapshotNode,
+  SnapshotPrimitive,
+  SnapshotUnavailableFrame,
+} from "./types.js";
+
+const MAX_ATTRIBUTE_NODE_LOOKUPS = 300;
+
+const REFS_BY_ROLE = new Set([
+  "RootWebArea",
+  "main",
+  "navigation",
+  "banner",
+  "contentinfo",
+  "form",
+  "search",
+  "article",
+  "section",
+  "region",
+  "heading",
+  "button",
+  "link",
+  "textbox",
+  "textField",
+  "checkbox",
+  "radio",
+  "switch",
+  "combobox",
+  "listbox",
+  "menuitem",
+  "tab",
+  "slider",
+]);
+
+const INTERESTING_ATTRIBUTES = new Set([
+  "data-testid",
+  "data-test",
+  "data-qa",
+  "data-cy",
+  "id",
+  "name",
+  "type",
+  "placeholder",
+  "href",
+  "src",
+  "aria-label",
+  "aria-expanded",
+  "aria-pressed",
+  "aria-selected",
+  "aria-checked",
+  "role",
+  "title",
+  "alt",
+  "onclick",
+  "tabindex",
+]);
+
+const STATE_PROPERTY_NAMES = [
+  "level",
+  "disabled",
+  "checked",
+  "expanded",
+  "selected",
+  "pressed",
+  "focused",
+  "required",
+  "invalid",
+  "readonly",
+  "multiline",
+  "autocomplete",
+  "haspopup",
+  "value",
+];
+
+type RawAxProperty = {
+  name: string;
+  value: SnapshotPrimitive;
+};
+
+type RawAxNode = {
+  nodeId: string;
+  parentId: string | null;
+  ignored: boolean;
+  role: string;
+  name: string | null;
+  value: SnapshotPrimitive;
+  description: string | null;
+  properties: RawAxProperty[];
+  childIds: string[];
+  backendDOMNodeId: number | null;
+};
+
+type MutableSnapshotNode = Omit<SnapshotNode, "children"> & {
+  childIds: string[];
+  children: MutableSnapshotNode[];
+  parent: MutableSnapshotNode | null;
+};
+
+type FrameInfo = {
+  id: string;
+  url: string;
+  name: string | null;
+  parentId: string | null;
+};
+
+export async function snapshot(page: Page): Promise<Snapshot> {
+  const cdp = await page.context().newCDPSession(page);
+
+  try {
+    await enableIfSupported(cdp, "DOM.enable");
+    await enableIfSupported(cdp, "Accessibility.enable");
+    await enableIfSupported(cdp, "Runtime.enable");
+
+    const [title, frames] = await Promise.all([
+      page.title().catch(() => ""),
+      getFrameInfos(cdp),
+    ]);
+
+    const snapshotFrames: Snapshot["frames"] = [];
+    let nextRef = 1;
+    for (const [index, frame] of frames.entries()) {
+      const frameSnapshot = await captureFrameSnapshot(cdp, frame, index);
+      if (frameSnapshot.ok) {
+        nextRef = assignRefs(frameSnapshot.roots, nextRef);
+        snapshotFrames.push({
+          status: "ok",
+          id: frame.id,
+          index,
+          url: frame.url,
+          name: frame.name,
+          parentId: frame.parentId,
+          roots: frameSnapshot.roots.map(toSnapshotNode),
+        });
+      } else {
+        snapshotFrames.push({
+          status: "unavailable",
+          id: frame.id,
+          index,
+          url: frame.url,
+          name: frame.name,
+          parentId: frame.parentId,
+          error: frameSnapshot.error,
+        });
+      }
+    }
+
+    return { title, url: page.url(), frames: snapshotFrames };
+  } finally {
+    await cdp.detach().catch(() => {});
+  }
+}
+
+export function findSnapshotNodeByRef(
+  snapshotTree: Snapshot,
+  ref: string,
+): SnapshotNode {
+  const normalizedRef = normalizeRequestedRef(ref);
+  const matchingNode = findNodeByRef(snapshotTree, normalizedRef);
+  if (!matchingNode) {
+    throw new Error(`Snapshot ref "${ref}" was not found.`);
+  }
+  return matchingNode;
+}
+
+export function scopeSnapshotToRef(
+  snapshotTree: Snapshot,
+  ref: string,
+): Snapshot {
+  const matchingNode = findSnapshotNodeByRef(snapshotTree, ref);
+
+  return {
+    ...snapshotTree,
+    frames: snapshotTree.frames.flatMap((frame) => {
+      if (frame.status !== "ok") return [];
+      if (!frameContainsNode(frame.roots, matchingNode)) return [];
+      return [{ ...frame, roots: [matchingNode] }];
+    }),
+  };
+}
+
+function normalizeRequestedRef(ref: string): string {
+  return ref.trim();
+}
+
+function findNodeByRef(
+  snapshotTree: Snapshot,
+  ref: string,
+): SnapshotNode | null {
+  const exact = findNode(snapshotTree, (node) => node.ref === ref);
+  if (exact) return exact;
+
+  const numericSuffix = ref.match(/^[a-zA-Z]+(\d+)$/)?.[1];
+  if (!numericSuffix) return null;
+  return findNode(
+    snapshotTree,
+    (node) => node.ref?.match(/^[a-zA-Z]+(\d+)$/)?.[1] === numericSuffix,
+  );
+}
+
+function findNode(
+  snapshotTree: Snapshot,
+  predicate: (node: SnapshotNode) => boolean,
+): SnapshotNode | null {
+  for (const frame of snapshotTree.frames) {
+    if (frame.status !== "ok") continue;
+    for (const root of frame.roots) {
+      const node = findNodeInTree(root, predicate);
+      if (node) return node;
+    }
+  }
+  return null;
+}
+
+function findNodeInTree(
+  node: SnapshotNode,
+  predicate: (node: SnapshotNode) => boolean,
+): SnapshotNode | null {
+  if (predicate(node)) return node;
+  for (const child of node.children) {
+    const match = findNodeInTree(child, predicate);
+    if (match) return match;
+  }
+  return null;
+}
+
+function frameContainsNode(
+  roots: SnapshotNode[],
+  target: SnapshotNode,
+): boolean {
+  return roots.some((root) => findNodeInTree(root, (node) => node === target));
+}
+
+async function enableIfSupported(
+  cdp: CDPSession,
+  method: "DOM.enable" | "Accessibility.enable" | "Runtime.enable",
+): Promise<void> {
+  try {
+    await cdp.send(method);
+  } catch {
+    // Some Chromium targets do not support every domain for every frame target.
+  }
+}
+
+async function captureFrameSnapshot(
+  cdp: CDPSession,
+  frame: FrameInfo,
+  frameIndex: number,
+): Promise<
+  { ok: true; roots: MutableSnapshotNode[] } | { ok: false; error: string }
+> {
+  try {
+    const response = await cdp.send("Accessibility.getFullAXTree", {
+      frameId: frame.id,
+    });
+    const rawNodes = parseAxNodes(response as unknown);
+    const attributeMap = await readAttributesByBackendNodeId(cdp, rawNodes);
+    return { ok: true, roots: buildSnapshotTree(rawNodes, attributeMap) };
+  } catch (error) {
+    if (frameIndex !== 0) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    try {
+      const response = await cdp.send("Accessibility.getFullAXTree");
+      const rawNodes = parseAxNodes(response as unknown);
+      const attributeMap = await readAttributesByBackendNodeId(cdp, rawNodes);
+      return { ok: true, roots: buildSnapshotTree(rawNodes, attributeMap) };
+    } catch (fallbackError) {
+      return {
+        ok: false,
+        error:
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : String(fallbackError),
+      };
+    }
+  }
+}
+
+async function getFrameInfos(cdp: CDPSession): Promise<FrameInfo[]> {
+  try {
+    const response = (await cdp.send("Page.getFrameTree")) as unknown;
+    const frames = parseFrameTree(response);
+    return frames.length > 0
+      ? frames
+      : [{ id: "main", url: "", name: null, parentId: null }];
+  } catch {
+    return [{ id: "main", url: "", name: null, parentId: null }];
+  }
+}
+
+function parseFrameTree(response: unknown): FrameInfo[] {
+  const root = readRecord(response).frameTree;
+  const frames: FrameInfo[] = [];
+
+  function visit(value: unknown, inheritedParentId: string | null): void {
+    const tree = readRecord(value);
+    const frame = readRecord(tree.frame);
+    const id = readString(frame.id);
+    if (!id) return;
+
+    frames.push({
+      id,
+      url: readString(frame.url) ?? "",
+      name: readString(frame.name),
+      parentId: readString(frame.parentId) ?? inheritedParentId,
+    });
+
+    const childFrames = Array.isArray(tree.childFrames) ? tree.childFrames : [];
+    for (const child of childFrames) visit(child, id);
+  }
+
+  visit(root, null);
+  return frames;
+}
+
+function parseAxNodes(response: unknown): RawAxNode[] {
+  const nodes = readRecord(response).nodes;
+  if (!Array.isArray(nodes)) return [];
+  return nodes.map(parseAxNode);
+}
+
+function parseAxNode(value: unknown): RawAxNode {
+  const record = readRecord(value);
+  const nodeId = readString(record.nodeId) ?? "";
+  const childIds = Array.isArray(record.childIds)
+    ? record.childIds.map(readString).filter((id): id is string => id !== null)
+    : [];
+
+  return {
+    nodeId,
+    parentId: readString(record.parentId),
+    ignored: readBoolean(record.ignored) ?? false,
+    role: readAxValueString(record.role) ?? "unknown",
+    name: readAxValueString(record.name),
+    value: readAxPrimitive(record.value),
+    description: readAxValueString(record.description),
+    properties: parseAxProperties(record.properties),
+    childIds,
+    backendDOMNodeId: readNumber(record.backendDOMNodeId),
+  };
+}
+
+function parseAxProperties(value: unknown): RawAxProperty[] {
+  if (!Array.isArray(value)) return [];
+  const properties: RawAxProperty[] = [];
+  for (const item of value) {
+    const record = readRecord(item);
+    const name = readString(record.name);
+    if (!name) continue;
+    properties.push({ name, value: readAxPrimitive(record.value) });
+  }
+  return properties;
+}
+
+async function readAttributesByBackendNodeId(
+  cdp: CDPSession,
+  nodes: RawAxNode[],
+): Promise<Map<number, Record<string, string>>> {
+  const backendNodeIds = unique(
+    nodes
+      .filter(shouldReadAttributes)
+      .sort((a, b) => attributeLookupPriority(a) - attributeLookupPriority(b))
+      .map((node) => node.backendDOMNodeId)
+      .filter((id): id is number => id !== null),
+  ).slice(0, MAX_ATTRIBUTE_NODE_LOOKUPS);
+
+  const result = new Map<number, Record<string, string>>();
+  await Promise.all(
+    backendNodeIds.map(async (backendNodeId) => {
+      const attributes = await readAttributesForBackendNodeId(
+        cdp,
+        backendNodeId,
+      );
+      if (Object.keys(attributes).length > 0) {
+        result.set(backendNodeId, attributes);
+      }
+    }),
+  );
+  return result;
+}
+
+function shouldReadAttributes(node: RawAxNode): boolean {
+  if (node.ignored) return false;
+  if (node.backendDOMNodeId === null) return false;
+  if (REFS_BY_ROLE.has(node.role)) return true;
+  if (node.role === "generic" || node.role === "group") return true;
+  if (node.name && node.name.trim().length > 0) return true;
+  return node.properties.some((property) =>
+    STATE_PROPERTY_NAMES.includes(property.name),
+  );
+}
+
+function attributeLookupPriority(node: RawAxNode): number {
+  if (REFS_BY_ROLE.has(node.role)) return 0;
+  if (node.name && node.name.trim().length > 0) return 1;
+  if (
+    node.properties.some((property) =>
+      STATE_PROPERTY_NAMES.includes(property.name),
+    )
+  ) {
+    return 1;
+  }
+  return 2;
+}
+
+async function readAttributesForBackendNodeId(
+  cdp: CDPSession,
+  backendNodeId: number,
+): Promise<Record<string, string>> {
+  try {
+    const response = (await cdp.send("DOM.describeNode", {
+      backendNodeId,
+      depth: 0,
+      pierce: false,
+    })) as unknown;
+    const node = readRecord(readRecord(response).node);
+    const rawAttributes = Array.isArray(node.attributes) ? node.attributes : [];
+    const attributes: Record<string, string> = {};
+    for (let i = 0; i < rawAttributes.length - 1; i += 2) {
+      const name = readString(rawAttributes[i]);
+      const value = readString(rawAttributes[i + 1]);
+      if (name && value !== null && INTERESTING_ATTRIBUTES.has(name)) {
+        if (name === "tabindex" && Number(value) < 0) continue;
+        attributes[name] = value;
+      }
+    }
+    const cursor = await readComputedCursorForBackendNodeId(cdp, backendNodeId);
+    if (cursor === "pointer") attributes.cursor = cursor;
+    return attributes;
+  } catch {
+    return {};
+  }
+}
+
+async function readComputedCursorForBackendNodeId(
+  cdp: CDPSession,
+  backendDOMNodeId: number,
+): Promise<string | null> {
+  let objectId: string | null = null;
+  try {
+    const resolved = (await cdp.send("DOM.resolveNode", {
+      backendNodeId: backendDOMNodeId,
+    })) as unknown;
+    objectId = readString(readRecord(readRecord(resolved).object).objectId);
+    if (!objectId) return null;
+
+    const response = (await cdp.send("Runtime.callFunctionOn", {
+      objectId,
+      functionDeclaration:
+        "function() { return getComputedStyle(this).cursor; }",
+      returnByValue: true,
+      silent: true,
+    })) as unknown;
+    return readString(readRecord(readRecord(response).result).value);
+  } catch {
+    return null;
+  } finally {
+    if (objectId) {
+      await cdp.send("Runtime.releaseObject", { objectId }).catch(() => {});
+    }
+  }
+}
+
+function buildSnapshotTree(
+  rawNodes: RawAxNode[],
+  attributesByBackendNodeId: Map<number, Record<string, string>>,
+): MutableSnapshotNode[] {
+  const byId = new Map<string, MutableSnapshotNode>();
+  const childIds = new Set<string>();
+
+  for (const rawNode of rawNodes) {
+    if (!rawNode.nodeId) continue;
+    byId.set(rawNode.nodeId, {
+      nodeId: rawNode.nodeId,
+      ignored: rawNode.ignored,
+      role: rawNode.role,
+      name: rawNode.name,
+      value: rawNode.value,
+      description: rawNode.description,
+      properties: Object.fromEntries(
+        rawNode.properties.map((property) => [property.name, property.value]),
+      ),
+      attributes:
+        rawNode.backendDOMNodeId !== null
+          ? (attributesByBackendNodeId.get(rawNode.backendDOMNodeId) ?? {})
+          : {},
+      childIds: rawNode.childIds,
+      children: [],
+      parent: null,
+      ref: null,
+      subtreeSize: 1,
+    });
+  }
+
+  for (const node of byId.values()) {
+    for (const childId of node.childIds) {
+      const child = byId.get(childId);
+      if (!child) continue;
+      child.parent = node;
+      node.children.push(child);
+      childIds.add(childId);
+    }
+  }
+
+  for (const rawNode of rawNodes) {
+    if (!rawNode.parentId || childIds.has(rawNode.nodeId)) continue;
+    const node = byId.get(rawNode.nodeId);
+    const parent = byId.get(rawNode.parentId);
+    if (!node || !parent) continue;
+    node.parent = parent;
+    parent.children.push(node);
+    childIds.add(rawNode.nodeId);
+  }
+
+  const roots = [...byId.values()].filter((node) => !childIds.has(node.nodeId));
+  for (const root of roots) annotateSubtreeSize(root);
+  return roots;
+}
+
+function annotateSubtreeSize(node: MutableSnapshotNode): number {
+  node.subtreeSize = 1;
+  for (const child of node.children) {
+    node.subtreeSize += annotateSubtreeSize(child);
+  }
+  return node.subtreeSize;
+}
+
+function assignRefs(nodes: MutableSnapshotNode[], nextRef: number): number {
+  for (const node of nodes) {
+    if (shouldAssignRef(node)) {
+      node.ref = `l${nextRef}`;
+      nextRef += 1;
+    }
+    nextRef = assignRefs(node.children, nextRef);
+  }
+  return nextRef;
+}
+
+function toSnapshotNode(node: MutableSnapshotNode): SnapshotNode {
+  return {
+    nodeId: node.nodeId,
+    ignored: node.ignored,
+    role: node.role,
+    name: node.name,
+    value: node.value,
+    description: node.description,
+    properties: node.properties,
+    attributes: node.attributes,
+    children: node.children.map(toSnapshotNode),
+    ref: node.ref,
+    subtreeSize: node.subtreeSize,
+  };
+}
+
+function shouldAssignRef(node: MutableSnapshotNode): boolean {
+  if (node.ignored) return false;
+  if (node.role === "StaticText" || node.role === "InlineTextBox") return false;
+  if (node.role === "none" || node.role === "presentation") return false;
+  if (REFS_BY_ROLE.has(node.role)) return true;
+  if (Object.keys(node.attributes).length > 0) return true;
+  return Boolean(node.name);
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function readAxValueString(value: unknown): string | null {
+  const rawValue = readRecord(value).value;
+  if (typeof rawValue === "string") return rawValue;
+  if (typeof rawValue === "number" || typeof rawValue === "boolean") {
+    return String(rawValue);
+  }
+  return null;
+}
+
+function readAxPrimitive(value: unknown): SnapshotPrimitive {
+  const rawValue = readRecord(value).value;
+  if (
+    typeof rawValue === "string" ||
+    typeof rawValue === "number" ||
+    typeof rawValue === "boolean"
+  ) {
+    return rawValue;
+  }
+  return null;
+}
+
+function unique(values: number[]): number[] {
+  return [...new Set(values)];
+}

--- a/packages/libretto/src/shared/snapshot/diff-snapshots.ts
+++ b/packages/libretto/src/shared/snapshot/diff-snapshots.ts
@@ -1,0 +1,579 @@
+import type { Snapshot } from "./types.js";
+import {
+  renderChildrenTruncationNotice,
+  renderFrame,
+  renderNode,
+  renderSnapshotFrames,
+  type RenderedSnapshotChild,
+  type RenderedSnapshotFrame,
+  type RenderedSnapshotNode,
+} from "./render-snapshot.js";
+
+const MAX_DIFF_CHILDREN_PER_PARENT = 4;
+const MAX_LABEL_CHARS = 140;
+
+const LOW_SIGNAL_DIFF_ATTRS = new Set(["ref"]);
+
+export type SnapshotDiff = {
+  before: Snapshot;
+  after: Snapshot;
+  changed: boolean;
+  pageChanged: boolean;
+  frames: SnapshotFrameDiff[];
+};
+
+export type SnapshotFrameDiff =
+  | {
+      type: "context";
+      frame: RenderedSnapshotFrame;
+      children: SnapshotDiffChild[];
+    }
+  | {
+      type: "modified";
+      before: RenderedSnapshotFrame;
+      after: RenderedSnapshotFrame;
+    }
+  | { type: "added"; frame: RenderedSnapshotFrame }
+  | { type: "removed"; frame: RenderedSnapshotFrame };
+
+export type SnapshotDiffChild = SnapshotNodeDiff | SnapshotTextDiff;
+
+export type SnapshotNodeDiff =
+  | {
+      kind: "node";
+      type: "context";
+      node: RenderedSnapshotNode;
+      children: SnapshotDiffChild[];
+    }
+  | {
+      kind: "node";
+      type: "modified";
+      before: RenderedSnapshotNode;
+      after: RenderedSnapshotNode;
+      children: SnapshotDiffChild[];
+    }
+  | { kind: "node"; type: "added"; node: RenderedSnapshotNode }
+  | { kind: "node"; type: "removed"; node: RenderedSnapshotNode };
+
+export type SnapshotTextDiff =
+  | {
+      kind: "text";
+      type: "modified";
+      before: Extract<RenderedSnapshotChild, { kind: "text" }>;
+      after: Extract<RenderedSnapshotChild, { kind: "text" }>;
+    }
+  | {
+      kind: "text";
+      type: "added";
+      node: Extract<RenderedSnapshotChild, { kind: "text" }>;
+    }
+  | {
+      kind: "text";
+      type: "removed";
+      node: Extract<RenderedSnapshotChild, { kind: "text" }>;
+    };
+
+export function diffSnapshots(before: Snapshot, after: Snapshot): SnapshotDiff {
+  const beforeFrames = renderSnapshotFrames(before);
+  const afterFrames = renderSnapshotFrames(after);
+  const pageChanged = before.title !== after.title || before.url !== after.url;
+  const frames = diffFrames(beforeFrames, afterFrames);
+  return {
+    before,
+    after,
+    pageChanged,
+    frames,
+    changed: pageChanged || frames.length > 0,
+  };
+}
+
+export function renderSnapshotDiff(diff: SnapshotDiff): string {
+  if (!diff.changed) return "";
+
+  if (diff.pageChanged && diff.frames.length === 0) {
+    return [
+      renderPageOpen(diff.before, "- ", true),
+      renderPageOpen(diff.after, "+ ", true),
+    ].join("\n");
+  }
+
+  const lines = [renderPageOpen(diff.after, "")];
+  for (const frameDiff of diff.frames) renderFrameDiff(frameDiff, 1, lines);
+  lines.push("</page>");
+  return lines.join("\n");
+}
+
+function renderPageOpen(
+  snapshot: Pick<Snapshot, "title" | "url">,
+  prefix: string,
+  selfClosing = false,
+): string {
+  return `${prefix}${formatTag(
+    "page",
+    [
+      ["title", firstNonEmpty(snapshot.title, snapshot.url) ?? ""],
+      ["url", snapshot.url],
+    ],
+    !selfClosing,
+  )}`;
+}
+
+function renderFrameLine(
+  frame: RenderedSnapshotFrame,
+  depth: number,
+  prefix: string,
+  selfClosing: boolean,
+): string {
+  const attrs: Array<[string, string]> = [
+    ["index", String(frame.index)],
+    ["url", normalizeText(frame.url, MAX_LABEL_CHARS)],
+  ];
+  if (frame.name)
+    attrs.push(["name", normalizeText(frame.name, MAX_LABEL_CHARS)]);
+  if (frame.parentId) attrs.push(["parent", frame.parentId]);
+  if (frame.status === "unavailable") {
+    attrs.push(["error", normalizeText(frame.error, 180)]);
+  }
+  return `${prefix}${indent(depth)}${formatTag("frame", attrs, !selfClosing)}`;
+}
+
+function renderTextNode(
+  node: Extract<RenderedSnapshotChild, { kind: "text" }>,
+  depth: number,
+  prefix: string,
+): string {
+  return `${prefix}${indent(depth)}${escapeText(node.text)}`;
+}
+
+function indent(depth: number): string {
+  return "\t".repeat(depth);
+}
+
+function formatTag(
+  tagName: string,
+  attributes: Array<[string, string]>,
+  hasChildren: boolean,
+): string {
+  const attrs = attributes
+    .filter(([, value]) => value !== "")
+    .map(([name, value]) => ` ${name}="${escapeAttribute(value)}"`)
+    .join("");
+  return hasChildren ? `<${tagName}${attrs}>` : `<${tagName}${attrs} />`;
+}
+
+function diffFrames(
+  beforeFrames: RenderedSnapshotFrame[],
+  afterFrames: RenderedSnapshotFrame[],
+): SnapshotFrameDiff[] {
+  const diffs: SnapshotFrameDiff[] = [];
+  const maxLength = Math.max(beforeFrames.length, afterFrames.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const before = beforeFrames[index];
+    const after = afterFrames[index];
+    if (before && !after) {
+      diffs.push({ type: "removed", frame: before });
+    } else if (!before && after) {
+      diffs.push({ type: "added", frame: after });
+    } else if (before && after) {
+      const diff = diffFrame(before, after);
+      if (diff) diffs.push(diff);
+    }
+  }
+
+  return diffs;
+}
+
+function diffFrame(
+  before: RenderedSnapshotFrame,
+  after: RenderedSnapshotFrame,
+): SnapshotFrameDiff | null {
+  if (before.status !== after.status)
+    return { type: "modified", before, after };
+  if (before.status === "unavailable" || after.status === "unavailable") {
+    return comparableFrame(before) === comparableFrame(after)
+      ? null
+      : { type: "modified", before, after };
+  }
+
+  const children = diffChildren(before.roots, after.roots);
+  const frameChanged = comparableFrame(before) !== comparableFrame(after);
+  if (!frameChanged && children.length === 0) return null;
+  if (frameChanged && children.length === 0)
+    return { type: "modified", before, after };
+  return { type: "context", frame: after, children };
+}
+
+function diffChildren(
+  beforeChildren: RenderedSnapshotChild[],
+  afterChildren: RenderedSnapshotChild[],
+): SnapshotDiffChild[] {
+  const diffs: SnapshotDiffChild[] = [];
+  const usedBefore = new Set<number>();
+
+  for (let afterIndex = 0; afterIndex < afterChildren.length; afterIndex += 1) {
+    const after = afterChildren[afterIndex]!;
+    const beforeIndex = findMatchingBeforeChild(
+      after,
+      afterIndex,
+      beforeChildren,
+      usedBefore,
+    );
+
+    if (beforeIndex === -1) {
+      diffs.push(addedChild(after));
+      continue;
+    }
+
+    usedBefore.add(beforeIndex);
+    const childDiff = diffChild(beforeChildren[beforeIndex]!, after);
+    if (childDiff) diffs.push(childDiff);
+  }
+
+  for (
+    let beforeIndex = 0;
+    beforeIndex < beforeChildren.length;
+    beforeIndex += 1
+  ) {
+    if (!usedBefore.has(beforeIndex))
+      diffs.push(removedChild(beforeChildren[beforeIndex]!));
+  }
+
+  return diffs;
+}
+
+function diffChild(
+  before: RenderedSnapshotChild,
+  after: RenderedSnapshotChild,
+): SnapshotDiffChild | null {
+  if (before.kind === "text" || after.kind === "text") {
+    if (before.kind === "text" && after.kind === "text") {
+      return before.text === after.text
+        ? null
+        : { kind: "text", type: "modified", before, after };
+    }
+    return after.kind === "text" ? addedChild(after) : removedChild(before);
+  }
+
+  const children = diffChildren(before.children, after.children);
+  const selfChanged = comparableNode(before) !== comparableNode(after);
+  const directTextChanged = children.some((child) => child.kind === "text");
+  if (!selfChanged && children.length === 0) return null;
+  if (selfChanged || (sameRef(before, after) && directTextChanged)) {
+    return { kind: "node", type: "modified", before, after, children };
+  }
+  return { kind: "node", type: "context", node: after, children };
+}
+
+function findMatchingBeforeChild(
+  after: RenderedSnapshotChild,
+  afterIndex: number,
+  beforeChildren: RenderedSnapshotChild[],
+  usedBefore: Set<number>,
+): number {
+  const beforeAtSameIndex = beforeChildren[afterIndex];
+  if (
+    beforeAtSameIndex &&
+    !usedBefore.has(afterIndex) &&
+    arePositionallySimilarChildren(beforeAtSameIndex, after)
+  ) {
+    return afterIndex;
+  }
+
+  if (after.kind === "node") {
+    const byKey = beforeChildren.findIndex(
+      (before, index) =>
+        !usedBefore.has(index) &&
+        before.kind === "node" &&
+        before.key === after.key,
+    );
+    if (byKey !== -1) return byKey;
+
+    const afterFingerprint = childFingerprint(after);
+    const byFingerprint = beforeChildren.findIndex(
+      (before, index) =>
+        !usedBefore.has(index) &&
+        before.kind === "node" &&
+        childFingerprint(before) === afterFingerprint,
+    );
+    if (byFingerprint !== -1) return byFingerprint;
+  }
+
+  return -1;
+}
+
+function addedChild(child: RenderedSnapshotChild): SnapshotDiffChild {
+  return child.kind === "text"
+    ? { kind: "text", type: "added", node: child }
+    : { kind: "node", type: "added", node: child };
+}
+
+function removedChild(child: RenderedSnapshotChild): SnapshotDiffChild {
+  return child.kind === "text"
+    ? { kind: "text", type: "removed", node: child }
+    : { kind: "node", type: "removed", node: child };
+}
+
+function arePositionallySimilarChildren(
+  before: RenderedSnapshotChild,
+  after: RenderedSnapshotChild,
+): boolean {
+  if (before.kind !== after.kind) return false;
+  if (before.kind === "text" && after.kind === "text") return true;
+  if (before.kind === "node" && after.kind === "node") {
+    return before.key === after.key || before.role === after.role;
+  }
+  return false;
+}
+
+function renderFrameDiff(
+  diff: SnapshotFrameDiff,
+  depth: number,
+  lines: string[],
+): void {
+  if (diff.type === "added") {
+    renderFrame(diff.frame, depth, lines, "+ ");
+  } else if (diff.type === "removed") {
+    renderFrame(diff.frame, depth, lines, "- ");
+  } else if (diff.type === "modified") {
+    renderFrame(diff.before, depth, lines, "- ");
+    renderFrame(diff.after, depth, lines, "+ ");
+  } else if (diff.frame.status === "ok") {
+    lines.push(renderFrameLine(diff.frame, depth, "", false));
+    if (
+      diff.frame.roots.length > diff.children.length &&
+      diff.children.length > 0
+    ) {
+      lines.push(`${indent(depth + 1)}...`);
+    }
+    renderChildDiffs(diff.children, depth + 1, lines);
+    lines.push(`${indent(depth)}</frame>`);
+  }
+}
+
+function renderChildDiffs(
+  diffs: SnapshotDiffChild[],
+  depth: number,
+  lines: string[],
+): void {
+  for (const diff of diffs.slice(0, MAX_DIFF_CHILDREN_PER_PARENT)) {
+    renderChildDiff(diff, depth, lines);
+  }
+
+  if (diffs.length > MAX_DIFF_CHILDREN_PER_PARENT) {
+    const truncated = diffs.slice(MAX_DIFF_CHILDREN_PER_PARENT);
+    const prefix = diffPrefixForSummary(truncated);
+    lines.push(
+      `${prefix}${indent(depth)}${renderChildrenTruncationNotice(
+        diffSummaryChildren(truncated),
+      )}`,
+    );
+  }
+}
+
+function renderChildDiff(
+  diff: SnapshotDiffChild,
+  depth: number,
+  lines: string[],
+): void {
+  if (diff.kind === "text") {
+    if (diff.type === "added")
+      lines.push(renderTextNode(diff.node, depth, "+ "));
+    else if (diff.type === "removed")
+      lines.push(renderTextNode(diff.node, depth, "- "));
+    else {
+      lines.push(renderTextNode(diff.before, depth, "- "));
+      lines.push(renderTextNode(diff.after, depth, "+ "));
+    }
+    return;
+  }
+
+  renderNodeDiff(diff, depth, lines);
+}
+
+function renderNodeDiff(
+  diff: SnapshotNodeDiff,
+  depth: number,
+  lines: string[],
+): void {
+  if (diff.type === "added") {
+    renderNode(diff.node, depth, lines, "+ ");
+  } else if (diff.type === "removed") {
+    renderRemovedNode(diff.node, depth, lines);
+  } else if (diff.type === "modified") {
+    if (sameRef(diff.before, diff.after)) {
+      renderModifiedSameRefNode(diff, depth, lines);
+    } else {
+      renderRemovedNode(diff.before, depth, lines);
+      renderNode(diff.after, depth, lines, "+ ");
+    }
+  } else {
+    if (diff.node.children.length === 0) {
+      lines.push(
+        `${indent(depth)}${formatTag(diff.node.role, diff.node.attrs, false)}`,
+      );
+      return;
+    }
+
+    lines.push(
+      `${indent(depth)}${formatTag(diff.node.role, diff.node.attrs, true)}`,
+    );
+    if (diff.node.children.length > diff.children.length)
+      lines.push(`${indent(depth + 1)}...`);
+    renderChildDiffs(diff.children, depth + 1, lines);
+    lines.push(`${indent(depth)}</${diff.node.role}>`);
+  }
+}
+
+function renderModifiedSameRefNode(
+  diff: Extract<SnapshotNodeDiff, { type: "modified" }>,
+  depth: number,
+  lines: string[],
+): void {
+  if (diff.children.length === 0 || singleTextChild(diff.after) !== null) {
+    renderNode(diff.after, depth, lines, "~ ");
+    return;
+  }
+
+  if (diff.after.children.length === 0) {
+    lines.push(
+      `~ ${indent(depth)}${formatTag(diff.after.role, diff.after.attrs, false)}`,
+    );
+    return;
+  }
+
+  lines.push(
+    `~ ${indent(depth)}${formatTag(diff.after.role, diff.after.attrs, true)}`,
+  );
+  if (diff.after.children.length > diff.children.length)
+    lines.push(`~ ${indent(depth + 1)}...`);
+  renderChildDiffs(diff.children, depth + 1, lines);
+  lines.push(`~ ${indent(depth)}</${diff.after.role}>`);
+}
+
+function renderRemovedNode(
+  node: RenderedSnapshotNode,
+  depth: number,
+  lines: string[],
+): void {
+  const attrs = node.attrs.filter(([name]) => name === "ref");
+  if (node.children.length === 0) {
+    lines.push(`- ${indent(depth)}${formatTag(node.role, attrs, false)}`);
+    return;
+  }
+
+  lines.push(
+    `- ${indent(depth)}${formatTag(node.role, attrs, true)}...</${node.role}>`,
+  );
+}
+
+function comparableFrame(frame: RenderedSnapshotFrame): string {
+  return JSON.stringify({
+    status: frame.status,
+    id: frame.id,
+    index: frame.index,
+    url: frame.url,
+    name: frame.name,
+    parentId: frame.parentId,
+    error: frame.status === "unavailable" ? frame.error : undefined,
+  });
+}
+
+function comparableNode(node: RenderedSnapshotNode): string {
+  return JSON.stringify({
+    role: node.role,
+    attrs: comparableAttrs(node.attrs),
+  });
+}
+
+function comparableAttrs(
+  attrs: Array<[string, string]>,
+): Array<[string, string]> {
+  return attrs.flatMap(([name, value]) => {
+    if (LOW_SIGNAL_DIFF_ATTRS.has(name)) return [];
+    if (name === "href") return [[name, normalizeComparableHref(value)]];
+    return [[name, value]];
+  });
+}
+
+function sameRef(
+  before: RenderedSnapshotNode,
+  after: RenderedSnapshotNode,
+): boolean {
+  const beforeRef = attrValue(before, "ref");
+  return beforeRef !== null && beforeRef === attrValue(after, "ref");
+}
+
+function attrValue(node: RenderedSnapshotNode, name: string): string | null {
+  return node.attrs.find(([attr]) => attr === name)?.[1] ?? null;
+}
+
+function singleTextChild(node: RenderedSnapshotNode): string | null {
+  if (node.children.length !== 1) return null;
+  const child = node.children[0]!;
+  return child.kind === "text" && !child.block ? child.text : null;
+}
+
+function childFingerprint(child: RenderedSnapshotChild): string {
+  if (child.kind === "text") return `text:${child.text}`;
+  return comparableNode(child);
+}
+
+function normalizeComparableHref(value: string): string {
+  const withoutEllipsis = value.endsWith("…") ? value.slice(0, -1) : value;
+  try {
+    const url = new URL(withoutEllipsis);
+    return `${url.protocol}//${url.host}${url.pathname}`;
+  } catch {
+    return withoutEllipsis.split(/[?#]/, 1)[0] ?? withoutEllipsis;
+  }
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const normalized = normalizeRawText(value ?? "");
+    if (normalized) return truncate(normalized, MAX_LABEL_CHARS);
+  }
+  return null;
+}
+
+function normalizeText(value: string, maxChars: number): string {
+  return truncate(value.replace(/\s+/g, " ").trim(), maxChars);
+}
+
+function normalizeRawText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value: string, maxChars: number): string {
+  return value.length > maxChars ? `${value.slice(0, maxChars - 1)}…` : value;
+}
+
+function escapeText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function diffPrefixForSummary(diffs: SnapshotDiffChild[]): string {
+  if (diffs.every((diff) => diff.type === "added")) return "+ ";
+  if (diffs.every((diff) => diff.type === "removed")) return "- ";
+  return "";
+}
+
+function diffSummaryChildren(
+  diffs: SnapshotDiffChild[],
+): RenderedSnapshotChild[] {
+  return diffs.map((diff) =>
+    diff.type === "modified" ? diff.after : diff.node,
+  );
+}

--- a/packages/libretto/src/shared/snapshot/render-snapshot.ts
+++ b/packages/libretto/src/shared/snapshot/render-snapshot.ts
@@ -12,8 +12,6 @@ const MAX_SUMMARY_TEXT_CHARS = 80;
 const MAX_HREF_CHARS = 96;
 const MAX_ACTIONS_IN_SUMMARY = 3;
 const MAX_ACTION_LABEL_CHARS = 80;
-const SNAPSHOT_HINT =
-  "Hint: Use libretto snapshot <ref> --session <name> to snapshot a subtree.";
 
 const PRESERVE_CHILDREN_BY_ROLE = new Set([
   "document",
@@ -157,7 +155,6 @@ export function renderSnapshot(snapshot: Snapshot, refId?: string): string {
     renderFrame(frame, 1, lines);
   }
   lines.push("</page>");
-  lines.push(SNAPSHOT_HINT);
   return lines.join("\n");
 }
 

--- a/packages/libretto/src/shared/snapshot/render-snapshot.ts
+++ b/packages/libretto/src/shared/snapshot/render-snapshot.ts
@@ -1,0 +1,965 @@
+import { scopeSnapshotToRef } from "./capture-snapshot.js";
+import type {
+  Snapshot,
+  SnapshotFrame,
+  SnapshotNode,
+  SnapshotPrimitive,
+} from "./types.js";
+
+const MAX_CHILDREN_PER_PARENT = 4;
+const MAX_LABEL_CHARS = 140;
+const MAX_SUMMARY_TEXT_CHARS = 80;
+const MAX_HREF_CHARS = 96;
+const MAX_ACTIONS_IN_SUMMARY = 3;
+const MAX_ACTION_LABEL_CHARS = 80;
+const SNAPSHOT_HINT =
+  "Hint: Use libretto snapshot <ref> --session <name> to snapshot a subtree.";
+
+const PRESERVE_CHILDREN_BY_ROLE = new Set([
+  "document",
+  "main",
+  "navigation",
+  "banner",
+  "contentinfo",
+  "form",
+  "search",
+  "list",
+  "table",
+  "tabpanel",
+]);
+
+const FLATTEN_ROLES = new Set([
+  "none",
+  "presentation",
+  "LayoutTable",
+  "LayoutTableRow",
+  "LayoutTableCell",
+]);
+
+const SKIP_ROLES = new Set(["InlineTextBox", "ListMarker"]);
+
+const ACTION_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "switch",
+  "combobox",
+  "listbox",
+  "menuitem",
+  "tab",
+  "slider",
+]);
+
+const ACTION_STATE_ATTRS = new Set([
+  "checked",
+  "disabled",
+  "expanded",
+  "pressed",
+  "selected",
+  "value",
+  "placeholder",
+]);
+
+const TEXT_ACTION_ROLES = new Set(["button", "link", "menuitem", "tab"]);
+
+const KEEP_ROLES = new Set([
+  "document",
+  "main",
+  "navigation",
+  "banner",
+  "contentinfo",
+  "form",
+  "search",
+  "list",
+  "listitem",
+  "button",
+  "link",
+  "image",
+  "textbox",
+  "checkbox",
+  "radio",
+  "switch",
+  "combobox",
+  "listbox",
+  "menu",
+  "menuitem",
+  "option",
+  "tab",
+  "slider",
+]);
+
+const BLOCK_FLATTEN_ROLES = new Set([
+  "paragraph",
+  "section",
+  "article",
+  "region",
+  "group",
+  "figure",
+]);
+
+const RENDERED_STATE_PROPERTIES = [
+  "disabled",
+  "checked",
+  "expanded",
+  "selected",
+  "pressed",
+  "required",
+  "invalid",
+  "readonly",
+  "multiline",
+  "autocomplete",
+  "haspopup",
+  "value",
+];
+
+type SnapshotTextNode = {
+  kind: "text";
+  text: string;
+  block?: boolean;
+};
+
+export type RenderedSnapshotNode = {
+  kind: "node";
+  key: string;
+  role: string;
+  attrs: Array<[string, string]>;
+  children: RenderedSnapshotChild[];
+};
+
+export type RenderedSnapshotChild = RenderedSnapshotNode | SnapshotTextNode;
+
+export type RenderedSnapshotFrame =
+  | {
+      status: "ok";
+      id: string;
+      index: number;
+      url: string;
+      name: string | null;
+      parentId: string | null;
+      roots: RenderedSnapshotNode[];
+    }
+  | {
+      status: "unavailable";
+      id: string;
+      index: number;
+      url: string;
+      name: string | null;
+      parentId: string | null;
+      error: string;
+    };
+
+export function renderSnapshot(snapshot: Snapshot, refId?: string): string {
+  const snapshotTree = refId ? scopeSnapshotToRef(snapshot, refId) : snapshot;
+  const lines = [renderPageOpen(snapshotTree, "")];
+  for (const frame of renderSnapshotFrames(snapshotTree)) {
+    renderFrame(frame, 1, lines);
+  }
+  lines.push("</page>");
+  lines.push(SNAPSHOT_HINT);
+  return lines.join("\n");
+}
+
+export function renderSnapshotFrames(snapshot: Snapshot): RenderedSnapshotFrame[] {
+  return snapshot.frames.map(toRenderedFrame).filter(hasRenderedFrameContent);
+}
+
+function renderPageOpen(
+  snapshot: Pick<Snapshot, "title" | "url">,
+  prefix: string,
+  selfClosing = false,
+): string {
+  return `${prefix}${formatTag(
+    "page",
+    [
+      ["title", firstNonEmpty(snapshot.title, snapshot.url) ?? ""],
+      ["url", snapshot.url],
+    ],
+    !selfClosing,
+  )}`;
+}
+
+function renderFrameLine(
+  frame: RenderedSnapshotFrame,
+  depth: number,
+  prefix: string,
+  selfClosing: boolean,
+): string {
+  const attrs: Array<[string, string]> = [
+    ["index", String(frame.index)],
+    ["url", normalizeText(frame.url, MAX_LABEL_CHARS)],
+  ];
+  if (frame.name)
+    attrs.push(["name", normalizeText(frame.name, MAX_LABEL_CHARS)]);
+  if (frame.parentId) attrs.push(["parent", frame.parentId]);
+  if (frame.status === "unavailable") {
+    attrs.push(["error", normalizeText(frame.error, 180)]);
+  }
+  return `${prefix}${indent(depth)}${formatTag("frame", attrs, !selfClosing)}`;
+}
+
+function renderTextNode(
+  node: SnapshotTextNode,
+  depth: number,
+  prefix: string,
+): string {
+  return `${prefix}${indent(depth)}${escapeText(node.text)}`;
+}
+
+function indent(depth: number): string {
+  return "\t".repeat(depth);
+}
+
+function formatTag(
+  tagName: string,
+  attributes: Array<[string, string]>,
+  hasChildren: boolean,
+): string {
+  const attrs = attributes
+    .filter(([, value]) => value !== "")
+    .map(([name, value]) => ` ${name}="${escapeAttribute(value)}"`)
+    .join("");
+  return hasChildren ? `<${tagName}${attrs}>` : `<${tagName}${attrs} />`;
+}
+
+export function renderChildrenTruncationNotice(
+  children: RenderedSnapshotChild[],
+): string {
+  const count = children.length;
+  const summaryActions = actionSummariesForChildren(children);
+  const textSnippet = previewForChildren(children, summaryActions.labels);
+  const elementLabel = count === 1 ? "element" : "elements";
+  const textSnippetPart = textSnippet
+    ? `. Text snippet: ${JSON.stringify(textSnippet)}`
+    : "";
+  const interactiveText = summaryActions.actions.length
+    ? `. Interactive elements: ${summaryActions.actions
+        .map((action) => action.markup)
+        .join(", ")}${summaryActions.hasMore ? ", ..." : ""}`
+    : "";
+  return `[Truncated ${count} more ${elementLabel}${textSnippetPart}${interactiveText}]`;
+}
+
+function toRenderedFrame(frame: SnapshotFrame): RenderedSnapshotFrame {
+  if (frame.status === "unavailable") return frame;
+  return {
+    status: "ok",
+    id: frame.id,
+    index: frame.index,
+    url: frame.url,
+    name: frame.name,
+    parentId: frame.parentId,
+    roots: frame.roots.flatMap((root) => toRenderedNodes(root, null)),
+  };
+}
+
+function hasRenderedFrameContent(frame: RenderedSnapshotFrame): boolean {
+  if (frame.status === "unavailable") return true;
+  return frame.roots.length > 0;
+}
+
+function toRenderedNodes(
+  node: SnapshotNode,
+  parent: SnapshotNode | null,
+): RenderedSnapshotNode[] {
+  return toRenderedChildren(node, parent).filter(isRenderedNode);
+}
+
+function toRenderedChildren(
+  node: SnapshotNode,
+  parent: SnapshotNode | null,
+): RenderedSnapshotChild[] {
+  if (shouldSkipNode(node, parent)) return [];
+  if (isTextRole(node.role)) {
+    const text = firstNonEmpty(
+      node.name,
+      node.description,
+      primitiveToString(node.value),
+    );
+    if (text && text !== parent?.name && text !== nodeTextValue(parent)) {
+      return [{ kind: "text", text }];
+    }
+    return [];
+  }
+
+  const children = renderableChildren(node);
+  const role = tagNameForRole(node.role);
+  if (role === "heading") return renderHeading(node, children);
+
+  const compactRole = roleForNode(node, role, children);
+  if (compactRole === "image" && !hasNonEmptyAttribute(node, "src"))
+    return [];
+  if (compactRole === "link" && !hasNonEmptyAttribute(node, "href")) {
+    return flattenedChildren(node, children).filter(
+      hasVisibleTextOrInteractive,
+    );
+  }
+  if (
+    node.ignored ||
+    FLATTEN_ROLES.has(node.role) ||
+    !KEEP_ROLES.has(compactRole)
+  ) {
+    return flattenedChildren(node, children).filter(
+      hasVisibleTextOrInteractive,
+    );
+  }
+
+  const text = normalizedText(children);
+  const suppressName = text.includes(normalizeRawText(node.name ?? ""))
+    ? node.name
+    : null;
+  const attrs = nodeAttributes(node, suppressName);
+  const content = nameAttributeAsContent(attrs, children);
+  const renderedChildren = removeDuplicateNestedActions(
+    compactRole,
+    content.attrs,
+    content.children,
+  ).filter(hasVisibleTextOrInteractive);
+
+  if (
+    !ACTION_ROLES.has(compactRole) &&
+    !renderedChildren.some(hasVisibleTextOrInteractive)
+  ) {
+    return [];
+  }
+
+  const rendered: RenderedSnapshotNode = {
+    kind: "node",
+    key:
+      node.nodeId ||
+      node.ref ||
+      `${compactRole}:${content.attrs.map(([name, value]) => `${name}=${value}`).join(";")}`,
+    role: compactRole,
+    attrs: content.attrs,
+    children: renderedChildren,
+  };
+  return [rendered];
+}
+
+function renderableChildren(node: SnapshotNode): RenderedSnapshotChild[] {
+  const children: RenderedSnapshotChild[] = [];
+  for (const child of node.children)
+    children.push(...toRenderedChildren(child, node));
+  return mergeAdjacentText(children).filter(hasVisibleTextOrInteractive);
+}
+
+function renderHeading(
+  node: SnapshotNode,
+  children: RenderedSnapshotChild[],
+): RenderedSnapshotChild[] {
+  const text = firstNonEmpty(node.name, normalizedText(children));
+  if (!text) return [];
+  return [
+    {
+      kind: "text",
+      text: `${"#".repeat(headingLevel(node))} ${text}`,
+      block: true,
+    },
+  ];
+}
+
+function headingLevel(node: SnapshotNode): number {
+  const rawLevel = node.properties.level;
+  const level = typeof rawLevel === "number" ? rawLevel : Number(rawLevel);
+  if (!Number.isFinite(level)) return 2;
+  return Math.min(6, Math.max(1, Math.round(level)));
+}
+
+function roleForNode(
+  node: SnapshotNode,
+  role: string,
+  children: RenderedSnapshotChild[],
+): string {
+  if (isPointerButtonCandidate(node, role, children)) return "button";
+  return role;
+}
+
+function isPointerButtonCandidate(
+  node: SnapshotNode,
+  role: string,
+  children: RenderedSnapshotChild[],
+): boolean {
+  if (KEEP_ROLES.has(role) && role !== "document") return false;
+  if (children.some(hasInteractiveNode)) return false;
+  if (!hasClickableHint(node)) return false;
+  return Boolean(firstNonEmpty(node.name, normalizedText(children)));
+}
+
+function hasClickableHint(node: SnapshotNode): boolean {
+  if (node.attributes.cursor === "pointer") return true;
+  if (Object.hasOwn(node.attributes, "onclick")) return true;
+  const tabindex = node.attributes.tabindex;
+  return tabindex !== undefined && Number(tabindex) >= 0;
+}
+
+function hasInteractiveNode(child: RenderedSnapshotChild): boolean {
+  if (child.kind === "text") return false;
+  if (ACTION_ROLES.has(child.role)) return true;
+  return child.children.some(hasInteractiveNode);
+}
+
+function flattenedChildren(
+  node: SnapshotNode,
+  children: RenderedSnapshotChild[],
+): RenderedSnapshotChild[] {
+  const fallbackText = fallbackTextForFlattenedNode(node);
+  const flattened =
+    children.length > 0 || !fallbackText
+      ? children
+      : [{ kind: "text" as const, text: fallbackText }];
+
+  if (!BLOCK_FLATTEN_ROLES.has(tagNameForRole(node.role))) return flattened;
+  return flattened.map((child) =>
+    child.kind === "text" ? { ...child, block: true } : child,
+  );
+}
+
+function fallbackTextForFlattenedNode(node: SnapshotNode): string | null {
+  const name = firstNonEmpty(node.name, primitiveToString(node.value));
+  if (!name) return null;
+  if (attributeMatchesName(node, "aria-label", name)) return null;
+  if (attributeMatchesName(node, "title", name)) return null;
+  if (attributeMatchesName(node, "alt", name)) return null;
+  return name;
+}
+
+function attributeMatchesName(
+  node: SnapshotNode,
+  attributeName: string,
+  name: string,
+): boolean {
+  return normalizeRawText(node.attributes[attributeName] ?? "") === name;
+}
+
+function hasNonEmptyAttribute(
+  node: SnapshotNode,
+  attributeName: string,
+): boolean {
+  return normalizeRawText(node.attributes[attributeName] ?? "") !== "";
+}
+
+function removeDuplicateNestedActions(
+  role: string,
+  attrs: Array<[string, string]>,
+  children: RenderedSnapshotChild[],
+): RenderedSnapshotChild[] {
+  if (!ACTION_ROLES.has(role)) return children;
+  const label = firstNonEmpty(
+    attrFromAttrs(attrs, "name"),
+    normalizedText(children),
+  );
+  if (!label) return children;
+
+  return children.flatMap((child) => {
+    if (child.kind === "text") return [child];
+    if (!ACTION_ROLES.has(child.role)) return [child];
+    const childLabel = firstNonEmpty(
+      attrValue(child, "name"),
+      singleTextChild(child),
+      normalizedText(child.children),
+    );
+    return childLabel === label ? child.children : [child];
+  });
+}
+
+function nameAttributeAsContent(
+  attrs: Array<[string, string]>,
+  children: RenderedSnapshotChild[],
+): { attrs: Array<[string, string]>; children: RenderedSnapshotChild[] } {
+  const name = attrFromAttrs(attrs, "name");
+  if (!name) return { attrs, children };
+
+  const attrsWithoutName = attrs.filter(([attr]) => attr !== "name");
+  if (normalizedText(children).includes(normalizeRawText(name))) {
+    return { attrs: attrsWithoutName, children };
+  }
+
+  return {
+    attrs: attrsWithoutName,
+    children: [{ kind: "text", text: name }, ...children],
+  };
+}
+
+export function renderFrame(
+  frame: RenderedSnapshotFrame,
+  depth: number,
+  lines: string[],
+  prefix = "",
+): void {
+  if (frame.status === "unavailable") {
+    lines.push(renderFrameLine(frame, depth, prefix, true));
+    return;
+  }
+
+  lines.push(renderFrameLine(frame, depth, prefix, false));
+  for (const root of frame.roots) renderNode(root, depth + 1, lines, prefix);
+  lines.push(`${prefix}${indent(depth)}</frame>`);
+}
+
+export function renderNode(
+  node: RenderedSnapshotNode,
+  depth: number,
+  lines: string[],
+  prefix = "",
+): void {
+  if (renderFoldedSingleChildChain(node, depth, lines, prefix)) return;
+
+  if (node.children.length === 0) {
+    lines.push(
+      `${prefix}${indent(depth)}${formatTag(node.role, node.attrs, false)}`,
+    );
+    return;
+  }
+
+  const singleText = singleTextChild(node);
+  if (singleText !== null) {
+    if (shouldRenderBareText(node)) {
+      lines.push(`${prefix}${indent(depth)}${escapeText(singleText)}`);
+      return;
+    }
+
+    lines.push(
+      `${prefix}${indent(depth)}${formatTag(node.role, node.attrs, true)}${escapeText(singleText)}</${node.role}>`,
+    );
+    return;
+  }
+
+  lines.push(
+    `${prefix}${indent(depth)}${formatTag(node.role, node.attrs, true)}`,
+  );
+  renderChildren(node.children, depth + 1, lines, prefix);
+  lines.push(`${prefix}${indent(depth)}</${node.role}>`);
+}
+
+function renderChildren(
+  children: RenderedSnapshotChild[],
+  depth: number,
+  lines: string[],
+  prefix: string,
+): void {
+  const renderedChildren = children.slice(0, MAX_CHILDREN_PER_PARENT);
+  for (const child of renderedChildren) {
+    if (child.kind === "text") {
+      lines.push(`${prefix}${indent(depth)}${escapeText(child.text)}`);
+      continue;
+    }
+    renderNode(child, depth, lines, prefix);
+  }
+
+  if (children.length > MAX_CHILDREN_PER_PARENT) {
+    const truncated = children.slice(MAX_CHILDREN_PER_PARENT);
+    lines.push(
+      `${prefix}${indent(depth)}${renderChildrenTruncationNotice(
+        truncated,
+      )}`,
+    );
+  }
+}
+
+function renderFoldedSingleChildChain(
+  node: RenderedSnapshotNode,
+  depth: number,
+  lines: string[],
+  prefix: string,
+): boolean {
+  const chain = singleChildChain(node);
+  if (chain.length <= 1) return false;
+
+  const keptIndexes = chain
+    .map((chainNode, index) => ({ chainNode, index }))
+    .filter(({ chainNode, index }) =>
+      shouldKeepFoldedChainNode(chainNode, index),
+    )
+    .map(({ index }) => index);
+  if (keptIndexes.length === chain.length) return false;
+
+  renderFoldedChainNode(chain, keptIndexes, 0, depth, lines, prefix);
+  return true;
+}
+
+function shouldKeepFoldedChainNode(
+  node: RenderedSnapshotNode,
+  index: number,
+): boolean {
+  return index === 0 || node.role === "list";
+}
+
+function renderFoldedChainNode(
+  chain: RenderedSnapshotNode[],
+  keptIndexes: number[],
+  keptIndexPosition: number,
+  depth: number,
+  lines: string[],
+  prefix: string,
+): void {
+  const currentIndex = keptIndexes[keptIndexPosition]!;
+  const current = chain[currentIndex]!;
+  lines.push(
+    `${prefix}${indent(depth)}${formatTag(current.role, current.attrs, true)}`,
+  );
+  renderFoldedChainNodeOwnContent(current, depth + 1, lines, prefix);
+
+  const nextKeptIndex = keptIndexes[keptIndexPosition + 1];
+  if (nextKeptIndex !== undefined) {
+    if (nextKeptIndex > currentIndex + 1)
+      lines.push(`${prefix}${indent(depth + 1)}...`);
+    renderFoldedChainNode(
+      chain,
+      keptIndexes,
+      keptIndexPosition + 1,
+      depth + 1,
+      lines,
+      prefix,
+    );
+  } else {
+    const terminal = chain[chain.length - 1]!;
+    if (chain.length - 1 > currentIndex)
+      lines.push(`${prefix}${indent(depth + 1)}...`);
+    renderChildren(terminal.children, depth + 1, lines, prefix);
+  }
+
+  lines.push(`${prefix}${indent(depth)}</${current.role}>`);
+}
+
+function renderFoldedChainNodeOwnContent(
+  node: RenderedSnapshotNode,
+  depth: number,
+  lines: string[],
+  prefix: string,
+): void {
+  for (const child of node.children) {
+    if (child.kind === "text")
+      lines.push(`${prefix}${indent(depth)}${escapeText(child.text)}`);
+  }
+}
+
+function singleChildChain(node: RenderedSnapshotNode): RenderedSnapshotNode[] {
+  const chain = [node];
+  let current = node;
+
+  while (isDeprioritizedSingleChildParent(current)) {
+    const child = singleElementChild(current);
+    if (!child) break;
+    if (ACTION_ROLES.has(child.role)) break;
+    chain.push(child);
+    current = child;
+  }
+
+  return chain;
+}
+
+function isDeprioritizedSingleChildParent(node: RenderedSnapshotNode): boolean {
+  if (node.role === "document") return false;
+  if (ACTION_ROLES.has(node.role)) return false;
+  return singleElementChild(node) !== null;
+}
+
+function singleElementChild(
+  node: RenderedSnapshotNode,
+): RenderedSnapshotNode | null {
+  let result: RenderedSnapshotNode | null = null;
+  for (const child of node.children) {
+    if (child.kind === "text") continue;
+    if (result) return null;
+    result = child;
+  }
+  return result;
+}
+
+function shouldRenderBareText(node: RenderedSnapshotNode): boolean {
+  if (ACTION_ROLES.has(node.role)) return false;
+  if (attrValue(node, "ref")) return false;
+  if (PRESERVE_CHILDREN_BY_ROLE.has(node.role)) return false;
+  return true;
+}
+
+function nodeAttributes(
+  node: SnapshotNode,
+  suppressName: string | null,
+): Array<[string, string]> {
+  const attributes: Array<[string, string]> = [];
+  const usedNames = new Set<string>();
+  const push = (name: string, value: SnapshotPrimitive | undefined): void => {
+    if (value === undefined || value === null || value === "") return;
+    if (value === false || value === "false") return;
+    const normalizedName = uniqueAttributeName(
+      sanitizeAttributeName(name),
+      usedNames,
+    );
+    attributes.push([
+      normalizedName,
+      normalizeAttributeValue(normalizedName, value),
+    ]);
+    usedNames.add(normalizedName);
+  };
+
+  push("ref", node.ref);
+  if (node.name !== suppressName) push("name", node.name);
+
+  const hasStateValue =
+    node.properties.value !== undefined &&
+    node.properties.value !== null &&
+    node.properties.value !== "";
+  for (const name of RENDERED_STATE_PROPERTIES) {
+    const value = node.properties[name];
+    if (value === true) push(name, "true");
+    else push(name, value);
+  }
+
+  if (!hasStateValue) push("value", node.value);
+  push("href", node.attributes.href);
+  push("placeholder", node.attributes.placeholder);
+  return attributes;
+}
+
+function normalizeAttributeValue(
+  name: string,
+  value: SnapshotPrimitive,
+): string {
+  const normalized = normalizeRawText(String(value));
+  return name === "href" ? truncate(normalized, MAX_HREF_CHARS) : normalized;
+}
+
+function singleTextChild(node: RenderedSnapshotNode): string | null {
+  if (node.children.length !== 1) return null;
+  const child = node.children[0]!;
+  return child.kind === "text" && !child.block ? child.text : null;
+}
+
+function mergeAdjacentText(
+  children: RenderedSnapshotChild[],
+): RenderedSnapshotChild[] {
+  const result: RenderedSnapshotChild[] = [];
+  for (const child of children) {
+    const previous = result[result.length - 1];
+    if (
+      child.kind === "text" &&
+      previous?.kind === "text" &&
+      !child.block &&
+      !previous.block
+    ) {
+      previous.text = normalizeRawText(`${previous.text} ${child.text}`);
+    } else {
+      result.push(child);
+    }
+  }
+  return result;
+}
+
+function normalizedText(children: RenderedSnapshotChild[]): string {
+  return children
+    .map((child) =>
+      child.kind === "text" ? child.text : normalizedText(child.children),
+    )
+    .join(" ");
+}
+
+function previewForChildren(
+  children: RenderedSnapshotChild[],
+  excludedText: Set<string>,
+): string {
+  const labels: string[] = [];
+  const seen = new Set<string>();
+
+  function visit(
+    child: RenderedSnapshotChild,
+    insideInteractive: boolean,
+  ): void {
+    if (child.kind === "text") {
+      if (!insideInteractive) pushLabel(child.text);
+      return;
+    }
+
+    const nextInsideInteractive =
+      insideInteractive || ACTION_ROLES.has(child.role);
+    if (labels.join(" · ").length > MAX_SUMMARY_TEXT_CHARS) return;
+    for (const grandchild of child.children)
+      visit(grandchild, nextInsideInteractive);
+  }
+
+  function pushLabel(value: string | null): void {
+    const normalized = normalizeRawText(value ?? "");
+    if (
+      !normalized ||
+      normalized === "no visible text" ||
+      seen.has(normalized) ||
+      excludedText.has(normalized)
+    ) {
+      return;
+    }
+    seen.add(normalized);
+    labels.push(normalized);
+  }
+
+  for (const child of children) visit(child, false);
+  const preview = labels.join(" · ");
+  return preview ? truncate(preview, MAX_SUMMARY_TEXT_CHARS) : "";
+}
+
+function actionSummariesForChildren(children: RenderedSnapshotChild[]): {
+  actions: Array<{ markup: string; label: string | null }>;
+  labels: Set<string>;
+  hasMore: boolean;
+} {
+  const actions: Array<{ markup: string; label: string | null }> = [];
+  const labels = new Set<string>();
+  const seenRefs = new Set<string>();
+  let hasMore = false;
+
+  function visit(child: RenderedSnapshotChild): void {
+    if (child.kind === "text") return;
+
+    const ref = attrValue(child, "ref");
+    if (ref && ACTION_ROLES.has(child.role) && !seenRefs.has(ref)) {
+      seenRefs.add(ref);
+      const label = actionLabel(child);
+      if (label) labels.add(label);
+      if (actions.length < MAX_ACTIONS_IN_SUMMARY) {
+        actions.push({ markup: renderActionSummary(child, ref), label });
+      } else {
+        hasMore = true;
+      }
+    }
+
+    for (const grandchild of child.children) visit(grandchild);
+  }
+
+  for (const child of children) visit(child);
+  return { actions, labels, hasMore };
+}
+
+function renderActionSummary(node: RenderedSnapshotNode, ref: string): string {
+  const label = actionLabel(node);
+  const attrs: Array<[string, string]> = [["ref", ref]];
+
+  for (const [name, value] of node.attrs) {
+    if (name === "ref" || !ACTION_STATE_ATTRS.has(name)) continue;
+    attrs.push([name, normalizeText(value, MAX_ACTION_LABEL_CHARS)]);
+  }
+
+  if (!label || !TEXT_ACTION_ROLES.has(node.role)) {
+    const name = attrValue(node, "name");
+    if (name) attrs.push(["name", normalizeText(name, MAX_ACTION_LABEL_CHARS)]);
+    return formatTag(node.role, attrs, false);
+  }
+
+  return `${formatTag(node.role, attrs, true)}${escapeText(
+    normalizeText(label, MAX_ACTION_LABEL_CHARS),
+  )}</${node.role}>`;
+}
+
+function actionLabel(node: RenderedSnapshotNode): string | null {
+  return firstNonEmpty(
+    singleTextChild(node),
+    attrValue(node, "name"),
+    attrValue(node, "value"),
+    attrValue(node, "placeholder"),
+  );
+}
+
+function attrValue(node: RenderedSnapshotNode, name: string): string | null {
+  return node.attrs.find(([attr]) => attr === name)?.[1] ?? null;
+}
+
+function attrFromAttrs(
+  attrs: Array<[string, string]>,
+  name: string,
+): string | null {
+  return attrs.find(([attr]) => attr === name)?.[1] ?? null;
+}
+
+function shouldSkipNode(
+  node: SnapshotNode,
+  parent: SnapshotNode | null,
+): boolean {
+  if (SKIP_ROLES.has(node.role)) return true;
+  if (node.role !== "StaticText") return false;
+  return Boolean(parent?.name && node.name && parent.name === node.name);
+}
+
+function isTextRole(role: string): boolean {
+  return role === "StaticText" || role === "InlineTextBox";
+}
+
+function isRenderedNode(
+  child: RenderedSnapshotChild,
+): child is RenderedSnapshotNode {
+  return child.kind === "node";
+}
+
+function hasVisibleTextOrInteractive(child: RenderedSnapshotChild): boolean {
+  if (child.kind === "text") return normalizeRawText(child.text) !== "";
+  if (ACTION_ROLES.has(child.role)) return true;
+  return child.children.some(hasVisibleTextOrInteractive);
+}
+
+function tagNameForRole(role: string): string {
+  const normalized = normalizeRole(role).replace(/[^a-zA-Z0-9_.:-]/g, "-");
+  return /^[a-zA-Z_:]/.test(normalized) ? normalized : "node";
+}
+
+function normalizeRole(role: string): string {
+  if (role === "RootWebArea") return "document";
+  if (role === "textField") return "textbox";
+  return role || "node";
+}
+
+function primitiveToString(value: SnapshotPrimitive): string | null {
+  return value === null ? null : String(value);
+}
+
+function nodeTextValue(node: SnapshotNode | null): string | null {
+  if (!node) return null;
+  const value = primitiveToString(node.properties.value ?? node.value);
+  return value ? normalizeRawText(value) : null;
+}
+
+function firstNonEmpty(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    const normalized = normalizeRawText(value ?? "");
+    if (normalized) return truncate(normalized, MAX_LABEL_CHARS);
+  }
+  return null;
+}
+
+function normalizeText(value: string, maxChars: number): string {
+  return truncate(value.replace(/\s+/g, " ").trim(), maxChars);
+}
+
+function normalizeRawText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value: string, maxChars: number): string {
+  return value.length > maxChars ? `${value.slice(0, maxChars - 1)}…` : value;
+}
+
+function uniqueAttributeName(name: string, usedNames: Set<string>): string {
+  if (!usedNames.has(name)) return name;
+  let index = 2;
+  while (usedNames.has(`${name}-${index}`)) index += 1;
+  return `${name}-${index}`;
+}
+
+function sanitizeAttributeName(name: string): string {
+  const sanitized = name.replace(/[^a-zA-Z0-9_.:-]/g, "-");
+  return /^[a-zA-Z_:]/.test(sanitized) ? sanitized : `attr-${sanitized}`;
+}
+
+function escapeText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/libretto/src/shared/snapshot/snapshot.spec.ts
+++ b/packages/libretto/src/shared/snapshot/snapshot.spec.ts
@@ -1,0 +1,388 @@
+import { chromium, type Page } from "playwright";
+import outdent from "outdent";
+import { describe, expect, test as base } from "vitest";
+import { snapshot } from "./capture-snapshot.js";
+import {
+  diffSnapshots,
+  renderSnapshotDiff,
+} from "./diff-snapshots.js";
+import { renderSnapshot } from "./render-snapshot.js";
+import type {
+  Snapshot,
+  SnapshotNode,
+  SnapshotPrimitive,
+} from "./types.js";
+
+type SnapshotRenderFixtures = {
+  page: Page;
+  expectSnapshot: (html: string, expected: string) => Promise<void>;
+  expectScopedSnapshot: (
+    html: string,
+    refId: string,
+    expected: string,
+  ) => Promise<void>;
+  expectSnapshotDiff: (
+    beforeHtml: string,
+    afterHtml: string,
+    expected: string,
+  ) => Promise<void>;
+};
+
+const test = base.extend<SnapshotRenderFixtures>({
+  page: async ({}, use) => {
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await use(page);
+    await page.close();
+    await browser.close();
+  },
+
+  expectSnapshot: async ({ page }, use) => {
+    await use(async (html: string, expected: string) => {
+      await page.setContent(outdent.string(html));
+      const raw = await snapshot(page);
+      expect(normalizeIncidentalUrls(renderSnapshot(raw))).toBe(
+        outdent.string(expected),
+      );
+    });
+  },
+
+  expectScopedSnapshot: async ({ page }, use) => {
+    await use(async (html: string, refId: string, expected: string) => {
+      await page.setContent(outdent.string(html));
+      const raw = await snapshot(page);
+      expect(normalizeIncidentalUrls(renderSnapshot(raw, refId))).toBe(
+        outdent.string(expected),
+      );
+    });
+  },
+
+  expectSnapshotDiff: async ({ page }, use) => {
+    await use(async (beforeHtml: string, afterHtml: string, expected: string) => {
+      await page.setContent(outdent.string(beforeHtml));
+      const before = await snapshot(page);
+      await page.setContent(outdent.string(afterHtml));
+      const after = await snapshot(page);
+      expect(
+        normalizeIncidentalUrls(
+          renderSnapshotDiff(diffSnapshots(before, after)),
+        ),
+      ).toBe(outdent.string(expected));
+    });
+  },
+});
+
+function normalizeIncidentalUrls(rendered: string): string {
+  return rendered.replaceAll(/url="[^"]*"/g, `url="<page-url>"`);
+}
+
+type SnapshotNodeInput = {
+  nodeId: string;
+  role: string;
+  name?: string | null;
+  ref?: string | null;
+  value?: SnapshotPrimitive;
+  description?: string | null;
+  properties?: Record<string, SnapshotPrimitive>;
+  attributes?: Record<string, string>;
+  children?: SnapshotNode[];
+  ignored?: boolean;
+};
+
+function makeNode(input: SnapshotNodeInput): SnapshotNode {
+  const node: SnapshotNode = {
+    nodeId: input.nodeId,
+    ignored: input.ignored ?? false,
+    role: input.role,
+    name: input.name ?? null,
+    value: input.value ?? null,
+    description: input.description ?? null,
+    properties: input.properties ?? {},
+    attributes: input.attributes ?? {},
+    children: input.children ?? [],
+    ref: input.ref ?? null,
+    subtreeSize: 1,
+  };
+  node.subtreeSize = countSubtree(node);
+  return node;
+}
+
+function countSubtree(node: SnapshotNode): number {
+  return 1 + node.children.reduce((sum, child) => sum + countSubtree(child), 0);
+}
+
+function makeSnapshot(
+  roots: SnapshotNode[],
+  options: { title?: string; url?: string } = {},
+): Snapshot {
+  const url = options.url ?? "about:blank";
+  return {
+    title: options.title ?? "Demo Page",
+    url,
+    frames: [
+      {
+        status: "ok",
+        id: "main",
+        index: 0,
+        url,
+        name: null,
+        parentId: null,
+        roots,
+      },
+    ],
+  };
+}
+
+describe("renderSnapshot", () => {
+  test("renders page, frame, semantic roles, heading text, refs, and no command hint", async ({
+    expectSnapshot,
+  }) => {
+    await expectSnapshot(
+      `
+      <!doctype html>
+      <html>
+        <head><title>Product Docs</title></head>
+        <body>
+          <header>
+            <nav aria-label="Primary">
+              <a href="/docs">Docs</a>
+            </nav>
+          </header>
+          <main>
+            <h1>Welcome</h1>
+            <button>Save</button>
+            <input placeholder="Search docs" value="query" />
+          </main>
+        </body>
+      </html>
+    `,
+      `
+      <page title="Product Docs" url="<page-url>">
+      	<frame index="0" url="<page-url>">
+      		<document ref="l1">
+      			Product Docs
+      			<banner ref="l2">
+      				...
+      				Primary
+      				<link ref="l4" href="/docs">Docs</link>
+      			</banner>
+      			<main ref="l5">
+      				# Welcome
+      				<button ref="l7">Save</button>
+      				<textbox ref="l8" value="query" placeholder="Search docs">
+      					Search docs
+      					query
+      				</textbox>
+      			</main>
+      		</document>
+      	</frame>
+      </page>
+    `,
+    );
+  });
+
+  test("scopes an already-captured tree by ref with numeric-suffix fallback", async ({
+    expectScopedSnapshot,
+  }) => {
+    await expectScopedSnapshot(
+      `
+      <!doctype html>
+      <title>Scoped Snapshot</title>
+      <main>
+        <button>Sibling</button>
+        <button>Target</button>
+      </main>
+    `,
+      "e4",
+      `
+      <page title="Scoped Snapshot" url="<page-url>">
+      	<frame index="0" url="<page-url>">
+      		<button ref="l4">Target</button>
+      	</frame>
+      </page>
+    `,
+    );
+  });
+
+  test("compacts low-value wrappers, clickable generics, single-child chains, and long child lists", async ({
+    expectSnapshot,
+  }) => {
+    await expectSnapshot(
+      `
+      <!doctype html>
+      <title>Compact Demo</title>
+      <style>.card { cursor: pointer; }</style>
+      <main>
+        <div><section><p>Flattened wrapper text</p></section></div>
+        <div class="card" onclick="void 0">Open card</div>
+        <main aria-label="Outer">
+          <nav aria-label="Navigation">
+            <form aria-label="Lookup"><button>Submit chain</button></form>
+          </nav>
+        </main>
+        <ul>
+          <li><button>One</button></li>
+          <li><button>Two</button></li>
+          <li><button>Three</button></li>
+          <li><button>Four</button></li>
+          <li><button>Five</button></li>
+          <li><button>Six</button></li>
+        </ul>
+      </main>
+    `,
+      `
+      <page title="Compact Demo" url="<page-url>">
+      	<frame index="0" url="<page-url>">
+      		<document ref="l1">
+      			Compact Demo
+      			<main ref="l2">
+      				Flattened wrapper text
+      				<button ref="l3">Open card</button>
+      				<main ref="l4">
+      					Outer
+      					...
+      					Lookup
+      					<button ref="l7">Submit chain</button>
+      				</main>
+      				<list>
+      					<listitem>
+      						<button ref="l9">One</button>
+      					</listitem>
+      					<listitem>
+      						<button ref="l11">Two</button>
+      					</listitem>
+      					<listitem>
+      						<button ref="l13">Three</button>
+      					</listitem>
+      					<listitem>
+      						<button ref="l15">Four</button>
+      					</listitem>
+      					[Truncated 2 more elements. Interactive elements: <button ref="l17">Five</button>, <button ref="l19">Six</button>]
+      				</list>
+      			</main>
+      		</document>
+      	</frame>
+      </page>
+    `,
+    );
+  });
+});
+
+describe("diffSnapshots", () => {
+  test("returns no rendered diff for unchanged browser-rendered snapshots", async ({
+    expectSnapshotDiff,
+  }) => {
+    const html = `
+      <!-- BEFORE -->
+      <!doctype html>
+      <title>Stable Demo</title>
+      <main><button>Stable</button></main>
+    `;
+
+    // AFTER: unchanged from BEFORE.
+    await expectSnapshotDiff(html, html, "");
+  });
+
+  test("tracks added, removed, and modified nodes under context ancestors", async ({
+    expectSnapshotDiff,
+  }) => {
+    await expectSnapshotDiff(
+      `
+        <!-- BEFORE -->
+        <!doctype html>
+        <title>Diff Demo</title>
+        <main>
+          <h1>Tasks</h1>
+          <button id="stable">Stable</button>
+          <button id="save">Save</button>
+          <button id="delete">Delete</button>
+        </main>
+      `,
+      `
+        <!-- AFTER -->
+        <!doctype html>
+        <title>Diff Demo</title>
+        <main>
+          <h1>Tasks</h1>
+          <button id="stable">Stable</button>
+          <button id="save">Saved</button>
+          <a id="docs" href="https://example.test/docs">Docs</a>
+        </main>
+      `,
+      `
+      <page title="Diff Demo" url="<page-url>">
+      	<frame index="0" url="<page-url>">
+      		<document ref="l1">
+      			...
+      			<main ref="l2">
+      				...
+      ~ 				<button ref="l5">Saved</button>
+      + 				<link ref="l6" href="https://example.test/docs">Docs</link>
+      - 				<button ref="l6">...</button>
+      			</main>
+      		</document>
+      	</frame>
+      </page>
+    `,
+    );
+  });
+
+  test("suppresses href query and hash changes from browser-rendered links", async ({
+    expectSnapshotDiff,
+  }) => {
+    await expectSnapshotDiff(
+      `
+        <!-- BEFORE -->
+        <!doctype html>
+        <title>Href Demo</title>
+        <main><a id="docs" href="https://example.test/docs?utm=old#intro">Docs</a></main>
+      `,
+      `
+        <!-- AFTER -->
+        <!doctype html>
+        <title>Href Demo</title>
+        <main><a id="docs" href="https://example.test/docs?utm=new#api">Docs</a></main>
+      `,
+      "",
+    );
+  });
+
+  test("suppresses ref-only changes that browser HTML cannot express directly", () => {
+    const before = makeSnapshot([
+      makeNode({
+        nodeId: "root",
+        role: "RootWebArea",
+        ref: "l1",
+        children: [
+          makeNode({
+            nodeId: "docs",
+            role: "link",
+            name: "Docs",
+            ref: "l2",
+            attributes: { href: "https://example.test/docs" },
+          }),
+        ],
+      }),
+    ]);
+    const after = makeSnapshot([
+      makeNode({
+        nodeId: "root",
+        role: "RootWebArea",
+        ref: "l10",
+        children: [
+          makeNode({
+            nodeId: "docs",
+            role: "link",
+            name: "Docs",
+            ref: "l20",
+            attributes: { href: "https://example.test/docs" },
+          }),
+        ],
+      }),
+    ]);
+
+    const diff = diffSnapshots(before, after);
+
+    expect(renderSnapshotDiff(diff)).toBe("");
+  });
+});

--- a/packages/libretto/src/shared/snapshot/types.ts
+++ b/packages/libretto/src/shared/snapshot/types.ts
@@ -1,0 +1,43 @@
+export type SnapshotPrimitive = string | number | boolean | null;
+
+export type Snapshot = {
+  title: string;
+  url: string;
+  frames: SnapshotFrame[];
+};
+
+export type SnapshotFrame = SnapshotAvailableFrame | SnapshotUnavailableFrame;
+
+export type SnapshotAvailableFrame = {
+  status: "ok";
+  id: string;
+  index: number;
+  url: string;
+  name: string | null;
+  parentId: string | null;
+  roots: SnapshotNode[];
+};
+
+export type SnapshotUnavailableFrame = {
+  status: "unavailable";
+  id: string;
+  index: number;
+  url: string;
+  name: string | null;
+  parentId: string | null;
+  error: string;
+};
+
+export type SnapshotNode = {
+  nodeId: string;
+  ignored: boolean;
+  role: string;
+  name: string | null;
+  value: SnapshotPrimitive;
+  description: string | null;
+  properties: Record<string, SnapshotPrimitive>;
+  attributes: Record<string, string>;
+  children: SnapshotNode[];
+  ref: string | null;
+  subtreeSize: number;
+};

--- a/packages/libretto/src/shared/snapshot/wait-for-page-stable.ts
+++ b/packages/libretto/src/shared/snapshot/wait-for-page-stable.ts
@@ -1,0 +1,381 @@
+import type { Page } from "playwright";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MUTATION_IDLE_MS = 400;
+const DEFAULT_MINIMUM_WAIT_MS = 800;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+
+type LoadState = "domcontentloaded" | "load";
+
+export type PageStabilityWaitOptions = {
+  timeoutMs?: number;
+  mutationIdleMs?: number;
+  minimumWaitMs?: number;
+  pollIntervalMs?: number;
+};
+
+export type PageStabilityWaitResult = {
+  ok: boolean;
+  diagnostics: string[];
+};
+
+type PageStabilityWaitArgs = Required<PageStabilityWaitOptions>;
+
+type BrowserWaiterApi = {
+  waitForStability(args: PageStabilityWaitArgs): Promise<string | null>;
+};
+
+export async function waitForPageStable(
+  page: Page,
+  options: PageStabilityWaitOptions = {},
+): Promise<PageStabilityWaitResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const mutationIdleMs = options.mutationIdleMs ?? DEFAULT_MUTATION_IDLE_MS;
+  const minimumWaitMs = options.minimumWaitMs ?? DEFAULT_MINIMUM_WAIT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  const loadDiagnostics = await Promise.all([
+    waitForLoadState(page, "domcontentloaded", deadline),
+    waitForLoadState(page, "load", deadline),
+  ]);
+  const browserDiagnostic = await waitForBrowserStability(page, {
+    timeoutMs: Math.max(0, deadline - Date.now()),
+    mutationIdleMs,
+    minimumWaitMs,
+    pollIntervalMs,
+  });
+
+  const diagnostics = [...loadDiagnostics, browserDiagnostic].filter(
+    (diagnostic): diagnostic is string => diagnostic !== null,
+  );
+
+  return { ok: diagnostics.length === 0, diagnostics };
+}
+
+async function waitForLoadState(
+  page: Page,
+  state: LoadState,
+  deadline: number,
+): Promise<string | null> {
+  const timeout = Math.max(0, deadline - Date.now());
+  if (timeout === 0) return `Timed out waiting for ${state}`;
+
+  try {
+    await page.waitForLoadState(state, { timeout });
+    return null;
+  } catch (error) {
+    return `Failed to wait for ${state}: ${errorMessage(error)}`;
+  }
+}
+
+async function waitForBrowserStability(
+  page: Page,
+  args: PageStabilityWaitArgs,
+): Promise<string | null> {
+  const deadline = Date.now() + args.timeoutMs;
+  let lastError: string | null = null;
+
+  while (Date.now() < deadline) {
+    try {
+      await page.evaluate(installBrowserStabilityWaiter);
+      return await page.evaluate(runBrowserStabilityWait, {
+        ...args,
+        timeoutMs: Math.max(0, deadline - Date.now()),
+      });
+    } catch (error) {
+      lastError = errorMessage(error);
+      if (!isRetryableExecutionContextError(lastError)) {
+        return `Failed to wait for page stability: ${lastError}`;
+      }
+      await sleep(Math.min(100, Math.max(0, deadline - Date.now())));
+    }
+  }
+
+  return lastError
+    ? `Failed to wait for page stability: ${lastError}`
+    : "Timed out waiting for page stability";
+}
+
+function installBrowserStabilityWaiter(): void {
+  const symbol = Symbol.for("libretto.pageStabilityWaiter");
+  const windowWithWaiter = window as Window & {
+    [symbol]?: BrowserWaiterApi;
+  };
+  if (windowWithWaiter[symbol]) return;
+
+  type WaiterState = {
+    pendingRequests: number;
+    pendingUrls: Set<string>;
+  };
+
+  type ResourceSnapshot = {
+    pendingResources: number;
+    pendingResourceLabels: string[];
+  };
+
+  const state: WaiterState = {
+    pendingRequests: 0,
+    pendingUrls: new Set<string>(),
+  };
+
+  const requestStarted = (url: string): void => {
+    state.pendingRequests += 1;
+    state.pendingUrls.add(url);
+  };
+
+  const requestFinished = (url: string): void => {
+    state.pendingRequests = Math.max(0, state.pendingRequests - 1);
+    state.pendingUrls.delete(url);
+  };
+
+  const originalFetch = window.fetch;
+  if (typeof originalFetch === "function") {
+    window.fetch = function trackedFetch(
+      this: Window,
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> {
+      const url = requestUrl(input);
+      requestStarted(url);
+      return originalFetch.call(this, input, init).finally(() => {
+        requestFinished(url);
+      });
+    };
+  }
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+  const originalSend = XMLHttpRequest.prototype.send;
+  const requestUrls = new WeakMap<XMLHttpRequest, string>();
+  const startedRequests = new WeakSet<XMLHttpRequest>();
+
+  XMLHttpRequest.prototype.open = function trackedOpen(
+    this: XMLHttpRequest,
+    method: string,
+    url: string | URL,
+    async?: boolean,
+    username?: string | null,
+    password?: string | null,
+  ): void {
+    requestUrls.set(this, String(url));
+    return originalOpen.call(
+      this,
+      method,
+      url,
+      async ?? true,
+      username,
+      password,
+    );
+  };
+
+  XMLHttpRequest.prototype.send = function trackedSend(
+    this: XMLHttpRequest,
+    body?: Document | XMLHttpRequestBodyInit | null,
+  ): void {
+    const url = requestUrls.get(this) ?? "XMLHttpRequest";
+    requestStarted(url);
+    startedRequests.add(this);
+
+    const finish = (): void => {
+      if (!startedRequests.has(this)) return;
+      startedRequests.delete(this);
+      requestFinished(url);
+    };
+
+    this.addEventListener("loadend", finish, { once: true });
+    try {
+      return originalSend.call(this, body);
+    } catch (error) {
+      finish();
+      throw error;
+    }
+  };
+
+  const waitForStability = async (
+    args: PageStabilityWaitArgs,
+  ): Promise<string | null> => {
+    const sleepInPage = (ms: number): Promise<void> =>
+      new Promise((resolve) => window.setTimeout(resolve, ms));
+
+    const startedAt = Date.now();
+    let lastActivityAt = Date.now();
+    let lastResources: ResourceSnapshot = {
+      pendingResources: 0,
+      pendingResourceLabels: [],
+    };
+    let lastPendingRequests = state.pendingRequests;
+    let lastPendingUrls = [...state.pendingUrls];
+
+    const markActivity = (): void => {
+      lastActivityAt = Date.now();
+    };
+
+    const observer = new MutationObserver(markActivity);
+    const root = document.documentElement ?? document.body;
+    if (root) {
+      observer.observe(root, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+
+    try {
+      while (Date.now() - startedAt < args.timeoutMs) {
+        lastResources = countPendingResourceElements();
+        lastPendingRequests = state.pendingRequests;
+        lastPendingUrls = [...state.pendingUrls];
+        const pageLoaded = document.readyState === "complete";
+        const mutationIdle = Date.now() - lastActivityAt >= args.mutationIdleMs;
+        const waitedLongEnough = Date.now() - startedAt >= args.minimumWaitMs;
+        const requestIdle = lastPendingRequests === 0;
+        const resourceIdle = lastResources.pendingResources === 0;
+
+        if (
+          pageLoaded &&
+          mutationIdle &&
+          waitedLongEnough &&
+          requestIdle &&
+          resourceIdle
+        ) {
+          return null;
+        }
+
+        await sleepInPage(args.pollIntervalMs);
+      }
+    } finally {
+      observer.disconnect();
+    }
+
+    return formatStabilityTimeout({
+      timeoutMs: args.timeoutMs,
+      readyState: document.readyState,
+      pendingRequests: lastPendingRequests,
+      pendingUrls: lastPendingUrls,
+      pendingResources: lastResources.pendingResources,
+      pendingResourceLabels: lastResources.pendingResourceLabels,
+    });
+  };
+
+  Object.defineProperty(windowWithWaiter, symbol, {
+    value: { waitForStability } satisfies BrowserWaiterApi,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+
+  function countPendingResourceElements(): ResourceSnapshot {
+    const elements = Array.from(
+      document.querySelectorAll(
+        'img,video,audio,embed,object,iframe[src],link[rel="stylesheet"][href]',
+      ),
+    );
+    let pendingResources = 0;
+    const pendingResourceLabels: string[] = [];
+
+    const markPending = (element: Element): void => {
+      pendingResources += 1;
+      if (pendingResourceLabels.length < 5) {
+        pendingResourceLabels.push(resourceLabel(element));
+      }
+    };
+
+    for (const element of elements) {
+      const tagName = element.tagName.toLowerCase();
+      if (tagName === "img") {
+        const image = element as HTMLImageElement;
+        if (image.loading !== "lazy" && !image.complete) markPending(element);
+        continue;
+      }
+
+      if (tagName === "video" || tagName === "audio") {
+        const media = element as HTMLMediaElement;
+        if (media.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+          markPending(element);
+        }
+        continue;
+      }
+
+      if (tagName === "iframe") {
+        const iframe = element as HTMLIFrameElement;
+        try {
+          if (
+            iframe.contentDocument &&
+            iframe.contentDocument.readyState !== "complete"
+          ) {
+            markPending(element);
+          }
+        } catch {
+          // Cross-origin iframes cannot be inspected; treat them as settled.
+        }
+        continue;
+      }
+
+      if (tagName === "link") {
+        const link = element as HTMLLinkElement;
+        if (!link.sheet) markPending(element);
+      }
+    }
+
+    return { pendingResources, pendingResourceLabels };
+  }
+
+  function requestUrl(input: RequestInfo | URL): string {
+    if (typeof input === "string") return input;
+    if (input instanceof URL) return input.href;
+    return input.url;
+  }
+
+  function resourceLabel(element: Element): string {
+    const tagName = element.tagName.toLowerCase();
+    const source =
+      element.getAttribute("src") ?? element.getAttribute("href") ?? "";
+    return source ? `${tagName}:${source}` : tagName;
+  }
+
+  function formatStabilityTimeout(args: {
+    timeoutMs: number;
+    readyState: DocumentReadyState;
+    pendingRequests: number;
+    pendingUrls: string[];
+    pendingResources: number;
+    pendingResourceLabels: string[];
+  }): string {
+    const urls = args.pendingUrls.slice(0, 5).join(", ");
+    const resources = args.pendingResourceLabels.join(", ");
+    return (
+      `Timed out waiting for page stability after ${args.timeoutMs}ms ` +
+      `(readyState=${args.readyState}, pendingRequests=${args.pendingRequests}` +
+      `${urls ? `, pendingUrls=${urls}` : ""}, pendingResources=${args.pendingResources}` +
+      `${resources ? `, pendingResourceLabels=${resources}` : ""})`
+    );
+  }
+}
+
+async function runBrowserStabilityWait(
+  args: PageStabilityWaitArgs,
+): Promise<string | null> {
+  const symbol = Symbol.for("libretto.pageStabilityWaiter");
+  const waiter = (
+    window as unknown as Window & Record<symbol, BrowserWaiterApi | undefined>
+  )[symbol];
+  if (!waiter) return "Page stability waiter was not installed.";
+  return waiter.waitForStability(args);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRetryableExecutionContextError(message: string): boolean {
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("Cannot find context with specified id") ||
+    message.includes("Most likely the page has been closed")
+  );
+}

--- a/packages/libretto/src/shared/snapshot/wait-for-page-stable.ts
+++ b/packages/libretto/src/shared/snapshot/wait-for-page-stable.ts
@@ -25,6 +25,20 @@ type BrowserWaiterApi = {
   waitForStability(args: PageStabilityWaitArgs): Promise<string | null>;
 };
 
+export async function preparePageStabilityWait(
+  page: Page,
+  options: Pick<PageStabilityWaitOptions, "timeoutMs"> = {},
+): Promise<PageStabilityWaitResult> {
+  const diagnostic = await installBrowserStabilityWaiterOnPage(
+    page,
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  return {
+    ok: diagnostic === null,
+    diagnostics: diagnostic === null ? [] : [diagnostic],
+  };
+}
+
 export async function waitForPageStable(
   page: Page,
   options: PageStabilityWaitOptions = {},
@@ -77,8 +91,13 @@ async function waitForBrowserStability(
   let lastError: string | null = null;
 
   while (Date.now() < deadline) {
+    const installDiagnostic = await installBrowserStabilityWaiterOnPage(
+      page,
+      Math.max(0, deadline - Date.now()),
+    );
+    if (installDiagnostic) return installDiagnostic;
+
     try {
-      await page.evaluate(installBrowserStabilityWaiter);
       return await page.evaluate(runBrowserStabilityWait, {
         ...args,
         timeoutMs: Math.max(0, deadline - Date.now()),
@@ -97,7 +116,32 @@ async function waitForBrowserStability(
     : "Timed out waiting for page stability";
 }
 
-function installBrowserStabilityWaiter(): void {
+async function installBrowserStabilityWaiterOnPage(
+  page: Page,
+  timeoutMs: number,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | null = null;
+
+  while (Date.now() < deadline) {
+    try {
+      await page.evaluate(installPageStabilityWaiter);
+      return null;
+    } catch (error) {
+      lastError = errorMessage(error);
+      if (!isRetryableExecutionContextError(lastError)) {
+        return `Failed to install page stability waiter: ${lastError}`;
+      }
+      await sleep(Math.min(100, Math.max(0, deadline - Date.now())));
+    }
+  }
+
+  return lastError
+    ? `Failed to install page stability waiter: ${lastError}`
+    : "Timed out installing page stability waiter";
+}
+
+export function installPageStabilityWaiter(): void {
   const symbol = Symbol.for("libretto.pageStabilityWaiter");
   const windowWithWaiter = window as Window & {
     [symbol]?: BrowserWaiterApi;

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -255,6 +255,87 @@ describe("daemon IPC", () => {
     expect(result.stderr).toContain(`snapshot --session ${session}`);
   }, 45_000);
 
+  test("compact exec diff uses the snapshot cache as its before state", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-exec-cached-diff";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-exec-cached-diff",
+      "Compact Exec Cached Diff Test",
+      `<main><h1>Before Heading</h1><button>Save Changes</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const beforeSnapshot = await librettoCli(`snapshot --session ${session}`);
+    expect(beforeSnapshot.stdout).toContain("Before Heading");
+
+    const result = await librettoCli(
+      `exec "await page.locator('h1').evaluate((node) => node.textContent = 'After Heading')" --session ${session}`,
+    );
+    expect(result.stdout).toContain("Executed successfully");
+    expect(result.stdout).toContain("Page changes:");
+    expect(result.stdout).toContain("Before Heading");
+    expect(result.stdout).toContain("After Heading");
+  }, 45_000);
+
+  test("compact exec diff captures a before state when no snapshot is cached", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-exec-fresh-diff";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-exec-fresh-diff",
+      "Compact Exec Fresh Diff Test",
+      `<main><h1>Stable Heading</h1></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const result = await librettoCli(
+      `exec "await page.locator('main').evaluate((node) => node.insertAdjacentHTML('beforeend', '<p>New Content</p>'))" --session ${session}`,
+    );
+    expect(result.stdout).toContain("Executed successfully");
+    expect(result.stdout).toContain("Page changes:");
+    expect(result.stdout).toContain("New Content");
+  }, 45_000);
+
+  test("readonly-exec does not print page changes or invalidate the snapshot cache", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-readonly-cache";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-readonly-cache",
+      "Compact Readonly Cache Test",
+      `<main><h1>Readonly Heading</h1><button>Cache Target</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const fullSnapshot = await librettoCli(`snapshot --session ${session}`);
+    const ref = fullSnapshot.stdout.match(/<button ref="([^"]+)"/)?.[1];
+    expect(ref).toBeTruthy();
+
+    const readonly = await librettoCli(
+      `readonly-exec "return await page.locator('h1').textContent()" --session ${session}`,
+    );
+    expect(readonly.stdout).toContain("Readonly Heading");
+    expect(readonly.stdout).not.toContain("Page changes:");
+
+    const scopedSnapshot = await librettoCli(
+      `snapshot ${ref} --session ${session}`,
+    );
+    expect(scopedSnapshot.stdout).toContain("Cache Target");
+  }, 45_000);
+
   test("exec without --page targets the original page after a workflow opens another page", async ({
     librettoCli,
     writeWorkflow,

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -235,6 +235,54 @@ describe("daemon IPC", () => {
     expect(scopedSnapshot.stdout).not.toContain("Sibling Details");
   }, 45_000);
 
+  test("compact snapshot refs only reuse cache for the same page", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-snapshot-page-cache";
+    const firstUrl = await writeFixturePage(
+      workspacePath,
+      "compact-snapshot-page-cache-first",
+      "Compact Snapshot First Page",
+      `<main><button>First Page Button</button></main>`,
+    );
+    const secondUrl = await writeFixturePage(
+      workspacePath,
+      "compact-snapshot-page-cache-second",
+      "Compact Snapshot Second Page",
+      `<main><button>Second Page Button</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${firstUrl}" --headless --session ${session}`);
+    await librettoCli(
+      `exec "const p = await context.newPage(); await p.goto('${secondUrl}')" --session ${session}`,
+    );
+
+    const pages = await librettoCli(`pages --session ${session}`);
+    const firstPageId = pages.stdout
+      .split("\n")
+      .find((line) => line.includes("compact-snapshot-page-cache-first"))
+      ?.match(/id=(\S+)/)?.[1];
+    const secondPageId = pages.stdout
+      .split("\n")
+      .find((line) => line.includes("compact-snapshot-page-cache-second"))
+      ?.match(/id=(\S+)/)?.[1];
+    expect(firstPageId).toBeTruthy();
+    expect(secondPageId).toBeTruthy();
+
+    const firstSnapshot = await librettoCli(
+      `snapshot --session ${session} --page ${firstPageId}`,
+    );
+    const ref = firstSnapshot.stdout.match(/<button ref="([^"]+)"/)?.[1];
+    expect(ref).toBeTruthy();
+
+    const secondScopedSnapshot = await librettoCli(
+      `snapshot ${ref} --session ${session} --page ${secondPageId}`,
+    );
+    expect(secondScopedSnapshot.stderr).toContain("No compact snapshot is cached");
+  }, 45_000);
+
   test("compact snapshot ref fails before a full compact snapshot is cached", async ({
     librettoCli,
     workspacePath,

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -353,6 +353,29 @@ describe("daemon IPC", () => {
     expect(result.stdout).toContain("New Content");
   }, 45_000);
 
+  test("compact exec preserves successful results when diff capture fails", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-exec-diff-fails";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-exec-diff-fails",
+      "Compact Exec Diff Fails Test",
+      `<main><h1>Closing Page</h1></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const result = await librettoCli(
+      `exec "await page.close(); return 'closed ok'" --session ${session}`,
+    );
+    expect(result.stdout).toContain("closed ok");
+    expect(result.stdout).not.toContain("Page changes:");
+    expect(result.stderr).not.toContain("Target page, context or browser has been closed");
+  }, 45_000);
+
   test("readonly-exec does not print page changes or invalidate the snapshot cache", async ({
     librettoCli,
     workspacePath,

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -181,6 +181,80 @@ describe("daemon IPC", () => {
     expect(result.stderr).not.toContain("daemon may have crashed");
   }, 45_000);
 
+  test("compact snapshot prints screenshot path, tree, and subtree hint", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-snapshot";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-snapshot",
+      "Compact Snapshot Test",
+      `<main><h1>Compact Heading</h1><button>Save Changes</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const result = await librettoCli(`snapshot --session ${session}`);
+    expect(result.stdout).toContain("Screenshot at ");
+    expect(result.stdout.indexOf("Screenshot at ")).toBeLessThan(
+      result.stdout.indexOf("<page"),
+    );
+    expect(result.stdout).toContain("<page");
+    expect(result.stdout).toContain("# Compact Heading");
+    expect(result.stdout).toContain("Save Changes");
+    expect(result.stdout).toContain("Hint: Use ");
+    expect(result.stdout).toContain("snapshot <ref> --session");
+  }, 45_000);
+
+  test("compact snapshot ref uses cached full snapshot and scopes output", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-snapshot-ref";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-snapshot-ref",
+      "Compact Snapshot Ref Test",
+      `<main><h1>Scoped Page</h1><p>Sibling Details</p><button>Save Changes</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const fullSnapshot = await librettoCli(`snapshot --session ${session}`);
+    const ref = fullSnapshot.stdout.match(/<button ref="([^"]+)"/)?.[1];
+    expect(ref).toBeTruthy();
+
+    const scopedSnapshot = await librettoCli(
+      `snapshot ${ref} --session ${session}`,
+    );
+    expect(scopedSnapshot.stdout).toContain("Screenshot at ");
+    expect(scopedSnapshot.stdout).toContain("Save Changes");
+    expect(scopedSnapshot.stdout).not.toContain("Sibling Details");
+  }, 45_000);
+
+  test("compact snapshot ref fails before a full compact snapshot is cached", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-snapshot-ref-missing";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-snapshot-ref-missing",
+      "Compact Snapshot Missing Ref Cache Test",
+      `<main><button>Save Changes</button></main>`,
+    );
+
+    await librettoCli("experiments enable compactSnapshotFormat");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const result = await librettoCli(`snapshot l1 --session ${session}`);
+    expect(result.stderr).toContain("No compact snapshot is cached");
+    expect(result.stderr).toContain(`snapshot --session ${session}`);
+  }, 45_000);
+
   test("exec without --page targets the original page after a workflow opens another page", async ({
     librettoCli,
     writeWorkflow,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       openai:
         specifier: ^6.29.0
         version: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      outdent:
+        specifier: ^0.8.0
+        version: 0.8.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -6332,6 +6335,9 @@ packages:
 
   openid-client@6.8.2:
     resolution: {integrity: sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==}
+
+  outdent@0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -15402,6 +15408,8 @@ snapshots:
     dependencies:
       jose: 6.2.2
       oauth4webapi: 3.8.5
+
+  outdent@0.8.0: {}
 
   own-keys@1.0.1:
     dependencies:

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -263,8 +263,8 @@ export {
 
 Document how maintainers enable and try the experiment without changing the public docs for the stable snapshot analysis path. Keep mirrored skill files in sync through the source skill file and mirror command.
 
-- [ ] Update `packages/libretto/skills/libretto/SKILL.md` with the experimental `snapshot [ref]` and `exec` diff behavior only if skill guidance should mention experiments
-- [ ] Do not hand-edit `.agents/skills/` or `.claude/skills/`; run `pnpm sync:mirrors` after editing the source skill file
-- [ ] Avoid changing Mintlify user docs unless the experiment is intended to be user-facing
-- [ ] Run `pnpm check:mirrors` if mirrored skill files change
-- [ ] Run `pnpm -s type-check --filter=libretto`
+- [x] Leave `packages/libretto/skills/libretto/SKILL.md` unchanged because skill guidance should not mention the experiment yet
+- [x] Do not hand-edit `.agents/skills/` or `.claude/skills/`; run `pnpm sync:mirrors` after editing the source skill file
+- [x] Avoid changing Mintlify user docs unless the experiment is intended to be user-facing
+- [x] Run `pnpm check:mirrors` if mirrored skill files change
+- [x] Run `pnpm -s type-check --filter=libretto`

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -69,10 +69,10 @@ export const EXPERIMENTS = {
 } as const;
 ```
 
-- [ ] Add `compactSnapshotFormat` to `packages/libretto/src/cli/core/experiments.ts` with `defaultValue: false`
-- [ ] Ensure `ExperimentName` and `Experiments` continue to infer from the registry without duplicated types
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes
-- [ ] Add or update a user-level experiment CLI test only if existing coverage does not already assert registry listing behavior
+- [x] Add `compactSnapshotFormat` to `packages/libretto/src/cli/core/experiments.ts` with `defaultValue: false`
+- [x] Ensure `ExperimentName` and `Experiments` continue to infer from the registry without duplicated types
+- [x] Verify `pnpm -s type-check --filter=libretto` passes
+- [x] Add or update a user-level experiment CLI test only if existing coverage does not already assert registry listing behavior
 
 ### Phase 2: Add the shared snapshot tree API
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -226,20 +226,20 @@ async function handleCompactExec(args: ExecArgs, cache: SnapshotCache) {
 }
 ```
 
-- [ ] Add daemon-owned snapshot cache state in `packages/libretto/src/cli/core/daemon/daemon.ts`, for example `latestCompactSnapshot: Snapshot | null`
-- [ ] Pass the cached before snapshot into the exec handler or keep the cache orchestration in daemon before/after calling `handleExec`
-- [ ] If no cached snapshot exists, capture a fresh before snapshot immediately before running user exec code
-- [ ] Always diff full snapshots; scoped `snapshot <ref>` must not replace the cache with a subtree
-- [ ] Run user exec code exactly once and preserve existing result/output/error behavior
-- [ ] After successful exec, wait for page stability, capture the after snapshot, and compute `diffSnapshots(before, after)`
-- [ ] Return the diff with the exec result and print user-visible page changes after normal exec output
-- [ ] Replace the daemon cache with the after snapshot after successful exec
-- [ ] Invalidate the daemon cache on exec failure unless an after snapshot is deliberately captured and stored; keep v1 simple by clearing it on failure
-- [ ] Ensure `readonly-exec` never captures, invalidates, or prints page-change diffs
-- [ ] Add a user-level daemon-backed test where `snapshot` is run first, then `exec` mutates the page, and the exec diff reflects the change from the previously returned snapshot
-- [ ] Add a user-level daemon-backed test where `exec` is run without a previous snapshot and still prints a diff by capturing its own before-state
-- [ ] Add a user-level daemon-backed test that `readonly-exec` does not print page changes and does not invalidate the snapshot cache
-- [ ] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts`
+- [x] Add daemon-owned snapshot cache state in `packages/libretto/src/cli/core/daemon/daemon.ts`, for example `latestCompactSnapshot: Snapshot | null`
+- [x] Pass the cached before snapshot into the exec handler or keep the cache orchestration in daemon before/after calling `handleExec`
+- [x] If no cached snapshot exists, capture a fresh before snapshot immediately before running user exec code
+- [x] Always diff full snapshots; scoped `snapshot <ref>` must not replace the cache with a subtree
+- [x] Run user exec code exactly once and preserve existing result/output/error behavior
+- [x] After successful exec, wait for page stability, capture the after snapshot, and compute `diffSnapshots(before, after)`
+- [x] Return the diff with the exec result and print user-visible page changes after normal exec output
+- [x] Replace the daemon cache with the after snapshot after successful exec
+- [x] Invalidate the daemon cache on exec failure unless an after snapshot is deliberately captured and stored; keep v1 simple by clearing it on failure
+- [x] Ensure `readonly-exec` never captures, invalidates, or prints page-change diffs
+- [x] Add a user-level daemon-backed test where `snapshot` is run first, then `exec` mutates the page, and the exec diff reflects the change from the previously returned snapshot
+- [x] Add a user-level daemon-backed test where `exec` is run without a previous snapshot and still prints a diff by capturing its own before-state
+- [x] Add a user-level daemon-backed test that `readonly-exec` does not print page changes and does not invalidate the snapshot cache
+- [x] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts`
 
 ### Phase 7: Keep package exports minimal
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -90,15 +90,15 @@ async function snapshot(page: Page): Promise<Snapshot> {
 }
 ```
 
-- [ ] Add `packages/libretto/src/shared/snapshot/types.ts`
-- [ ] Add `snapshot(page)`, `findSnapshotNodeByRef`, and `scopeSnapshotToRef` in `packages/libretto/src/shared/snapshot/capture-snapshot.ts`
-- [ ] Keep `Snapshot` as a tree type, not a pre-rendered string
-- [ ] Preserve the useful ref behavior from the worktree: `l<number>` assignment and numeric-suffix fallback for refs like `e16`
-- [ ] Reuse only the capture details from the worktree that are needed for the compact tree: accessibility role/name/value/state, useful DOM attributes, and enough metadata for clickable elements
-- [ ] Avoid adding renderer profile fields, alternate raw/default render models, or a `projected` argument
-- [ ] Treat `snapshot(page)` as daemon/internal machinery; compact snapshot CLI calls must go through daemon IPC
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes
-- [ ] Add focused coverage through user-level CLI tests in later phases rather than testing CDP internals directly
+- [x] Add `packages/libretto/src/shared/snapshot/types.ts`
+- [x] Add `snapshot(page)`, `findSnapshotNodeByRef`, and `scopeSnapshotToRef` in `packages/libretto/src/shared/snapshot/capture-snapshot.ts`
+- [x] Keep `Snapshot` as a tree type, not a pre-rendered string
+- [x] Preserve the useful ref behavior from the worktree: `l<number>` assignment and numeric-suffix fallback for refs like `e16`
+- [x] Reuse only the capture details from the worktree that are needed for the compact tree: accessibility role/name/value/state, useful DOM attributes, and enough metadata for clickable elements
+- [x] Avoid adding renderer profile fields, alternate raw/default render models, or a `projected` argument
+- [x] Treat `snapshot(page)` as daemon/internal machinery; compact snapshot CLI calls must go through daemon IPC
+- [x] Verify `pnpm -s type-check --filter=libretto` passes
+- [x] Add focused coverage through user-level CLI tests in later phases rather than testing CDP internals directly
 
 ### Phase 3: Add the single snapshot renderer and diff helper
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -63,7 +63,7 @@ export const EXPERIMENTS = {
   },
   compactSnapshotFormat: {
     title: "Compact snapshot format",
-    description:
+    oneSentenceDescription:
       "Use compact accessibility snapshots and exec page-change diffs without an AI sub-agent.",
     defaultValue: false,
   },
@@ -192,23 +192,24 @@ async function runCompactSnapshot(input: SnapshotInput, ctx: SnapshotContext) {
 }
 ```
 
-- [ ] Add `withExperiments()` to `snapshotCommand`
-- [ ] Change `objective` and `context` input fields to optional at parse time, then require them in the disabled/default path with the existing error wording as closely as possible
-- [ ] Add optional positional `ref` and reject it with an actionable error when the experiment is disabled
-- [ ] Extend daemon snapshot IPC args/results to support compact snapshot requests and a cached-snapshot request flag for `snapshot <ref>`
-- [ ] In `packages/libretto/src/cli/core/daemon/snapshot.ts`, keep the existing PNG+HTML return shape for default mode and add a compact return shape containing a screenshot `pngPath` and full `Snapshot` tree
-- [ ] For every compact `snapshot` command, capture a screenshot before returning and print it in CLI output before the tree as `Screenshot at <path>`
-- [ ] After compact snapshot output, print the subtree guidance hint at the CLI/daemon output layer rather than from `renderSnapshot`; use `librettoCommand(...)` for the command text
-- [ ] Reuse the existing screenshot viewport normalization and zero-width retry behavior where practical; do not create a separate screenshot abstraction unless duplication becomes unavoidable
-- [ ] In `packages/libretto/src/cli/core/daemon/daemon.ts`, store the latest full compact snapshot in daemon memory after each unscoped compact `snapshot` command
-- [ ] If a ref is requested, do not capture a new snapshot tree; capture only the screenshot, return the latest cached full snapshot, then let `renderSnapshot(snapshot, refId)` scope it
-- [ ] If a ref is requested and no compact snapshot is cached, throw an actionable error telling the user to run `libretto snapshot --session <name>` first
-- [ ] Keep compact snapshot capture inside the daemon; the CLI must not use `connect()` or open a second browser/CDP connection
-- [ ] Verify disabled behavior with an existing or updated test: `snapshot --session <name>` still reports missing `--objective`
-- [ ] Add a user-level daemon-backed test that enables the experiment, opens a fixture page, runs `snapshot --session <name>`, and sees `Screenshot at ` before compact output such as `<page`, `# Heading`, and the subtree hint
-- [ ] Add a user-level daemon-backed test that runs `snapshot <ref> --session <name>` after a previous full snapshot and sees only the expected subtree text
-- [ ] Add a user-level daemon-backed test that `snapshot <ref> --session <name>` fails before any compact snapshot has been cached
-- [ ] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts stateful.spec.ts` or the closest existing targeted test command supported by the repo
+- [x] Add `withExperiments()` to `snapshotCommand`
+- [x] Change `objective` and `context` input fields to optional at parse time, then require them in the disabled/default path with the existing error wording as closely as possible
+- [x] Add optional positional `ref` and reject it with an actionable error when the experiment is disabled
+- [x] Extend daemon snapshot IPC args/results to support compact snapshot requests and a cached-snapshot request flag for `snapshot <ref>`
+- [x] In `packages/libretto/src/cli/core/daemon/snapshot.ts`, keep the existing PNG+HTML return shape for default mode and add a compact return shape containing a screenshot `pngPath` and full `Snapshot` tree
+- [x] For every compact `snapshot` command, capture a screenshot before returning and print it in CLI output before the tree as `Screenshot at <path>`
+- [x] After compact snapshot output, print the subtree guidance hint at the CLI/daemon output layer rather than from `renderSnapshot`; use `librettoCommand(...)` for the command text
+- [x] Reuse the existing screenshot viewport normalization and zero-width retry behavior where practical; do not create a separate screenshot abstraction unless duplication becomes unavoidable
+- [x] In `packages/libretto/src/cli/core/daemon/daemon.ts`, store the latest full compact snapshot in daemon memory after each unscoped compact `snapshot` command
+- [x] If a ref is requested, do not capture a new snapshot tree; capture only the screenshot, return the latest cached full snapshot, then let `renderSnapshot(snapshot, refId)` scope it
+- [x] If a ref is requested and no compact snapshot is cached, throw an actionable error telling the user to run `libretto snapshot --session <name>` first
+- [x] Keep compact snapshot capture inside the daemon; the CLI must not use `connect()` or open a second browser/CDP connection
+- [x] Verify disabled behavior with an existing or updated test: `snapshot --session <name>` still reports missing `--objective`
+- [x] Add a user-level daemon-backed test that enables the experiment, opens a fixture page, runs `snapshot --session <name>`, and sees `Screenshot at ` before compact output such as `<page`, `# Heading`, and the subtree hint
+- [x] Add a user-level daemon-backed test that runs `snapshot <ref> --session <name>` after a previous full snapshot and sees only the expected subtree text
+- [x] Add a user-level daemon-backed test that `snapshot <ref> --session <name>` fails before any compact snapshot has been cached
+- [x] Add experiment description docs discoverable with `libretto experiments describe compactSnapshotFormat`
+- [x] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts stateful.spec.ts` or the closest existing targeted test command supported by the repo
 
 ### Phase 6: Use the daemon snapshot cache for exec diffs
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -98,7 +98,7 @@ async function snapshot(page: Page): Promise<Snapshot> {
 - [x] Avoid adding renderer profile fields, alternate raw/default render models, or a `projected` argument
 - [x] Treat `snapshot(page)` as daemon/internal machinery; compact snapshot CLI calls must go through daemon IPC
 - [x] Verify `pnpm -s type-check --filter=libretto` passes
-- [x] Add focused coverage through user-level CLI tests in later phases rather than testing CDP internals directly
+- [x] Add focused coverage through renderer/diff unit tests and later user-level CLI tests rather than testing CDP capture internals directly
 
 ### Phase 3: Add the single snapshot renderer and diff helper
 
@@ -115,15 +115,30 @@ function diffSnapshots(before: Snapshot, after: Snapshot): SnapshotDiff {
 }
 ```
 
-- [ ] Add `packages/libretto/src/shared/snapshot/render-snapshot.ts`
-- [ ] Add `packages/libretto/src/shared/snapshot/diff-snapshots.ts`
-- [ ] Match the intended compact snapshot format: page/frame tags, semantic role tags, heading text, refs, and a final subtree hint
-- [ ] Implement ref scoping in `renderSnapshot(snapshot, refId?)` by rendering a scoped view of the already-captured tree; do not recapture the page to satisfy a ref request
-- [ ] Keep only one rendering path; do not add `toRenderedSnapshot(snapshot, "projected")` or any equivalent profile switch
-- [ ] Include the minimal compaction needed for useful agent output: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
-- [ ] Preserve the useful diff behavior from the worktree: structural tree comparison, `+`/`-`/`~` output or equivalent typed metadata, context ancestors, low-signal attr suppression, normalized href comparison, and diff truncation summaries
-- [ ] Add a small `renderSnapshotDiff(diff)` only if CLI output needs a separate formatting step; keep `diffSnapshots(before, after) -> SnapshotDiff` as the core API
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+- [x] Add `packages/libretto/src/shared/snapshot/render-snapshot.ts`
+- [x] Add `packages/libretto/src/shared/snapshot/diff-snapshots.ts`
+- [x] Match the intended compact snapshot format: page/frame tags, semantic role tags, heading text, refs, and a final subtree hint
+- [x] Implement ref scoping in `renderSnapshot(snapshot, refId?)` by rendering a scoped view of the already-captured tree; do not recapture the page to satisfy a ref request
+- [x] Keep only one rendering path; do not add `toRenderedSnapshot(snapshot, "projected")` or any equivalent profile switch
+- [x] Keep renderer module exports limited to APIs and types needed by `render-snapshot.ts` and `diff-snapshots.ts`; do not export private formatting helpers
+- [x] Include the minimal compaction needed for useful agent output: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
+- [x] Preserve the useful diff behavior from the worktree: structural tree comparison, `+`/`-`/`~` output or equivalent typed metadata, context ancestors, low-signal attr suppression, normalized href comparison, and diff truncation summaries
+- [x] Add a small `renderSnapshotDiff(diff)` only if CLI output needs a separate formatting step; keep `diffSnapshots(before, after) -> SnapshotDiff` as the core API
+- [x] Verify `pnpm -s type-check --filter=libretto` passes
+
+### Phase 3.5: Add snapshot renderer and diff unit tests
+
+Add focused unit tests for the pure snapshot renderer and diff helpers. Use hand-built `Snapshot` fixtures so tests cover behavior without launching Playwright, opening CDP sessions, or asserting capture internals.
+
+- [ ] Add a unit test file under `packages/libretto/test/`, for example `snapshot-render-diff.spec.ts`
+- [ ] Cover `renderSnapshot(snapshot)` output for page/frame tags, heading text, refs, semantic role tags, and the final subtree hint
+- [ ] Cover `renderSnapshot(snapshot, refId)` scoping from an already-captured tree, including numeric-suffix fallback such as `e16` matching `l16`
+- [ ] Cover renderer compaction behavior that is easy to regress: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
+- [ ] Cover `diffSnapshots(before, after)` and `renderSnapshotDiff(diff)` for unchanged, added, removed, and modified nodes with context ancestors
+- [ ] Cover diff signal handling for ref-only changes and href query/hash changes so low-signal differences do not produce noisy diffs
+- [ ] Keep tests behavior-focused; do not assert private helper names or CDP capture details
+- [ ] Run `pnpm -s test --filter=libretto -- snapshot-render-diff.spec.ts`
+- [ ] Run `pnpm -s type-check --filter=libretto`
 
 ### Phase 4: Add page stability waiting
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -35,6 +35,7 @@ None yet.
 
 - `packages/libretto/docs/experiments.md` — experiment registry, CLI, config, and daemon plumbing conventions.
 - `docs/tests-guide.md` — testing rules for user-level CLI tests.
+- `packages/libretto/package.json` — add test-only dev dependencies such as `outdent` when needed.
 - `packages/libretto/src/cli/core/experiments.ts` — add the new internal experiment flag.
 - `packages/libretto/src/cli/commands/experiments.ts` — listing/enable/disable output will include the new flag automatically through the registry.
 - `packages/libretto/src/cli/commands/snapshot.ts` — switch snapshot command parsing and dispatch based on the experiment while preserving default AI analysis behavior.
@@ -117,7 +118,7 @@ function diffSnapshots(before: Snapshot, after: Snapshot): SnapshotDiff {
 
 - [x] Add `packages/libretto/src/shared/snapshot/render-snapshot.ts`
 - [x] Add `packages/libretto/src/shared/snapshot/diff-snapshots.ts`
-- [x] Match the intended compact snapshot format: page/frame tags, semantic role tags, heading text, refs, and a final subtree hint
+- [x] Match the intended compact snapshot format: page/frame tags, semantic role tags, heading text, and refs
 - [x] Implement ref scoping in `renderSnapshot(snapshot, refId?)` by rendering a scoped view of the already-captured tree; do not recapture the page to satisfy a ref request
 - [x] Keep only one rendering path; do not add `toRenderedSnapshot(snapshot, "projected")` or any equivalent profile switch
 - [x] Keep renderer module exports limited to APIs and types needed by `render-snapshot.ts` and `diff-snapshots.ts`; do not export private formatting helpers
@@ -126,19 +127,26 @@ function diffSnapshots(before: Snapshot, after: Snapshot): SnapshotDiff {
 - [x] Add a small `renderSnapshotDiff(diff)` only if CLI output needs a separate formatting step; keep `diffSnapshots(before, after) -> SnapshotDiff` as the core API
 - [x] Verify `pnpm -s type-check --filter=libretto` passes
 
-### Phase 3.5: Add snapshot renderer and diff unit tests
+### Phase 3.5: Replace renderer/diff tests with browser-backed HTML fixtures
 
-Add focused unit tests for the pure snapshot renderer and diff helpers. Use hand-built `Snapshot` fixtures so tests cover behavior without launching Playwright, opening CDP sessions, or asserting capture internals.
+Add focused renderer and diff tests that read like real pages. The tests should render HTML in Playwright, call the existing `snapshot(page)` capture helper, then assert `renderSnapshot(snapshot, refId?)` and `renderSnapshotDiff(diffSnapshots(before, after))`. This keeps fixtures easy to copy from real HTML while avoiding a second hand-maintained HTML or accessibility parser in tests.
 
-- [ ] Add a unit test file under `packages/libretto/test/`, for example `snapshot-render-diff.spec.ts`
-- [ ] Cover `renderSnapshot(snapshot)` output for page/frame tags, heading text, refs, semantic role tags, and the final subtree hint
-- [ ] Cover `renderSnapshot(snapshot, refId)` scoping from an already-captured tree, including numeric-suffix fallback such as `e16` matching `l16`
-- [ ] Cover renderer compaction behavior that is easy to regress: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
-- [ ] Cover `diffSnapshots(before, after)` and `renderSnapshotDiff(diff)` for unchanged, added, removed, and modified nodes with context ancestors
-- [ ] Cover diff signal handling for ref-only changes and href query/hash changes so low-signal differences do not produce noisy diffs
-- [ ] Keep tests behavior-focused; do not assert private helper names or CDP capture details
-- [ ] Run `pnpm -s test --filter=libretto -- snapshot-render-diff.spec.ts`
-- [ ] Run `pnpm -s type-check --filter=libretto`
+Keep `renderSnapshot` itself pure: it should render only the snapshot tree. Command guidance such as the subtree hint belongs in the higher-level compact snapshot command output, not in the shared renderer.
+
+- [x] Add `outdent` as a `packages/libretto` dev dependency for readable HTML and expected-output fixtures
+- [x] Add or update a colocated test file, for example `packages/libretto/src/shared/snapshot/snapshot.spec.ts`
+- [x] Add browser-backed helpers such as `expectSnapshot(html)` and `expectSnapshotDiff(beforeHtml, afterHtml)` that render HTML with Playwright, call `snapshot(page)`, then compare the rendered snapshot/diff output
+- [x] Do not require helpers to load a fake URL just to set page metadata; use the simplest Playwright setup that lets copied HTML render reliably, and treat the page URL as incidental test output
+- [x] Use `<title>` metadata from the fixture HTML for snapshot titles
+- [x] Cover `renderSnapshot(snapshot)` output for page/frame tags, heading text, refs, and semantic role tags
+- [x] Cover `renderSnapshot(snapshot, refId)` scoping from an already-captured tree, including numeric-suffix fallback such as `e16` matching `l16`
+- [x] Cover renderer compaction behavior that is easy to regress: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
+- [x] Cover `diffSnapshots(before, after)` and `renderSnapshotDiff(diff)` for unchanged, added, removed, and modified nodes with context ancestors
+- [x] Cover diff signal handling for ref-only changes and href query/hash changes so low-signal differences do not produce noisy diffs; use direct `Snapshot` fixtures only for edge cases that cannot be expressed through real rendered HTML
+- [x] Remove the subtree hint from `renderSnapshot`; keep the hint requirement in the later compact snapshot CLI/daemon phase
+- [x] Keep tests behavior-focused; do not assert private helper names or CDP capture details
+- [x] Run `pnpm -s test --filter=libretto -- snapshot-render-diff.spec.ts`
+- [x] Run `pnpm -s type-check --filter=libretto`
 
 ### Phase 4: Add page stability waiting
 
@@ -190,6 +198,7 @@ async function runCompactSnapshot(input: SnapshotInput, ctx: SnapshotContext) {
 - [ ] Extend daemon snapshot IPC args/results to support compact snapshot requests and a cached-snapshot request flag for `snapshot <ref>`
 - [ ] In `packages/libretto/src/cli/core/daemon/snapshot.ts`, keep the existing PNG+HTML return shape for default mode and add a compact return shape containing a screenshot `pngPath` and full `Snapshot` tree
 - [ ] For every compact `snapshot` command, capture a screenshot before returning and print it in CLI output before the tree as `Screenshot at <path>`
+- [ ] After compact snapshot output, print the subtree guidance hint at the CLI/daemon output layer rather than from `renderSnapshot`; use `librettoCommand(...)` for the command text
 - [ ] Reuse the existing screenshot viewport normalization and zero-width retry behavior where practical; do not create a separate screenshot abstraction unless duplication becomes unavoidable
 - [ ] In `packages/libretto/src/cli/core/daemon/daemon.ts`, store the latest full compact snapshot in daemon memory after each unscoped compact `snapshot` command
 - [ ] If a ref is requested, do not capture a new snapshot tree; capture only the screenshot, return the latest cached full snapshot, then let `renderSnapshot(snapshot, refId)` scope it

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -1,0 +1,245 @@
+## Problem overview
+
+The experimental worktree `.worktrees/tk-snapshot-exec-diff-pw-ai/` has the rough draft of a more agent-friendly snapshot tree and structural page-change diff after `exec`. This branch still uses `snapshot` for PNG+HTML capture plus API analysis, and `exec` returns only command output, so maintainers cannot try the new snapshot/diff loop here without replacing stable behavior.
+
+## Solution overview
+
+Add one internal experiment that switches `libretto snapshot` to a daemon-backed compact accessibility snapshot and enables structural page-change diffs after `libretto exec`. The implementation has one snapshot format and one rendering path: Playwright `Page` -> full `Snapshot` tree -> rendered string. The daemon owns snapshot capture and caching: unscoped `snapshot` captures a screenshot, refreshes and stores the latest full snapshot tree, scoped `snapshot <ref>` captures a fresh screenshot but reuses that cached tree and errors if no snapshot has been captured yet, and `exec` uses the cached snapshot as its before-state when available before replacing/invalidating it with the latest page state.
+
+## Goals
+
+- Users can enable an experiment and run `libretto snapshot --session <name>` to capture, cache, and print a compact accessibility snapshot from the session daemon.
+- Users see the screenshot path before the compact accessibility tree, so they can inspect the visual page state alongside the tree.
+- Users can run `libretto snapshot <ref> --session <name>` after a full snapshot has been captured to print only that cached subtree without recapturing the snapshot tree.
+- Users get an actionable error when they request `snapshot <ref>` before a full compact snapshot exists in the daemon cache.
+- Users who run `libretto exec` while the experiment is enabled see a structural page-change diff after successful mutating exec calls.
+- A snapshot taken immediately before `exec` can be reused as the exec before-state, so diffs align with the snapshot the user just saw.
+- Existing `libretto snapshot --objective ... --context ...` behavior remains unchanged while the experiment is disabled.
+- The experiment stays internal to CLI and daemon machinery and is not exposed to workflow code.
+
+## Non-goals
+
+- No migrations or backfills.
+- Do not remove the current PNG+HTML+AI snapshot analysis path.
+- Do not redesign daemon lifecycle, daemon transport, page selection, or workflow execution.
+- Do not add a public workflow API for experiments or snapshots.
+- Do not add alternative snapshot render formats, renderer profiles, or a `projected`/`default` rendering switch.
+- Do not add a new user-facing snapshot subcommand in v1; the experiment replaces `snapshot` behavior only while enabled.
+- Do not persist snapshot cache to disk; daemon memory is enough for the experiment.
+
+## Future work
+
+None yet.
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto/docs/experiments.md` — experiment registry, CLI, config, and daemon plumbing conventions.
+- `docs/tests-guide.md` — testing rules for user-level CLI tests.
+- `packages/libretto/src/cli/core/experiments.ts` — add the new internal experiment flag.
+- `packages/libretto/src/cli/commands/experiments.ts` — listing/enable/disable output will include the new flag automatically through the registry.
+- `packages/libretto/src/cli/commands/snapshot.ts` — switch snapshot command parsing and dispatch based on the experiment while preserving default AI analysis behavior.
+- `packages/libretto/src/cli/core/daemon/snapshot.ts` — add compact screenshot capture, snapshot tree capture, and cached-snapshot lookup paths next to the existing PNG+HTML capture path.
+- `packages/libretto/src/cli/core/daemon/exec.ts` — use cached before snapshots, capture after snapshots, diff, and return the diff with exec results.
+- `packages/libretto/src/cli/core/daemon/ipc.ts` — extend daemon IPC types for compact snapshot requests, cached ref lookups, compact snapshot results with screenshot paths, and optional exec diff output.
+- `packages/libretto/src/cli/core/daemon/daemon.ts` — own the in-memory latest snapshot cache and route snapshot/exec requests using the daemon’s startup experiment snapshot.
+- `packages/libretto/src/shared/snapshot/` — new shared snapshot capture, render, stability wait, and diff implementation.
+- `.worktrees/tk-snapshot-exec-diff-pw-ai/packages/libretto/src/shared/snapshot/` — rough reference implementation to adapt selectively, not port wholesale.
+- `.worktrees/tk-snapshot-exec-diff-pw-ai/packages/libretto/src/cli/core/daemon/exec.ts` — rough exec diff integration to adapt to cached before snapshots.
+- `.worktrees/tk-snapshot-exec-diff-pw-ai/packages/libretto/src/cli/commands/snapshot.ts` — rough text snapshot command behavior to adapt to daemon-returned snapshot trees.
+- `packages/libretto/test/daemon-ipc.spec.ts` — best place for daemon-backed user-level snapshot cache and exec diff regression tests.
+- `packages/libretto/test/stateful.spec.ts` — current missing `--objective` behavior should remain covered when the experiment is disabled.
+
+## Implementation
+
+### Phase 1: Register the compact snapshot experiment
+
+Add the experiment flag first so later phases can be gated without exposing unstable behavior by default. Keep this phase limited to registry metadata and any user-visible experiment listing expectation updates.
+
+```ts
+export const EXPERIMENTS = {
+  exampleExperiment: {
+    /* existing */
+  },
+  compactSnapshotFormat: {
+    title: "Compact snapshot format",
+    description:
+      "Use compact accessibility snapshots and exec page-change diffs without an AI sub-agent.",
+    defaultValue: false,
+  },
+} as const;
+```
+
+- [ ] Add `compactSnapshotFormat` to `packages/libretto/src/cli/core/experiments.ts` with `defaultValue: false`
+- [ ] Ensure `ExperimentName` and `Experiments` continue to infer from the registry without duplicated types
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+- [ ] Add or update a user-level experiment CLI test only if existing coverage does not already assert registry listing behavior
+
+### Phase 2: Add the shared snapshot tree API
+
+Add the snapshot tree type and capture helper. Keep the core capture API simple and singular: `snapshot(page) -> Snapshot`, where `Snapshot` is always the full tree that later code can render, scope by ref, cache, or diff.
+
+```ts
+type Snapshot = {
+  title: string;
+  url: string;
+  frames: SnapshotFrame[];
+};
+
+async function snapshot(page: Page): Promise<Snapshot> {
+  return captureFullSnapshotTree(page);
+}
+```
+
+- [ ] Add `packages/libretto/src/shared/snapshot/types.ts`
+- [ ] Add `snapshot(page)`, `findSnapshotNodeByRef`, and `scopeSnapshotToRef` in `packages/libretto/src/shared/snapshot/capture-snapshot.ts`
+- [ ] Keep `Snapshot` as a tree type, not a pre-rendered string
+- [ ] Preserve the useful ref behavior from the worktree: `l<number>` assignment and numeric-suffix fallback for refs like `e16`
+- [ ] Reuse only the capture details from the worktree that are needed for the compact tree: accessibility role/name/value/state, useful DOM attributes, and enough metadata for clickable elements
+- [ ] Avoid adding renderer profile fields, alternate raw/default render models, or a `projected` argument
+- [ ] Treat `snapshot(page)` as daemon/internal machinery; compact snapshot CLI calls must go through daemon IPC
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+- [ ] Add focused coverage through user-level CLI tests in later phases rather than testing CDP internals directly
+
+### Phase 3: Add the single snapshot renderer and diff helper
+
+Add one renderer for the `Snapshot` tree and one structural diff helper. Do not introduce alternate render formats; the snapshot tree is the source of truth, `renderSnapshot(snapshot, refId?)` is the only user-visible string conversion, and `diffSnapshots(before, after)` compares two full trees.
+
+```ts
+function renderSnapshot(snapshot: Snapshot, refId?: string): string {
+  const tree = refId ? scopeSnapshotToRef(snapshot, refId) : snapshot;
+  return renderSnapshotTree(tree);
+}
+
+function diffSnapshots(before: Snapshot, after: Snapshot): SnapshotDiff {
+  return diffSnapshotTrees(before, after);
+}
+```
+
+- [ ] Add `packages/libretto/src/shared/snapshot/render-snapshot.ts`
+- [ ] Add `packages/libretto/src/shared/snapshot/diff-snapshots.ts`
+- [ ] Match the intended compact snapshot format: page/frame tags, semantic role tags, heading text, refs, and a final subtree hint
+- [ ] Implement ref scoping in `renderSnapshot(snapshot, refId?)` by rendering a scoped view of the already-captured tree; do not recapture the page to satisfy a ref request
+- [ ] Keep only one rendering path; do not add `toRenderedSnapshot(snapshot, "projected")` or any equivalent profile switch
+- [ ] Include the minimal compaction needed for useful agent output: low-value wrapper flattening, clickable generic promotion, single-child chain folding, and child truncation summaries
+- [ ] Preserve the useful diff behavior from the worktree: structural tree comparison, `+`/`-`/`~` output or equivalent typed metadata, context ancestors, low-signal attr suppression, normalized href comparison, and diff truncation summaries
+- [ ] Add a small `renderSnapshotDiff(diff)` only if CLI output needs a separate formatting step; keep `diffSnapshots(before, after) -> SnapshotDiff` as the core API
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+
+### Phase 4: Add page stability waiting
+
+Add a small page stability wait helper for the daemon paths that capture compact snapshots. Do not add a combined `stableSnapshot` abstraction; each caller should explicitly wait for page stability and then call `snapshot(page)` so the capture flow stays obvious.
+
+```ts
+async function captureCompactSnapshot(page: Page): Promise<Snapshot> {
+  const waitResult = await waitForPageStable(page);
+  if (!waitResult.ok) logSnapshotStabilityWarning(waitResult.diagnostics);
+  return snapshot(page);
+}
+```
+
+- [ ] Add a page stability helper, for example `waitForPageStable(page)`, under `packages/libretto/src/shared/snapshot/`
+- [ ] Preserve the useful behavior from the worktree: bounded wait, load-state checks, DOM mutation idle, minimum wait, and pending resource checks
+- [ ] Treat stability failures as warnings for snapshot command and exec diff; do not fail the command only because stability timed out
+- [ ] Inline the caller flow in daemon code as `waitForPageStable(page)` followed by `snapshot(page)` before user-requested compact snapshots and before exec after-snapshots
+- [ ] Do not add a `stableSnapshot`, `captureStableSnapshot`, or equivalent helper that combines waiting and capture
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+
+### Phase 5: Gate daemon-backed `libretto snapshot [ref]` behind the experiment
+
+Make the snapshot command support both modes. With `compactSnapshotFormat` disabled, keep requiring `--objective` and `--context` and use the existing PNG+HTML+AI path; with it enabled, unscoped `snapshot` asks the daemon to capture a screenshot plus a full snapshot tree and cache the tree, while scoped `snapshot <ref>` asks the daemon to capture a fresh screenshot and return the latest cached tree without recapturing the tree. The CLI prints the screenshot path, then renders the returned tree with `renderSnapshot(snapshot, input.ref)` and prints it.
+
+```ts
+type CompactSnapshotResult = {
+  mode: "compact";
+  pngPath: string;
+  snapshot: Snapshot;
+};
+
+async function runCompactSnapshot(input: SnapshotInput, ctx: SnapshotContext) {
+  const client = await DaemonClient.connect(
+    requireDaemonSocket(ctx.sessionState),
+  );
+  const result = await client.snapshot({
+    mode: "compact",
+    pageId: input.page,
+    useCachedSnapshot: input.ref !== undefined,
+  });
+  console.log(`Screenshot at ${result.pngPath}`);
+  console.log(renderSnapshot(result.snapshot, input.ref));
+}
+```
+
+- [ ] Add `withExperiments()` to `snapshotCommand`
+- [ ] Change `objective` and `context` input fields to optional at parse time, then require them in the disabled/default path with the existing error wording as closely as possible
+- [ ] Add optional positional `ref` and reject it with an actionable error when the experiment is disabled
+- [ ] Extend daemon snapshot IPC args/results to support compact snapshot requests and a cached-snapshot request flag for `snapshot <ref>`
+- [ ] In `packages/libretto/src/cli/core/daemon/snapshot.ts`, keep the existing PNG+HTML return shape for default mode and add a compact return shape containing a screenshot `pngPath` and full `Snapshot` tree
+- [ ] For every compact `snapshot` command, capture a screenshot before returning and print it in CLI output before the tree as `Screenshot at <path>`
+- [ ] Reuse the existing screenshot viewport normalization and zero-width retry behavior where practical; do not create a separate screenshot abstraction unless duplication becomes unavoidable
+- [ ] In `packages/libretto/src/cli/core/daemon/daemon.ts`, store the latest full compact snapshot in daemon memory after each unscoped compact `snapshot` command
+- [ ] If a ref is requested, do not capture a new snapshot tree; capture only the screenshot, return the latest cached full snapshot, then let `renderSnapshot(snapshot, refId)` scope it
+- [ ] If a ref is requested and no compact snapshot is cached, throw an actionable error telling the user to run `libretto snapshot --session <name>` first
+- [ ] Keep compact snapshot capture inside the daemon; the CLI must not use `connect()` or open a second browser/CDP connection
+- [ ] Verify disabled behavior with an existing or updated test: `snapshot --session <name>` still reports missing `--objective`
+- [ ] Add a user-level daemon-backed test that enables the experiment, opens a fixture page, runs `snapshot --session <name>`, and sees `Screenshot at ` before compact output such as `<page`, `# Heading`, and the subtree hint
+- [ ] Add a user-level daemon-backed test that runs `snapshot <ref> --session <name>` after a previous full snapshot and sees only the expected subtree text
+- [ ] Add a user-level daemon-backed test that `snapshot <ref> --session <name>` fails before any compact snapshot has been cached
+- [ ] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts stateful.spec.ts` or the closest existing targeted test command supported by the repo
+
+### Phase 6: Use the daemon snapshot cache for exec diffs
+
+Implement exec diffs around the daemon-owned latest snapshot cache. Exec should use the cached snapshot as its before-state when available, capture a fresh before-state only when no cache exists, run user code, wait for stability, capture the after-state, diff the two trees, return the diff with the exec result, and replace the cache with the after-state.
+
+```ts
+async function handleCompactExec(args: ExecArgs, cache: SnapshotCache) {
+  const before = cache.latest ?? (await snapshot(args.page));
+  const result = await runUserExec(args);
+  await waitForPageStable(args.page);
+  const after = await snapshot(args.page);
+  cache.latest = after;
+  return { ...result, snapshotDiff: diffSnapshots(before, after) };
+}
+```
+
+- [ ] Add daemon-owned snapshot cache state in `packages/libretto/src/cli/core/daemon/daemon.ts`, for example `latestCompactSnapshot: Snapshot | null`
+- [ ] Pass the cached before snapshot into the exec handler or keep the cache orchestration in daemon before/after calling `handleExec`
+- [ ] If no cached snapshot exists, capture a fresh before snapshot immediately before running user exec code
+- [ ] Always diff full snapshots; scoped `snapshot <ref>` must not replace the cache with a subtree
+- [ ] Run user exec code exactly once and preserve existing result/output/error behavior
+- [ ] After successful exec, wait for page stability, capture the after snapshot, and compute `diffSnapshots(before, after)`
+- [ ] Return the diff with the exec result and print user-visible page changes after normal exec output
+- [ ] Replace the daemon cache with the after snapshot after successful exec
+- [ ] Invalidate the daemon cache on exec failure unless an after snapshot is deliberately captured and stored; keep v1 simple by clearing it on failure
+- [ ] Ensure `readonly-exec` never captures, invalidates, or prints page-change diffs
+- [ ] Add a user-level daemon-backed test where `snapshot` is run first, then `exec` mutates the page, and the exec diff reflects the change from the previously returned snapshot
+- [ ] Add a user-level daemon-backed test where `exec` is run without a previous snapshot and still prints a diff by capturing its own before-state
+- [ ] Add a user-level daemon-backed test that `readonly-exec` does not print page changes and does not invalidate the snapshot cache
+- [ ] Run `pnpm -s test --filter=libretto -- daemon-ipc.spec.ts`
+
+### Phase 7: Keep package exports minimal
+
+Expose snapshot helpers from the package root only if tests or internal experiment consumers require direct imports. Do not introduce a barrel file inside `shared/snapshot`, and do not expose experiment state on public workflow APIs.
+
+```ts
+export {
+  snapshot,
+  renderSnapshot,
+  diffSnapshots,
+  type Snapshot,
+  type SnapshotDiff,
+} from "./shared/snapshot/capture-snapshot.js";
+```
+
+- [ ] Export snapshot helpers from `packages/libretto/src/index.ts` only if external package consumers or tests need them
+- [ ] Skip this phase if all usage stays inside CLI/daemon internals
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+
+### Phase 8: Update skill/docs guidance for the experiment
+
+Document how maintainers enable and try the experiment without changing the public docs for the stable snapshot analysis path. Keep mirrored skill files in sync through the source skill file and mirror command.
+
+- [ ] Update `packages/libretto/skills/libretto/SKILL.md` with the experimental `snapshot [ref]` and `exec` diff behavior only if skill guidance should mention experiments
+- [ ] Do not hand-edit `.agents/skills/` or `.claude/skills/`; run `pnpm sync:mirrors` after editing the source skill file
+- [ ] Avoid changing Mintlify user docs unless the experiment is intended to be user-facing
+- [ ] Run `pnpm check:mirrors` if mirrored skill files change
+- [ ] Run `pnpm -s type-check --filter=libretto`

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -255,9 +255,9 @@ export {
 } from "./shared/snapshot/capture-snapshot.js";
 ```
 
-- [ ] Export snapshot helpers from `packages/libretto/src/index.ts` only if external package consumers or tests need them
-- [ ] Skip this phase if all usage stays inside CLI/daemon internals
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+- [x] Export snapshot helpers from `packages/libretto/src/index.ts` only if external package consumers or tests need them
+- [x] Skip this phase if all usage stays inside CLI/daemon internals
+- [x] Verify `pnpm -s type-check --filter=libretto` passes
 
 ### Phase 8: Update skill/docs guidance for the experiment
 

--- a/specs/experimental-snapshot-exec-diff-spec.md
+++ b/specs/experimental-snapshot-exec-diff-spec.md
@@ -150,7 +150,7 @@ Keep `renderSnapshot` itself pure: it should render only the snapshot tree. Comm
 
 ### Phase 4: Add page stability waiting
 
-Add a small page stability wait helper for the daemon paths that capture compact snapshots. Do not add a combined `stableSnapshot` abstraction; each caller should explicitly wait for page stability and then call `snapshot(page)` so the capture flow stays obvious.
+Add a small page stability wait helper for the daemon paths that capture compact snapshots. Use an Alumnium-style browser-side waiter: inject an idempotent script that tracks page load, DOM mutation idle, pending DOM resources, and pending `fetch`/`XMLHttpRequest` activity before resolving stability. Do not add a combined `stableSnapshot` abstraction; each caller should explicitly wait for page stability and then call `snapshot(page)` so the capture flow stays obvious.
 
 ```ts
 async function captureCompactSnapshot(page: Page): Promise<Snapshot> {
@@ -160,12 +160,12 @@ async function captureCompactSnapshot(page: Page): Promise<Snapshot> {
 }
 ```
 
-- [ ] Add a page stability helper, for example `waitForPageStable(page)`, under `packages/libretto/src/shared/snapshot/`
-- [ ] Preserve the useful behavior from the worktree: bounded wait, load-state checks, DOM mutation idle, minimum wait, and pending resource checks
-- [ ] Treat stability failures as warnings for snapshot command and exec diff; do not fail the command only because stability timed out
-- [ ] Inline the caller flow in daemon code as `waitForPageStable(page)` followed by `snapshot(page)` before user-requested compact snapshots and before exec after-snapshots
-- [ ] Do not add a `stableSnapshot`, `captureStableSnapshot`, or equivalent helper that combines waiting and capture
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes
+- [x] Add a page stability helper, for example `waitForPageStable(page)`, under `packages/libretto/src/shared/snapshot/`
+- [x] Preserve the useful behavior from the worktree and Alumnium research: bounded wait, load-state checks, DOM mutation idle, minimum wait, pending resource checks, and browser-side `fetch`/`XMLHttpRequest` tracking
+- [x] Treat stability failures as warnings for snapshot command and exec diff; do not fail the command only because stability timed out
+- [x] Inline the caller flow in daemon code as `waitForPageStable(page)` followed by `snapshot(page)` before user-requested compact snapshots and before exec after-snapshots. Compact daemon snapshot and exec-diff paths are added in later phases; those callers will use this helper inline rather than a combined capture helper.
+- [x] Do not add a `stableSnapshot`, `captureStableSnapshot`, or equivalent helper that combines waiting and capture
+- [x] Verify `pnpm -s type-check --filter=libretto` passes
 
 ### Phase 5: Gate daemon-backed `libretto snapshot [ref]` behind the experiment
 


### PR DESCRIPTION
## Summary
- add the internal `compactSnapshotFormat` experiment and `experiments describe` documentation for trying it
- add compact accessibility snapshot capture, rendering, ref scoping, page-stability waiting, and structural snapshot diffs
- gate daemon-backed `snapshot [ref]` behavior and mutating `exec` page-change diffs behind the experiment while leaving stable snapshot analysis and workflow APIs unchanged
- cover renderer/diff behavior and daemon-backed compact snapshot/cache/exec-diff flows with tests

## Verification
- `pnpm -s type-check --filter=libretto`
- `pnpm -s test --filter=libretto`
- `pnpm check:mirrors`
