### PR TITLE
Parallelize eval runs and score from artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,30 +22,16 @@ This is a pnpm monorepo.
 Root (runs across all packages):
 
 ```bash
-pnpm i
-pnpm build
-pnpm type-check
-pnpm test
+pnpm -s type-check
+pnpm -s test
+pnpm -s lint
+pnpm -s cli
 ```
 
 - Prefer `pnpm -s <script>` (or `pnpm --silent ...`) for routine scripted commands when you want less pnpm noise in logs.
 
-Targeted (most common during development):
-
-```bash
-pnpm sync:mirrors
-pnpm check:mirrors
-pnpm -s type-check --filter=libretto
-pnpm -s test --filter=libretto
-```
-
 - Do not pipe test commands through `grep`, `tail`, or other filters. The test reporter is minimal and token-efficient by default.
-
-Local CLI invocation:
-
-```bash
-pnpm -s cli help
-```
+- Use `pnpm -s cli` to build and run the local development version of libretto.
 
 ## Code Quality
 
@@ -66,24 +52,14 @@ pnpm -s cli help
 - Prefer small, focused functions over large ones.
 - Name things for what they do, not how they're implemented.
 
-## **CRITICAL** Forbidden Actions **CRITICAL**
+## **FORBIDDEN** Actions
 
 - NEVER manually edit the `version` field in `packages/libretto/package.json`. Use `pnpm prepare-release`.
 - NEVER hand-edit mirrored files in `.agents/skills/` or `.claude/skills/`. Edit the source in `packages/libretto/skills/` and run `pnpm sync:mirrors`.
 - NEVER run `pnpm build` just to type-check. Use `pnpm type-check` instead.
 - NEVER use `git add -A` or `git add .` — only stage the files you changed.
 
-## Releasing
-
-To bump the version and create a release PR, run from the repo root:
-
-```bash
-pnpm prepare-release [patch|minor|major]
-```
-
-This command handles the version bump, SKILL.md version updates, mirror syncing, and PR creation.
-
-## Skill Documentation Source of Truth
+## Skill Mirrors
 
 - Edit `packages/libretto/README.template.md` directly for README changes, then run `pnpm sync:mirrors`.
 - Edit `packages/libretto/skills/libretto/SKILL.md` directly.

--- a/evals/README.md
+++ b/evals/README.md
@@ -19,6 +19,8 @@ pnpm evals
 pnpm evals run
 ```
 
+Cases run in parallel by default.
+
 Run only cases that do not declare an auth profile:
 
 ```bash

--- a/evals/artifacts.ts
+++ b/evals/artifacts.ts
@@ -8,15 +8,10 @@ export type EvalArtifactPaths = {
   judgeTranscript: string;
 };
 
-let currentArtifactPaths: EvalArtifactPaths | null = null;
 const artifactPathsStorage = new AsyncLocalStorage<EvalArtifactPaths | null>();
 
-export function setEvalArtifactPaths(paths: EvalArtifactPaths | null): void {
-  currentArtifactPaths = paths;
-}
-
 export function getEvalArtifactPaths(): EvalArtifactPaths | null {
-  return artifactPathsStorage.getStore() ?? currentArtifactPaths;
+  return artifactPathsStorage.getStore() ?? null;
 }
 
 export async function withEvalArtifactPaths<T>(

--- a/evals/artifacts.ts
+++ b/evals/artifacts.ts
@@ -1,21 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 
 export type EvalArtifactPaths = {
   transcript: string;
-  agentEvents: string;
-  agentTranscript: string;
+  transcriptMarkdown: string;
   judgeEvents: string;
   judgeTranscript: string;
 };
 
 let currentArtifactPaths: EvalArtifactPaths | null = null;
+const artifactPathsStorage = new AsyncLocalStorage<EvalArtifactPaths | null>();
 
 export function setEvalArtifactPaths(paths: EvalArtifactPaths | null): void {
   currentArtifactPaths = paths;
 }
 
 export function getEvalArtifactPaths(): EvalArtifactPaths | null {
-  return currentArtifactPaths;
+  return artifactPathsStorage.getStore() ?? currentArtifactPaths;
+}
+
+export async function withEvalArtifactPaths<T>(
+  paths: EvalArtifactPaths,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await artifactPathsStorage.run(paths, fn);
 }
 
 export type EvalUsageTurn = {

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -12,9 +12,14 @@ import {
   type EvalCaseRecord,
 } from "./eval-case.js";
 import { createEvalContext } from "./fixtures.js";
-import { takeRecordedScores, type EvalScoreRecord } from "./scoring.js";
+import {
+  takeRecordedScores,
+  withScoreRecording,
+  type EvalScoreRecord,
+} from "./scoring.js";
 import {
   takeRecordedEvalCalls,
+  withEvalCallRecording,
   type EvalCallRecord,
 } from "./run-recorder.js";
 import {
@@ -26,7 +31,7 @@ import {
 } from "./auth-profiles.js";
 import {
   aggregateMetrics,
-  setEvalArtifactPaths,
+  withEvalArtifactPaths,
   type EvalMetrics,
 } from "./artifacts.js";
 
@@ -78,8 +83,7 @@ type CaseResult = {
   artifacts: {
     result: string;
     transcript: string;
-    agentEvents: string;
-    agentTranscript: string;
+    transcriptMarkdown: string;
     judgeEvents: string;
     judgeTranscript: string;
   };
@@ -176,13 +180,9 @@ function metricArtifactsForCase(
   return {
     result: relativeArtifact(outputDir, join(caseDir, "result.json")),
     transcript: relativeArtifact(outputDir, join(caseDir, "transcript.jsonl")),
-    agentEvents: relativeArtifact(
+    transcriptMarkdown: relativeArtifact(
       outputDir,
-      join(caseDir, "agent-events.jsonl"),
-    ),
-    agentTranscript: relativeArtifact(
-      outputDir,
-      join(caseDir, "agent-transcript.md"),
+      join(caseDir, "transcript.md"),
     ),
     judgeEvents: relativeArtifact(
       outputDir,
@@ -680,40 +680,48 @@ async function runCase(
   const artifacts = metricArtifactsForCase(outputDir, id);
   await rm(caseDir, { recursive: true, force: true });
   await mkdir(caseDir, { recursive: true });
-  setEvalArtifactPaths({
+  const artifactPaths = {
     transcript: join(caseDir, "transcript.jsonl"),
-    agentEvents: join(caseDir, "agent-events.jsonl"),
-    agentTranscript: join(caseDir, "agent-transcript.md"),
+    transcriptMarkdown: join(caseDir, "transcript.md"),
     judgeEvents: join(caseDir, "judge-events.jsonl"),
     judgeTranscript: join(caseDir, "judge-transcript.md"),
-  });
-  takeRecordedScores();
-  takeRecordedEvalCalls();
+  };
 
   let status: CaseResult["status"] = "completed";
   let errorMessage: string | undefined;
   let cleanupErrorMessage: string | undefined;
   let context: Awaited<ReturnType<typeof createEvalContext>> | null = null;
-  try {
-    context = await createEvalContext(evalCase, { model });
-    await evalCase.run(context);
-  } catch (error) {
-    status = "error";
-    errorMessage = formatError(error);
-  } finally {
-    try {
-      await context?.dispose();
-    } catch (error) {
-      status = "error";
-      cleanupErrorMessage = `Cleanup failed:\n${formatError(error)}`;
-    } finally {
-      setEvalArtifactPaths(null);
-    }
-  }
+  let scores: EvalScoreRecord[] = [];
+  let calls: EvalCallRecord[] = [];
+
+  await withScoreRecording(async () => {
+    await withEvalCallRecording(async () => {
+      await withEvalArtifactPaths(artifactPaths, async () => {
+        takeRecordedScores();
+        takeRecordedEvalCalls();
+
+        try {
+          context = await createEvalContext(evalCase, { model });
+          await evalCase.run(context);
+        } catch (error) {
+          status = "error";
+          errorMessage = formatError(error);
+        } finally {
+          try {
+            await context?.dispose();
+          } catch (error) {
+            status = "error";
+            cleanupErrorMessage = `Cleanup failed:\n${formatError(error)}`;
+          }
+        }
+
+        scores = takeRecordedScores();
+        calls = takeRecordedEvalCalls();
+      });
+    });
+  });
 
   const finishedMs = Date.now();
-  const scores = takeRecordedScores();
-  const calls = takeRecordedEvalCalls();
   const scorePassed = scores.reduce((total, score) => total + score.passed, 0);
   const scoreTotal = scores.reduce((total, score) => total + score.total, 0);
   const agentMetrics = aggregateMetrics(
@@ -769,8 +777,7 @@ function artifactRecord(value: unknown, label: string): CaseResult["artifacts"] 
   return {
     result: artifactPath("result"),
     transcript: artifactPath("transcript"),
-    agentEvents: artifactPath("agentEvents"),
-    agentTranscript: artifactPath("agentTranscript"),
+    transcriptMarkdown: artifactPath("transcriptMarkdown"),
     judgeEvents: artifactPath("judgeEvents"),
     judgeTranscript: artifactPath("judgeTranscript"),
   };
@@ -947,6 +954,41 @@ async function runSummary(options: SummaryCliOptions): Promise<number> {
   return 0;
 }
 
+async function runSelectedCases(
+  selectedCases: EvalCaseRecord[],
+  ids: Map<EvalCaseRecord, string>,
+  options: RunCliOptions,
+): Promise<CaseResult[]> {
+  return await Promise.all(
+    selectedCases.map(async (evalCase) => {
+      const id = ids.get(evalCase);
+      if (!id) {
+        throw new Error(`Failed to allocate result ID for ${evalCase.name}`);
+      }
+
+      process.stdout.write(`\n▶ ${evalCase.name}\n`);
+      const result = await runCase(
+        evalCase,
+        id,
+        options.outputDir,
+        options.model,
+      );
+      if (result.status === "completed") {
+        process.stdout.write(`✓ ${evalCase.name}\n`);
+      } else if (result.status === "skipped") {
+        process.stdout.write(
+          `- ${evalCase.name} skipped: ${result.skipReason ?? "No reason provided."}\n`,
+        );
+      } else {
+        process.stdout.write(
+          `✗ ${evalCase.name}\n${result.error ?? "Unknown error"}\n`,
+        );
+      }
+      return result;
+    }),
+  );
+}
+
 async function run(options: CliOptions): Promise<number> {
   if (options.command === "summary") {
     return await runSummary(options);
@@ -983,30 +1025,11 @@ async function run(options: CliOptions): Promise<number> {
 
   await mkdir(options.outputDir, { recursive: true });
   process.stdout.write(`Running ${selectedCases.length} eval case(s)\n`);
+  process.stdout.write("Execution: parallel\n");
   process.stdout.write(`Output: ${options.outputDir}\n`);
 
   const ids = caseIds(selectedCases);
-  const results: CaseResult[] = [];
-  for (const evalCase of selectedCases) {
-    const id = ids.get(evalCase);
-    if (!id) {
-      throw new Error(`Failed to allocate result ID for ${evalCase.name}`);
-    }
-    process.stdout.write(`\n▶ ${evalCase.name}\n`);
-    const result = await runCase(evalCase, id, options.outputDir, options.model);
-    results.push(result);
-    if (result.status === "completed") {
-      process.stdout.write(`✓ ${evalCase.name}\n`);
-    } else if (result.status === "skipped") {
-      process.stdout.write(
-        `- ${evalCase.name} skipped: ${result.skipReason ?? "No reason provided."}\n`,
-      );
-    } else {
-      process.stdout.write(
-        `✗ ${evalCase.name}\n${result.error ?? "Unknown error"}\n`,
-      );
-    }
-  }
+  const results = await runSelectedCases(selectedCases, ids, options);
 
   const completed = results.filter(
     (result) => result.status === "completed",

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -37,11 +37,6 @@ const DEFAULT_EVAL_MODEL: EvalModelSelector = "openai/gpt-5.5";
 const DEFAULT_THINKING_LEVEL = "medium" satisfies NonNullable<
   CreateAgentSessionOptions["thinkingLevel"]
 >;
-const TRANSCRIPT_EVENT_TYPES = new Set<AgentSessionEvent["type"]>([
-  "message_end",
-  "tool_execution_start",
-  "tool_execution_end",
-]);
 const PROGRESS_TEXT_CHARS = 240;
 const PROGRESS_TOOL_ARGS_CHARS = 180;
 const PROGRESS_TOOL_ERROR_CHARS = 360;
@@ -234,21 +229,6 @@ function appendMarkdown(path: string | null, markdown: string): void {
   if (!path) return;
   mkdirSync(dirname(path), { recursive: true });
   appendFileSync(path, markdown, "utf8");
-}
-
-function appendTranscriptRecord(record: Record<string, unknown>): void {
-  void record;
-}
-
-function recordUserPrompt(source: "agent" | "judge", prompt: string): void {
-  appendTranscriptRecord({ source, type: "user", prompt });
-}
-
-function recordEvent(
-  source: "agent" | "judge",
-  event: AgentSessionEvent,
-): void {
-  appendTranscriptRecord({ source, type: "event", event });
 }
 
 function recordRawEvent(
@@ -464,9 +444,6 @@ async function runPiJudge(opts: {
   const unsubscribe = session.subscribe((event) => {
     events.push(event);
     recordRawEvent("judge", event);
-    if (TRANSCRIPT_EVENT_TYPES.has(event.type)) {
-      recordEvent("judge", event);
-    }
     if (event.type === "tool_execution_start") {
       logProgress(formatToolProgress(event.toolName, event.args));
     } else if (event.type === "tool_execution_end" && event.isError) {
@@ -478,7 +455,6 @@ async function runPiJudge(opts: {
 
   try {
     logUserProgress(opts.prompt);
-    recordUserPrompt("judge", opts.prompt);
     await session.prompt(opts.prompt);
     const finishedMs = Date.now();
     const messages = [...session.messages];
@@ -585,7 +561,6 @@ function parseJsonObject(text: string): unknown {
 
 async function scoreTranscript(opts: {
   criteria: string[];
-  transcript: string;
   cwd: string;
   model?: EvalModelSelector;
 }): Promise<z.infer<typeof TranscriptScoreSchema> & { judge: EvalJudgeRecord }> {
@@ -745,7 +720,6 @@ export class EvalResponse {
   async score(criteria: string[]): Promise<EvalScore> {
     const score = await scoreTranscript({
       criteria,
-      transcript: this.transcript,
       cwd: this.cwd,
       model: this.model,
     });
@@ -788,9 +762,6 @@ export class PiEvalHarness {
     const unsubscribe = this.session.subscribe((event) => {
       events.push(event);
       recordRawEvent("agent", event);
-      if (TRANSCRIPT_EVENT_TYPES.has(event.type)) {
-        recordEvent("agent", event);
-      }
       if (event.type === "tool_execution_start") {
         logProgress(formatToolProgress(event.toolName, event.args));
       } else if (event.type === "tool_execution_end" && event.isError) {
@@ -832,7 +803,6 @@ export class PiEvalHarness {
         callRecorded = true;
       };
       logUserProgress(prompt);
-      recordUserPrompt("agent", prompt);
       const update = async () => {
         if (!sendOptions.onUpdate || !this.session) return;
         await sendOptions.onUpdate(buildResponse());

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -21,10 +21,6 @@ import {
 } from "./artifacts.js";
 import { recordEvalCall } from "./run-recorder.js";
 
-const EvaluationVerdictSchema = z.object({
-  success: z.boolean(),
-  reason: z.string().trim().min(1),
-});
 const ScoredCriterionSchema = z.object({
   criterion: z.string().trim().min(1),
   pass: z.boolean(),
@@ -37,7 +33,6 @@ const TranscriptScoreSchema = z.object({
   percent: z.number().min(0).max(100),
 });
 
-const MAX_TRANSCRIPT_CHARS = 20_000;
 const DEFAULT_EVAL_MODEL: EvalModelSelector = "openai/gpt-5.5";
 const DEFAULT_THINKING_LEVEL = "medium" satisfies NonNullable<
   CreateAgentSessionOptions["thinkingLevel"]
@@ -54,7 +49,6 @@ const ANSI_BOLD = "\x1b[1m";
 const ANSI_RED = "\x1b[31m";
 const ANSI_RESET = "\x1b[0m";
 
-type EvaluationVerdict = z.infer<typeof EvaluationVerdictSchema>;
 export type ScoredCriterion = z.infer<typeof ScoredCriterionSchema>;
 export type EvalModelSelector = `${string}/${string}`;
 
@@ -98,19 +92,6 @@ export type PiEvalHarnessOptions = {
 export type PiEvalHarnessSendOptions = {
   onUpdate?: (response: EvalResponse) => void | Promise<void>;
 };
-
-function clip(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  const headChars = Math.max(1, Math.floor(maxChars / 2));
-  const tailChars = Math.max(1, maxChars - headChars);
-  return [
-    text.slice(0, headChars),
-    "",
-    `[truncated: showing first ${headChars} chars and last ${tailChars} chars of ${text.length}]`,
-    "",
-    text.slice(-tailChars),
-  ].join("\n");
-}
 
 function extractFinalResultLine(transcript: string): string | null {
   const finalResultLine = transcript
@@ -256,18 +237,7 @@ function appendMarkdown(path: string | null, markdown: string): void {
 }
 
 function appendTranscriptRecord(record: Record<string, unknown>): void {
-  const path = getEvalArtifactPaths()?.transcript ?? null;
-  if (!path) return;
-  mkdirSync(dirname(path), { recursive: true });
-  try {
-    appendJsonl(path, record);
-  } catch (error) {
-    appendJsonl(path, {
-      source: record.source,
-      type: "transcript_write_error",
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  void record;
 }
 
 function recordUserPrompt(source: "agent" | "judge", prompt: string): void {
@@ -288,7 +258,7 @@ function recordRawEvent(
   const paths = getEvalArtifactPaths();
   appendJsonl(
     source === "agent"
-      ? (paths?.agentEvents ?? null)
+      ? (paths?.transcript ?? null)
       : (paths?.judgeEvents ?? null),
     { source, event },
   );
@@ -304,7 +274,7 @@ function recordTranscriptMarkdown(opts: {
   const paths = getEvalArtifactPaths();
   appendMarkdown(
     opts.source === "agent"
-      ? (paths?.agentTranscript ?? null)
+      ? (paths?.transcriptMarkdown ?? null)
       : (paths?.judgeTranscript ?? null),
     [
       `## ${opts.source === "agent" ? "Agent" : "Judge"} turn`,
@@ -485,7 +455,7 @@ async function runPiJudge(opts: {
   const session = await createPiEvalSession({
     cwd: opts.cwd,
     model: opts.model,
-    tools: [],
+    tools: ["read", "bash"],
   });
   const events: AgentSessionEvent[] = [];
   const startedMs = Date.now();
@@ -613,39 +583,6 @@ function parseJsonObject(text: string): unknown {
   return JSON.parse(candidate) as unknown;
 }
 
-async function evaluateTranscript(opts: {
-  assertion: string;
-  transcript: string;
-  cwd: string;
-  model?: EvalModelSelector;
-}): Promise<EvaluationVerdict> {
-  const prompt = [
-    "Evaluate whether TRANSCRIPT satisfies ASSERTION.",
-    "Return only JSON with keys: success (boolean), reason (string).",
-    "Be strict and set success=false if evidence is missing.",
-    "",
-    `ASSERTION:\n${opts.assertion}`,
-    "",
-    `TRANSCRIPT:\n${clip(opts.transcript, MAX_TRANSCRIPT_CHARS)}`,
-  ].join("\n");
-
-  const result = await runPiJudge({
-    prompt,
-    cwd: opts.cwd,
-    model: opts.model,
-  });
-
-  const parsed = EvaluationVerdictSchema.safeParse(
-    parseJsonObject(result.text),
-  );
-  if (!parsed.success) {
-    throw new Error(
-      `Evaluation returned invalid schema output: ${result.text}`,
-    );
-  }
-  return parsed.data;
-}
-
 async function scoreTranscript(opts: {
   criteria: string[];
   transcript: string;
@@ -659,17 +596,30 @@ async function scoreTranscript(opts: {
     throw new Error("score() requires at least one non-empty criterion.");
   }
 
-  const prompt = [
-    "Score whether TRANSCRIPT satisfies each criterion in CRITERIA.",
-    "Return only JSON with key `criteria` where each item is:",
-    "{ criterion: <exact criterion string>, pass: <boolean>, reason: <string> }",
-    "Use the exact criterion text; do not rewrite criterion names.",
-    "Be strict and mark pass=false when evidence is missing.",
-    "",
-    `CRITERIA:\n${JSON.stringify(normalizedCriteria, null, 2)}`,
-    "",
-    `TRANSCRIPT:\n${clip(opts.transcript, MAX_TRANSCRIPT_CHARS)}`,
-  ].join("\n");
+  const artifactPaths = getEvalArtifactPaths();
+  const caseDir = artifactPaths ? dirname(artifactPaths.transcript) : null;
+
+  const prompt = caseDir
+    ? [
+        "Score whether the eval run artifacts satisfy each criterion in CRITERIA.",
+        "Use the read and bash tools to inspect files in CASE_DIR.",
+        "Prioritize CASE_DIR/transcript.jsonl, which is the raw agent event stream and includes full tool call arguments.",
+        "Use jq with bash to query transcript.jsonl when you need structured evidence from tool calls or events.",
+        "Use CASE_DIR/transcript.md as a human-readable secondary view.",
+        "Return only JSON with key `criteria` where each item is:",
+        "{ criterion: <exact criterion string>, pass: <boolean>, reason: <string> }",
+        "Use the exact criterion text; do not rewrite criterion names.",
+        "Be strict and mark pass=false when evidence is missing from the artifacts.",
+        "",
+        `CASE_DIR:
+${caseDir}`,
+        "",
+        `CRITERIA:
+${JSON.stringify(normalizedCriteria, null, 2)}`,
+      ].join("\n")
+    : (() => {
+        throw new Error("score() requires eval artifact paths.");
+      })();
 
   const result = await runPiJudge({
     prompt,
@@ -790,19 +740,6 @@ export class EvalResponse {
     });
     this.cwd = opts.cwd;
     this.model = opts.model;
-  }
-
-  async evaluate(assertion: string): Promise<EvaluationVerdict> {
-    const verdict = await evaluateTranscript({
-      assertion,
-      transcript: this.transcript,
-      cwd: this.cwd,
-      model: this.model,
-    });
-    if (!verdict.success) {
-      throw new Error(verdict.reason);
-    }
-    return verdict;
   }
 
   async score(criteria: string[]): Promise<EvalScore> {

--- a/evals/run-recorder.ts
+++ b/evals/run-recorder.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { EvalMetrics } from "./artifacts.js";
 
 export type EvalCallRecord = {
@@ -10,11 +11,23 @@ export type EvalCallRecord = {
 };
 
 const recordedCalls: EvalCallRecord[] = [];
+const callStorage = new AsyncLocalStorage<EvalCallRecord[]>();
+
+function currentRecordedCalls(): EvalCallRecord[] {
+  return callStorage.getStore() ?? recordedCalls;
+}
 
 export function recordEvalCall(record: EvalCallRecord): void {
-  recordedCalls.push(record);
+  currentRecordedCalls().push(record);
 }
 
 export function takeRecordedEvalCalls(): EvalCallRecord[] {
-  return recordedCalls.splice(0, recordedCalls.length);
+  const calls = currentRecordedCalls();
+  return calls.splice(0, calls.length);
+}
+
+export async function withEvalCallRecording<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await callStorage.run([], fn);
 }

--- a/evals/scoring.ts
+++ b/evals/scoring.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { EvalJudgeRecord, EvalScore, ScoredCriterion } from "./harness.js";
 import type { EvalMetrics } from "./artifacts.js";
 
@@ -20,6 +21,11 @@ export type EvalScoreRecord = {
 };
 
 const recordedScores: EvalScoreRecord[] = [];
+const scoreStorage = new AsyncLocalStorage<EvalScoreRecord[]>();
+
+function currentRecordedScores(): EvalScoreRecord[] {
+  return scoreStorage.getStore() ?? recordedScores;
+}
 
 function toRecord(name: string, score: EvalScore): EvalScoreRecord {
   return {
@@ -38,10 +44,17 @@ function toRecord(name: string, score: EvalScore): EvalScoreRecord {
 
 export function recordScore(name: string, score: EvalScore): EvalScoreRecord {
   const record = toRecord(name, score);
-  recordedScores.push(record);
+  currentRecordedScores().push(record);
   return record;
 }
 
 export function takeRecordedScores(): EvalScoreRecord[] {
-  return recordedScores.splice(0, recordedScores.length);
+  const scores = currentRecordedScores();
+  return scores.splice(0, scores.length);
+}
+
+export async function withScoreRecording<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await scoreStorage.run([], fn);
 }


### PR DESCRIPTION
## Summary
- run selected eval cases in parallel by default
- isolate per-case score, call, and artifact state with async-local storage
- make judges inspect run artifacts with `read`/`bash`, prioritizing `transcript.jsonl` and `jq` for structured queries
- rename agent artifacts to `transcript.jsonl` and `transcript.md`
- simplify root `AGENTS.md` command and skill-mirror guidance

## Verification
- `pnpm --dir evals -s lint`
- `pnpm -s type-check --filter @libretto/evals`
