### PR TITLE
Add focused Fallow lint check

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/fallow.schema.json",
+  "ignorePatterns": ["docs/**", "specs/**", "apps/website/docs/**"],
+  "duplicates": {
+    "enabled": false,
+    "threshold": 100,
+    "ignore": ["**/*"]
+  },
+  "health": {
+    "maxCyclomatic": 65535,
+    "maxCognitive": 65535,
+    "maxCrap": 1000000,
+    "ignore": ["**/*"]
+  },
+  "rules": {
+    "unused-files": "off",
+    "unused-exports": "off",
+    "unused-types": "off",
+    "private-type-leaks": "off",
+    "unused-dependencies": "off",
+    "unused-dev-dependencies": "off",
+    "unused-optional-dependencies": "off",
+    "unused-enum-members": "off",
+    "unused-class-members": "off",
+    "unresolved-imports": "error",
+    "unlisted-dependencies": "error",
+    "duplicate-exports": "error",
+    "type-only-dependencies": "off",
+    "test-only-dependencies": "off",
+    "circular-dependencies": "off",
+    "boundary-violation": "off",
+    "coverage-gaps": "off",
+    "feature-flags": "off",
+    "stale-suppressions": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ evals/private/
 evals/runs/
 tmp/
 .turbo/
+.fallow/
 .worktrees/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@ai-sdk/google-vertex": "^4.0.80",
     "@ai-sdk/openai": "^3.0.41",
     "@types/sharp": "^0.32.0",
+    "fallow": "^2.55.0",
     "lintcn": "^0.9.0",
     "mint": "4.2.525",
     "playwright": "^1.58.2",
@@ -16,7 +17,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "lint": "turbo run lint --concurrency=1",
+    "lint": "turbo run lint --concurrency=1 && fallow --summary",
     "docs:dev": "cd docs && mint dev --no-open",
     "docs:validate": "cd docs && mint validate",
     "docs:broken-links": "cd docs && mint broken-links --check-anchors",

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -11,7 +11,7 @@ import {
 } from "../core/browser.js";
 import { resolveProviderName } from "../core/providers/index.js";
 import { readLibrettoConfig } from "../core/config.js";
-import { createLoggerForSession, withSessionLogger } from "../core/context.js";
+import { createLoggerForSession } from "../core/context.js";
 import { librettoCommand } from "../../shared/package-manager.js";
 import {
   type SessionAccessMode,
@@ -295,9 +295,3 @@ export const browserCommands = {
   "session-mode": sessionModeCommand,
   close: closeCommand,
 };
-
-export async function runClose(session: string): Promise<void> {
-  await withSessionLogger(session, async (logger) => {
-    await runCloseWithLogger(session, logger);
-  });
-}

--- a/packages/libretto/src/cli/index.ts
+++ b/packages/libretto/src/cli/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { runLibrettoCLI } from "./cli.js";
 
-export { runClose } from "./commands/browser.js";
 export { runLibrettoCLI };
 
 void runLibrettoCLI();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@types/sharp':
         specifier: ^0.32.0
         version: 0.32.0
+      fallow:
+        specifier: ^2.55.0
+        version: 2.55.0
       lintcn:
         specifier: ^0.9.0
         version: 0.9.0
@@ -802,6 +805,46 @@ packages:
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fallow-cli/darwin-arm64@2.55.0':
+    resolution: {integrity: sha512-zWU4GIEAT8P+zFrYWbtK/CCMOxx460g/StdbFnOLV1jG9tVBbGFTcpXfbHFydPPZSthZAIqYVZI0IVXZHHETcw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.55.0':
+    resolution: {integrity: sha512-gAiAgO3sFcajjeJdNed4SjIBn+y6iQOITVhoa/+npCcZmtjwRTcJEzTGaUhExiYfNC52VafgW/EWh20KpTU21w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.55.0':
+    resolution: {integrity: sha512-6aW0TzN2wfcjoT1Ti1lysNr7teWJeqEPUYUNQpVknijrYyytMPlMXGOcT4vEu97EjPpMuxYPC6vyqVobcf2UCQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.55.0':
+    resolution: {integrity: sha512-OgdmRH6NaDZlXc+xDTi+Dp0WHyv5bIs+UYvoqTC3imy9eSHZ+k65FnHeMmViy4lGcc4LRjBGDEXX3ACStVCprA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.55.0':
+    resolution: {integrity: sha512-/K8ZRVZ1TNl1x19VTa+WRAo7O1I6A/ZTbCPAkMop7eqqS5uweNgHpqh2H+x4fVclk8tjC45kXFdv4HuWrcL43A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.55.0':
+    resolution: {integrity: sha512-f90KQY6bpmrECGmmh0C/qfCxA9UzxevnGGbj3sKMqnJc2g7Ce3Yj5WeGukoyzI2VHtBhf/O5o7vagsNLyejt0Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-arm64-msvc@2.55.0':
+    resolution: {integrity: sha512-GaF3Hg1Iio0xXJ2zpBwPgFKgXmLsHRzwVJG+ZZx0XGb5MyVcmaXV+bcdntnWCaFk/77WXo0Opbz7L9/0HXotWA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@fallow-cli/win32-x64-msvc@2.55.0':
+    resolution: {integrity: sha512-Asprc4o3YNk2TizCNwBnQkdd4T84XJUkCC3ZBJVDC6VoiSQ46M4JrKcX9BDuSrkfFuTrfB6ZbsR0+g2fgF+lFQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5210,6 +5253,11 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  fallow@2.55.0:
+    resolution: {integrity: sha512-AmHbIJXaPnUI2OH5xF2jxVhKqJHSLWNIQcnyc/aEK2MrwJYPS6lQRPE59CsqRLeAiHNqIA4f8TN5nrQy1UH+4w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -9344,6 +9392,30 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@fallow-cli/darwin-arm64@2.55.0':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.55.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.55.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.55.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.55.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.55.0':
+    optional: true
+
+  '@fallow-cli/win32-arm64-msvc@2.55.0':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.55.0':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -14543,6 +14615,19 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fallow@2.55.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.55.0
+      '@fallow-cli/darwin-x64': 2.55.0
+      '@fallow-cli/linux-arm64-gnu': 2.55.0
+      '@fallow-cli/linux-arm64-musl': 2.55.0
+      '@fallow-cli/linux-x64-gnu': 2.55.0
+      '@fallow-cli/linux-x64-musl': 2.55.0
+      '@fallow-cli/win32-arm64-msvc': 2.55.0
+      '@fallow-cli/win32-x64-msvc': 2.55.0
 
   fast-deep-equal@3.1.3: {}
 


### PR DESCRIPTION
## Summary
- add a focused Fallow config for deterministic lint-like checks: unresolved imports, unlisted dependencies, and duplicate exports
- run `fallow --summary` as part of the root `pnpm lint` script
- remove the duplicate `runClose` CLI export so the new Fallow check passes
- ignore Fallow cache files

## Testing
- `npx fallow --summary`
- `pnpm -s type-check`
- `pnpm -s lint`
