### PR TITLE
Wait for Libretto Cloud browser capacity

### DIFF
--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -21,11 +21,11 @@ import { SimpleCLI } from "../framework/simple-cli.js";
 import {
   ApiCallError,
   betterAuthCall,
-  HOSTED_API_URL,
   NOT_AUTHENTICATED_MESSAGE,
   orpcCall,
   pickCredential,
   resolveApiUrl,
+  resolveHostedApiUrl,
 } from "../core/auth-fetch.js";
 import {
   authStatePath,
@@ -202,7 +202,7 @@ export const signupCommand = SimpleCLI.command({
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .handle(async () => {
-    const apiUrl = HOSTED_API_URL;
+    const apiUrl = resolveHostedApiUrl();
     console.log("Sign up for libretto cloud");
     console.log();
     console.log("Heads up: a libretto user can only belong to one organization.");
@@ -308,7 +308,7 @@ export const loginCommand = SimpleCLI.command({
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .handle(async () => {
-    const apiUrl = HOSTED_API_URL;
+    const apiUrl = resolveHostedApiUrl();
 
     const email = await prompt("Email:");
     const password = await promptPassword("Password:");
@@ -514,7 +514,7 @@ export const acceptInviteCommand = SimpleCLI.command({
   )
   .handle(async ({ input }) => {
     const stored = await readAuthState();
-    const apiUrl = HOSTED_API_URL;
+    const apiUrl = resolveHostedApiUrl();
     const credential = pickCredential(stored);
     const expectedTenantSlug = input.tenantSlug;
 
@@ -746,7 +746,7 @@ export const whoamiCommand = SimpleCLI.command({
     }
 
     console.log(`Auth source:      ${credential.source}`);
-    console.log(`API URL:          ${HOSTED_API_URL}`);
+    console.log(`API URL:          ${resolveHostedApiUrl()}`);
     console.log(
       `LIBRETTO_API_KEY: ${envKey ? `set in env (${envKey.slice(0, 6)}…)` : "not set in env"}`,
     );

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
-import { HOSTED_API_URL } from "../core/auth-fetch.js";
+import { resolveHostedApiUrl } from "../core/auth-fetch.js";
 import { buildHostedDeployTarball } from "../core/deploy-artifact.js";
 import { SimpleCLI } from "../framework/simple-cli.js";
 
@@ -28,7 +28,7 @@ function getConfig() {
     );
   }
 
-  return { apiUrl: HOSTED_API_URL, apiKey };
+  return { apiUrl: resolveHostedApiUrl(), apiKey };
 }
 
 async function postJson(

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -29,7 +29,10 @@ import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
 import { renderSnapshotDiff } from "../../shared/snapshot/diff-snapshots.js";
-import { resolveProviderName } from "../core/providers/index.js";
+import {
+  getProviderStartupTimeoutMs,
+  resolveProviderName,
+} from "../core/providers/index.js";
 import { getAbsoluteIntegrationPath } from "../core/workflow-runtime.js";
 import {
   compileExecFunction,
@@ -609,7 +612,7 @@ async function runIntegrationFromFile(
     },
     logger,
     logPath: runLogPath,
-    startupTimeoutMs: 60_000,
+    startupTimeoutMs: getProviderStartupTimeoutMs(args.providerName),
     handlers,
   });
 

--- a/packages/libretto/src/cli/core/auth-fetch.ts
+++ b/packages/libretto/src/cli/core/auth-fetch.ts
@@ -11,7 +11,11 @@
 
 import { readAuthState, writeAuthState, type AuthState } from "./auth-storage.js";
 
-export const HOSTED_API_URL = "https://api.libretto.sh";
+export const DEFAULT_HOSTED_API_URL = "https://api.libretto.sh";
+
+export function resolveHostedApiUrl(): string {
+  return process.env.LIBRETTO_API_URL?.trim() || DEFAULT_HOSTED_API_URL;
+}
 
 /**
  * Shared "you have no usable credential" message. Pointed at the two
@@ -41,7 +45,7 @@ export function pickCredential(state: AuthState | null): CredentialChoice {
 }
 
 export function resolveApiUrl(_state: AuthState | null): string {
-  return HOSTED_API_URL;
+  return resolveHostedApiUrl();
 }
 
 type FetchOptions = {

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -15,7 +15,10 @@ import type { Experiments } from "./experiments.js";
 import { getSessionProviderClosePath, PROFILES_DIR } from "./context.js";
 import { readLibrettoConfig } from "./config.js";
 import { librettoCommand } from "../../shared/package-manager.js";
-import { getCloudProviderApi } from "./providers/index.js";
+import {
+  getCloudProviderApi,
+  getProviderStartupTimeoutMs,
+} from "./providers/index.js";
 import {
   assertSessionAvailableForStart,
   clearSessionState,
@@ -548,8 +551,8 @@ export async function runOpenWithProvider(
     },
     logger,
     logPath: runLogPath,
-    // Remote CDP connection + navigation; must cover both.
-    startupTimeoutMs: 60_000,
+    // Remote provider creation can wait for cloud capacity before CDP exists.
+    startupTimeoutMs: getProviderStartupTimeoutMs(providerName),
   });
   client.destroy();
 

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -878,9 +878,14 @@ function createProviderStartupCleanup(args: {
   const requestClose = (reason: string): void => {
     if (disposed) return;
     disposed = true;
+    // Startup cancellation should preserve the signal-style exit code even if
+    // provider.createSession() later rejects through the normal startup path.
     process.exitCode = reason === "received SIGINT" ? 130 : 1;
     const providerSession = args.getProviderSession();
     if (!providerSession) {
+      // If cancellation lands while createSession() is still awaiting provider
+      // capacity, provider-specific signal handlers may still need a tick to
+      // close a queued session id that this daemon has not received yet.
       fallbackExit = setTimeout(() => {
         process.exit(process.exitCode);
       }, 5_000);
@@ -900,6 +905,8 @@ function createProviderStartupCleanup(args: {
   const onSigint = (): void => requestClose("received SIGINT");
   const onSigterm = (): void => requestClose("received SIGTERM");
 
+  // These handlers only cover the pre-ready window. Once the daemon is ready,
+  // normal shutdown owns provider cleanup through BrowserDaemon.shutdown().
   if (typeof process.send === "function") {
     process.once("disconnect", onDisconnect);
   }

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -873,12 +873,20 @@ function createProviderStartupCleanup(args: {
   getProviderSession: () => ProviderSession | undefined;
 }): { dispose: () => void } {
   let disposed = false;
+  let fallbackExit: NodeJS.Timeout | undefined;
 
   const requestClose = (reason: string): void => {
     if (disposed) return;
     disposed = true;
+    process.exitCode = reason === "received SIGINT" ? 130 : 1;
     const providerSession = args.getProviderSession();
-    if (!providerSession) return;
+    if (!providerSession) {
+      fallbackExit = setTimeout(() => {
+        process.exit(process.exitCode);
+      }, 5_000);
+      fallbackExit.unref();
+      return;
+    }
 
     void args.provider
       .closeSession(providerSession.sessionId)
@@ -901,6 +909,7 @@ function createProviderStartupCleanup(args: {
   return {
     dispose: () => {
       disposed = true;
+      if (fallbackExit) clearTimeout(fallbackExit);
       process.off("disconnect", onDisconnect);
       process.off("SIGINT", onSigint);
       process.off("SIGTERM", onSigterm);
@@ -1009,7 +1018,9 @@ function reportStartupError(error: unknown): never {
       message: error.message,
     });
   }
-  process.exit(1);
+  process.exit(
+    process.exitCode && process.exitCode !== 0 ? process.exitCode : 1,
+  );
 }
 
 try {

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -82,7 +82,7 @@ import {
 } from "./config.js";
 import type { Experiments } from "../experiments.js";
 import { getCloudProviderApi } from "../providers/index.js";
-import type { ProviderApi } from "../providers/types.js";
+import type { ProviderApi, ProviderSession } from "../providers/types.js";
 import {
   getAbsoluteIntegrationPath,
   loadDefaultWorkflow,
@@ -230,6 +230,7 @@ class BrowserDaemon {
       name: string;
       sessionId: string;
     };
+    beforeReady?: () => void;
   }): Promise<BrowserDaemon> {
     const {
       session,
@@ -242,6 +243,7 @@ class BrowserDaemon {
       navigateUrl,
       readyProvider,
       providerSession,
+      beforeReady,
     } = args;
 
     await mkdir(getSessionDir(session), { recursive: true });
@@ -346,6 +348,7 @@ class BrowserDaemon {
     });
 
     await listenOnIpcSocket(ipcServer, socketPath);
+    beforeReady?.();
     process.send?.({ type: "ready", socketPath, provider: readyProvider });
     daemon.logger.info("ipc-server-listening", { socketPath });
 
@@ -471,8 +474,13 @@ class BrowserDaemon {
   }): Promise<BrowserDaemon> {
     const { session, browser: config } = args;
     const provider = getCloudProviderApi(config.providerName);
-    const providerSession = await provider.createSession();
+    let providerSession: ProviderSession | undefined;
+    const startupCleanup = createProviderStartupCleanup({
+      provider,
+      getProviderSession: () => providerSession,
+    });
     try {
+      providerSession = await provider.createSession();
       const browser = await chromium.connectOverCDP(
         providerSession.cdpEndpoint,
       );
@@ -506,6 +514,7 @@ class BrowserDaemon {
           name: config.providerName,
           sessionId: providerSession.sessionId,
         },
+        beforeReady: startupCleanup.dispose,
       });
 
       daemon.logger.info("child-provider-connected", {
@@ -518,7 +527,10 @@ class BrowserDaemon {
 
       return daemon;
     } catch (error) {
-      await provider.closeSession(providerSession.sessionId);
+      startupCleanup.dispose();
+      if (providerSession) {
+        await provider.closeSession(providerSession.sessionId);
+      }
       throw error;
     }
   }
@@ -854,6 +866,46 @@ class BrowserDaemon {
       }
     }
   }
+}
+
+function createProviderStartupCleanup(args: {
+  provider: ProviderApi;
+  getProviderSession: () => ProviderSession | undefined;
+}): { dispose: () => void } {
+  let disposed = false;
+
+  const requestClose = (reason: string): void => {
+    if (disposed) return;
+    disposed = true;
+    const providerSession = args.getProviderSession();
+    if (!providerSession) return;
+
+    void args.provider
+      .closeSession(providerSession.sessionId)
+      .catch(() => {})
+      .finally(() => {
+        process.exit(reason === "received SIGINT" ? 130 : 1);
+      });
+  };
+
+  const onDisconnect = (): void => requestClose("parent command disconnected");
+  const onSigint = (): void => requestClose("received SIGINT");
+  const onSigterm = (): void => requestClose("received SIGTERM");
+
+  if (typeof process.send === "function") {
+    process.once("disconnect", onDisconnect);
+  }
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+
+  return {
+    dispose: () => {
+      disposed = true;
+      process.off("disconnect", onDisconnect);
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+    },
+  };
 }
 
 // ── Main ───────────────────────────────────────────────────────────────

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -105,6 +105,11 @@ export type DaemonStartupErrorMessage = {
   message: string;
 };
 
+export type DaemonStartupStatusMessage = {
+  type: "startup-status";
+  message: string;
+};
+
 function isDaemonReadyMessage(message: unknown): message is DaemonReadyMessage {
   if (typeof message !== "object" || message === null) return false;
   const candidate = message as { type?: unknown; socketPath?: unknown };
@@ -118,6 +123,16 @@ function isDaemonStartupErrorMessage(
   const candidate = message as { type?: unknown; message?: unknown };
   return (
     candidate.type === "startup-error" && typeof candidate.message === "string"
+  );
+}
+
+function isDaemonStartupStatusMessage(
+  message: unknown,
+): message is DaemonStartupStatusMessage {
+  if (typeof message !== "object" || message === null) return false;
+  const candidate = message as { type?: unknown; message?: unknown };
+  return (
+    candidate.type === "startup-status" && typeof candidate.message === "string"
   );
 }
 
@@ -257,6 +272,13 @@ export class DaemonClient {
       onExit: (code, signal, ready) => {
         logger.warn("daemon-exit", { code, signal, session, pid, ready });
       },
+      onStatus: (message) => {
+        logger.info("daemon-startup-status", {
+          session,
+          message: message.message,
+        });
+        console.log(message.message);
+      },
     }).catch(async (error: unknown) => {
       try {
         process.kill(pid, "SIGTERM");
@@ -292,6 +314,7 @@ export class DaemonClient {
       signal: NodeJS.Signals | null,
       ready: boolean,
     ) => void;
+    onStatus?: (message: DaemonStartupStatusMessage) => void;
   }): Promise<DaemonReadyMessage> {
     const {
       child,
@@ -302,6 +325,7 @@ export class DaemonClient {
       onReady,
       onSpawnError,
       onExit,
+      onStatus,
     } = args;
 
     return new Promise<DaemonReadyMessage>((resolve, reject) => {
@@ -325,6 +349,10 @@ export class DaemonClient {
       const onMessage = (message: unknown): void => {
         if (isDaemonStartupErrorMessage(message)) {
           fail(new Error(message.message));
+          return;
+        }
+        if (isDaemonStartupStatusMessage(message)) {
+          onStatus?.(message);
           return;
         }
         if (!isDaemonReadyMessage(message)) return;

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -337,6 +337,8 @@ export class DaemonClient {
         child.off("message", onMessage);
         child.off("error", onError);
         child.off("exit", onChildExit);
+        process.off("SIGINT", onParentSigint);
+        process.off("SIGTERM", onParentSigterm);
       };
 
       const fail = (error: Error): void => {
@@ -376,9 +378,22 @@ export class DaemonClient {
         fail(formatExitError(code, signal));
       };
 
+      const forwardSignalToChild = (signal: NodeJS.Signals): void => {
+        try {
+          child.kill(signal);
+        } catch {
+          // Child may have already exited.
+        }
+      };
+
+      const onParentSigint = (): void => forwardSignalToChild("SIGINT");
+      const onParentSigterm = (): void => forwardSignalToChild("SIGTERM");
+
       child.on("message", onMessage);
       child.on("error", onError);
       child.on("exit", onChildExit);
+      process.once("SIGINT", onParentSigint);
+      process.once("SIGTERM", onParentSigterm);
     });
   }
 

--- a/packages/libretto/src/cli/core/providers/index.ts
+++ b/packages/libretto/src/cli/core/providers/index.ts
@@ -4,9 +4,16 @@ import { createKernelProvider } from "./kernel.js";
 import { createLibrettoCloudProvider } from "./libretto-cloud.js";
 import type { ProviderApi } from "./types.js";
 
-const VALID_PROVIDERS = new Set(["local", "kernel", "browserbase", "libretto-cloud"] as const);
+const VALID_PROVIDERS = new Set([
+  "local",
+  "kernel",
+  "browserbase",
+  "libretto-cloud",
+] as const);
 export type ProviderName =
   typeof VALID_PROVIDERS extends Set<infer T> ? T : never;
+const DEFAULT_PROVIDER_STARTUP_TIMEOUT_MS = 60_000;
+const LIBRETTO_CLOUD_STARTUP_TIMEOUT_MS = 10 * 60_000;
 
 function assertValidProviderName(value: string, source: string): ProviderName {
   if (!VALID_PROVIDERS.has(value as ProviderName)) {
@@ -50,13 +57,19 @@ export function getCloudProviderApi(name: string): ProviderApi {
     case "browserbase":
       return createBrowserbaseProvider();
     case "libretto-cloud":
-      console.warn(
-        "Note: The libretto-cloud provider is in alpha.",
-      );
+      console.warn("Note: The libretto-cloud provider is in alpha.");
       return createLibrettoCloudProvider();
     default:
       throw new Error(
         `Unknown provider "${name}". Valid cloud providers: kernel, browserbase`,
       );
   }
+}
+
+export function getProviderStartupTimeoutMs(
+  providerName: string | undefined,
+): number {
+  return providerName === "libretto-cloud"
+    ? LIBRETTO_CLOUD_STARTUP_TIMEOUT_MS
+    : DEFAULT_PROVIDER_STARTUP_TIMEOUT_MS;
 }

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -1,6 +1,18 @@
 import { HOSTED_API_URL } from "../auth-fetch.js";
 import type { ProviderApi } from "./types.js";
 
+type CloudSessionResponse = {
+  session_id: string;
+  status: string;
+  cdp_url: string | null;
+  live_view_url: string | null;
+  recording_url: string | null;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS = 7_200;
+const QUEUE_WAIT_TIMEOUT_MS = 10 * 60_000;
+
 export function createLibrettoCloudProvider(): ProviderApi {
   const apiKey = process.env.LIBRETTO_API_KEY;
   if (!apiKey)
@@ -13,8 +25,9 @@ export function createLibrettoCloudProvider(): ProviderApi {
   // must be wrapped as { json: ... } and outputs arrive the same way.
   return {
     async createSession() {
-      const timeoutSeconds = Number(
-        process.env.LIBRETTO_TIMEOUT_SECONDS ?? 7200,
+      const browserSessionTimeoutSeconds = readPositiveNumberEnv(
+        "LIBRETTO_TIMEOUT_SECONDS",
+        DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS,
       );
       const resp = await fetch(`${endpoint}/v1/sessions/create`, {
         method: "POST",
@@ -23,48 +36,223 @@ export function createLibrettoCloudProvider(): ProviderApi {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          json: { timeout_seconds: timeoutSeconds },
+          json: { timeout_seconds: browserSessionTimeoutSeconds },
         }),
       });
       if (!resp.ok) {
         const body = await resp.text();
-        throw new Error(
-          `Libretto Cloud API error (${resp.status}): ${body}`,
-        );
+        throw new Error(`Libretto Cloud API error (${resp.status}): ${body}`);
       }
-      const { json } = (await resp.json()) as {
-        json: {
-          session_id: string;
-          cdp_url: string;
-          live_view_url: string | null;
-          recording_url: string | null;
-        };
-      };
+      const { json } = (await resp.json()) as { json: CloudSessionResponse };
+      const startupCleanup = createStartupSessionCleanup(
+        endpoint,
+        apiKey,
+        json.session_id,
+      );
+      let readySession: CloudSessionResponse & { cdp_url: string };
+      try {
+        readySession = await waitForCloudSessionReady({
+          endpoint,
+          apiKey,
+          session: json,
+          timeoutMs: QUEUE_WAIT_TIMEOUT_MS,
+          isCancelled: startupCleanup.isCancelled,
+        });
+      } catch (error) {
+        if (startupCleanup.isCancelled()) {
+          await startupCleanup.waitForClose();
+        } else {
+          await closeCloudSession(endpoint, apiKey, json.session_id).catch(
+            () => {},
+          );
+        }
+        throw error;
+      } finally {
+        startupCleanup.dispose();
+      }
       return {
-        sessionId: json.session_id,
-        cdpEndpoint: json.cdp_url,
-        liveViewUrl: json.live_view_url ?? undefined,
+        sessionId: readySession.session_id,
+        cdpEndpoint: readySession.cdp_url,
+        liveViewUrl: readySession.live_view_url ?? undefined,
       };
     },
     async closeSession(sessionId) {
-      const resp = await fetch(`${endpoint}/v1/sessions/close`, {
-        method: "POST",
-        headers: {
-          "x-api-key": apiKey,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ json: { session_id: sessionId } }),
-      });
-      if (!resp.ok) {
-        const body = await resp.text();
-        throw new Error(
-          `Libretto Cloud API error closing session ${sessionId} (${resp.status}): ${body}`,
-        );
-      }
-      const { json } = (await resp.json()) as {
-        json: { replay_url: string | null };
-      };
+      const json = await closeCloudSession(endpoint, apiKey, sessionId);
       return { replayUrl: json.replay_url ?? undefined };
     },
   };
+}
+
+async function waitForCloudSessionReady(args: {
+  endpoint: string;
+  apiKey: string;
+  session: CloudSessionResponse;
+  timeoutMs: number;
+  isCancelled?: () => boolean;
+}): Promise<CloudSessionResponse & { cdp_url: string }> {
+  let session = args.session;
+  if (args.isCancelled?.()) {
+    throw new Error(
+      `Libretto Cloud session ${session.session_id} was cancelled before browser capacity was available.`,
+    );
+  }
+  if (session.cdp_url) {
+    return { ...session, cdp_url: session.cdp_url };
+  }
+
+  sendStartupStatus(
+    `Libretto Cloud browser session queued (session: ${session.session_id}). Waiting for browser capacity...`,
+  );
+
+  const pollIntervalMs = readPositiveNumberEnv(
+    "LIBRETTO_CLOUD_SESSION_POLL_INTERVAL_MS",
+    DEFAULT_POLL_INTERVAL_MS,
+  );
+  const deadline = Date.now() + args.timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (args.isCancelled?.()) {
+      throw new Error(
+        `Libretto Cloud session ${session.session_id} was cancelled before browser capacity was available.`,
+      );
+    }
+    await sleep(pollIntervalMs);
+    if (args.isCancelled?.()) {
+      throw new Error(
+        `Libretto Cloud session ${session.session_id} was cancelled before browser capacity was available.`,
+      );
+    }
+    session = await getCloudSession(
+      args.endpoint,
+      args.apiKey,
+      session.session_id,
+    );
+    if (session.cdp_url) {
+      sendStartupStatus(
+        `Libretto Cloud browser capacity available (session: ${session.session_id}). Connecting...`,
+      );
+      return { ...session, cdp_url: session.cdp_url };
+    }
+    if (!["queued", "starting"].includes(session.status)) {
+      throw new Error(
+        `Libretto Cloud session ${session.session_id} entered status "${session.status}" before a CDP URL was available.`,
+      );
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for Libretto Cloud browser capacity after ${Math.ceil(args.timeoutMs / 1_000)}s (session: ${session.session_id}).`,
+  );
+}
+
+async function getCloudSession(
+  endpoint: string,
+  apiKey: string,
+  sessionId: string,
+): Promise<CloudSessionResponse> {
+  const resp = await fetch(`${endpoint}/v1/sessions/get`, {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ json: { session_id: sessionId } }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(
+      `Libretto Cloud API error reading session ${sessionId} (${resp.status}): ${body}`,
+    );
+  }
+  const { json } = (await resp.json()) as { json: CloudSessionResponse };
+  return json;
+}
+
+async function closeCloudSession(
+  endpoint: string,
+  apiKey: string,
+  sessionId: string,
+): Promise<{ replay_url: string | null }> {
+  const resp = await fetch(`${endpoint}/v1/sessions/close`, {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ json: { session_id: sessionId } }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(
+      `Libretto Cloud API error closing session ${sessionId} (${resp.status}): ${body}`,
+    );
+  }
+  const { json } = (await resp.json()) as {
+    json: { replay_url: string | null };
+  };
+  return json;
+}
+
+function createStartupSessionCleanup(
+  endpoint: string,
+  apiKey: string,
+  sessionId: string,
+): {
+  isCancelled: () => boolean;
+  waitForClose: () => Promise<void>;
+  dispose: () => void;
+} {
+  let cancelled = false;
+  let closePromise: Promise<void> | null = null;
+
+  const requestClose = (reason: string): void => {
+    if (cancelled) return;
+    cancelled = true;
+    sendStartupStatus(
+      `Libretto Cloud browser session cancelled (${reason}). Cleaning up queued session...`,
+    );
+    closePromise = closeCloudSession(endpoint, apiKey, sessionId).then(
+      () => {},
+      () => {},
+    );
+  };
+
+  const onDisconnect = (): void => requestClose("parent command disconnected");
+  const onSigint = (): void => requestClose("received SIGINT");
+  const onSigterm = (): void => requestClose("received SIGTERM");
+
+  if (typeof process.send === "function") {
+    process.once("disconnect", onDisconnect);
+  }
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+
+  return {
+    isCancelled: () => cancelled,
+    waitForClose: async () => {
+      await closePromise;
+    },
+    dispose: () => {
+      process.off("disconnect", onDisconnect);
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+    },
+  };
+}
+
+function readPositiveNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sendStartupStatus(message: string): void {
+  if (typeof process.send === "function") {
+    process.send({ type: "startup-status", message });
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -1,4 +1,4 @@
-import { HOSTED_API_URL } from "../auth-fetch.js";
+import { resolveHostedApiUrl } from "../auth-fetch.js";
 import type { ProviderApi } from "./types.js";
 
 type CloudSessionResponse = {
@@ -10,7 +10,7 @@ type CloudSessionResponse = {
 };
 
 const DEFAULT_POLL_INTERVAL_MS = 2_000;
-const DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS = 7_200;
+const DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS = 3_600;
 const QUEUE_WAIT_TIMEOUT_MS = 10 * 60_000;
 
 export function createLibrettoCloudProvider(): ProviderApi {
@@ -19,7 +19,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
     throw new Error(
       "LIBRETTO_API_KEY is required for the Libretto Cloud provider.",
     );
-  const endpoint = HOSTED_API_URL;
+  const endpoint = resolveHostedApiUrl();
 
   // The Libretto Cloud API is an oRPC RPCHandler, not plain REST, so inputs
   // must be wrapped as { json: ... } and outputs arrive the same way.

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -1,6 +1,7 @@
 import { writeFile } from "node:fs/promises";
-import { describe, expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
+import { createLibrettoCloudProvider } from "../src/cli/core/providers/libretto-cloud.js";
 import { test } from "./fixtures.js";
 
 describe("browser URL normalization", () => {
@@ -166,3 +167,149 @@ describe("provider session guards", () => {
     expect(result.stderr).toContain("kernel");
   });
 });
+
+describe("Libretto Cloud provider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("waits for queued sessions to receive a CDP URL", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+    vi.stubEnv("LIBRETTO_TIMEOUT_SECONDS", "123");
+    vi.stubEnv("LIBRETTO_CLOUD_SESSION_POLL_INTERVAL_MS", "1");
+
+    let getCalls = 0;
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-queued",
+              status: "queued",
+              cdp_url: null,
+              live_view_url: null,
+              recording_url: null,
+            },
+          });
+        }
+        if (pathname === "/v1/sessions/get") {
+          getCalls += 1;
+          return jsonResponse({
+            json: {
+              session_id: "session-queued",
+              status: getCalls === 1 ? "queued" : "open",
+              cdp_url:
+                getCalls === 1
+                  ? null
+                  : "wss://cloud.example.test/devtools/session-queued",
+              live_view_url:
+                getCalls === 1 ? null : "https://cloud.example.test/live",
+              recording_url: null,
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const session = await createLibrettoCloudProvider().createSession();
+
+    expect(session).toEqual({
+      sessionId: "session-queued",
+      cdpEndpoint: "wss://cloud.example.test/devtools/session-queued",
+      liveViewUrl: "https://cloud.example.test/live",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      json: { timeout_seconds: 123 },
+    });
+  });
+
+  it("closes a queued session when the parent command disconnects before CDP is ready", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+    vi.stubEnv("LIBRETTO_CLOUD_SESSION_POLL_INTERVAL_MS", "1");
+
+    const originalSend = process.send;
+    const sendMock = vi.fn();
+    (process as typeof process & { send?: typeof process.send }).send =
+      sendMock;
+    let closeCallFinished = false;
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-cancelled",
+              status: "queued",
+              cdp_url: null,
+              live_view_url: null,
+              recording_url: null,
+            },
+          });
+        }
+        if (pathname === "/v1/sessions/get") {
+          return jsonResponse({
+            json: {
+              session_id: "session-cancelled",
+              status: "queued",
+              cdp_url: null,
+              live_view_url: null,
+              recording_url: null,
+            },
+          });
+        }
+        if (pathname === "/v1/sessions/close") {
+          closeCallFinished = true;
+          return jsonResponse({ json: { replay_url: null } });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const sessionPromise = createLibrettoCloudProvider().createSession();
+
+      await waitFor(() =>
+        sendMock.mock.calls.some(([message]) =>
+          JSON.stringify(message).includes("Waiting for browser capacity"),
+        ),
+      );
+      process.emit("disconnect");
+
+      await expect(sessionPromise).rejects.toThrow(
+        "cancelled before browser capacity was available",
+      );
+      expect(fetchMock.mock.calls.map(([url]) => new URL(String(url)).pathname))
+        .toContain("/v1/sessions/close");
+      expect(closeCallFinished).toBe(true);
+    } finally {
+      process.send = originalSend;
+    }
+  });
+});
+
+async function readJsonBody(init: unknown): Promise<unknown> {
+  return JSON.parse(String((init as { body?: unknown })?.body));
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 100;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -174,6 +174,36 @@ describe("Libretto Cloud provider", () => {
     vi.unstubAllGlobals();
   });
 
+  it("defaults cloud browser sessions to 60 minutes", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-ready",
+              status: "open",
+              cdp_url: "wss://cloud.example.test/devtools/session-ready",
+              live_view_url: null,
+              recording_url: null,
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const session = await createLibrettoCloudProvider().createSession();
+
+    expect(session.sessionId).toBe("session-ready");
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      json: { timeout_seconds: 3600 },
+    });
+  });
+
   it("waits for queued sessions to receive a CDP URL", async () => {
     vi.stubEnv("LIBRETTO_API_KEY", "test-key");
     vi.stubEnv("LIBRETTO_TIMEOUT_SECONDS", "123");


### PR DESCRIPTION
## Summary
- make the Libretto Cloud provider poll queued sessions until a CDP URL is available
- print daemon startup status while waiting for browser capacity
- keep LIBRETTO_TIMEOUT_SECONDS scoped to browser session TTL
- use a fixed 10 minute daemon startup wait for Libretto Cloud capacity
- clean up queued/provider sessions when startup is cancelled before the daemon is ready

## Tests
- pnpm --filter libretto test:vitest test/browser.spec.ts
- pnpm --filter libretto type-check

## Notes
- Full queued-session behavior depends on the companion browser-automations API change that returns queued sessions from sessions/create and lets queued sessions be closed without billing.