### PR TITLE
Fix Fallow schema URL

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/fallow.schema.json",
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
   "ignorePatterns": ["docs/**", "specs/**", "apps/website/docs/**"],
   "duplicates": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- update `.fallowrc.json` to use Fallow's canonical published schema URL

## Testing
- `npx fallow --summary`
