### PR TITLE
docs: bill cloud sessions per-second

### DIFF
--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, by the underlying browser provider's reported active running time. Time the browser spends in standby is not billed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser hours are priced at approximately $0.667 per browser hour, which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.00018518518 per second ("$0.667 per browser hour"), which is reflected in the included hours on each plan.
 
 #### Standby and idle time
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, by the underlying browser provider's reported active running time. Time the browser spends in standby is not billed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.00018518518 per second ($0.667 per browser hour), which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.000185185 per second ($0.667 per browser hour), which is reflected in the included hours on each plan.
 
 #### Standby and idle time
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, by the underlying browser provider's reported active running time. Time the browser spends in standby is not billed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.00018518518 per second ("$0.667 per browser hour"), which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.00018518518 per second ($0.667 per browser hour), which is reflected in the included hours on each plan.
 
 #### Standby and idle time
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, by the underlying browser provider's reported active running time. Time the browser spends in standby is not billed.
 
-Each session is billed by the minute and rounds up to the next whole minute. Browser hours are priced at approximately $0.667 per browser hour, which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser hours are priced at approximately $0.667 per browser hour, which is reflected in the included hours on each plan.
 
 #### Standby and idle time
 


### PR DESCRIPTION
## Summary

- Update Libretto Cloud billing docs to state that sessions are billed by the second (rounding up to the next whole second, with a 1-second minimum), not by the minute.
- Mirrors the upstream API change in `browser-automations` that switches the billing meter granularity from minutes to seconds (paired DB rename `billed_minutes` → `billed_seconds` + per-second ceiling).

## Test plan

- [ ] Render docs site and confirm the `libretto-cloud-hosting/billing.mdx` page reflects per-second billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)