### PR TITLE
Support daemon IPC paths on Windows

### DIFF
--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createServer } from "node:net";
+import { isWindowsNamedPipePath } from "../../shared/ipc/socket-transport.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import type { Experiments } from "./experiments.js";
@@ -977,6 +978,8 @@ function unlinkDaemonSocket(
   session: string,
 ): void {
   if (!socketPath) return;
+  if (isWindowsNamedPipePath(socketPath)) return;
+
   try {
     unlinkSync(socketPath);
   } catch (err) {

--- a/packages/libretto/src/cli/core/daemon/ipc.spec.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { getDaemonSocketPath } from "./ipc.js";
+
+describe("daemon IPC endpoint paths", () => {
+  test("uses a Windows named pipe path on Windows", () => {
+    const socketPath = getDaemonSocketPath("windows-session", "win32");
+
+    expect(socketPath).toMatch(/^\\\\\.\\pipe\\libretto-[a-f0-9]{12}$/);
+    expect(socketPath).not.toContain("/tmp/");
+    expect(socketPath).not.toContain(".sock");
+  });
+
+  test("uses a short Unix socket path on Unix-like platforms", () => {
+    const socketPath = getDaemonSocketPath("unix-session", "linux");
+
+    expect(socketPath).toMatch(/^\/tmp\/libretto-.+-[a-f0-9]{12}\.sock$/);
+  });
+
+  test("keeps daemon IPC endpoints deterministic per session", () => {
+    const firstPath = getDaemonSocketPath("stable-session", "linux");
+    const secondPath = getDaemonSocketPath("stable-session", "linux");
+    const otherPath = getDaemonSocketPath("other-session", "linux");
+
+    expect(secondPath).toBe(firstPath);
+    expect(otherPath).not.toBe(firstPath);
+  });
+});

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { openSync, closeSync } from "node:fs";
 import { createRequire } from "node:module";
+import { homedir, userInfo } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createIpcPeer, type IpcPeer } from "../../../shared/ipc/ipc.js";
 import { connectToIpcSocket } from "../../../shared/ipc/socket-transport.js";
@@ -157,18 +158,43 @@ export type DaemonClientSpawnResult = {
 // ---------------------------------------------------------------------------
 
 /**
- * Deterministic Unix domain socket path for a given session.
+ * Deterministic IPC endpoint for a given session.
  *
- * The path lives in `/tmp` to stay well under the macOS 104-byte Unix socket
- * path limit. The hash combines `REPO_ROOT` and the session name so different
- * repos (or sessions within the same repo) never collide.
+ * Unix-like platforms use a socket path in `/tmp` to stay well under the macOS
+ * 104-byte Unix socket path limit. Windows uses a named pipe path because
+ * filesystem Unix domain socket paths are not portable there.
+ *
+ * The hash combines `REPO_ROOT`, the session name, and a user key so different
+ * repos, sessions, or local users never collide.
  */
-export function getDaemonSocketPath(session: string): string {
+export function getDaemonSocketPath(
+  session: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const userKey = getDaemonUserKey();
   const hash = createHash("sha256")
-    .update(`${REPO_ROOT}:${session}`)
+    .update(`${REPO_ROOT}:${session}:${userKey}`)
     .digest("hex")
     .slice(0, 12);
-  return `/tmp/libretto-${process.getuid!()}-${hash}.sock`;
+
+  if (platform === "win32") {
+    return `\\\\.\\pipe\\libretto-${hash}`;
+  }
+
+  return `/tmp/libretto-${userKey}-${hash}.sock`;
+}
+
+function getDaemonUserKey(): string {
+  if (typeof process.getuid === "function") return String(process.getuid());
+
+  try {
+    const info = userInfo();
+    if (info.username) return info.username;
+  } catch {
+    // Fall back below.
+  }
+
+  return createHash("sha256").update(homedir()).digest("hex").slice(0, 12);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/libretto/src/shared/ipc/socket-transport.spec.ts
+++ b/packages/libretto/src/shared/ipc/socket-transport.spec.ts
@@ -6,6 +6,7 @@ import { expect, test as base } from "vitest";
 import { createIpcPeer, type IpcPeer } from "./ipc.js";
 import {
   connectToIpcSocket,
+  isWindowsNamedPipePath,
   listenForIpcConnections,
 } from "./socket-transport.js";
 
@@ -62,6 +63,11 @@ test("sends concurrent calls over one socket", async ({ socketPath }) => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
   await expect(stat(socketPath)).rejects.toThrow();
+});
+
+test("recognizes Windows named pipe paths", () => {
+  expect(isWindowsNamedPipePath("\\\\.\\pipe\\libretto-abc123")).toBe(true);
+  expect(isWindowsNamedPipePath("/tmp/libretto-501-abc123.sock")).toBe(false);
 });
 
 test("rejects pending calls when the socket closes", async ({ socketPath }) => {

--- a/packages/libretto/src/shared/ipc/socket-transport.ts
+++ b/packages/libretto/src/shared/ipc/socket-transport.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import {
   createServer,
   createConnection,
@@ -6,7 +6,6 @@ import {
   type Socket,
 } from "node:net";
 import { dirname } from "node:path";
-import { mkdir } from "node:fs/promises";
 import type { IpcProtocolMessage, IpcTransport } from "./ipc.js";
 
 function createJsonSocketTransport(
@@ -109,13 +108,12 @@ export async function listenOnIpcSocket(
   server: Server,
   socketPath: string,
 ): Promise<void> {
-  await mkdir(dirname(socketPath), { recursive: true });
-  await rm(socketPath, { force: true });
+  await prepareIpcSocketPath(socketPath);
 
   const originalClose = server.close.bind(server);
   server.close = ((callback?: (error?: Error) => void) => {
     return originalClose((error?: Error) => {
-      void rm(socketPath, { force: true }).finally(() => callback?.(error));
+      void removeStaleSocketFile(socketPath).finally(() => callback?.(error));
     });
   }) as Server["close"];
 
@@ -133,6 +131,23 @@ export async function listenOnIpcSocket(
     server.once("listening", onListening);
     server.listen(socketPath);
   });
+}
+
+export function isWindowsNamedPipePath(socketPath: string): boolean {
+  return socketPath.startsWith("\\\\.\\pipe\\");
+}
+
+async function prepareIpcSocketPath(socketPath: string): Promise<void> {
+  if (isWindowsNamedPipePath(socketPath)) return;
+
+  await mkdir(dirname(socketPath), { recursive: true });
+  await removeStaleSocketFile(socketPath);
+}
+
+async function removeStaleSocketFile(socketPath: string): Promise<void> {
+  if (isWindowsNamedPipePath(socketPath)) return;
+
+  await rm(socketPath, { force: true });
 }
 
 async function connectSocket(socketPath: string): Promise<Socket> {


### PR DESCRIPTION
## Summary
- use Windows named pipe paths for daemon IPC endpoints on `win32`
- remove the `process.getuid!()` hard dependency by falling back to OS user info or the home directory hash
- skip Unix socket file cleanup for named pipe paths in shared IPC and close-session cleanup

## Verification
- `pnpm -s --filter libretto exec vitest run src/cli/core/daemon/ipc.spec.ts src/shared/ipc/socket-transport.spec.ts`
- `pnpm -s --filter libretto type-check`
- `pnpm -s type-check`

## Notes
- Replaces #268, which targeted older daemon IPC code before shared socket transport cleanup moved into `src/shared/ipc/socket-transport.ts`.
- Full `pnpm -s --filter libretto test:vitest` currently fails on existing CLI behavior suites unrelated to this patch; targeted IPC coverage passes.
