### PR TITLE
Update Libretto Cloud session timeout docs

### DIFF
--- a/docs/libretto-cloud-api/sessions.mdx
+++ b/docs/libretto-cloud-api/sessions.mdx
@@ -12,7 +12,7 @@ Start a hosted browser session.
 
 Request fields:
 
-- `timeout_seconds`: optional session timeout, default `7200`, max `18000`
+- `timeout_seconds`: optional session timeout, default `3600`, max `7200`
 
 Response fields:
 


### PR DESCRIPTION
## Summary
- Update the direct sessions API reference to document `timeout_seconds` as defaulting to 3600 seconds.
- Update the documented maximum to 7200 seconds to match the hosted browser automation service limit.

## Tests
- Not run; docs-only change.
