### PR TITLE
docs: $0.25/browser-hour pricing; drop standby framing

### DIFF
--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, from the time a session starts until Libretto records it as closed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at **$0.25 per browser hour**, which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at **$0.000069444 per second** (**$0.25 per browser hour**), which is reflected in the included hours on each plan.
 
 #### Plans and pricing
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -37,7 +37,7 @@ Example output:
 
 ```text
 Plan:    Team (active)
-Usage:   26.40 / 150 browser hours this period
+Usage:   26.40 / 400 browser hours this period
 Period:  ends 2026-05-21
 ```
 
@@ -56,15 +56,20 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 #### How usage is measured
 
-Hosted usage is measured per browser session, by the underlying browser provider's reported active running time. Time the browser spends in standby is not billed.
+Hosted usage is measured per browser session, from the time a session starts until Libretto records it as closed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at $0.000185185 per second ($0.667 per browser hour), which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at **$0.25 per browser hour**, which is reflected in the included hours on each plan.
 
-#### Standby and idle time
+#### Plans and pricing
 
-To keep costs predictable, browsers automatically drop into a standby state during periods of inactivity. While in standby, the session keeps its full state (open tabs, cookies, authenticated logins) but does not accrue any usage.
+| Plan       | Monthly price | Browser hours included |
+| ---------- | ------------- | ---------------------- |
+| Free       | $0            | 1                      |
+| Pro        | $20           | 80                     |
+| Team       | $100          | 400                    |
+| Enterprise | Custom        | Custom                 |
 
-A session enters standby after five seconds without an active Chrome DevTools Protocol or Live View client connection. Once it does, the session's inactivity timeout begins counting down toward automatic teardown. Reconnecting any client wakes the session immediately and metering resumes.
+Run `billing portal` to compare and switch plans.
 
 If your organization exceeds its plan limit, Libretto Cloud will not spin up new browser sessions until you move to a plan with more capacity.
 


### PR DESCRIPTION
## Summary
- Update `docs/libretto-cloud-hosting/billing.mdx` to reflect the new flat **\$0.25 per browser hour** rate and the updated plan tiers (Free 1 / Pro 80 / Team 400 / Enterprise).
- Drop the "active running time / time the browser spends in standby is not billed" framing and the dedicated "Standby and idle time" section. The cloud billing logic still prefers the provider-reported running-time metric where available, but we no longer surface that as a user-facing pricing promise.
- Bump the example `billing status` output from `150 → 400 browser hours` to match the new Team tier.

Pairs with the API-side change in saffron-health/browser-automations#114, which updates the live Stripe products/prices and the internal spec catalog.

## Test plan
- [ ] Render the Mintlify docs and confirm the Plans and pricing table looks right.
- [ ] After merge, bump the libretto submodule pointer in the API repo (separate PR) so the customer-facing site picks up the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)