### PR TITLE
docs(libretto-skill): point to libretto.sh/docs/llms.txt for cloud platform

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -26,6 +26,10 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
+## Hosted Cloud Platform
+
+For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
+
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -26,10 +26,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
-## Hosted Cloud Platform
-
-For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
-
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
@@ -269,3 +265,4 @@ To watch it yourself in a browser, run: npx libretto run ./integration.ts --head
 - Read `references/auth-profiles.md` when auth-profile behavior is relevant.
 - Read `references/pages-and-page-targeting.md` when a session has multiple open pages or you need `--page`.
 - Read `references/action-logs.md` for full action log field descriptions and user-vs-agent event semantics.
+- If the workflow code is deployed to the Libretto Cloud platform and you need to reference its API docs, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -26,6 +26,10 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
+## Hosted Cloud Platform
+
+For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
+
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -26,10 +26,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
-## Hosted Cloud Platform
-
-For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
-
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
@@ -269,3 +265,4 @@ To watch it yourself in a browser, run: npx libretto run ./integration.ts --head
 - Read `references/auth-profiles.md` when auth-profile behavior is relevant.
 - Read `references/pages-and-page-targeting.md` when a session has multiple open pages or you need `--page`.
 - Read `references/action-logs.md` for full action log field descriptions and user-vs-agent event semantics.
+- If the workflow code is deployed to the Libretto Cloud platform and you need to reference its API docs, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -26,6 +26,10 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
+## Hosted Cloud Platform
+
+For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
+
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -26,10 +26,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Library API: [workflow](https://libretto.sh/library-api/workflow), [AI extraction](https://libretto.sh/library-api/ai-extraction), [network requests](https://libretto.sh/library-api/network-requests), [file downloads](https://libretto.sh/library-api/file-downloads)
 - Hosting: [introduction](https://libretto.sh/hosting/introduction), [GCP](https://libretto.sh/hosting/gcp), [AWS](https://libretto.sh/hosting/aws)
 
-## Hosted Cloud Platform
-
-For the hosted Libretto Cloud platform's APIs and documentation, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.
-
 ## Default Integration Approach
 
 - Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
@@ -269,3 +265,4 @@ To watch it yourself in a browser, run: npx libretto run ./integration.ts --head
 - Read `references/auth-profiles.md` when auth-profile behavior is relevant.
 - Read `references/pages-and-page-targeting.md` when a session has multiple open pages or you need `--page`.
 - Read `references/action-logs.md` for full action log field descriptions and user-vs-agent event semantics.
+- If the workflow code is deployed to the Libretto Cloud platform and you need to reference its API docs, fetch [https://libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow the relevant page links.


### PR DESCRIPTION
## Summary
- Adds a one-line **Hosted Cloud Platform** section to the libretto skill (source + `.agents`/`.claude` mirrors).
- Tells agents loaded with the skill to fetch [libretto.sh/docs/llms.txt](https://libretto.sh/docs/llms.txt) and follow page links when the user asks about Libretto Cloud APIs or hosted-platform docs — leveraging Mintlify's auto-served llms.txt rather than inlining the API surface into the skill.

## Test plan
- [ ] `pnpm check:mirrors` passes (already verified locally).
- [ ] Spot-check the rendered SKILL.md in a fresh agent session: ask about the hosted platform and confirm the agent fetches `llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)