### PR TITLE
Extract CLI framework into affordance

### DIFF
--- a/packages/affordance/README.md
+++ b/packages/affordance/README.md
@@ -1,0 +1,35 @@
+# affordance
+
+A small TypeScript framework for building agent-friendly CLIs with typed command inputs, nested route groups, middleware, and generated help.
+
+## Install
+
+```sh
+pnpm add affordance zod
+```
+
+## Example
+
+```ts
+import { SimpleCLI } from "affordance";
+import { z } from "zod";
+
+const app = SimpleCLI.define("mycli", {
+  open: SimpleCLI.command({ description: "Open a URL" })
+    .input(
+      SimpleCLI.input({
+        positionals: [
+          SimpleCLI.positional("url", z.string(), { help: "URL to open" }),
+        ],
+        named: {
+          headless: SimpleCLI.flag({ help: "Run without a visible browser" }),
+        },
+      }),
+    )
+    .handle(async ({ input }) => {
+      console.log(`Opening ${input.url}`);
+    }),
+});
+
+await app.run(process.argv.slice(2));
+```

--- a/packages/affordance/package.json
+++ b/packages/affordance/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "affordance",
+  "version": "0.1.0",
+  "description": "A TypeScript framework for building agent-friendly CLIs",
+  "license": "MIT",
+  "homepage": "https://libretto.sh",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/saffron-health/libretto.git",
+    "directory": "packages/affordance"
+  },
+  "type": "module",
+  "packageManager": "pnpm@10.33.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "lint": "lintcn lint --tsconfig tsconfig.json",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:vitest": "vitest run",
+    "prepack": "pnpm run build"
+  },
+  "peerDependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5",
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/affordance/src/index.ts
+++ b/packages/affordance/src/index.ts
@@ -4,7 +4,6 @@ type RecordUnknown = Record<string, unknown>;
 
 export type SimpleCLICommandConfig = {
   description: string;
-  experimental?: boolean;
 };
 
 export type SimpleCLIInputRaw = {
@@ -112,7 +111,6 @@ export type SimpleCLIResolvedCommand = {
 };
 
 type InternalResolvedCommand = SimpleCLIResolvedCommand & {
-  experimental?: boolean;
   input?: SimpleCLIInput<unknown>;
   middlewares: AnySimpleCLIMiddleware[];
   handler: SimpleCLIHandler<unknown, SimpleCLIContext, unknown>;
@@ -154,9 +152,6 @@ type ExtractedGlobalArgs = {
   args: readonly string[];
   named: Readonly<Record<string, unknown>>;
 };
-
-const EXPERIMENTAL_COMMAND_PREFIX = "experimental";
-const EXPERIMENTAL_GROUP_DESCRIPTION = "Experimental commands";
 
 function toCamelCase(input: string): string {
   return input.replace(/-([a-zA-Z0-9])/g, (_match, letter: string) =>
@@ -881,43 +876,7 @@ export class SimpleCLIApp {
     label: string;
     description?: string;
   }> {
-    return this.getImmediateRouteEntries([]).filter((entry) => {
-      const token = entry.label.replace(/\s+<subcommand>$/, "");
-      const group = this.findGroupByPath([token]);
-      if (!group) {
-        return true;
-      }
-      if (token === EXPERIMENTAL_COMMAND_PREFIX) {
-        return this.groupHasExperimentalCommand(group.path);
-      }
-      return this.groupHasVisibleNonExperimentalCommand(group.path);
-    });
-  }
-
-  private groupHasVisibleNonExperimentalCommand(path: readonly string[]): boolean {
-    for (const routeEntry of this.routeEntries) {
-      if (routeEntry.kind !== "command") continue;
-      if (!pathStartsWith(routeEntry.path, path)) continue;
-      const command = this.findCommandByPath(routeEntry.path);
-      if (command && !command.experimental) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private groupHasExperimentalCommand(path: readonly string[]): boolean {
-    for (const routeEntry of this.routeEntries) {
-      if (routeEntry.kind !== "command") continue;
-      if (!pathStartsWith(routeEntry.path, path)) continue;
-      const command = this.findCommandByPath(routeEntry.path);
-      if (command?.experimental) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.getImmediateRouteEntries([]);
   }
 
   private findBestMatchingCommand(
@@ -1134,15 +1093,11 @@ function collectRouteTree(
       );
     }
 
-    const rawPath = [...parentPath, token];
-    const path = command.config.experimental
-      ? [EXPERIMENTAL_COMMAND_PREFIX, ...rawPath]
-      : rawPath;
+    const path = [...parentPath, token];
     resolved.commands.push({
       routeKey: pathToRouteKey(path),
       path,
       description: command.config.description,
-      experimental: command.config.experimental,
       input: command.input,
       middlewares: mergeInheritedMiddlewares(
         parentMiddlewares,
@@ -1199,13 +1154,7 @@ function resolveGroupDescription(
   path: readonly string[],
   groupDescriptions: ReadonlyMap<string, string | undefined>,
 ): string | undefined {
-  if (path.length === 1 && path[0] === EXPERIMENTAL_COMMAND_PREFIX) {
-    return EXPERIMENTAL_GROUP_DESCRIPTION;
-  }
-
-  const originalPath =
-    path[0] === EXPERIMENTAL_COMMAND_PREFIX ? path.slice(1) : path;
-  return groupDescriptions.get(pathToRouteKey(originalPath));
+  return groupDescriptions.get(pathToRouteKey(path));
 }
 
 function mergeInheritedMiddlewares(

--- a/packages/affordance/test/affordance.spec.ts
+++ b/packages/affordance/test/affordance.spec.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import {
   SimpleCLI,
   type SimpleCLIMiddleware,
-} from "../src/cli/framework/simple-cli.js";
+} from "../src/index.js";
 
 describe("SimpleCLI framework", () => {
   test("derives route keys and path tokens from tree keys", () => {
@@ -33,22 +33,26 @@ describe("SimpleCLI framework", () => {
     ]);
   });
 
-  test("prefixes experimental commands under the experimental namespace", async () => {
+  test("supports explicit experimental command groups", async () => {
     const noInput = SimpleCLI.input({ positionals: [], named: {} });
     const noop = SimpleCLI.command({ description: "noop" })
       .input(noInput)
       .handle(async () => {});
 
     const app = SimpleCLI.define("libretto", {
-      ai: SimpleCLI.group({
-        description: "AI commands",
+      experimental: SimpleCLI.group({
+        description: "Experimental commands",
         routes: {
-          configure: SimpleCLI.command({
-            description: "Configure AI runtime",
-            experimental: true,
-          })
-            .input(noInput)
-            .handle(async () => {}),
+          ai: SimpleCLI.group({
+            description: "AI commands",
+            routes: {
+              configure: SimpleCLI.command({
+                description: "Configure AI runtime",
+              })
+                .input(noInput)
+                .handle(async () => {}),
+            },
+          }),
         },
       }),
       open: noop,

--- a/packages/affordance/tsconfig.json
+++ b/packages/affordance/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/affordance/tsup.config.ts
+++ b/packages/affordance/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  bundle: false,
+  minify: false,
+  clean: true,
+  outDir: "dist",
+});

--- a/packages/affordance/vitest.config.ts
+++ b/packages/affordance/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "affordance",
+    environment: "node",
+    include: ["test/**/*.spec.ts", "src/**/*.spec.ts"],
+    testTimeout: 30_000,
+    reporters: ["minimal"],
+  },
+});

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -86,6 +86,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
+    "affordance": "^0.1.0",
     "ai": "^6.0.116",
     "esbuild": "^0.27.0",
     "playwright": "^1.58.2",

--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from "zod";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 import {
   ApiCallError,
   betterAuthCall,
@@ -198,7 +198,6 @@ async function issueApiKey(
 
 export const signupCommand = SimpleCLI.command({
   description: "Create a new hosted-platform account and organization",
-  experimental: true,
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .handle(async () => {
@@ -304,7 +303,6 @@ export const signupCommand = SimpleCLI.command({
 
 export const loginCommand = SimpleCLI.command({
   description: "Sign in to an existing hosted-platform account",
-  experimental: true,
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .handle(async () => {
@@ -375,7 +373,6 @@ export const loginCommand = SimpleCLI.command({
 
 export const logoutCommand = SimpleCLI.command({
   description: "Clear local libretto credentials",
-  experimental: true,
 })
   .handle(async () => {
     const state = await readAuthState();
@@ -400,7 +397,6 @@ export const logoutCommand = SimpleCLI.command({
 
 export const inviteCommand = SimpleCLI.command({
   description: "Invite a teammate to your active organization",
-  experimental: true,
 })
   .input(
     SimpleCLI.input({
@@ -485,7 +481,6 @@ export const inviteCommand = SimpleCLI.command({
 
 export const acceptInviteCommand = SimpleCLI.command({
   description: "Accept an organization invitation",
-  experimental: true,
 })
   .input(
     SimpleCLI.input({
@@ -621,7 +616,6 @@ export const acceptInviteCommand = SimpleCLI.command({
 
 export const apiKeyIssueCommand = SimpleCLI.command({
   description: "Issue a new API key for the active organization",
-  experimental: true,
 })
   .input(
     SimpleCLI.input({
@@ -658,7 +652,6 @@ export const apiKeyIssueCommand = SimpleCLI.command({
 
 export const apiKeyListCommand = SimpleCLI.command({
   description: "List API keys for the active organization",
-  experimental: true,
 })
   .handle(async () => {
     const stored = await readAuthState();
@@ -691,7 +684,6 @@ export const apiKeyListCommand = SimpleCLI.command({
 
 export const apiKeyRevokeCommand = SimpleCLI.command({
   description: "Revoke an API key by id",
-  experimental: true,
 })
   .input(
     SimpleCLI.input({
@@ -730,7 +722,6 @@ export const apiKeyRevokeCommand = SimpleCLI.command({
 
 export const whoamiCommand = SimpleCLI.command({
   description: "Print the active session and credential source",
-  experimental: true,
 })
   .handle(async () => {
     const stored = await readAuthState();

--- a/packages/libretto/src/cli/commands/billing.ts
+++ b/packages/libretto/src/cli/commands/billing.ts
@@ -15,7 +15,7 @@
  * Auth: requires a session cookie (or LIBRETTO_API_KEY).
  */
 
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 import {
   NOT_AUTHENTICATED_MESSAGE,
   orpcCall,
@@ -71,7 +71,6 @@ function formatLimit(limit: number | null): string {
 
 export const billingPortalCommand = SimpleCLI.command({
   description: "Open the libretto plans page (current plan + switch options)",
-  experimental: true,
 })
   .handle(async () => {
     const { apiUrl, credential } = await requireAuth();
@@ -97,7 +96,6 @@ export const billingPortalCommand = SimpleCLI.command({
 
 export const billingStatusCommand = SimpleCLI.command({
   description: "Print the current plan, status, and browser-hour usage",
-  experimental: true,
 })
   .handle(async () => {
     const { apiUrl, credential } = await requireAuth();

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -20,7 +20,7 @@ import {
   validateSessionName,
 } from "../core/session.js";
 import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 import {
   sessionOption,
   withAutoSession,

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { z } from "zod";
 import { resolveHostedApiUrl } from "../core/auth-fetch.js";
 import { buildHostedDeployTarball } from "../core/deploy-artifact.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 
 type DeploymentStatus = "building" | "ready" | "failed";
 
@@ -132,7 +132,6 @@ export const deployInput = SimpleCLI.input({
 
 export const deployCommand = SimpleCLI.command({
   description: "Deploy workflows to the hosted platform",
-  experimental: true,
 })
   .input(deployInput)
   .handle(async ({ input }) => {

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -52,7 +52,7 @@ import {
 } from "../core/telemetry.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import type { Experiments } from "../core/experiments.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 import {
   pageOption,
   sessionOption,

--- a/packages/libretto/src/cli/commands/experiments.ts
+++ b/packages/libretto/src/cli/commands/experiments.ts
@@ -8,7 +8,7 @@ import {
   type ExperimentName,
   type Experiments,
 } from "../core/experiments.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 
 const experimentNames = Object.keys(EXPERIMENTS) as ExperimentName[];
 

--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -8,7 +8,7 @@ import {
   REPO_ROOT,
 } from "../core/context.js";
 import { librettoCommand } from "../../shared/package-manager.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 
 function installBrowsers(): void {
   console.log("Installing Playwright Chromium...");

--- a/packages/libretto/src/cli/commands/shared.ts
+++ b/packages/libretto/src/cli/commands/shared.ts
@@ -14,7 +14,7 @@ import {
   type SimpleCLIMiddlewareArgs,
   type SimpleCLIContext,
   type SimpleCLIMiddleware,
-} from "../framework/simple-cli.js";
+} from "affordance";
 
 export function sessionOption(help = "Session name") {
   return SimpleCLI.option(z.string().optional(), { help });

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import { readSessionState } from "../core/session.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 import {
   pageOption,
   sessionOption,

--- a/packages/libretto/src/cli/commands/status.ts
+++ b/packages/libretto/src/cli/commands/status.ts
@@ -1,5 +1,5 @@
 import { listRunningSessions, type SessionState } from "../core/session.js";
-import { SimpleCLI } from "../framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 
 // ── Session status printing ─────────────────────────────────────────────────
 

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -8,15 +8,20 @@ import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
 import { librettoCommand } from "../shared/package-manager.js";
-import { SimpleCLI } from "./framework/simple-cli.js";
+import { SimpleCLI } from "affordance";
 
 export const cliRoutes = {
   ...browserCommands,
-  deploy: deployCommand,
+  experimental: SimpleCLI.group({
+    description: "Experimental commands",
+    routes: {
+      deploy: deployCommand,
+      auth: authCommands,
+      billing: billingCommands,
+    },
+  }),
   experiments: experimentsCommand,
   ...executionCommands,
-  auth: authCommands,
-  billing: billingCommands,
   setup: setupCommand,
   status: statusCommand,
   snapshot: snapshotCommand,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,24 @@ importers:
         specifier: workspace:*
         version: link:../packages/libretto
 
+  packages/affordance:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
   packages/create-libretto: {}
 
   packages/dev-tools:
@@ -199,6 +217,9 @@ importers:
 
   packages/libretto:
     dependencies:
+      affordance:
+        specifier: ^0.1.0
+        version: 0.1.0(zod@4.3.6)
       ai:
         specifier: ^6.0.116
         version: 6.0.140(zod@4.3.6)
@@ -4274,6 +4295,11 @@ packages:
   adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
     engines: {node: '>=12.0'}
+
+  affordance@0.1.0:
+    resolution: {integrity: sha512-SFJLHHmauypQvxpsLdzu//OuifZw3gAcEdl3XltWgQkDGaoPKEyLle/yOMuHH0CDtpUq1c/P3DQq/ksdMLJdbg==}
+    peerDependencies:
+      zod: ^4.0.0
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -13527,6 +13553,10 @@ snapshots:
   address@1.2.2: {}
 
   adm-zip@0.5.16: {}
+
+  affordance@0.1.0(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   agent-base@6.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
+  - affordance
   - libretto
 
 enablePrePostScripts: false


### PR DESCRIPTION
## Summary
- extract the internal SimpleCLI framework into a new `affordance` workspace package
- publish and consume `affordance@0.1.0` from the Libretto CLI
- move framework tests into the new package and keep Libretto experimental commands as an explicit router group

## Verification
- `pnpm -s --filter affordance type-check`
- `pnpm -s --filter affordance test`
- `pnpm -s --filter affordance lint`
- `pnpm -s --filter libretto type-check`
- `pnpm -s --filter libretto test -- test/basic.spec.ts`
- `pnpm -s --filter libretto lint`
- `pnpm -s --filter libretto build`
- `npm view affordance@0.1.0 name version description --json --registry=https://registry.npmjs.org/`
