### PR TITLE
Harden supply chain: pnpm 11, blockExoticSubdeps, allowBuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libretto-monorepo",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.58",
     "@ai-sdk/google": "^3.0.51",

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/saffron-health/libretto"
   },
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,15 @@ minimumReleaseAgeExclude:
   - libretto
 
 enablePrePostScripts: false
+
+blockExoticSubdeps: true
+
+allowBuilds:
+  esbuild: true
+  fallow: false
+  glimpseui: false
+  keytar: true
+  koffi: true
+  protobufjs: true
+  puppeteer: true
+  sharp: true


### PR DESCRIPTION
## Summary

Hardens the pnpm supply chain configuration:

- **Upgrade pnpm** from 10.33.0 to 11.1.1 (with corepack integrity hash)
- **`blockExoticSubdeps: true`** — prevents transitive dependencies from resolving exotic protocols (`git+ssh:`, direct tarball URLs)
- **Migrate `onlyBuiltDependencies` → `allowBuilds`** (the newer preferred config from pnpm 10.26+)
  - Explicitly allow trusted native packages: `esbuild`, `keytar`, `koffi`, `protobufjs`, `puppeteer`, `sharp`
  - Explicitly block install scripts for `fallow` and `glimpseui` (single-maintainer packages with smaller communities)
- **Remove nested `packageManager` pin** from `packages/libretto/package.json` — the root `package.json` is the single source of truth
