### PR TITLE
Fix docs dark mode enforcement

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,7 +28,8 @@
     }
   },
   "appearance": {
-    "default": "dark"
+    "default": "dark",
+    "strict": true
   },
   "background": {
     "color": {


### PR DESCRIPTION
## Summary
- Force Mintlify docs to stay in dark mode by enabling strict appearance mode.
- Prevent user-stored light mode from applying light prose colors against the forced dark background.

## Validation
- `pnpm -s docs:validate`
