### PR TITLE
Add website blog section

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -28,13 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Choose the least bot-detectable method that matches how the site normally makes the request.
-- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
+- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
 - Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
 - Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
+- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
 
 ## Setup
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -32,7 +32,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
-- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -29,7 +29,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 ## Default Integration Approach
 
 - Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
-- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
 - Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -49,8 +49,8 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Do not treat visibility as interactivity. If an element will not act, inspect blockers before retrying.
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
-- Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
+- Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
+- After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, `--headless`, or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -140,8 +140,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 
 ### `run`
 
-- Use `run` to verify a workflow file after creating it or editing it, preferring `run --headless` for the normal fix/verify loop.
-- Plain `run` defaults to headed mode.
+- Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
@@ -150,9 +150,9 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Re-run the same workflow after each fix to verify the browser behavior end to end.
 
 ```bash
-npx libretto run ./integration.ts --headless --params '{"status":"open"}'
-npx libretto run ./integration.ts --headless --read-only
-npx libretto run ./integration.ts --headless --stay-open-on-success
+npx libretto run ./integration.ts --params '{"status":"open"}'
+npx libretto run ./integration.ts --read-only
+npx libretto run ./integration.ts --stay-open-on-success
 npx libretto run ./integration.ts --auth-profile app.example.com
 ```
 
@@ -232,10 +232,10 @@ Assistant: [Uses `snapshot` and `exec` as needed to understand the site and deci
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./target-workflow.ts --params '{"status":"open"}'
 </example>
 ```
 
@@ -245,17 +245,17 @@ To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --
 <example>
 [Context: The user has an existing Libretto workflow that is failing]
 Assistant: I'll reproduce the failure first so we can inspect the exact browser state it leaves behind.
-Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow --headed`]
+Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow`]
 Assistant: The workflow failed and Libretto kept the browser open. I'll inspect the page state before changing code.
 Assistant: [Runs `npx libretto snapshot --session debug-flow`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: [Runs `npx libretto run ./integration.ts` to validate the fix]
 Assistant: Fix verified. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./integration.ts
 </example>
 ```
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -28,7 +28,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
 - Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -28,13 +28,11 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
-- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
-- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
-- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
+- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
+- Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
+- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -28,9 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
-- Read `references/site-security-review.md` before committing to a network-first approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules network requests out, the request path is not workable, or the user explicitly asks for Playwright.
+- Choose the least bot-detectable method that matches how the site normally makes the request.
+- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
+- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
+- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
 
 ## Setup
 

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,8 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Network request methods are for active fetch/XHR endpoints the site already uses. Prefer them for data extraction or form submissions when the security review shows the path is safe and workable.
+
 Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
 
 Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,10 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
+
+Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.
+
 When codifying network-based data extraction or form submissions, wrap `page.evaluate(() => fetch(...))` calls in typed methods on a shared API client class:
 
 ```typescript

--- a/.agents/skills/libretto/references/site-security-review.md
+++ b/.agents/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,26 +54,44 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
+### Probe 3: Request Type Matching
+
+Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
+
+Common examples:
+
+| Request Type | Typical Context |
+| --- | --- |
+| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
+| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
+| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
+| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
+| Stylesheet load | `sec-fetch-dest: style` |
+| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
+
+Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+
 ## Choosing a Data Capture Strategy
 
 Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin. They look identical to requests the site's own JS would make.
+Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
 
 When to prioritize this:
 
+- The target endpoint is normally called by the site with fetch/XHR
 - No enterprise bot protection is detected
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
-Risk: if the site monitors fetch call stacks, your calls may be flagged because they do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -111,10 +129,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| No bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| No bot protection, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
-| Bot protection detected, fetch not patched | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Bot protection detected, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -127,6 +144,7 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
+- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 

--- a/.agents/skills/libretto/references/site-security-review.md
+++ b/.agents/skills/libretto/references/site-security-review.md
@@ -69,11 +69,11 @@ Common examples:
 | Stylesheet load | `sec-fetch-dest: style` |
 | Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
 
-Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
 
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
@@ -86,6 +86,7 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
+- The user has not asked for Playwright-only or UI-only automation
 
 Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
@@ -129,8 +130,8 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 

--- a/.agents/skills/libretto/references/site-security-review.md
+++ b/.agents/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,30 +54,13 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
-### Probe 3: Request Type Matching
-
-Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
-
-Common examples:
-
-| Request Type | Typical Context |
-| --- | --- |
-| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
-| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
-| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
-| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
-| Stylesheet load | `sec-fetch-dest: style` |
-| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
-
-Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
-
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
+Make fetch calls directly from within the browser's JavaScript context. Use this only for endpoints the site already calls with fetch/XHR, not for page navigation or asset loads.
 
 When to prioritize this:
 
@@ -86,13 +69,12 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
-- The user has not asked for Playwright-only or UI-only automation
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
 
-Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: fetch is the wrong primitive for page HTML and asset URLs; use Playwright navigation or DOM-driven loads for those. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -130,9 +112,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
+| No bot protection, fetch/XHR endpoint, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| No bot protection, fetch is patched or endpoint is not fetch/XHR | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -145,7 +127,6 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
-- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -28,13 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Choose the least bot-detectable method that matches how the site normally makes the request.
-- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
+- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
 - Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
 - Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
+- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
 
 ## Setup
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -32,7 +32,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
-- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -29,7 +29,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 ## Default Integration Approach
 
 - Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
-- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
 - Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -49,8 +49,8 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Do not treat visibility as interactivity. If an element will not act, inspect blockers before retrying.
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
-- Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
+- Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
+- After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, `--headless`, or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -140,8 +140,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 
 ### `run`
 
-- Use `run` to verify a workflow file after creating it or editing it, preferring `run --headless` for the normal fix/verify loop.
-- Plain `run` defaults to headed mode.
+- Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
@@ -150,9 +150,9 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Re-run the same workflow after each fix to verify the browser behavior end to end.
 
 ```bash
-npx libretto run ./integration.ts --headless --params '{"status":"open"}'
-npx libretto run ./integration.ts --headless --read-only
-npx libretto run ./integration.ts --headless --stay-open-on-success
+npx libretto run ./integration.ts --params '{"status":"open"}'
+npx libretto run ./integration.ts --read-only
+npx libretto run ./integration.ts --stay-open-on-success
 npx libretto run ./integration.ts --auth-profile app.example.com
 ```
 
@@ -232,10 +232,10 @@ Assistant: [Uses `snapshot` and `exec` as needed to understand the site and deci
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./target-workflow.ts --params '{"status":"open"}'
 </example>
 ```
 
@@ -245,17 +245,17 @@ To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --
 <example>
 [Context: The user has an existing Libretto workflow that is failing]
 Assistant: I'll reproduce the failure first so we can inspect the exact browser state it leaves behind.
-Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow --headed`]
+Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow`]
 Assistant: The workflow failed and Libretto kept the browser open. I'll inspect the page state before changing code.
 Assistant: [Runs `npx libretto snapshot --session debug-flow`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: [Runs `npx libretto run ./integration.ts` to validate the fix]
 Assistant: Fix verified. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./integration.ts
 </example>
 ```
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -28,7 +28,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
 - Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -28,13 +28,11 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
-- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
-- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
-- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
+- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
+- Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
+- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -28,9 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
-- Read `references/site-security-review.md` before committing to a network-first approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules network requests out, the request path is not workable, or the user explicitly asks for Playwright.
+- Choose the least bot-detectable method that matches how the site normally makes the request.
+- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
+- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
+- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
 
 ## Setup
 

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,8 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Network request methods are for active fetch/XHR endpoints the site already uses. Prefer them for data extraction or form submissions when the security review shows the path is safe and workable.
+
 Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
 
 Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,10 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
+
+Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.
+
 When codifying network-based data extraction or form submissions, wrap `page.evaluate(() => fetch(...))` calls in typed methods on a shared API client class:
 
 ```typescript

--- a/.claude/skills/libretto/references/site-security-review.md
+++ b/.claude/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,26 +54,44 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
+### Probe 3: Request Type Matching
+
+Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
+
+Common examples:
+
+| Request Type | Typical Context |
+| --- | --- |
+| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
+| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
+| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
+| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
+| Stylesheet load | `sec-fetch-dest: style` |
+| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
+
+Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+
 ## Choosing a Data Capture Strategy
 
 Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin. They look identical to requests the site's own JS would make.
+Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
 
 When to prioritize this:
 
+- The target endpoint is normally called by the site with fetch/XHR
 - No enterprise bot protection is detected
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
-Risk: if the site monitors fetch call stacks, your calls may be flagged because they do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -111,10 +129,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| No bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| No bot protection, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
-| Bot protection detected, fetch not patched | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Bot protection detected, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -127,6 +144,7 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
+- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 

--- a/.claude/skills/libretto/references/site-security-review.md
+++ b/.claude/skills/libretto/references/site-security-review.md
@@ -69,11 +69,11 @@ Common examples:
 | Stylesheet load | `sec-fetch-dest: style` |
 | Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
 
-Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
 
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
@@ -86,6 +86,7 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
+- The user has not asked for Playwright-only or UI-only automation
 
 Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
@@ -129,8 +130,8 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 

--- a/.claude/skills/libretto/references/site-security-review.md
+++ b/.claude/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,30 +54,13 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
-### Probe 3: Request Type Matching
-
-Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
-
-Common examples:
-
-| Request Type | Typical Context |
-| --- | --- |
-| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
-| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
-| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
-| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
-| Stylesheet load | `sec-fetch-dest: style` |
-| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
-
-Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
-
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
+Make fetch calls directly from within the browser's JavaScript context. Use this only for endpoints the site already calls with fetch/XHR, not for page navigation or asset loads.
 
 When to prioritize this:
 
@@ -86,13 +69,12 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
-- The user has not asked for Playwright-only or UI-only automation
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
 
-Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: fetch is the wrong primitive for page HTML and asset URLs; use Playwright navigation or DOM-driven loads for those. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -130,9 +112,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
+| No bot protection, fetch/XHR endpoint, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| No bot protection, fetch is patched or endpoint is not fetch/XHR | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -145,7 +127,6 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
-- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,5 +1,19 @@
+import { useLocation } from "wouter";
 import { HomePage } from "./HomePage";
+import { BlogIndexPage, BlogPostPage } from "./blog/BlogPage";
+import { normalizeAppPathname } from "./routing";
 
 export function App() {
+  const [location] = useLocation();
+  const pathname = normalizeAppPathname(location);
+
+  if (pathname === "/blog") {
+    return <BlogIndexPage />;
+  }
+
+  if (pathname.startsWith("/blog/")) {
+    return <BlogPostPage slug={pathname.slice("/blog/".length)} />;
+  }
+
   return <HomePage />;
 }

--- a/apps/website/src/blog/BlogPage.tsx
+++ b/apps/website/src/blog/BlogPage.tsx
@@ -1,0 +1,204 @@
+import type * as React from "react";
+import { SafeMdxRenderer } from "safe-mdx";
+import { AppLink } from "../routing";
+import { Button } from "../components/Button";
+import { Footer } from "../components/Footer";
+import { Navbar } from "../components/Navbar";
+import { Text } from "../components/Text";
+import { BLOG_POSTS, getBlogPost, type BlogPost } from "./posts";
+
+const BLOG_LOGO = String.raw`
+ ██████╗ ██╗      ██████╗  ██████╗
+ ██╔══██╗██║     ██╔═══██╗██╔════╝
+ ██████╔╝██║     ██║   ██║██║  ███╗
+ ██╔══██╗██║     ██║   ██║██║   ██║
+ ██████╔╝███████╗╚██████╔╝╚██████╔╝
+ ╚═════╝ ╚══════╝ ╚═════╝  ╚═════╝`;
+
+function formatPostDate(date: string): string {
+  return new Intl.DateTimeFormat("en", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+function BlogShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="crt-page flex min-h-screen flex-col bg-bg text-ink">
+      <Navbar />
+      <main className="section-rails relative mx-auto mt-16 flex w-full max-w-[1100px] flex-1 flex-col px-8">
+        <div className="flex-1">{children}</div>
+        <Footer />
+      </main>
+    </div>
+  );
+}
+
+function BlogPostPreview({ post }: { post: BlogPost }) {
+  return (
+    <article className="border-t border-rule py-8">
+      <AppLink href={`/blog/${post.slug}`} className="group block no-underline">
+        <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <Text as="time" size="xs" className="text-muted/70">
+            {formatPostDate(post.publishedAt)}
+          </Text>
+          <Text size="xs" className="text-muted/50">
+            {post.readingTime}
+          </Text>
+        </div>
+        <Text
+          as="h2"
+          size="3xl"
+          style="serif"
+          className="mb-4 max-w-[760px] font-[300] leading-tight text-ink transition-colors group-hover:text-accent-bright"
+        >
+          {post.title}
+        </Text>
+        <Text as="p" size="md" className="max-w-[660px] leading-relaxed text-muted">
+          {post.description}
+        </Text>
+      </AppLink>
+    </article>
+  );
+}
+
+export function BlogIndexPage() {
+  return (
+    <BlogShell>
+      <section className="mx-auto max-w-[800px] pt-8">
+        <div
+          className="mb-10 flex overflow-hidden"
+          style={{
+            filter:
+              "drop-shadow(0 0 6px color-mix(in oklch, var(--color-amber-bright) 28%, transparent)) drop-shadow(0 0 18px color-mix(in oklch, var(--color-amber-bright) 14%, transparent))",
+          }}
+        >
+          <pre
+            aria-label="Blog"
+            className="whitespace-pre font-mono text-[6px] leading-none tracking-[0] text-amber sm:text-[8.25px] md:text-[10.5px] lg:text-[12px]"
+            style={{
+              textShadow:
+                "0 0 4px color-mix(in oklch, var(--color-amber-bright) 28%, transparent), 0 0 12px color-mix(in oklch, var(--color-amber-bright) 14%, transparent)",
+            }}
+          >
+            {BLOG_LOGO}
+          </pre>
+        </div>
+        {BLOG_POSTS.map((post) => (
+          <BlogPostPreview key={post.slug} post={post} />
+        ))}
+      </section>
+    </BlogShell>
+  );
+}
+
+const markdownComponents = {
+  h2({ children }: { children?: React.ReactNode }) {
+    return (
+      <Text
+        as="h2"
+        size="3xl"
+        style="serif"
+        className="mt-14 mb-6 font-[300] leading-tight text-ink first:mt-0"
+      >
+        {children}
+      </Text>
+    );
+  },
+  p({ children }: { children?: React.ReactNode }) {
+    return <p className="mb-6 leading-[1.85] text-muted">{children}</p>;
+  },
+  ol({ children }: { children?: React.ReactNode }) {
+    return (
+      <ol className="mb-8 list-decimal space-y-4 pl-6 leading-[1.75] text-muted marker:text-accent">
+        {children}
+      </ol>
+    );
+  },
+  ul({ children }: { children?: React.ReactNode }) {
+    return (
+      <ul className="mb-8 list-disc space-y-4 pl-6 leading-[1.75] text-muted marker:text-accent">
+        {children}
+      </ul>
+    );
+  },
+  li({ children }: { children?: React.ReactNode }) {
+    return <li className="pl-2">{children}</li>;
+  },
+  strong({ children }: { children?: React.ReactNode }) {
+    return <strong className="font-semibold text-ink">{children}</strong>;
+  },
+  em({ children }: { children?: React.ReactNode }) {
+    return <em className="text-ink">{children}</em>;
+  },
+  a({ href, children }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+    const isExternal = typeof href === "string" && /^https?:\/\//.test(href);
+
+    return (
+      <AppLink
+        href={href ?? "#"}
+        target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        className="text-accent-bright underline decoration-accent/40 underline-offset-4 transition-colors hover:text-ink"
+      >
+        {children}
+      </AppLink>
+    );
+  },
+};
+
+export function BlogPostPage({ slug }: { slug: string }) {
+  const post = getBlogPost(slug);
+
+  if (!post) {
+    return (
+      <BlogShell>
+        <section className="mx-auto max-w-[760px] pt-8 pb-20">
+          <Text as="p" size="xs" className="mb-5 uppercase tracking-[0.16em] text-accent">
+            404
+          </Text>
+          <Text
+            as="h1"
+            size="5xl"
+            style="serif"
+            className="crt-glow mb-6 font-[300] leading-none text-ink"
+          >
+            Post not found.
+          </Text>
+          <Button href="/blog" variant="secondary">
+            Back to blog
+          </Button>
+        </section>
+      </BlogShell>
+    );
+  }
+
+  return (
+    <BlogShell>
+      <article className="mx-auto max-w-[760px] pt-8 pb-20">
+        <AppLink
+          href="/blog"
+          className="mb-10 inline-block text-sm text-muted/70 no-underline transition-colors hover:text-accent-bright"
+        >
+          Back to blog
+        </AppLink>
+        <div className="mb-10 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <Text as="time" size="xs" className="text-muted/70">
+            {formatPostDate(post.publishedAt)}
+          </Text>
+          <Text size="xs" className="text-muted/50">
+            {post.readingTime}
+          </Text>
+        </div>
+        <div className="blog-markdown text-[1rem]">
+          <SafeMdxRenderer
+            markdown={post.markdown}
+            mdast={post.mdast}
+            components={markdownComponents}
+          />
+        </div>
+      </article>
+    </BlogShell>
+  );
+}

--- a/apps/website/src/blog/posts.ts
+++ b/apps/website/src/blog/posts.ts
@@ -1,0 +1,82 @@
+import { mdxParse } from "safe-mdx/parse";
+
+type BlogPostInput = {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  readingTime: string;
+  markdown: string;
+};
+
+export type BlogPost = BlogPostInput & {
+  mdast: ReturnType<typeof mdxParse>;
+};
+
+function createBlogPost(post: BlogPostInput): BlogPost {
+  return {
+    ...post,
+    mdast: mdxParse(post.markdown),
+  };
+}
+
+export const BLOG_POSTS = [
+  createBlogPost({
+    slug: "what-we-learned-building-healthcare-integrations",
+    title: "What we learned building healthcare integrations for a year",
+    description:
+      "Why we moved from runtime browser agents to development-time AI, Playwright scripts, and direct network calls.",
+    publishedAt: "2026-05-14",
+    readingTime: "7 min read",
+    markdown: String.raw`## What we learned building healthcare integrations for a year
+
+We spent the past year building and maintaining browser automations for EHR and payor portal integrations at our healthcare startup. The APIs we needed either didn't exist, were missing critical functionality, or were locked behind expensive and slow vendor processes. So, like every other healthcare startup, we leaned on browser automation. Building these automations and debugging failed ones was incredibly time-consuming, and most of what we believed going in turned out to be wrong.
+
+The biggest shift in our thinking was moving from run-time AI (agents making decisions live on running scripts) to development-time AI (using coding agents to generate and iterate on Playwright scripts, and to debug them when they break). Everything else we figured out came after that.
+
+## Why runtime browser agents didn't work for us
+
+We started where most people start: fully AI-driven browser agents. It was the lowest implementation lift and seemed like the most robust approach, since if the agent could see the page it should be able to adapt to anything. Then we tried Stagehand, which looked like the right tradeoff: deterministic Playwright underneath, AI on top to handle the messy parts.
+
+Neither held up. Four problems kept coming back:
+
+1. **DOM parsing was unreliable on the websites we cared about.** Tools like Browser Use and Stagehand lean on the accessibility tree or custom DOM parsing to figure out what to click. That works fine on modern, well-built sites. It doesn't work on Athena, on older EHRs, or on most payor portals. Using a site's internal network calls turned out to be faster and more reliable wherever it was feasible.
+2. **They got expensive fast.** Every action needed an LLM call, and for workflows with complicated branching logic you can't always rely on caching prior actions to keep things cheap and consistent.
+3. **Runtime behavior wasn't interpretable.** You kind of hope you prompted the agent correctly. Legacy healthcare workflows are unintuitive and inconsistent across sites, so you can't trust an agent to just figure them out live, especially on a production patient chart.
+4. **They didn't help us generate new automations or debug existing ones.** Once a script broke in production, we were on our own.
+
+## What was actually breaking in production
+
+After enough postmortems, our failures almost always fell into three buckets:
+
+- **Nondeterministic popups.** Modals that appeared sometimes, usually unrelated to the flow we cared about.
+- **Things on screen rendering extremely slowly.** Elements that took unpredictable amounts of time to appear, where naive waits would either time out or pass too early.
+- **Edge cases with internal logic we hadn't anticipated.** Duplicate patients with no clear way to know which chart to access, mismatched referrals, etc. Stuff we absolutely did not want an AI resolving on its own.
+
+None of these are problems a runtime agent is going to fix reliably. Popups are solvable with a lightweight detector. Slow rendering is solvable with smarter waits and retries. And the edge cases are the cases where you *want* a human in the loop, because the right resolution depends on context the agent doesn't have.
+
+## Where we landed: development-time AI + Playwright + network calls
+
+We ended up rewriting almost everything around a different philosophy: AI at development time, not runtime. Instead of an agent driving the browser live, we use Claude Code to generate and iterate on Playwright scripts. We step through workflows ourselves, leave comments, then run the recorded flow and have Claude connect to the running script to inspect logs and network requests as it builds the automation. When something breaks in production, the agent helps debug, but in the form of a PR back to the repo, not a live decision on a patient chart.
+
+Where it made sense, we rebuilt integrations as direct network/API calls instead of UI automation. Faster, more reliable, easier to maintain. Some sites have anti-bot setups that make this the wrong call and you have to drive the UI. So we ended up with a hybrid: Playwright for UI, direct network calls where feasible, both living in the same script.
+
+Runtime AI didn't disappear entirely. We still use it in narrow, well-scoped places where the failure mode is bounded and the worst case is a retry. The popup detector, for example, takes a screenshot, uses coordinates to dismiss whatever appeared, and retries the original action. Runtime AI is fine when the worst case is a retry. It's not fine when the agent is making decisions you can't anticipate or review.
+
+## The better approach we landed on
+
+Once we put all the pieces together, the better approach became pretty clear. The way to reliably build and maintain these automations was:
+
+- Generate Playwright scripts ahead of time with a coding agent, instead of having an agent drive the browser live.
+- Have the agent record manual actions and inspect network requests as it writes the script, so you get a real script you can read and modify rather than opaque agent behavior.
+- Mix Playwright UI automation with direct network/API calls in the same script, so you get reliability and speed where the site allows it and fall back to the UI where it doesn't.
+- Use runtime AI only in narrow, bounded places where the worst case is a retry.
+- When something breaks in production, have the agent help debug by inspecting the failure and sending a PR back to the repo, not by making a live decision on real data.
+
+This is what eventually became [Libretto](https://libretto.sh), the Skill + CLI we built internally and have since open-sourced. If you're building web automations, give it a try!`,
+  }),
+] satisfies BlogPost[];
+
+export function getBlogPost(slug: string): BlogPost | undefined {
+  return BLOG_POSTS.find((post) => post.slug === slug);
+}

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Text } from "./Text";
 import { DiscordIcon, GitHubIcon, NpmIcon } from "../icons";
-import {
-  DISCORD_URL,
-  DISCUSSIONS_URL,
-  NPM_URL,
-  RELEASES_URL,
-  REPO_URL,
-} from "../site";
+import { DISCORD_URL, DISCUSSIONS_URL, NPM_URL, RELEASES_URL, REPO_URL } from "../site";
 
 const LOGO = String.raw` ██╗     ██╗██████╗ ██████╗ ███████╗████████╗████████╗ ██████╗
  ██║     ██║██╔══██╗██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔═══██╗
@@ -18,8 +12,7 @@ const LOGO = String.raw` ██╗     ██╗██████╗ ███�
 
 const LOGO_COLS = 63; // widest line in the ASCII logo
 
-const linkClass =
-  "text-muted/60 transition-colors hover:text-accent-bright text-xs no-underline";
+const linkClass = "text-muted/60 transition-colors hover:text-accent-bright text-xs no-underline";
 
 function useLogoFontSize() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -62,6 +55,9 @@ export function Footer() {
             © {new Date().getFullYear()} Saffron Health
           </Text>
           <div className="flex gap-6">
+            <a href="/blog" className={linkClass}>
+              Blog
+            </a>
             <a href="/docs/get-started/introduction" className={linkClass}>
               Docs
             </a>
@@ -73,12 +69,7 @@ export function Footer() {
             >
               Forum
             </a>
-            <a
-              href={RELEASES_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={linkClass}
-            >
+            <a href={RELEASES_URL} target="_blank" rel="noopener noreferrer" className={linkClass}>
               Changelog
             </a>
           </div>

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
-import {
-  MenuTrigger,
-  Menu,
-  MenuItem,
-  Popover,
-  Button as AriaButton,
-} from "react-aria-components";
+import { MenuTrigger, Menu, MenuItem, Popover, Button as AriaButton } from "react-aria-components";
 import { motion } from "motion/react";
 import { GitHubStarIcon, NpmIcon } from "../icons";
 import { DISCUSSIONS_URL, NPM_URL, RELEASES_URL, REPO_URL } from "../site";
@@ -79,9 +73,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
   const [animation, setAnimation] = useState<AnimationState>("unmounted");
 
   return (
-    <MenuTrigger
-      onOpenChange={(isOpen) => setAnimation(isOpen ? "visible" : "hidden")}
-    >
+    <MenuTrigger onOpenChange={(isOpen) => setAnimation(isOpen ? "visible" : "hidden")}>
       <AriaButton
         aria-label="Menu"
         className="relative flex size-9 items-center justify-center rounded-lg text-ink outline-none hover:bg-ink/[0.06] focus-visible:ring-2 focus-visible:ring-ink/20"
@@ -115,6 +107,9 @@ export function MobileMenu({ stars }: { stars: string | null }) {
           className="min-w-[180px] origin-top-right rounded-xl border border-accent/20 bg-panel p-1.5 shadow-lg shadow-black/30"
         >
           <Menu className="outline-none">
+            <MenuItem href="/blog" className={itemClass}>
+              Blog
+            </MenuItem>
             <MenuItem
               href={DISCUSSIONS_URL}
               target="_blank"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -68,17 +68,19 @@ function useGlitchText(text: string) {
 function GlitchNavLink({
   href,
   children,
+  external = true,
 }: {
   href: string;
   children: string;
+  external?: boolean;
 }) {
   const { display, isScrambling, hovered, onEnter, onLeave } = useGlitchText(children);
 
   return (
-    <a
+    <AppLink
       href={href}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
       className="no-underline"
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
@@ -86,16 +88,12 @@ function GlitchNavLink({
       <Text
         size="sm"
         className={`font-medium transition-colors duration-75 ${
-          isScrambling
-            ? "text-amber font-mono"
-            : hovered
-              ? "text-accent-bright"
-              : "text-ink"
+          isScrambling ? "text-amber font-mono" : hovered ? "text-accent-bright" : "text-ink"
         }`}
       >
         {display}
       </Text>
-    </a>
+    </AppLink>
   );
 }
 
@@ -141,6 +139,9 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             </Text>
           </AppLink>
           <div className="absolute left-1/2 hidden -translate-x-1/2 gap-7 md:flex">
+            <GlitchNavLink href="/blog" external={false}>
+              Blog
+            </GlitchNavLink>
             <GlitchNavLink href={DISCUSSIONS_URL}>Forum</GlitchNavLink>
             <GlitchNavLink href={RELEASES_URL}>Changelog</GlitchNavLink>
           </div>
@@ -162,9 +163,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             className="hidden items-center gap-1.5 text-ink/70 transition-colors hover:text-ink md:flex"
           >
             <GitHubStarIcon width={15} height={15} />
-            {stars !== null && (
-              <span className="text-sm font-medium">{formatStars(stars)}</span>
-            )}
+            {stars !== null && <span className="text-sm font-medium">{formatStars(stars)}</span>}
           </a>
           <Button href="/docs/get-started/introduction" size="sm">
             Go to docs

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -22,12 +22,12 @@
 
 @theme {
   --font-sans:
-    "Commit Mono", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco,
-    Consolas, "Liberation Mono", monospace;
+    "Commit Mono", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
   --font-serif: "Fraunces", "Newsreader", Georgia, serif;
   --font-mono:
-    "Commit Mono", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco,
-    Consolas, "Liberation Mono", monospace;
+    "Commit Mono", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
 
   /* ── Gray scale (green-tinted) ── */
   --color-gray-1: #0f120f;
@@ -68,7 +68,7 @@
   --color-accent-bright: #2fdb4f;
   --color-accent-dim: #2e7e37;
   --color-amber: oklch(0.75 0.15 80);
-  --color-amber-bright: oklch(0.90 0.18 80);
+  --color-amber-bright: oklch(0.9 0.18 80);
   --color-rule: #262a26;
 }
 
@@ -149,12 +149,11 @@ body {
   line-height: 1;
   text-decoration: none;
   text-rendering: geometricPrecision;
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-green-9) 95%, transparent) 0%,
-      color-mix(in oklch, var(--color-green-8) 95%, transparent) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-green-9) 95%, transparent) 0%,
+    color-mix(in oklch, var(--color-green-8) 95%, transparent) 100%
+  );
   box-shadow:
     inset 0 0.5px 0 rgba(255, 255, 255, 0.18),
     inset 0 0 0 1px color-mix(in oklch, var(--color-green-9) 50%, transparent),
@@ -168,12 +167,11 @@ body {
 }
 
 .libretto-button:hover {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-green-11) 95%, transparent) 0%,
-      color-mix(in oklch, var(--color-green-9) 95%, transparent) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-green-11) 95%, transparent) 0%,
+    color-mix(in oklch, var(--color-green-9) 95%, transparent) 100%
+  );
   box-shadow:
     inset 0 0.5px 0 rgba(255, 255, 255, 0.22),
     inset 0 0 0 1px color-mix(in oklch, var(--color-green-11) 60%, transparent),
@@ -182,12 +180,11 @@ body {
 }
 
 .libretto-button[aria-pressed="true"] {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-green-11) 95%, transparent) 0%,
-      color-mix(in oklch, var(--color-green-9) 95%, transparent) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-green-11) 95%, transparent) 0%,
+    color-mix(in oklch, var(--color-green-9) 95%, transparent) 100%
+  );
   box-shadow:
     inset 0 0.5px 0 rgba(255, 255, 255, 0.22),
     inset 0 0 0 1px color-mix(in oklch, var(--color-green-11) 60%, transparent),
@@ -205,12 +202,11 @@ body {
 
 .libretto-button:active {
   transform: translateY(1px);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--color-green-10) 95%, transparent) 0%,
-      color-mix(in oklch, var(--color-green-7) 95%, transparent) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-green-10) 95%, transparent) 0%,
+    color-mix(in oklch, var(--color-green-7) 95%, transparent) 100%
+  );
   box-shadow:
     inset 0 0.5px 0 rgba(255, 255, 255, 0.12),
     inset 0 0 0 1px color-mix(in oklch, var(--color-green-10) 50%, transparent),
@@ -260,7 +256,9 @@ body {
   text-underline-offset: 3px;
   text-decoration-color: var(--color-muted);
   text-decoration-thickness: 1.5px;
-  transition: color 85ms ease-out, text-decoration-color 85ms ease-out;
+  transition:
+    color 85ms ease-out,
+    text-decoration-color 85ms ease-out;
 }
 
 .libretto-button--secondary:hover {
@@ -362,8 +360,11 @@ body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    radial-gradient(ellipse at 50% 80px, color-mix(in oklch, var(--color-green-9) 8%, transparent), transparent 50%);
+  background: radial-gradient(
+    ellipse at 50% 80px,
+    color-mix(in oklch, var(--color-green-9) 8%, transparent),
+    transparent 50%
+  );
 }
 
 .section-crt::after {
@@ -371,14 +372,13 @@ body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      rgb(255 255 255 / 0.025) 0px,
-      rgb(255 255 255 / 0.025) 1px,
-      transparent 1px,
-      transparent 4px
-    );
+  background: repeating-linear-gradient(
+    to bottom,
+    rgb(255 255 255 / 0.025) 0px,
+    rgb(255 255 255 / 0.025) 1px,
+    transparent 1px,
+    transparent 4px
+  );
   background-size: 100% 4px;
   animation: crt-scanline-scroll 10s linear infinite;
   opacity: 0.6;
@@ -404,26 +404,41 @@ body {
   -webkit-mask-image: linear-gradient(to bottom, transparent 0px, black 120px);
 }
 
-.section-rails::before { left: 0; }
-.section-rails::after { right: 0; }
+.section-rails::before {
+  left: 0;
+}
+.section-rails::after {
+  right: 0;
+}
 
 /* ── Footer hollow logo ── */
 
 .footer-hollow-logo {
   color: transparent;
   -webkit-text-stroke: 0;
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      color-mix(in oklch, var(--color-amber-bright) 80%, transparent) 0px,
-      color-mix(in oklch, var(--color-amber-bright) 80%, transparent) 2px,
-      color-mix(in oklch, var(--color-amber-bright) 15%, transparent) 2px,
-      color-mix(in oklch, var(--color-amber-bright) 15%, transparent) 6px
-    );
+  background: repeating-linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--color-amber-bright) 80%, transparent) 0px,
+    color-mix(in oklch, var(--color-amber-bright) 80%, transparent) 2px,
+    color-mix(in oklch, var(--color-amber-bright) 15%, transparent) 2px,
+    color-mix(in oklch, var(--color-amber-bright) 15%, transparent) 6px
+  );
   background-size: 100% 6px;
   -webkit-background-clip: text;
   background-clip: text;
   animation: crt-scanline-scroll 10s linear infinite;
+}
+
+/* ── Blog markdown ── */
+
+.blog-markdown > h2:first-child {
+  margin-top: 0;
+  margin-bottom: 2.25rem;
+  font-size: clamp(40px, 6vw, 72px);
+  line-height: 1;
+  text-shadow:
+    0 0 12px color-mix(in oklch, var(--color-green-11) 50%, transparent),
+    0 0 32px color-mix(in oklch, var(--color-green-11) 20%, transparent);
 }
 
 /* ── CRT global effects ── */
@@ -433,7 +448,11 @@ body {
   isolation: isolate;
   min-height: 100vh;
   background:
-    radial-gradient(ellipse at 50% 0%, color-mix(in oklch, var(--color-green-3) 70%, transparent), transparent 50%),
+    radial-gradient(
+      ellipse at 50% 0%,
+      color-mix(in oklch, var(--color-green-3) 70%, transparent),
+      transparent 50%
+    ),
     var(--color-bg);
 }
 
@@ -443,12 +462,9 @@ body {
   inset: 0;
   z-index: 50;
   pointer-events: none;
-  background:
-    radial-gradient(circle at center, transparent 55%, rgb(0 0 0 / 0.5) 100%);
+  background: radial-gradient(circle at center, transparent 55%, rgb(0 0 0 / 0.5) 100%);
   opacity: 0.65;
 }
-
-
 
 .crt-page::after {
   content: "";
@@ -490,18 +506,37 @@ body {
 }
 
 @keyframes crt-scanline-scroll {
-  from { background-position: 0 0; }
-  to { background-position: 0 24px; }
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 0 24px;
+  }
 }
 
 @keyframes crt-flicker {
-  0%, 100% { opacity: 0.03; }
-  8% { opacity: 0.05; }
-  9% { opacity: 0.02; }
-  10% { opacity: 0.04; }
-  48% { opacity: 0.025; }
-  49% { opacity: 0.055; }
-  50% { opacity: 0.03; }
+  0%,
+  100% {
+    opacity: 0.03;
+  }
+  8% {
+    opacity: 0.05;
+  }
+  9% {
+    opacity: 0.02;
+  }
+  10% {
+    opacity: 0.04;
+  }
+  48% {
+    opacity: 0.025;
+  }
+  49% {
+    opacity: 0.055;
+  }
+  50% {
+    opacity: 0.03;
+  }
 }
 
 @keyframes crt-boot {
@@ -537,5 +572,4 @@ body {
   .crt-page::after {
     animation: none;
   }
-
 }

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -16,7 +16,11 @@ export function normalizeAppPathname(pathname: string): string {
 export function isAppOwnedPathname(pathname: string): boolean {
   const normalizedPathname = normalizeAppPathname(pathname);
 
-  return normalizedPathname === "/";
+  return (
+    normalizedPathname === "/" ||
+    normalizedPathname === "/blog" ||
+    normalizedPathname.startsWith("/blog/")
+  );
 }
 
 function shouldUseSpaNavigation({

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -29,6 +29,14 @@
       "destination": "https://libretto.sh/docs/robots.txt"
     },
     {
+      "source": "/blog",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/blog/:path*",
+      "destination": "/index.html"
+    },
+    {
       "source": "/docs",
       "destination": "https://saffron-health-libretto-73.mintlify.dev/docs"
     },

--- a/docs/fundamentals/automation-and-bot-detection.mdx
+++ b/docs/fundamentals/automation-and-bot-detection.mdx
@@ -12,7 +12,7 @@ Libretto supports four distinct approaches to capturing data and automating web 
 | -------------------------------------------- | ------------------ | --------------------------------------------------- |
 | Regular Playwright                           | Low-Moderate       | Simple DOM extraction, server-rendered sites        |
 | Passive interception (`page.on('response')`) | Low                | SPAs that load data via API calls during navigation |
-| In-browser fetch (`pageRequest()`)           | Low-Moderate    | Deep pagination, bulk queries without UI clicking   |
+| In-browser fetch (`pageRequest()`)           | Moderate           | API endpoints normally called with fetch/XHR        |
 | Direct HTTP from Node.js                     | Very high          | Sites with no bot detection where API speed matters |
 
 ### Assessing bot detection
@@ -28,6 +28,7 @@ Libretto captures all network traffic and page state during a session, which let
 
 - **Network log inspection.** Query `.libretto/sessions/<session>/network.jsonl` with `jq` to review all requests and responses. Look for calls to bot detection services (Cloudflare, Akamai, PerimeterX, DataDome) or challenge endpoints.
 - **Fetch patching check.** Run `npx libretto exec` to evaluate `window.fetch.toString()` in the browser console. If it returns actual JavaScript (not `"[native code]"`), the site monkey-patches fetch and you should prefer passive interception over in-browser fetch.
+- **Request type comparison.** Compare requests in `network.jsonl` before replacing browser behavior with `pageRequest()`. Browsers attach request-context headers that say what caused the request. A top-level navigation has `sec-fetch-dest: document` and `sec-fetch-mode: navigate`. A JavaScript fetch has `sec-fetch-dest: empty` and `sec-fetch-mode: cors` or `same-origin`. Script, image, stylesheet, and iframe loads have their own shapes too.
 - **Snapshot inspection.** Use `npx libretto snapshot` to check for challenge pages, CAPTCHAs, or interstitials that indicate detection.
 
 ***
@@ -122,7 +123,7 @@ Libretto captures all network traffic and page state during a session, which let
   </Tab>
 
   <Tab title="In-Browser Fetch">
-    Execute fetch calls from within the browser page's JavaScript context. The requests originate from the browser process itself with all the right credentials and fingerprints. Libretto's `pageRequest()` function provides a typed wrapper for this pattern.
+    Execute fetch calls from within the browser page's JavaScript context. The requests originate from the browser process with the browser's cookies, session, and TLS fingerprint. They still look like fetch/XHR requests. Libretto's `pageRequest()` function provides a typed wrapper for this pattern.
 
     ```typescript  theme={null}
     const data = await page.evaluate(async () => {
@@ -138,7 +139,7 @@ Libretto captures all network traffic and page state during a session, which let
 
     **Pros:**
 
-    * Requests come from the real browser with the same TLS fingerprint, cookies, origin, and HTTP/2 settings. From the server's perspective, it looks identical to a request the site's own JS would make.
+    * Requests come from the real browser with the same TLS fingerprint, cookies, origin, and HTTP/2 settings. This works best for endpoints the site's own app calls with fetch or XHR.
     * Full control over which endpoints you call and with what parameters, no need to trigger UI flows
     * Can call endpoints the UI doesn't naturally hit (e.g., fetch page 50 of results without clicking "next" 49 times)
     * Gets clean, structured API data (JSON)
@@ -147,17 +148,20 @@ Libretto captures all network traffic and page state during a session, which let
     **Cons:**
 
     * Requires understanding the site's API: you need to know the endpoint URLs, required headers, authentication tokens, and request body format. You'll need to reverse-engineer the site's network traffic first.
+    * Does not inherit the request type of the browser primitive the site normally uses. A browser fetch is sent as `resourceType: "fetch"` with headers like `sec-fetch-dest: empty` and `sec-fetch-mode: cors`, while a page navigation is sent as `resourceType: "document"` with `sec-fetch-dest: document`, `sec-fetch-mode: navigate`, `sec-fetch-user: ?1`, and `upgrade-insecure-requests: 1`. Script, image, CSS, and iframe loads have different request shapes too.
+    * Browser JavaScript generally cannot set the key `Sec-Fetch-*` headers manually. Copying headers into a fetch call usually does not make it look like a different kind of browser request.
     * Vulnerable to fetch/XHR monkey-patching. If the site wraps `window.fetch`, your calls may be intercepted and flagged because the call stack won't match the site's expected code paths.
+    * Riskier for full document URLs, such as search result pages. Use `page.goto()` and parse the loaded document, or capture the responses the site's own app naturally triggers.
     * Still requires a Playwright browser to be running (for the execution context)
     * API endpoints can change without notice
     * Must handle authentication tokens and CSRF tokens that the site's own code normally manages
 
-    **Bot detection risk: LOW to MODERATE**
+    **Bot detection risk: MODERATE**
 
-    The network-level risk is very low because the requests are genuine browser requests. The risk comes from browser fingerprinting (same as regular Playwright), fetch/XHR monkey-patching detecting unexpected call stacks, and timing/pattern analysis if your requests don't match normal UI flow patterns.
+    The requests are genuine browser requests, but they still expose a fetch/XHR request context. The risk comes from browser fingerprinting, request type mismatches, fetch/XHR monkey-patching, and timing or pattern analysis if your requests don't match normal UI flow.
 
     <Note>
-      Most sites do not implement fetch call stack monitoring. This approach is effectively undetectable on the vast majority of sites. Only sites with enterprise-grade bot protection from services like PerimeterX or Shape Security are likely to catch this.
+      Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or a link click for page HTML, `pageRequest()` for API requests the site normally makes with fetch/XHR, and passive interception when you can let the site's own code make the request.
     </Note>
   </Tab>
 
@@ -200,9 +204,9 @@ Libretto captures all network traffic and page state during a session, which let
 ### Decision guide
 
 <Tip>
-  **Recommended approach:** Use in-browser fetch (`pageRequest()`) for most sites. It gives you full control over which endpoints you call, structured JSON responses, and the real browser's network fingerprint.
+  **Recommended approach:** Use in-browser fetch (`pageRequest()`) for verified API endpoints that the site normally calls with fetch/XHR. It gives you full control over which endpoints you call, structured JSON responses, and the real browser's network fingerprint.
 
-  For high-security sites with aggressive bot detection (Cloudflare, Akamai, PerimeterX), use Regular Playwright for navigation and passive `page.on('response')` interception for data capture. This avoids making any extra requests that could trigger detection.
+  For high-security sites with aggressive bot detection (Cloudflare, Akamai, PerimeterX, DataDome), use Regular Playwright for navigation and passive `page.on('response')` interception for data capture. This avoids making any extra requests that could trigger detection.
 </Tip>
 
 **Use Regular Playwright when:**
@@ -223,6 +227,7 @@ Libretto captures all network traffic and page state during a session, which let
 
 * You need data from API endpoints that the UI doesn't naturally trigger (e.g., deep pagination, bulk exports)
 * You've verified the site doesn't monkey-patch `fetch` (or you can work around it)
+* You've verified the target endpoint is normally called with fetch/XHR, not loaded as a document, script, image, stylesheet, or iframe
 * You want maximum control over which data you fetch and when
 * You've already reverse-engineered the relevant API endpoints
 

--- a/docs/library-api/network-requests.mdx
+++ b/docs/library-api/network-requests.mdx
@@ -6,7 +6,13 @@ title: Network requests
 
 ### `pageRequest()`
 
-Executes a `fetch()` call inside the browser context via `page.evaluate()`. Because the request runs inside the real browser process, it uses the browser's TLS fingerprint, cookies, and session. This avoids bot-detection issues that arise when making the same request from Node.js directly.
+Executes a `fetch()` call inside the browser context via `page.evaluate()`. Because the request runs inside the real browser process, it uses the browser's TLS fingerprint, cookies, and session. It still looks like a fetch/XHR request, so use it for endpoints the site normally calls with fetch or XHR.
+
+<Note>
+  `pageRequest()` is not a replacement for every browser request. For page HTML,
+  navigate with `page.goto()` or click a link. For images, scripts, stylesheets,
+  and iframes, let the DOM load the resource naturally when possible.
+</Note>
 
 ```typescript theme={null}
 async function pageRequest<T extends z.ZodType | undefined = undefined>(

--- a/docs/workflow-guides/convert-to-network-requests.mdx
+++ b/docs/workflow-guides/convert-to-network-requests.mdx
@@ -12,6 +12,7 @@ Libretto captures all network traffic during a browser session, so your agent ca
   Not every site is a good candidate for network conversion. Stay with browser automation if:
 
 - The site has enterprise bot protection (Akamai, PerimeterX, Shape Security) **and** monkey-patches `window.fetch` with call-stack inspection
+- The request you want to make is normally loaded as a document, script, image, stylesheet, or iframe rather than fetch/XHR
 - The site does API-level monitoring that correlates request timing to UI interactions
 - The data you need is rendered client-side and doesn't come from a clean API response
 
@@ -49,7 +50,7 @@ In these cases, stick with your existing Playwright automation or use passive in
   <Step title="Review the agent's approach">
     The agent reports what API endpoints it found and whether the site has bot protection. It recommends one of two approaches:
 
-    - **In-browser fetch**: call endpoints directly from within the browser's JavaScript context. The requests share the browser's cookies and TLS fingerprint, so they look identical to the site's own requests. Faster, but only safe when the site doesn't monitor for anomalous call patterns.
+    - **In-browser fetch**: call endpoints directly from within the browser's JavaScript context. The requests share the browser's cookies and TLS fingerprint, but they still look like fetch/XHR requests. Use this when the real site also calls that endpoint with fetch or XHR.
     - **Passive interception**: set up a `page.on('response', ...)` listener and let the site's own code make the requests. Zero detection risk because no extra requests are made, but you're limited to whatever requests the site naturally triggers. Safer, but less flexible. Use this when the site has bot protection.
 
     If the agent's recommendation looks reasonable, let it proceed. If you'd rather use one approach over the other, say so:
@@ -91,6 +92,7 @@ In these cases, stick with your existing Playwright automation or use passive in
 ### When to convert to network requests
 
 - The site exposes a usable JSON API behind the UI
+- The target requests are normally made with fetch/XHR by the site itself
 - You need to paginate deeply (fetching page 50 without clicking "next" 49 times)
 - You want data the UI doesn't display (hidden fields, metadata, IDs)
 - Speed and reliability matter more than DOM fidelity

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -28,13 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Choose the least bot-detectable method that matches how the site normally makes the request.
-- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
+- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
 - Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
 - Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
+- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
 
 ## Setup
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -32,7 +32,6 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
-- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -29,7 +29,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 ## Default Integration Approach
 
 - Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
-- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Prefer browser-context `fetch()` for data extraction and form submission when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
 - Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -49,8 +49,8 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Do not treat visibility as interactivity. If an element will not act, inspect blockers before retrying.
 - Defer repo/code review until you begin generating code, unless the user explicitly asks for it earlier.
 - Read and follow guidelines in `references/code-generation-rules.md` before generating or editing production workflow code.
-- Validation requires a successful clean `run --headless` with confirmation of the actual returned output, not just process success. If the user wants to watch the finished workflow, do a final headed `run` after headless validation succeeds.
-- After validation, always show the user: (1) the output/results from the headless validation run, and (2) a headed version of the same command so they can re-run it themselves and watch the browser (e.g. replace `--headless` with `--headed`). Include any `--params` or `--auth-profile` flags the workflow needs.
+- Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
+- After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, `--headless`, or `--auth-profile` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
@@ -140,8 +140,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 
 ### `run`
 
-- Use `run` to verify a workflow file after creating it or editing it, preferring `run --headless` for the normal fix/verify loop.
-- Plain `run` defaults to headed mode.
+- Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
@@ -150,9 +150,9 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Re-run the same workflow after each fix to verify the browser behavior end to end.
 
 ```bash
-npx libretto run ./integration.ts --headless --params '{"status":"open"}'
-npx libretto run ./integration.ts --headless --read-only
-npx libretto run ./integration.ts --headless --stay-open-on-success
+npx libretto run ./integration.ts --params '{"status":"open"}'
+npx libretto run ./integration.ts --read-only
+npx libretto run ./integration.ts --stay-open-on-success
 npx libretto run ./integration.ts --auth-profile app.example.com
 ```
 
@@ -232,10 +232,10 @@ Assistant: [Uses `snapshot` and `exec` as needed to understand the site and deci
 Assistant: [Reads `references/code-generation-rules.md` before writing production workflow code]
 Assistant: I found the working path. I'll now create the workflow file and verify it.
 Assistant: [Creates or edits `target-workflow.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./target-workflow.ts --headless --params '{"status":"open"}'` to validate]
+Assistant: [Runs `npx libretto run ./target-workflow.ts --params '{"status":"open"}'` to validate]
 Assistant: Validation passed. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --headed --params '{"status":"open"}'
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./target-workflow.ts --params '{"status":"open"}'
 </example>
 ```
 
@@ -245,17 +245,17 @@ To watch it yourself in a browser, run: npx libretto run ./target-workflow.ts --
 <example>
 [Context: The user has an existing Libretto workflow that is failing]
 Assistant: I'll reproduce the failure first so we can inspect the exact browser state it leaves behind.
-Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow --headed`]
+Assistant: [Runs `npx libretto run ./integration.ts --session debug-flow`]
 Assistant: The workflow failed and Libretto kept the browser open. I'll inspect the page state before changing code.
 Assistant: [Runs `npx libretto snapshot --session debug-flow`]
 Assistant: [Runs `npx libretto exec --session debug-flow "...focused inspection or prototype..."`]
 Assistant: [Reads `references/code-generation-rules.md` before patching the workflow file]
 Assistant: I found the issue. I'll patch the workflow code and verify.
 Assistant: [Edits `integration.ts` following `references/code-generation-rules.md`]
-Assistant: [Runs `npx libretto run ./integration.ts --headless` to validate the fix]
+Assistant: [Runs `npx libretto run ./integration.ts` to validate the fix]
 Assistant: Fix verified. Here are the results:
-[Shows the output/results from the headless run]
-To watch it yourself in a browser, run: npx libretto run ./integration.ts --headed
+[Shows the output/results from the validation run]
+To run it again, use: npx libretto run ./integration.ts
 </example>
 ```
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -28,7 +28,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Use Playwright for navigation and other non-fetch browser behavior, including document and asset loads.
 - Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
 - Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
 - Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -28,13 +28,11 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for data extraction and form submission when the site exposes real fetch/XHR endpoints you can call from the browser context.
-- Use Playwright for navigation and non-fetch browser behavior. Use `page.goto()` or link clicks for page HTML, and let the DOM load scripts, images, stylesheets, and iframes naturally.
-- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
-- Use in-browser `fetch()` only to replace requests the real site already makes with fetch/XHR. Do not use `fetch()` to load URLs normally requested as documents or assets.
-- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
-- Read `references/site-security-review.md` before committing to a fetch-based network path on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules fetch out, the request path is not workable, or the user explicitly asks for Playwright or UI automation.
+- Use Playwright for navigation, login/session setup, and non-fetch browser behavior. Use `page.goto()` or link clicks for documents, and let the DOM load assets naturally.
+- Prefer browser-context `fetch()` for data extraction and form submission only when the target is a real site fetch/XHR endpoint and `references/site-security-review.md` says the path is safe and workable.
+- Use passive interception when the UI already triggers useful fetch/XHR requests or active fetch is risky.
+- Fall back to Playwright UI automation when fetch is ruled out, the request path is not workable, or the user explicitly asks for Playwright/UI automation.
+- Do not copy headers to hide a request-type mismatch. Browsers set request-context headers from the primitive that caused the request.
 
 ## Setup
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -28,9 +28,13 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 
 ## Default Integration Approach
 
-- Prefer network requests first for new integrations unless the user explicitly asks for Playwright or UI automation, then do not use the site's internal API.
-- Read `references/site-security-review.md` before committing to a network-first approach on a new site.
-- Fall back to passive interception or Playwright-driven UI automation when the security review rules network requests out, the request path is not workable, or the user explicitly asks for Playwright.
+- Choose the least bot-detectable method that matches how the site normally makes the request.
+- Use Playwright navigation (`page.goto()` or link clicks) for page HTML and navigation flows.
+- Use passive interception when the site's own UI naturally triggers the data-bearing requests.
+- Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Do not use `fetch()` for URLs normally loaded as documents, scripts, images, stylesheets, or iframes.
+- Do not try to fix request type mismatches by copying headers. Browsers set request-context headers based on the primitive that caused the request.
+- Read `references/site-security-review.md` before committing to a network-heavy approach on a new site.
+- Fall back to passive interception or Playwright-driven UI automation when request type, bot protection, or fetch interception makes direct browser fetch risky.
 
 ## Setup
 

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,8 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Network request methods are for active fetch/XHR endpoints the site already uses. Prefer them for data extraction or form submissions when the security review shows the path is safe and workable.
+
 Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
 
 Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -117,6 +117,10 @@ Do not rely on broad DOM querying inside `page.evaluate()` for production flows 
 
 ## Network Request Methods
 
+Before codifying a network request, confirm that the browser primitive matches how the site normally makes that request. Use `page.goto()` or link clicks for document navigation. Use `page.evaluate(fetch)` only for endpoints the site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type.
+
+Do not use `fetch()` to avoid UI navigation for page HTML or asset URLs. The request still comes from the browser, but the browser marks it as fetch/XHR with different request-context headers than a navigation, script, image, stylesheet, or iframe load. Do not try to fix that by copying headers, because the browser controls the request context. Prefer passive network interception when the site's own UI already triggers the useful request.
+
 When codifying network-based data extraction or form submissions, wrap `page.evaluate(() => fetch(...))` calls in typed methods on a shared API client class:
 
 ```typescript

--- a/packages/libretto/skills/libretto/references/site-security-review.md
+++ b/packages/libretto/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,26 +54,44 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
+### Probe 3: Request Type Matching
+
+Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
+
+Common examples:
+
+| Request Type | Typical Context |
+| --- | --- |
+| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
+| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
+| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
+| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
+| Stylesheet load | `sec-fetch-dest: style` |
+| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
+
+Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+
 ## Choosing a Data Capture Strategy
 
 Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin. They look identical to requests the site's own JS would make.
+Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
 
 When to prioritize this:
 
+- The target endpoint is normally called by the site with fetch/XHR
 - No enterprise bot protection is detected
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
-Risk: if the site monitors fetch call stacks, your calls may be flagged because they do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -111,10 +129,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| No bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| No bot protection, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
-| Bot protection detected, fetch not patched | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Bot protection detected, fetch is patched | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -127,6 +144,7 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
+- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 

--- a/packages/libretto/skills/libretto/references/site-security-review.md
+++ b/packages/libretto/skills/libretto/references/site-security-review.md
@@ -69,11 +69,11 @@ Common examples:
 | Stylesheet load | `sec-fetch-dest: style` |
 | Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
 
-Rule of thumb: match the browser primitive to the site's real request type. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
+Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
 
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
@@ -86,6 +86,7 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
+- The user has not asked for Playwright-only or UI-only automation
 
 Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
 
@@ -129,8 +130,8 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, fetch patched or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
+| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 

--- a/packages/libretto/skills/libretto/references/site-security-review.md
+++ b/packages/libretto/skills/libretto/references/site-security-review.md
@@ -1,6 +1,6 @@
 # Site Security Review
 
-Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, request type matching, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
+Purpose: You are connected to a live Chrome session on a target website. Your job is to review the site's bot-detection and security posture before committing to an integration strategy. Probe for bot protection, fetch interception, and challenge flows, then use that review to decide which integration approaches are safe and which one to try first for this site.
 
 After completing the probes below, produce a Site Assessment Summary (see the output format at the end of this document).
 
@@ -54,30 +54,13 @@ window.fetch.hasOwnProperty('prototype')
 
 Important: some sites use `Proxy` to wrap fetch, which makes `toString()` still return `"[native code]"`. The prototype check is a heuristic, not definitive. If you see any sign of fetch interception, treat it as patched.
 
-### Probe 3: Request Type Matching
-
-Compare the target request in `network.jsonl` before replacing it. Browsers attach request context metadata that describes what caused the request.
-
-Common examples:
-
-| Request Type | Typical Context |
-| --- | --- |
-| Page navigation | `sec-fetch-dest: document`, `sec-fetch-mode: navigate` |
-| Fetch/XHR | `sec-fetch-dest: empty`, `sec-fetch-mode: cors` or `same-origin` |
-| Script load | `sec-fetch-dest: script`, `sec-fetch-mode: no-cors` |
-| Image load | `sec-fetch-dest: image`, `sec-fetch-mode: no-cors` |
-| Stylesheet load | `sec-fetch-dest: style` |
-| Iframe load | `sec-fetch-dest: iframe` or `document`, `sec-fetch-mode: navigate` |
-
-Rule of thumb: prefer network requests for data extraction when the site exposes real fetch/XHR endpoints, but keep normal browser primitives for everything else. Use `page.goto()` or link clicks for page HTML. Use in-browser `fetch()` only for endpoints the real site calls with fetch/XHR. Let the DOM load scripts, images, stylesheets, and iframes naturally, or create the corresponding DOM element if you truly need that request type. Do not try to fix a mismatch by copying headers, because the browser controls the request-context headers.
-
 ## Choosing a Data Capture Strategy
 
-Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls for real fetch/XHR endpoints, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
+Use the review above to decide what is safe to prioritize. Every integration uses Playwright to control the browser. The question is what to lean on for data capture: direct browser fetch calls, passive network interception, or DOM extraction. In practice, many integrations mix approaches, but the site-security review should tell you which approach is safest to try first.
 
 ### Strategy A: Prioritize `page.evaluate(fetch(...))`
 
-Make fetch calls directly from within the browser's JavaScript context. The requests share the browser's TLS fingerprint, cookies, and origin, but they still look like fetch/XHR requests. They match site behavior only when the real site calls that endpoint with fetch/XHR.
+Make fetch calls directly from within the browser's JavaScript context. Use this only for endpoints the site already calls with fetch/XHR, not for page navigation or asset loads.
 
 When to prioritize this:
 
@@ -86,13 +69,12 @@ When to prioritize this:
 - `fetch` is not monkey-patched
 - The API responses are parseable and useful
 - You need data that requires many API calls (deep pagination, bulk queries) where driving the UI would be slow
-- The user has not asked for Playwright-only or UI-only automation
 
-Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach for real fetch/XHR endpoints.
+Why: maximum control and efficiency. You call exactly the endpoints you want with the parameters you want, skip UI rendering, and get structured JSON back. On sites without aggressive detection, this is the fastest and cleanest approach.
 
-Risk: if you fetch a URL the site normally loads as a document, script, image, stylesheet, or iframe, the request context will not match normal browser behavior. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code. This is uncommon but exists on high-security sites.
+Risk: fetch is the wrong primitive for page HTML and asset URLs; use Playwright navigation or DOM-driven loads for those. Sites can also monitor fetch call stacks and flag calls that do not originate from the site's bundled code.
 
-You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any browser primitive that should not be fetch.
+You will still use Playwright for initial navigation, login/auth flows, cookie consent, and any UI interactions needed to establish session state before making fetch calls.
 
 ### Strategy B: Prioritize `page.on('response', ...)`
 
@@ -130,9 +112,9 @@ Trade-off: it is slower, more fragile against DOM changes, and you only get data
 
 | Site Profile | Primary Strategy | Supplement With |
 | --- | --- | --- |
-| Fetch/XHR API endpoint, no bot protection, fetch not patched, request path workable | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
-| Fetch/XHR API endpoint, request path not workable, fetch patched, or bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
-| Page/document/script/image/style/iframe URL | Matching Playwright or DOM primitive | Passive interception when useful |
+| No bot protection, fetch/XHR endpoint, fetch not patched | A (`page.evaluate(fetch)`) | Playwright for navigation/auth |
+| No bot protection, fetch is patched or endpoint is not fetch/XHR | B (`page.on('response', ...)`) | Playwright for navigation; DOM extraction as fallback |
+| Bot protection detected | B (`page.on('response', ...)`) | Playwright for navigation; cautious use of `page.evaluate(fetch)` only if needed |
 | Server-rendered content (no API calls) | C (DOM extraction) | Playwright for all interaction |
 
 ## Output: Site Assessment Summary
@@ -145,7 +127,6 @@ After running the probes, produce a summary in this format. This assessment tell
 ### Bot Detection Profile
 - Enterprise bot protection: [None detected / Detected — describe what you found]
 - Fetch/XHR interception: [Native (not patched) / Patched — describe what you found]
-- Request type match: [Fetch/XHR API / Document navigation / Asset or iframe / Unknown]
 - Challenge pages: [None / Present — describe type]
 - Overall security posture: [None / Low / Moderate / High / Very High]
 


### PR DESCRIPTION
## Summary
- add `/blog` and `/blog/:slug` routes to the website
- render the first post from markdown with `safe-mdx`
- add blog links to desktop nav, mobile menu, and footer, plus Vercel rewrites for direct blog URLs
- style the blog index/post pages to match the existing Libretto visual language
- clarify docs guidance for in-browser fetch, request type matching, and bot detection risk
- update the Libretto skill guidance to choose request primitives that match real browser behavior

## Testing
- `pnpm -s --filter @libretto/website type-check`
- scoped `vp check --fix` on changed website files
- `pnpm -s docs:validate`
- `git diff --check`
- `diff -rq packages/libretto/skills/libretto .agents/skills/libretto`
- `diff -rq packages/libretto/skills/libretto .claude/skills/libretto`
- verified `/blog` locally in the browser