### PR TITLE
feat(cli): move hosted commands under cloud

### DIFF
--- a/apps/website/src/components/CloudProviders.tsx
+++ b/apps/website/src/components/CloudProviders.tsx
@@ -11,7 +11,7 @@ import {
 } from "../icons";
 
 const linkClass = "underline text-ink/70 transition-colors hover:text-ink";
-const DEPLOY_COMMAND = "libretto deploy";
+const DEPLOY_COMMAND = "libretto cloud deploy";
 
 const LOGOS = [
   <BrowserbaseLogo key="bb" className="h-5 w-auto text-ink/35" />,

--- a/docs/libretto-cloud-hosting/authentication.mdx
+++ b/docs/libretto-cloud-hosting/authentication.mdx
@@ -10,10 +10,10 @@ The examples below use `npx libretto`. If `libretto` is already on your `PATH`, 
 
 ### Create a new user account and organization
 
-Use `auth signup` when you are creating a brand new Libretto Cloud organization:
+Use `libretto cloud auth signup` when you are creating a brand new Libretto Cloud organization:
 
 ```bash theme={null}
-npx libretto experimental auth signup
+npx libretto cloud auth signup
 ```
 
 The CLI prompts for your name, email, password, organization name, organization slug, and the alert email that Libretto Cloud should use for workflow failure notifications. After the account is created, it waits for email verification and stores the session locally in `~/.libretto/auth.json`.
@@ -26,10 +26,10 @@ If the organization slug is already taken, the CLI re-prompts for just the slug 
 
 ### Log in to an existing account
 
-Use `auth login` when the account already exists:
+Use `libretto cloud auth login` when the account already exists:
 
 ```bash theme={null}
-npx libretto experimental auth login
+npx libretto cloud auth login
 ```
 
 This stores a new Libretto Cloud session in `~/.libretto/auth.json`. If the account is not verified yet, the CLI re-sends the verification email.
@@ -37,25 +37,25 @@ This stores a new Libretto Cloud session in `~/.libretto/auth.json`. If the acco
 To clear local credentials:
 
 ```bash theme={null}
-npx libretto experimental auth logout
+npx libretto cloud auth logout
 ```
 
 ### Check the active identity
 
-Use `whoami` to confirm which Libretto Cloud account the CLI is using:
+Use `libretto cloud auth whoami` to confirm which Libretto Cloud account the CLI is using:
 
 ```bash theme={null}
-npx libretto experimental auth whoami
+npx libretto cloud auth whoami
 ```
 
 If `LIBRETTO_API_KEY` is set, the CLI prefers that key over the stored session cookie.
 
 ### Invite a teammate
 
-Use `invite` from an account that can manage members in the active organization:
+Use `libretto cloud auth invite` from an account that can manage members in the active organization:
 
 ```bash theme={null}
-npx libretto experimental auth invite teammate@example.com --role member
+npx libretto cloud auth invite teammate@example.com --role member
 ```
 
 The command prints the invitation id and the organization slug that the recipient needs for `accept-invite`.
@@ -65,7 +65,7 @@ The command prints the invitation id and the organization slug that the recipien
 Use `accept-invite` when you are joining an existing organization:
 
 ```bash theme={null}
-npx libretto experimental auth accept-invite <tenant-slug> <invitation-id>
+npx libretto cloud auth accept-invite <tenant-slug> <invitation-id>
 ```
 
 If you are not logged in yet, the CLI creates the account first, waits for email verification, and then saves the hosted session locally.
@@ -77,27 +77,27 @@ If you are already logged in, `accept-invite` only works when that account is no
 Use API keys for project `.env` files, CI, or other non-interactive Libretto Cloud runs:
 
 ```bash theme={null}
-npx libretto experimental auth api-key issue --label laptop-dev
+npx libretto cloud auth api-key issue --label laptop-dev
 ```
 
 The command prints the raw key once. The CLI does not store that key on disk for you.
 
-Add it to your project:
+Add it to your project `.env` file:
 
-```bash theme={null}
+```dotenv theme={null}
 LIBRETTO_API_KEY=<issued-key>
 ```
 
 To inspect existing keys:
 
 ```bash theme={null}
-npx libretto experimental auth api-key list
+npx libretto cloud auth api-key list
 ```
 
 To revoke a key:
 
 ```bash theme={null}
-npx libretto experimental auth api-key revoke <key-id>
+npx libretto cloud auth api-key revoke <key-id>
 ```
 
 ### Troubleshooting

--- a/docs/libretto-cloud-hosting/authentication.mdx
+++ b/docs/libretto-cloud-hosting/authentication.mdx
@@ -10,7 +10,7 @@ The examples below use `npx libretto`. If `libretto` is already on your `PATH`, 
 
 ### Create a new user account and organization
 
-Use `npx libretto cloud auth signup` when you are creating a brand new Libretto Cloud organization:
+Use `auth signup` when you are creating a brand new Libretto Cloud organization:
 
 ```bash theme={null}
 npx libretto cloud auth signup
@@ -26,7 +26,7 @@ If the organization slug is already taken, the CLI re-prompts for just the slug 
 
 ### Log in to an existing account
 
-Use `npx libretto cloud auth login` when the account already exists:
+Use `auth login` when the account already exists:
 
 ```bash theme={null}
 npx libretto cloud auth login
@@ -42,7 +42,7 @@ npx libretto cloud auth logout
 
 ### Check the active identity
 
-Use `npx libretto cloud auth whoami` to confirm which Libretto Cloud account the CLI is using:
+Use `auth whoami` to confirm which Libretto Cloud account the CLI is using:
 
 ```bash theme={null}
 npx libretto cloud auth whoami
@@ -52,17 +52,17 @@ If `LIBRETTO_API_KEY` is set, the CLI prefers that key over the stored session c
 
 ### Invite a teammate
 
-Use `npx libretto cloud auth invite` from an account that can manage members in the active organization:
+Use `auth invite` from an account that can manage members in the active organization:
 
 ```bash theme={null}
 npx libretto cloud auth invite teammate@example.com --role member
 ```
 
-The command prints the invitation id and the organization slug that the recipient needs for `npx libretto cloud auth accept-invite`.
+The command prints the invitation id and the organization slug that the recipient needs for `auth accept-invite`.
 
 ### Accept an invite
 
-Use `npx libretto cloud auth accept-invite` when you are joining an existing organization:
+Use `auth accept-invite` when you are joining an existing organization:
 
 ```bash theme={null}
 npx libretto cloud auth accept-invite <tenant-slug> <invitation-id>
@@ -70,7 +70,7 @@ npx libretto cloud auth accept-invite <tenant-slug> <invitation-id>
 
 If you are not logged in yet, the CLI creates the account first, waits for email verification, and then saves the hosted session locally.
 
-If you are already logged in, `npx libretto cloud auth accept-invite` only works when that account is not already a member of another organization.
+If you are already logged in, `auth accept-invite` only works when that account is not already a member of another organization.
 
 ### Issue an API key
 

--- a/docs/libretto-cloud-hosting/authentication.mdx
+++ b/docs/libretto-cloud-hosting/authentication.mdx
@@ -10,7 +10,7 @@ The examples below use `npx libretto`. If `libretto` is already on your `PATH`, 
 
 ### Create a new user account and organization
 
-Use `libretto cloud auth signup` when you are creating a brand new Libretto Cloud organization:
+Use `npx libretto cloud auth signup` when you are creating a brand new Libretto Cloud organization:
 
 ```bash theme={null}
 npx libretto cloud auth signup
@@ -26,7 +26,7 @@ If the organization slug is already taken, the CLI re-prompts for just the slug 
 
 ### Log in to an existing account
 
-Use `libretto cloud auth login` when the account already exists:
+Use `npx libretto cloud auth login` when the account already exists:
 
 ```bash theme={null}
 npx libretto cloud auth login
@@ -42,7 +42,7 @@ npx libretto cloud auth logout
 
 ### Check the active identity
 
-Use `libretto cloud auth whoami` to confirm which Libretto Cloud account the CLI is using:
+Use `npx libretto cloud auth whoami` to confirm which Libretto Cloud account the CLI is using:
 
 ```bash theme={null}
 npx libretto cloud auth whoami
@@ -52,17 +52,17 @@ If `LIBRETTO_API_KEY` is set, the CLI prefers that key over the stored session c
 
 ### Invite a teammate
 
-Use `libretto cloud auth invite` from an account that can manage members in the active organization:
+Use `npx libretto cloud auth invite` from an account that can manage members in the active organization:
 
 ```bash theme={null}
 npx libretto cloud auth invite teammate@example.com --role member
 ```
 
-The command prints the invitation id and the organization slug that the recipient needs for `accept-invite`.
+The command prints the invitation id and the organization slug that the recipient needs for `npx libretto cloud auth accept-invite`.
 
 ### Accept an invite
 
-Use `accept-invite` when you are joining an existing organization:
+Use `npx libretto cloud auth accept-invite` when you are joining an existing organization:
 
 ```bash theme={null}
 npx libretto cloud auth accept-invite <tenant-slug> <invitation-id>
@@ -70,7 +70,7 @@ npx libretto cloud auth accept-invite <tenant-slug> <invitation-id>
 
 If you are not logged in yet, the CLI creates the account first, waits for email verification, and then saves the hosted session locally.
 
-If you are already logged in, `accept-invite` only works when that account is not already a member of another organization.
+If you are already logged in, `npx libretto cloud auth accept-invite` only works when that account is not already a member of another organization.
 
 ### Issue an API key
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -12,7 +12,7 @@ Only organization owners can view billing status or open billing-management link
 
 ### Open the plans page
 
-Use `npx libretto cloud billing portal` to print a short-lived link to Libretto's plans page:
+Use `billing portal` to print a short-lived link to Libretto's plans page:
 
 ```bash theme={null}
 npx libretto cloud billing portal
@@ -27,7 +27,7 @@ The page shows:
 
 ### Check the current plan and usage
 
-Use `npx libretto cloud billing status` to inspect the current plan, subscription status, usage, and period end:
+Use `billing status` to inspect the current plan, subscription status, usage, and period end:
 
 ```bash theme={null}
 npx libretto cloud billing status
@@ -69,13 +69,13 @@ Each session is billed by the second and rounds up to the next whole second, wit
 | Team       | $100          | 400                    |
 | Enterprise | Custom        | Custom                 |
 
-Run `npx libretto cloud billing portal` to compare and switch plans.
+Run `billing portal` to compare and switch plans.
 
 If your organization exceeds its plan limit, Libretto Cloud will not spin up new browser sessions until you move to a plan with more capacity.
 
 ### Change plans, payment methods, invoices, and cancellation
 
-Run `npx libretto cloud billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `npx libretto cloud billing status` again in your terminal to confirm the updated plan.
+Run `billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `billing status` again in your terminal to confirm the updated plan.
 
 ### BAA and Enterprise
 
@@ -83,7 +83,7 @@ For BAA and Enterprise, please reach out to us at `team@saffron.health`.
 
 ### Troubleshooting
 
-- If the plans link says it is expired or invalid, run `npx libretto cloud billing portal` again to get a fresh link.
+- If the plans link says it is expired or invalid, run `billing portal` again to get a fresh link.
 - If billing commands fail with an auth error, log in again or set `LIBRETTO_API_KEY`.
 - If you can authenticate but still cannot access billing, confirm that your user is an organization owner.
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -12,10 +12,10 @@ Only organization owners can view billing status or open billing-management link
 
 ### Open the plans page
 
-Use `billing portal` to print a short-lived link to Libretto's plans page:
+Use `libretto cloud billing portal` to print a short-lived link to Libretto's plans page:
 
 ```bash theme={null}
-npx libretto experimental billing portal
+npx libretto cloud billing portal
 ```
 
 The page shows:
@@ -27,10 +27,10 @@ The page shows:
 
 ### Check the current plan and usage
 
-Use `billing status` to inspect the current plan, subscription status, usage, and period end:
+Use `libretto cloud billing status` to inspect the current plan, subscription status, usage, and period end:
 
 ```bash theme={null}
-npx libretto experimental billing status
+npx libretto cloud billing status
 ```
 
 Example output:
@@ -69,13 +69,13 @@ Each session is billed by the second and rounds up to the next whole second, wit
 | Team       | $100          | 400                    |
 | Enterprise | Custom        | Custom                 |
 
-Run `billing portal` to compare and switch plans.
+Run `libretto cloud billing portal` to compare and switch plans.
 
 If your organization exceeds its plan limit, Libretto Cloud will not spin up new browser sessions until you move to a plan with more capacity.
 
 ### Change plans, payment methods, invoices, and cancellation
 
-Run `billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `billing status` again in your terminal to confirm the updated plan.
+Run `libretto cloud billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `libretto cloud billing status` again in your terminal to confirm the updated plan.
 
 ### BAA and Enterprise
 
@@ -83,7 +83,7 @@ For BAA and Enterprise, please reach out to us at `team@saffron.health`.
 
 ### Troubleshooting
 
-- If the plans link says it is expired or invalid, run `npx libretto experimental billing portal` again to get a fresh link.
+- If the plans link says it is expired or invalid, run `npx libretto cloud billing portal` again to get a fresh link.
 - If billing commands fail with an auth error, log in again or set `LIBRETTO_API_KEY`.
 - If you can authenticate but still cannot access billing, confirm that your user is an organization owner.
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -12,7 +12,7 @@ Only organization owners can view billing status or open billing-management link
 
 ### Open the plans page
 
-Use `libretto cloud billing portal` to print a short-lived link to Libretto's plans page:
+Use `npx libretto cloud billing portal` to print a short-lived link to Libretto's plans page:
 
 ```bash theme={null}
 npx libretto cloud billing portal
@@ -27,7 +27,7 @@ The page shows:
 
 ### Check the current plan and usage
 
-Use `libretto cloud billing status` to inspect the current plan, subscription status, usage, and period end:
+Use `npx libretto cloud billing status` to inspect the current plan, subscription status, usage, and period end:
 
 ```bash theme={null}
 npx libretto cloud billing status
@@ -69,13 +69,13 @@ Each session is billed by the second and rounds up to the next whole second, wit
 | Team       | $100          | 400                    |
 | Enterprise | Custom        | Custom                 |
 
-Run `libretto cloud billing portal` to compare and switch plans.
+Run `npx libretto cloud billing portal` to compare and switch plans.
 
 If your organization exceeds its plan limit, Libretto Cloud will not spin up new browser sessions until you move to a plan with more capacity.
 
 ### Change plans, payment methods, invoices, and cancellation
 
-Run `libretto cloud billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `libretto cloud billing status` again in your terminal to confirm the updated plan.
+Run `npx libretto cloud billing portal`, open the printed plans page, and use it to change plans or open Stripe's customer portal for payment details, invoices, and cancellation. After any plan change, run `npx libretto cloud billing status` again in your terminal to confirm the updated plan.
 
 ### BAA and Enterprise
 

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -6,15 +6,15 @@ title: Deployments
 
 ### Before you deploy
 
-Libretto Cloud commands and API requests use `https://api.libretto.sh`. Issue an API key for the deployment environment:
+Libretto Cloud commands and API requests use `https://api.libretto.sh`. Issue an API key, then add it to your project `.env` file:
 
-```bash theme={null}
-export LIBRETTO_API_KEY=<issued-api-key>
+```dotenv theme={null}
+LIBRETTO_API_KEY=<issued-api-key>
 ```
 
 ### Expected deploy directory
 
-`libretto experimental deploy` uploads one package directory at a time. That directory must contain:
+`libretto cloud deploy` uploads one package directory at a time. That directory must contain:
 
 - A `package.json`
 - An entry file for workflow discovery
@@ -43,7 +43,7 @@ export { default as submitPriorAuth } from "./src/workflows/submit-prior-auth";
 
 The API uses the workflow name from the `workflow("...")` call inside the file, not the filename or the export alias from `index.ts`.
 
-If your workflows live in a package inside a monorepo, run `deploy` against that package directory instead of the monorepo root.
+If your workflows live in a package inside a monorepo, run `libretto cloud deploy` against that package directory instead of the monorepo root.
 
 The deploy command has two separate path concepts:
 
@@ -53,7 +53,7 @@ The deploy command has two separate path concepts:
 For example:
 
 ```bash theme={null}
-npx libretto experimental deploy my-automations --entry-point src/workflows/check-eligibility.ts
+npx libretto cloud deploy my-automations --entry-point src/workflows/check-eligibility.ts
 ```
 
 In that command:
@@ -63,11 +63,11 @@ In that command:
 
 ### Deploy workflows
 
-Use `deploy` to upload a workflow bundle to Libretto Cloud:
+Use `libretto cloud deploy` to upload a workflow bundle to Libretto Cloud:
 
 ```bash theme={null}
 cd my-automations
-npx libretto experimental deploy .
+npx libretto cloud deploy .
 ```
 
 That command expects:
@@ -81,7 +81,7 @@ The positional argument to `deploy` is the source directory to package and uploa
 If you want to deploy from a different entry file, keep the source directory as the package root and use `--entry-point` relative to that directory:
 
 ```bash theme={null}
-npx libretto experimental deploy my-automations \
+npx libretto cloud deploy my-automations \
   --description "payer portal workflows" \
   --entry-point src/workflows/check-eligibility.ts
 ```

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -14,7 +14,7 @@ LIBRETTO_API_KEY=<issued-api-key>
 
 ### Expected deploy directory
 
-`libretto cloud deploy` uploads one package directory at a time. That directory must contain:
+`npx libretto cloud deploy` uploads one package directory at a time. That directory must contain:
 
 - A `package.json`
 - An entry file for workflow discovery
@@ -43,7 +43,7 @@ export { default as submitPriorAuth } from "./src/workflows/submit-prior-auth";
 
 The API uses the workflow name from the `workflow("...")` call inside the file, not the filename or the export alias from `index.ts`.
 
-If your workflows live in a package inside a monorepo, run `libretto cloud deploy` against that package directory instead of the monorepo root.
+If your workflows live in a package inside a monorepo, run `npx libretto cloud deploy` against that package directory instead of the monorepo root.
 
 The deploy command has two separate path concepts:
 
@@ -63,7 +63,7 @@ In that command:
 
 ### Deploy workflows
 
-Use `libretto cloud deploy` to upload a workflow bundle to Libretto Cloud:
+Use `npx libretto cloud deploy` to upload a workflow bundle to Libretto Cloud:
 
 ```bash theme={null}
 cd my-automations

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -14,7 +14,7 @@ LIBRETTO_API_KEY=<issued-api-key>
 
 ### Expected deploy directory
 
-`npx libretto cloud deploy` uploads one package directory at a time. That directory must contain:
+`cloud deploy` uploads one package directory at a time. That directory must contain:
 
 - A `package.json`
 - An entry file for workflow discovery
@@ -43,7 +43,7 @@ export { default as submitPriorAuth } from "./src/workflows/submit-prior-auth";
 
 The API uses the workflow name from the `workflow("...")` call inside the file, not the filename or the export alias from `index.ts`.
 
-If your workflows live in a package inside a monorepo, run `npx libretto cloud deploy` against that package directory instead of the monorepo root.
+If your workflows live in a package inside a monorepo, run `cloud deploy` against that package directory instead of the monorepo root.
 
 The deploy command has two separate path concepts:
 
@@ -63,7 +63,7 @@ In that command:
 
 ### Deploy workflows
 
-Use `npx libretto cloud deploy` to upload a workflow bundle to Libretto Cloud:
+Use `cloud deploy` to upload a workflow bundle to Libretto Cloud:
 
 ```bash theme={null}
 cd my-automations

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -27,7 +27,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
     Create a new Libretto Cloud account with:
 
     ```bash theme={null}
-    npx libretto experimental auth signup
+    npx libretto cloud auth signup
     ```
 
     If you are joining an existing organization, use `accept-invite` instead.
@@ -39,12 +39,12 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
     Issue an API key for your project or environment:
 
     ```bash theme={null}
-    npx libretto experimental auth api-key issue --label laptop-dev
+    npx libretto cloud auth api-key issue --label laptop-dev
     ```
 
     Store the printed key as `LIBRETTO_API_KEY` in your `.env` file:
 
-    ```bash theme={null}
+    ```dotenv theme={null}
     # .env
     LIBRETTO_API_KEY=<issued-key>
     ```
@@ -90,7 +90,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
 
     ```bash theme={null}
     cd my-automations
-    npx libretto experimental deploy .
+    npx libretto cloud deploy .
     ```
 
     See [Expected deploy directory](/libretto-cloud-hosting/deployments#expected-deploy-directory) and [Deploy workflows](/libretto-cloud-hosting/deployments#deploy-workflows).

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -30,7 +30,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
     npx libretto cloud auth signup
     ```
 
-    If you are joining an existing organization, use `accept-invite` instead.
+    If you are joining an existing organization, use `npx libretto cloud auth accept-invite` instead.
 
     See [Create a new user account and organization](/libretto-cloud-hosting/authentication#create-a-new-user-account-and-organization).
   </Step>

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -30,7 +30,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
     npx libretto cloud auth signup
     ```
 
-    If you are joining an existing organization, use `npx libretto cloud auth accept-invite` instead.
+    If you are joining an existing organization, use `auth accept-invite` instead.
 
     See [Create a new user account and organization](/libretto-cloud-hosting/authentication#create-a-new-user-account-and-organization).
   </Step>

--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -1,15 +1,15 @@
 /**
- * Experimental auth commands for the libretto hosted platform.
+ * Hosted-platform auth commands.
  *
- *   libretto experimental auth signup
- *   libretto experimental auth login
- *   libretto experimental auth logout
- *   libretto experimental auth invite <email> [--role member|admin|owner]
- *   libretto experimental auth accept-invite <tenantSlug> <invitationId>
- *   libretto experimental auth api-key issue [--label <label>]
- *   libretto experimental auth api-key list
- *   libretto experimental auth api-key revoke <id>
- *   libretto experimental auth whoami
+ *   libretto cloud auth signup
+ *   libretto cloud auth login
+ *   libretto cloud auth logout
+ *   libretto cloud auth invite <email> [--role member|admin|owner]
+ *   libretto cloud auth accept-invite <tenantSlug> <invitationId>
+ *   libretto cloud auth api-key issue [--label <label>]
+ *   libretto cloud auth api-key list
+ *   libretto cloud auth api-key revoke <id>
+ *   libretto cloud auth whoami
  *
  * Credentials live at ~/.libretto/auth.json (mode 0600). The CLI sends either
  * the stored API key or the stored session cookie depending on what's
@@ -214,7 +214,7 @@ export const signupCommand = SimpleCLI.command({
     const name = await prompt("Your name:");
     if (name.toLowerCase() === "q" || name.length === 0) {
       console.log(
-        "OK — ask an existing teammate to run `libretto experimental auth invite <your-email>` and then run `libretto experimental auth accept-invite <slug> <invitation-id>` from this machine.",
+        "OK — ask an existing teammate to run `libretto cloud auth invite <your-email>` and then run `libretto cloud auth accept-invite <slug> <invitation-id>` from this machine.",
       );
       return;
     }
@@ -293,7 +293,7 @@ export const signupCommand = SimpleCLI.command({
     console.log(`Session saved to ${authStatePath()}`);
     console.log();
     console.log("To generate an API key, run:");
-    console.log("  libretto experimental auth api-key issue --label <label>");
+    console.log("  libretto cloud auth api-key issue --label <label>");
     console.log("Then add LIBRETTO_API_KEY=<key> to your project's .env file.");
   });
 
@@ -471,7 +471,7 @@ export const inviteCommand = SimpleCLI.command({
     console.log();
     console.log("Tell them to run:");
     console.log(
-      `  libretto experimental auth accept-invite ${orgSlug} ${data.id}`,
+      `  libretto cloud auth accept-invite ${orgSlug} ${data.id}`,
     );
   });
 
@@ -530,7 +530,7 @@ export const acceptInviteCommand = SimpleCLI.command({
           [
             "You're already a member of an organization.",
             "A libretto user can only belong to one organization at a time.",
-            "To accept this invite: log out, delete the existing account, and re-run `auth accept-invite` with a new account (or a fresh email).",
+            "To accept this invite: log out, delete the existing account, and re-run `libretto cloud auth accept-invite` with a new account (or a fresh email).",
           ].join("\n"),
         );
       }
@@ -606,7 +606,7 @@ export const acceptInviteCommand = SimpleCLI.command({
     console.log();
     console.log("Email verified. You're logged in and a member of the organization.");
     console.log("To generate an API key, run:");
-    console.log("  libretto experimental auth api-key issue --label <label>");
+    console.log("  libretto cloud auth api-key issue --label <label>");
     console.log("Then add LIBRETTO_API_KEY=<key> to your project's .env file.");
   });
 
@@ -689,7 +689,7 @@ export const apiKeyRevokeCommand = SimpleCLI.command({
     SimpleCLI.input({
       positionals: [
         SimpleCLI.positional("id", z.string().min(1), {
-          help: "API key id (from `auth api-key list`).",
+          help: "API key id (from `libretto cloud auth api-key list`).",
         }),
       ],
       named: {},
@@ -712,7 +712,7 @@ export const apiKeyRevokeCommand = SimpleCLI.command({
 
     console.log(`API key ${input.id} revoked.`);
     console.log(
-      "If this key was in your .env, remove the LIBRETTO_API_KEY value and issue a new one with `auth api-key issue --label <label>`.",
+      "If this key was in your .env, remove the LIBRETTO_API_KEY value and issue a new one with `libretto cloud auth api-key issue --label <label>`.",
     );
   });
 
@@ -731,7 +731,7 @@ export const whoamiCommand = SimpleCLI.command({
 
     if (credential.source === "none") {
       console.log(
-        "Not authenticated. Run `libretto experimental auth signup`, `login`, or set LIBRETTO_API_KEY in your env.",
+        "Not authenticated. Run `libretto cloud auth signup`, `libretto cloud auth login`, or set LIBRETTO_API_KEY in your env.",
       );
       return;
     }

--- a/packages/libretto/src/cli/commands/billing.ts
+++ b/packages/libretto/src/cli/commands/billing.ts
@@ -6,8 +6,8 @@
  * them switch between any of the configured Subscription Update
  * products (Free / Pro / Team).
  *
- *   libretto experimental billing portal   → Stripe Customer Portal
- *   libretto experimental billing status   → plan + usage + period end
+ *   libretto cloud billing portal   → Stripe Customer Portal
+ *   libretto cloud billing status   → plan + usage + period end
  *
  * `libretto init` is unchanged. New tenants start on Free automatically
  * (with a real Stripe Customer + Free Subscription created at signup).

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
-import { resolveHostedApiUrl } from "../core/auth-fetch.js";
+import {
+  orpcCall,
+  resolveApiUrl,
+} from "../core/auth-fetch.js";
 import { buildHostedDeployTarball } from "../core/deploy-artifact.js";
+import { readAuthState } from "../core/auth-storage.js";
 import { SimpleCLI } from "affordance";
 
 type DeploymentStatus = "building" | "ready" | "failed";
@@ -19,37 +23,34 @@ function generateDeploymentName(): string {
   return `deploy-${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
 }
 
-function getConfig() {
-  const apiKey = process.env.LIBRETTO_API_KEY;
-
-  if (!apiKey) {
-    throw new Error(
-      "LIBRETTO_API_KEY environment variable is required.",
-    );
-  }
-
-  return { apiUrl: resolveHostedApiUrl(), apiKey };
+function deployApiKeyRequiredMessage(hasStoredSession: boolean): string {
+  return [
+    "LIBRETTO_API_KEY is required to deploy to Libretto Cloud.",
+    hasStoredSession
+      ? "A local cloud session is saved, but deploy endpoints require API-key auth."
+      : "No local cloud session was found.",
+    "  • New account: run `libretto cloud auth signup`, then verify your email.",
+    "  • Existing account: run `libretto cloud auth login`.",
+    "  • Generate a key: run `libretto cloud auth api-key issue --label <label>`.",
+    "  • Add it to your project .env file: `LIBRETTO_API_KEY=<issued-key>`.",
+  ].join("\n");
 }
 
-async function postJson(
-  apiUrl: string,
-  apiKey: string,
-  path: string,
-  input: Record<string, unknown> = {},
-): Promise<Response> {
-  return fetch(`${apiUrl}${path}`, {
-    method: "POST",
-    headers: {
-      "x-api-key": apiKey,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ json: input }),
-  });
+async function requireDeployApiKey() {
+  const stored = await readAuthState();
+  const apiUrl = resolveApiUrl(stored);
+  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error(deployApiKeyRequiredMessage(Boolean(stored?.session)));
+  }
+
+  return { apiUrl, credential: { source: "env-api-key" as const, apiKey } };
 }
 
 async function pollDeployment(
   apiUrl: string,
-  apiKey: string,
+  credential: { source: "env-api-key"; apiKey: string },
   deploymentId: string,
   pollIntervalMs: number,
   maxWaitMs: number,
@@ -68,18 +69,14 @@ async function pollDeployment(
 
     await new Promise((r) => setTimeout(r, pollIntervalMs));
 
-    const res = await postJson(apiUrl, apiKey, "/v1/deployments/sync", {
-      id: deploymentId,
+    deployment = await orpcCall<DeploymentResponse["json"]>({
+      apiUrl,
+      path: "/v1/deployments/sync",
+      input: { id: deploymentId },
+      credential,
     });
-    const body = (await res.json()) as DeploymentResponse;
-    if (res.status !== 200) {
-      throw new Error(
-        `Failed to sync deployment status (${res.status}): ${JSON.stringify(body)}`,
-      );
-    }
-    status = body.json.status;
-    workflows = body.json.workflows;
-    deployment = body.json;
+    status = deployment.status;
+    workflows = deployment.workflows;
     if (status === "ready" && readyAt === null) readyAt = Date.now();
     process.stdout.write(".");
   }
@@ -135,7 +132,7 @@ export const deployCommand = SimpleCLI.command({
 })
   .input(deployInput)
   .handle(async ({ input }) => {
-    const { apiUrl, apiKey } = getConfig();
+    const { apiUrl, credential } = await requireDeployApiKey();
     const deploymentName = generateDeploymentName();
 
     // Hosted deploy uploads a generated artifact with a deploy entrypoint and
@@ -156,20 +153,14 @@ export const deployCommand = SimpleCLI.command({
     if (input.description) createPayload.description = input.description;
 
     console.log("Uploading deployment...");
-    const res = await postJson(
+    const body = await orpcCall<DeploymentResponse["json"]>({
       apiUrl,
-      apiKey,
-      "/v1/deployments/create",
-      createPayload,
-    );
-    const body = (await res.json()) as DeploymentResponse;
-    if (res.status !== 200) {
-      throw new Error(
-        `Failed to create deployment (${res.status}): ${JSON.stringify(body)}`,
-      );
-    }
+      path: "/v1/deployments/create",
+      input: createPayload,
+      credential,
+    });
 
-    const { deployment_id, status } = body.json;
+    const { deployment_id, status } = body;
     console.log(`Deployment created: ${deployment_id}`);
     console.log(`Status: ${status}`);
 
@@ -177,7 +168,7 @@ export const deployCommand = SimpleCLI.command({
       process.stdout.write("Waiting for build");
       const deployment = await pollDeployment(
         apiUrl,
-        apiKey,
+        credential,
         deployment_id,
         10_000,
         5 * 60 * 1000,

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -24,11 +24,18 @@ function generateDeploymentName(): string {
 }
 
 function deployApiKeyRequiredMessage(hasStoredSession: boolean): string {
+  if (hasStoredSession) {
+    return [
+      "LIBRETTO_API_KEY is required to deploy to Libretto Cloud.",
+      "You are logged in locally, but deploy endpoints require API-key auth.",
+      "  • Generate a key: run `libretto cloud auth api-key issue --label <label>`.",
+      "  • Add it to your project .env file: `LIBRETTO_API_KEY=<issued-key>`.",
+    ].join("\n");
+  }
+
   return [
     "LIBRETTO_API_KEY is required to deploy to Libretto Cloud.",
-    hasStoredSession
-      ? "A local cloud session is saved, but deploy endpoints require API-key auth."
-      : "No local cloud session was found.",
+    "No local cloud session was found.",
     "  • New account: run `libretto cloud auth signup`, then verify your email.",
     "  • Existing account: run `libretto cloud auth login`.",
     "  • Generate a key: run `libretto cloud auth api-key issue --label <label>`.",

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -37,15 +37,24 @@ function deployApiKeyRequiredMessage(hasStoredSession: boolean): string {
 }
 
 async function requireDeployApiKey() {
-  const stored = await readAuthState();
-  const apiUrl = resolveApiUrl(stored);
   const apiKey = process.env.LIBRETTO_API_KEY?.trim();
 
   if (!apiKey) {
-    throw new Error(deployApiKeyRequiredMessage(Boolean(stored?.session)));
+    throw new Error(deployApiKeyRequiredMessage(await hasStoredCloudSession()));
   }
 
-  return { apiUrl, credential: { source: "env-api-key" as const, apiKey } };
+  return {
+    apiUrl: resolveApiUrl(null),
+    credential: { source: "env-api-key" as const, apiKey },
+  };
+}
+
+async function hasStoredCloudSession(): Promise<boolean> {
+  try {
+    return Boolean((await readAuthState())?.session);
+  } catch {
+    return false;
+  }
 }
 
 async function pollDeployment(

--- a/packages/libretto/src/cli/core/auth-fetch.ts
+++ b/packages/libretto/src/cli/core/auth-fetch.ts
@@ -23,8 +23,9 @@ export function resolveHostedApiUrl(): string {
  */
 export const NOT_AUTHENTICATED_MESSAGE = [
   "Not authenticated.",
-  "  • Cookie expired or never set: run `libretto experimental auth login` to refresh it.",
-  "  • Or set LIBRETTO_API_KEY in your .env (issue one with `libretto experimental auth api-key issue --label <label>` after logging in).",
+  "  • New account: run `libretto cloud auth signup`.",
+  "  • Existing account: run `libretto cloud auth login`.",
+  "  • Automation: set LIBRETTO_API_KEY in your env (issue one with `libretto cloud auth api-key issue --label <label>` after signing in).",
 ].join("\n");
 
 export type CredentialSource = "env-api-key" | "cookie" | "none";

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -12,8 +12,8 @@ import { SimpleCLI } from "affordance";
 
 export const cliRoutes = {
   ...browserCommands,
-  experimental: SimpleCLI.group({
-    description: "Experimental commands",
+  cloud: SimpleCLI.group({
+    description: "Libretto Cloud commands",
     routes: {
       deploy: deployCommand,
       auth: authCommands,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -234,6 +234,24 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).not.toContain("Bundling hosted deployment artifact");
   });
 
+  test("deploy with API key ignores broken local auth state", async ({
+    librettoCli,
+    workspaceDir,
+    workspacePath,
+  }) => {
+    await mkdir(workspacePath(".libretto"), { recursive: true });
+    await writeFile(workspacePath(".libretto", "auth.json"), "{broken", "utf8");
+
+    const result = await librettoCli("cloud deploy .", {
+      HOME: workspaceDir,
+      LIBRETTO_API_KEY: "test-key",
+    });
+
+    expect(result.stderr).toContain("No package.json found");
+    expect(result.stderr).not.toContain("LIBRETTO_API_KEY is required");
+    expect(result.stderr).not.toContain("auth.json");
+  });
+
   test("prints run help with explicit visualization disable flag", async ({
     librettoCli,
   }) => {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -234,6 +234,41 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).not.toContain("Bundling hosted deployment artifact");
   });
 
+  test("deploy requires only API key setup when already logged in", async ({
+    librettoCli,
+    workspaceDir,
+    workspacePath,
+  }) => {
+    await mkdir(workspacePath(".libretto"), { recursive: true });
+    await writeFile(
+      workspacePath(".libretto", "auth.json"),
+      JSON.stringify({
+        apiUrl: "https://api.libretto.sh",
+        session: {
+          cookie: "better-auth.session_token=test-session",
+          userId: "user-test",
+          email: "user@example.com",
+          expiresAt: null,
+        },
+      }),
+      "utf8",
+    );
+
+    const result = await librettoCli("cloud deploy .", {
+      HOME: workspaceDir,
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "You are logged in locally, but deploy endpoints require API-key auth.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
+    expect(result.stderr).toContain("LIBRETTO_API_KEY=<issued-key>");
+    expect(result.stderr).not.toContain("libretto cloud auth signup");
+    expect(result.stderr).not.toContain("libretto cloud auth login");
+    expect(result.stdout).not.toContain("Bundling hosted deployment artifact");
+  });
+
   test("deploy with API key ignores broken local auth state", async ({
     librettoCli,
     workspaceDir,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -178,8 +178,8 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("readonly-exec");
     expect(result.stdout).toContain("snapshot");
     expect(result.stdout).toContain("compact accessibility snapshot");
-    expect(result.stdout).not.toContain("cloud <subcommand>");
-    expect(result.stdout).toContain("experimental <subcommand>");
+    expect(result.stdout).toContain("cloud <subcommand>");
+    expect(result.stdout).not.toContain("experimental <subcommand>");
     expect(result.stdout).toContain("Docs (agent-friendly): https://libretto.sh/docs");
     expect(result.stderr).toBe("");
   });
@@ -200,16 +200,38 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
-  test("prints experimental group help with deploy listed under the new namespace", async ({
+  test("prints cloud group help with hosted commands", async ({
     librettoCli,
   }) => {
-    const result = await librettoCli("help experimental");
-    expect(result.stdout).toContain("Experimental commands");
+    const result = await librettoCli("help cloud");
+    expect(result.stdout).toContain("Libretto Cloud commands");
     expect(result.stdout).toContain(
-      "libretto experimental <subcommand>",
+      "libretto cloud <subcommand>",
     );
     expect(result.stdout).toContain("deploy");
+    expect(result.stdout).toContain("auth");
+    expect(result.stdout).toContain("billing");
     expect(result.stderr).toBe("");
+  });
+
+  test("deploy requires an API key and points users to signup", async ({
+    librettoCli,
+    workspaceDir,
+  }) => {
+    const result = await librettoCli("cloud deploy .", {
+      HOME: workspaceDir,
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to deploy to Libretto Cloud.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth signup");
+    expect(result.stderr).toContain("libretto cloud auth login");
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
+    expect(result.stderr).toContain("LIBRETTO_API_KEY=<issued-key>");
+    expect(result.stderr).toContain(".env");
+    expect(result.stdout).not.toContain("Bundling hosted deployment artifact");
   });
 
   test("prints run help with explicit visualization disable flag", async ({


### PR DESCRIPTION
## Summary
- Move hosted Libretto Cloud commands from `libretto experimental ...` to `libretto cloud ...`.
- Keep future experimental command support in the CLI framework while updating auth, deploy, billing, website, and docs command text.
- Make `cloud deploy` fail fast when `LIBRETTO_API_KEY` is missing, with signup/login/API-key issuance and `.env` setup guidance that matches the API-key-only deployment endpoint.
- Keep deploy API-key auth independent from local cookie auth state so a broken `~/.libretto/auth.json` cannot block API-key deploys.

## Verification
- `pnpm -s type-check`
- `pnpm -s --filter libretto build`
- `pnpm -s --filter libretto test:vitest test/basic.spec.ts`
- `pnpm -s --filter libretto test:vitest test/basic.spec.ts -t "deploy with API key ignores broken local auth state"`
- Manual built CLI checks: `help cloud`, `help cloud auth api-key`, `help cloud billing`, `help experimental` confirming the old hosted-command namespace is gone, and missing-key `cloud deploy .`

## Notes
- `pnpm -s lint` is currently blocked locally by the website lint tool requiring Node `^20.19.0 || >=22.18.0`; this shell reports Node `22.14.0`.
