### PR TITLE
Support about:blank open default

### DIFF
--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -63,8 +63,8 @@ function resolveRequestedSessionMode(
 
 export const openInput = SimpleCLI.input({
   positionals: [
-    SimpleCLI.positional("url", z.string().optional(), {
-      help: "URL to open",
+    SimpleCLI.positional("url", z.string().default("about:blank"), {
+      help: "URL to open (defaults to about:blank)",
     }),
   ],
   named: {
@@ -93,10 +93,6 @@ export const openInput = SimpleCLI.input({
   },
 })
   .refine(
-    (input) => Boolean(input.url),
-    `Usage: ${librettoCommand("open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]")}`,
-  )
-  .refine(
     (input) => !(input.headed && input.headless),
     "Cannot pass both --headed and --headless.",
   )
@@ -119,7 +115,7 @@ export const openCommand = SimpleCLI.command({
     if (providerName === "local") {
       const headed = input.headed || !input.headless;
       const viewport = parseViewportArg(input.viewport);
-      await runOpen(input.url!, headed, ctx.session, ctx.logger, {
+      await runOpen(input.url, headed, ctx.session, ctx.logger, {
         viewport,
         accessMode: resolveRequestedSessionMode(
           input.readOnly,
@@ -130,7 +126,7 @@ export const openCommand = SimpleCLI.command({
       });
     } else {
       await runOpenWithProvider(
-        input.url!,
+        input.url,
         providerName,
         ctx.session,
         ctx.logger,

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -93,7 +93,8 @@ export function normalizeUrl(url: string): URL {
   if (
     parsedUrl.protocol === "http:" ||
     parsedUrl.protocol === "https:" ||
-    parsedUrl.protocol === "file:"
+    parsedUrl.protocol === "file:" ||
+    parsedUrl.href === "about:blank"
   ) {
     return parsedUrl;
   }
@@ -103,7 +104,7 @@ export function normalizeUrl(url: string): URL {
   }
 
   throw new Error(
-    `Unsupported URL protocol: ${parsedUrl.protocol}. Use http://, https://, or file://.`,
+    `Unsupported URL protocol: ${parsedUrl.protocol}. Use http://, https://, file://, or about:blank.`,
   );
 }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -386,11 +386,10 @@ export default workflow("main", async (ctx) => {
     expect(result.stdout).toContain("libretto <command>");
   });
 
-  test("fails open with missing url usage error", async ({ librettoCli }) => {
-    const result = await librettoCli("open");
-    expect(result.stderr).toContain(
-      "libretto open <url> [--headless] [--read-only|--write-access] [--auth-profile <domain>] [--viewport WxH] [--session <name>]",
-    );
+  test("open help shows url is optional", async ({ librettoCli }) => {
+    const result = await librettoCli("open --help");
+    expect(result.stdout).toContain("open [url] [options]");
+    expect(result.stdout).toContain("URL to open (defaults to about:blank)");
   });
 
   test("session-mode prints and updates the current session mode", async ({

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { openInput } from "../src/cli/commands/browser.js";
 import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
 import { createLibrettoCloudProvider } from "../src/cli/core/providers/libretto-cloud.js";
 import { test } from "./fixtures.js";
@@ -31,9 +32,21 @@ describe("browser URL normalization", () => {
     );
   });
 
+  test("preserves about:blank", () => {
+    expect(normalizeUrl("about:blank").href).toBe("about:blank");
+  });
+
   test("normalizes www hostnames from parsed URLs", () => {
     expect(normalizeDomain(normalizeUrl("https://www.example.com/path"))).toBe(
       "example.com",
+    );
+  });
+});
+
+describe("open command input", () => {
+  test("defaults URL to about:blank", () => {
+    expect(openInput.parse({ positionals: [], named: {} }).url).toBe(
+      "about:blank",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Allow `libretto open about:blank` by accepting `about:blank` during URL normalization.
- Default `libretto open` with no URL argument to `about:blank`.
- Add tests covering the new default input, `about:blank` normalization, and optional URL help text.

## Verification
- `pnpm -s --filter libretto test:vitest test/browser.spec.ts`
- `pnpm -s --filter libretto test:vitest test/basic.spec.ts -t "open help shows url is optional"`
- `pnpm -s --filter libretto type-check`