### PR TITLE
Fix eval workspace setup

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -2,13 +2,6 @@ name: Evals
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - "package.json"
-      - "evals/**"
-      - ".github/workflows/evals.yml"
   pull_request:
     branches:
       - main
@@ -42,16 +35,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Validate eval credentials
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${OPENAI_API_KEY:-}" ]; then
-            echo "OPENAI_API_KEY secret is required to run evals." >&2
-            exit 1
-          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/benchmarks/webVoyager/runner.ts
+++ b/benchmarks/webVoyager/runner.ts
@@ -87,12 +87,9 @@ const BENCHMARK_MODEL_PROVIDER = "anthropic";
 const BENCHMARK_MODEL_ID = "claude-opus-4-6";
 const DEFAULT_GCP_PROJECT = "saffron-health";
 const DEFAULT_ANTHROPIC_SECRET_NAME = "anthropic-api-key";
-const BENCHMARK_SNAPSHOT_MODEL = "vertex/gemini-2.5-flash";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 const librettoPackageRoot = resolve(repoRoot, "packages", "libretto");
-const librettoPackageManifest = readLibrettoPackageManifest();
-const rootPackageManager = readRootPackageManager();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -125,37 +122,6 @@ function extractAssistantText(message: unknown): string {
     .trim();
 }
 
-function readLibrettoPackageManifest(): {
-  peerDependencies?: Record<string, string>;
-} {
-  try {
-    const packageJsonPath = resolve(librettoPackageRoot, "package.json");
-    return JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-      peerDependencies?: Record<string, string>;
-    };
-  } catch {
-    return {};
-  }
-}
-
-function readRootPackageManager(): string {
-  try {
-    const packageJsonPath = resolve(repoRoot, "package.json");
-    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-      packageManager?: unknown;
-    };
-    return typeof parsed.packageManager === "string"
-      ? parsed.packageManager
-      : "pnpm@9.15.4";
-  } catch {
-    return "pnpm@9.15.4";
-  }
-}
-
-function resolveSnapshotModelForBenchmarkWorkspace(): string {
-  return BENCHMARK_SNAPSHOT_MODEL;
-}
-
 function resolveBenchmarkWorkspaceProjectId(): string | null {
   return (
     process.env.GOOGLE_CLOUD_PROJECT?.trim() ||
@@ -181,38 +147,6 @@ async function writeBenchmarkWorkspaceEnvFile(runDir: string): Promise<void> {
     ].join("\n"),
     "utf8",
   );
-}
-
-function resolveProviderPackageForModel(model: string): string | null {
-  const provider = model.split("/", 1)[0]?.toLowerCase();
-  if (!provider) {
-    return null;
-  }
-
-  switch (provider) {
-    case "anthropic":
-      return "@ai-sdk/anthropic";
-    case "google":
-    case "gemini":
-      return "@ai-sdk/google";
-    case "vertex":
-      return "@ai-sdk/google-vertex";
-    case "openai":
-    case "codex":
-      return "@ai-sdk/openai";
-    default:
-      return null;
-  }
-}
-
-function resolveProviderInstallSpec(model: string): string | null {
-  const packageName = resolveProviderPackageForModel(model);
-  if (!packageName) {
-    return null;
-  }
-
-  const version = librettoPackageManifest.peerDependencies?.[packageName];
-  return version ? `${packageName}@${version}` : packageName;
 }
 
 function runWorkspaceCommand(
@@ -576,7 +510,6 @@ async function prepareRunWorkspace(
   const parentDir = resolve(repoRoot, "benchmarks", BENCHMARK_NAME, "runs");
   const runDir = resolve(parentDir, runName);
   const { text: prompt, sessionName } = buildWebVoyagerPrompt(row);
-  const snapshotModel = resolveSnapshotModelForBenchmarkWorkspace();
 
   // Clean any previous run
   await rm(runDir, { recursive: true, force: true });
@@ -585,7 +518,6 @@ async function prepareRunWorkspace(
   await createTmpWorkspace({
     name: runName,
     parentDir,
-    snapshotModel,
     skipBrowsers: true,
     skipBuild: true,
     quiet: true,
@@ -600,7 +532,6 @@ async function prepareRunWorkspace(
       "",
       "- Use the libretto skill in this workspace.",
       "- Use the local CLI via `npx libretto ...`.",
-      `- Libretto snapshot analysis is preconfigured to \`${snapshotModel}\`; do not run \`libretto ai configure\` to change it.`,
       "- Do not inspect sibling benchmark files or parent benchmark directories to discover the answer.",
       "- End with a direct final answer to the task.",
       "",

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -135,6 +135,7 @@ const here = fileURLToPath(new URL(".", import.meta.url));
 const evalsRoot = resolve(here);
 const repoRoot = resolve(evalsRoot, "..");
 const DEFAULT_EVAL_MODEL = "openai/gpt-5.5";
+const DEFAULT_OPENAI_SECRET_NAME = "libretto-test-openai-api-key";
 
 function gitSha(): string | null {
   try {
@@ -461,11 +462,85 @@ function preflightRequiredProfiles(cases: EvalCaseRecord[]): void {
   throw new Error(missing.map(missingAuthProfileMessage).join("\n\n"));
 }
 
-function formatError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
+function providerForModel(model: string): string {
+  return model.split("/", 1)[0]?.toLowerCase() || "";
+}
+
+function ensureOpenAiApiKey(): void {
+  if (process.env.OPENAI_API_KEY?.trim()) return;
+
+  const secretName =
+    process.env.LIBRETTO_EVAL_OPENAI_SECRET_NAME?.trim() ||
+    DEFAULT_OPENAI_SECRET_NAME;
+
+  try {
+    const apiKey = execFileSync(
+      "gcloud",
+      ["secrets", "versions", "access", "latest", `--secret=${secretName}`],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      },
+    ).trim();
+    if (apiKey) {
+      process.env.OPENAI_API_KEY = apiKey;
+      process.stdout.write(`Loaded OPENAI_API_KEY from GCP secret ${secretName}.\n`);
+      return;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      [
+        "OpenAI eval credentials are missing.",
+        `Tried GCP Secret Manager secret: ${secretName}`,
+        `Set OPENAI_API_KEY, grant access to ${secretName}, or set LIBRETTO_EVAL_OPENAI_SECRET_NAME to another secret name.`,
+        `Original error: ${message}`,
+      ].join("\n"),
+    );
   }
-  return String(error);
+
+  throw new Error(
+    [
+      "OpenAI eval credentials are missing.",
+      `GCP Secret Manager secret ${secretName} returned an empty value.`,
+      "Set OPENAI_API_KEY or update the secret value.",
+    ].join("\n"),
+  );
+}
+
+function ensureEvalModelCredentials(model: string): void {
+  if (providerForModel(model) === "openai") {
+    ensureOpenAiApiKey();
+  }
+}
+
+function missingApiKeyRecommendations(
+  message: string,
+  model: string | null,
+): string | null {
+  const provider = message.match(/No API key found for ([^.\s]+)\./)?.[1];
+  if (!provider) return null;
+
+  const envVar = `${provider.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
+  const selectedModel = model ?? DEFAULT_EVAL_MODEL;
+  return [
+    "Recommended next actions:",
+    `- Evals are running with model \`${selectedModel}\`, which requires credentials for \`${provider}\`.`,
+    `- For local runs, set \`${envVar}\` and rerun \`pnpm evals --no-auth\`.`,
+    `- For OpenAI evals, you can also authenticate with gcloud and grant access to the \`${DEFAULT_OPENAI_SECRET_NAME}\` Secret Manager secret.`,
+    "- To use a different provider, rerun with `pnpm evals --no-auth --model <provider/model>` and configure that provider's credentials.",
+    "- In GitHub Actions, add `OPENAI_API_KEY` as a repository secret or authenticate gcloud with access to the eval OpenAI secret.",
+  ].join("\n");
+}
+
+function formatError(error: unknown, options?: { model?: string }): string {
+  const base = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  const recommendations = missingApiKeyRecommendations(
+    base,
+    options?.model ?? null,
+  );
+  return recommendations ? `${base}\n\n${recommendations}` : base;
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {
@@ -705,7 +780,7 @@ async function runCase(
           await evalCase.run(context);
         } catch (error) {
           status = "error";
-          errorMessage = formatError(error);
+          errorMessage = formatError(error, { model });
         } finally {
           try {
             await context?.dispose();
@@ -1022,6 +1097,7 @@ async function run(options: CliOptions): Promise<number> {
     );
   }
   preflightRequiredProfiles(selectedCases);
+  ensureEvalModelCredentials(options.model);
 
   await mkdir(options.outputDir, { recursive: true });
   process.stdout.write(`Running ${selectedCases.length} eval case(s)\n`);

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -66,7 +66,6 @@ export async function createEvalContext(
     await createTmpWorkspace({
       name: workspaceName,
       parentDir: DETERMINISTIC_WORKSPACE_ROOT,
-      skipBrowsers: true,
       skipBuild: true,
       quiet: true,
     });

--- a/packages/dev-tools/src/create-tmp-workspace.ts
+++ b/packages/dev-tools/src/create-tmp-workspace.ts
@@ -4,7 +4,6 @@
  *
  * The workspace is a minimal git repo with:
  * - package.json pointing to the local libretto package
- * - libretto configured with google-vertex/gemini-2.5-flash for snapshots
  * - Playwright browsers installed
  *
  * Usage:

--- a/packages/dev-tools/src/tmp-workspace.ts
+++ b/packages/dev-tools/src/tmp-workspace.ts
@@ -5,7 +5,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 export type CreateTmpWorkspaceOptions = {
@@ -13,8 +13,6 @@ export type CreateTmpWorkspaceOptions = {
   name: string;
   /** Parent directory (default: <repoRoot>/tmp). */
   parentDir?: string;
-  /** Snapshot model (default: vertex/gemini-2.5-flash). */
-  snapshotModel?: string;
   /** Skip Playwright browser installation (default: false). */
   skipBrowsers?: boolean;
   /** Additional npm packages to install. */
@@ -58,43 +56,11 @@ function run(
   });
 }
 
-function resolveProviderPackage(model: string): string | null {
-  const provider = model.split("/", 1)[0]?.toLowerCase();
-  switch (provider) {
-    case "anthropic":
-      return "@ai-sdk/anthropic";
-    case "google":
-    case "gemini":
-      return "@ai-sdk/google";
-    case "vertex":
-      return "@ai-sdk/google-vertex";
-    case "openai":
-    case "codex":
-      return "@ai-sdk/openai";
-    default:
-      return null;
-  }
-}
-
-function resolveProviderInstallSpec(
-  model: string,
-  librettoPackageRoot: string,
-): string | null {
-  const packageName = resolveProviderPackage(model);
-  if (!packageName) return null;
-
-  const manifestPath = join(librettoPackageRoot, "package.json");
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
-  const version = manifest.peerDependencies?.[packageName];
-  return version ? `${packageName}@${version}` : packageName;
-}
-
 export async function createTmpWorkspace(
   options: CreateTmpWorkspaceOptions,
 ): Promise<string> {
   const repoRoot = findRepoRoot();
   const librettoPackageRoot = resolve(repoRoot, "packages", "libretto");
-  const snapshotModel = options.snapshotModel ?? "vertex/gemini-2.5-flash";
   const quiet = options.quiet ?? false;
   const parentDir = options.parentDir
     ? resolve(options.parentDir)
@@ -150,16 +116,12 @@ export async function createTmpWorkspace(
     "utf-8",
   );
 
-  // Install local libretto + provider package
-  const providerSpec = resolveProviderInstallSpec(
-    snapshotModel,
-    librettoPackageRoot,
-  );
+  // Install local libretto plus any caller-requested packages.
   const installArgs = [
     "add",
     "--lockfile=false",
+    "--ignore-scripts",
     `file:${librettoPackageRoot}`,
-    ...(providerSpec ? [providerSpec] : []),
     ...(options.extraPackages ?? []),
   ];
   log(`  Installing packages: pnpm ${installArgs.join(" ")}`);
@@ -176,15 +138,6 @@ export async function createTmpWorkspace(
   }
   log(`  Running npx ${setupArgs.join(" ")}...`);
   run(workspaceDir, "npx", setupArgs, quiet);
-
-  // Configure snapshot model
-  log(`  Configuring snapshot model: ${snapshotModel}`);
-  run(
-    workspaceDir,
-    "npx",
-    ["libretto", "ai", "configure", snapshotModel],
-    quiet,
-  );
 
   // Write .env with GCP project if available
   const projectId =


### PR DESCRIPTION
## Summary
- Remove automatic eval runs on `main` pushes while keeping manual dispatch and release-labeled PR runs.
- Stop temp workspaces from installing snapshot-model provider packages or running `libretto ai configure`.
- Load OpenAI eval credentials from `OPENAI_API_KEY` or the `libretto-test-openai-api-key` GCP Secret Manager secret.

## Verification
- `pnpm -s --filter @libretto/evals lint`
- `pnpm -s --filter @libretto/dev-tools type-check`
- `pnpm -s evals --no-auth -t smoke`
