### PR TITLE
Add eval browser provider option

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -41,6 +41,15 @@ pnpm evals run -t network
 pnpm evals --testNamePattern "broken selector"
 ```
 
+Run workflows against a specific browser provider:
+
+```bash
+pnpm evals --provider kernel
+pnpm evals --provider browserbase
+```
+
+The provider is written into the temporary eval workspace config for each case.
+
 Temporarily focus from code with `evalCase.only(...)`. Do not commit `.only` unless the narrowed run is intentional.
 
 Write artifacts to a specific directory:

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -41,6 +41,7 @@ type RunCliOptions = {
   fileFilters: string[];
   testNamePattern: string | null;
   model: string;
+  provider: BrowserProviderName | null;
   noAuth: boolean;
 };
 
@@ -102,6 +103,7 @@ type RunSummary = {
   totalCaseDurationMs: number;
   averageCompletedDurationMs: number | null;
   selectedModel: string;
+  selectedProvider: BrowserProviderName;
   totals: {
     cases: number;
     completed: number;
@@ -136,6 +138,28 @@ const evalsRoot = resolve(here);
 const repoRoot = resolve(evalsRoot, "..");
 const DEFAULT_EVAL_MODEL = "openai/gpt-5.5";
 const DEFAULT_OPENAI_SECRET_NAME = "libretto-test-openai-api-key";
+const BROWSER_PROVIDER_NAMES = [
+  "local",
+  "kernel",
+  "browserbase",
+  "libretto-cloud",
+] as const;
+type BrowserProviderName = (typeof BROWSER_PROVIDER_NAMES)[number];
+
+function parseBrowserProviderName(value: string): BrowserProviderName {
+  if (BROWSER_PROVIDER_NAMES.includes(value as BrowserProviderName)) {
+    return value as BrowserProviderName;
+  }
+  throw new Error(
+    `Invalid provider "${value}". Valid providers: ${BROWSER_PROVIDER_NAMES.join(", ")}`,
+  );
+}
+
+function selectedProviderName(
+  provider: BrowserProviderName | null,
+): BrowserProviderName {
+  return provider ?? "local";
+}
 
 function gitSha(): string | null {
   try {
@@ -199,7 +223,7 @@ function metricArtifactsForCase(
 function usage(): string {
   return [
     "Usage:",
-    "  pnpm evals [run] [file-filter ...] [-t <pattern>] [--output <dir>] [--model <provider/model>] [--no-auth]",
+    "  pnpm evals [run] [file-filter ...] [-t <pattern>] [--output <dir>] [--model <provider/model>] [--provider <browser-provider>] [--no-auth]",
     "  pnpm evals summary [run-dir] [--allow-empty]",
     "  pnpm evals profiles status",
     "  pnpm evals profiles login <domain>",
@@ -207,7 +231,7 @@ function usage(): string {
     "Examples:",
     "  pnpm evals",
     "  pnpm evals --no-auth",
-    "  pnpm evals run -t network --model openai/gpt-5.5",
+    "  pnpm evals run -t network --model openai/gpt-5.5 --provider kernel",
     "  pnpm evals basic.eval.ts --output temp/eval-run",
     "  pnpm evals summary",
     "  pnpm evals summary temp/eval-run",
@@ -267,6 +291,7 @@ function parseArgs(argv: string[]): CliOptions {
   let outputDir: string | null = null;
   let testNamePattern: string | null = null;
   let model = DEFAULT_EVAL_MODEL;
+  let provider: BrowserProviderName | null = null;
   let noAuth = false;
   const fileFilters: string[] = [];
 
@@ -312,6 +337,23 @@ function parseArgs(argv: string[]): CliOptions {
       if (!model) throw new Error("--model requires a provider/model value.");
       continue;
     }
+    if (arg === "--provider") {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error("--provider requires a browser provider value.");
+      }
+      provider = parseBrowserProviderName(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--provider=")) {
+      const value = arg.slice("--provider=".length);
+      if (!value) {
+        throw new Error("--provider requires a browser provider value.");
+      }
+      provider = parseBrowserProviderName(value);
+      continue;
+    }
     if (arg.startsWith("-")) {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -327,6 +369,7 @@ function parseArgs(argv: string[]): CliOptions {
     fileFilters,
     testNamePattern,
     model,
+    provider,
     noAuth,
   };
 }
@@ -707,6 +750,7 @@ function buildSummaryMarkdown(summary: RunSummary): string {
     "",
     `- Run ID: \`${summary.runId}\``,
     `- Model: \`${summary.selectedModel}\``,
+    `- Browser provider: \`${summary.selectedProvider}\``,
     `- Duration: \`${formatDuration(summary.durationMs)}\``,
     `- Total case duration: \`${formatDuration(summary.totalCaseDurationMs)}\``,
     `- Average completed case duration: \`${formatDuration(summary.averageCompletedDurationMs)}\``,
@@ -748,6 +792,7 @@ async function runCase(
   id: string,
   outputDir: string,
   model: string,
+  provider: BrowserProviderName | null,
 ): Promise<CaseResult> {
   const startedMs = Date.now();
   const startedAt = new Date(startedMs).toISOString();
@@ -776,7 +821,7 @@ async function runCase(
         takeRecordedEvalCalls();
 
         try {
-          context = await createEvalContext(evalCase, { model });
+          context = await createEvalContext(evalCase, { model, provider });
           await evalCase.run(context);
         } catch (error) {
           status = "error";
@@ -1005,6 +1050,10 @@ async function runSummary(options: SummaryCliOptions): Promise<number> {
         : null,
     selectedModel:
       typeof runRecord.selectedModel === "string" ? runRecord.selectedModel : "-",
+    selectedProvider:
+      typeof runRecord.selectedProvider === "string"
+        ? parseBrowserProviderName(runRecord.selectedProvider)
+        : "local",
     totals: {
       cases: cases.length,
       completed: completed.length,
@@ -1047,6 +1096,7 @@ async function runSelectedCases(
         id,
         options.outputDir,
         options.model,
+        options.provider,
       );
       if (result.status === "completed") {
         process.stdout.write(`✓ ${evalCase.name}\n`);
@@ -1102,6 +1152,9 @@ async function run(options: CliOptions): Promise<number> {
   await mkdir(options.outputDir, { recursive: true });
   process.stdout.write(`Running ${selectedCases.length} eval case(s)\n`);
   process.stdout.write("Execution: parallel\n");
+  process.stdout.write(
+    `Browser provider: ${selectedProviderName(options.provider)}\n`,
+  );
   process.stdout.write(`Output: ${options.outputDir}\n`);
 
   const ids = caseIds(selectedCases);
@@ -1155,6 +1208,7 @@ async function run(options: CliOptions): Promise<number> {
           )
         : null,
     selectedModel: options.model,
+    selectedProvider: selectedProviderName(options.provider),
     totals: {
       cases: results.length,
       completed,
@@ -1197,6 +1251,7 @@ async function run(options: CliOptions): Promise<number> {
     fileFilters: options.fileFilters,
     testNamePattern: options.testNamePattern,
     selectedModel: options.model,
+    selectedProvider: selectedProviderName(options.provider),
     noAuth: options.noAuth,
     totals: summary.totals,
     metrics: summary.metrics,

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { cp, mkdir, rm } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -22,6 +22,7 @@ export type EvalContext = {
 
 export type CreateEvalContextOptions = {
   model?: string;
+  provider?: string | null;
 };
 
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -53,6 +54,21 @@ function assertWithinRoot(
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function readExistingLibrettoConfig(
+  configPath: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(await readFile(configPath, "utf8")) as unknown;
+    return isRecord(parsed) ? parsed : { version: 1 };
+  } catch {
+    return { version: 1 };
+  }
+}
+
 export async function createEvalContext(
   evalCase: EvalCaseRecord,
   options: CreateEvalContextOptions = {},
@@ -76,6 +92,22 @@ export async function createEvalContext(
 
   if (evalCase.authProfile) {
     await provisionAuthProfile(evalCase.authProfile, evalWorkspaceDir);
+  }
+
+  if (options.provider) {
+    const configDir = join(evalWorkspaceDir, ".libretto");
+    const configPath = join(configDir, "config.json");
+    await mkdir(configDir, { recursive: true });
+    const config = await readExistingLibrettoConfig(configPath);
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        { ...config, version: 1, provider: options.provider },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
   }
 
   const harness = new PiEvalHarness({

--- a/opencode.json
+++ b/opencode.json
@@ -4,17 +4,5 @@
     "explore": {
       "disable": true
     }
-  },
-  "mcp": {
-    "css-studio": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "cssstudio"
-      ],
-      "enabled": true,
-      "environment": {}
-    }
   }
 }

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -765,7 +765,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: ${librettoCommand("run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH]")}`;
+const runUsage = `Usage: ${librettoCommand("run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH] [--provider <provider>]")}`;
 
 export const runInput = SimpleCLI.input({
   positionals: [

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { openInput } from "../src/cli/commands/browser.js";
 import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
+import { resolveProviderName } from "../src/cli/core/providers/index.js";
 import { createLibrettoCloudProvider } from "../src/cli/core/providers/libretto-cloud.js";
 import { test } from "./fixtures.js";
 
@@ -69,14 +70,10 @@ describe("provider resolution via CLI", () => {
     expect(result.stderr).not.toContain("Invalid provider");
   });
 
-  test("LIBRETTO_PROVIDER env var rejects invalid values", async ({
-    librettoCli,
-  }) => {
-    const result = await librettoCli("open https://example.com", {
-      LIBRETTO_PROVIDER: "invalid",
-    });
-    expect(result.stderr).toContain('Invalid provider "invalid"');
-    expect(result.stderr).toContain("LIBRETTO_PROVIDER env var");
+  test("LIBRETTO_PROVIDER env var rejects invalid values", () => {
+    vi.stubEnv("LIBRETTO_PROVIDER", "invalid");
+    expect(() => resolveProviderName()).toThrow('Invalid provider "invalid"');
+    expect(() => resolveProviderName()).toThrow("LIBRETTO_PROVIDER env var");
   });
 
   test("--provider flag overrides LIBRETTO_PROVIDER env var", async ({


### PR DESCRIPTION
## Summary
- Add `pnpm evals --provider <browser-provider>` so eval runs can target Kernel, Browserbase, Libretto Cloud, or local browsers.
- Write the selected provider into each eval workspace config while preserving existing config fields.
- Remove the CSS Studio MCP registration from `opencode.json` so Studio skills are not regenerated.

## Verification
- `pnpm -s --dir evals lint`
- `pnpm -s --filter libretto type-check`
- `pnpm -s --filter libretto lint`
- `pnpm -s --filter libretto test:vitest test/browser.spec.ts`
- `pnpm -s check:mirrors`
- `pnpm -s evals --help`
