### PR TITLE
Add forgot-password auth command

### DIFF
--- a/docs/libretto-cloud-hosting/authentication.mdx
+++ b/docs/libretto-cloud-hosting/authentication.mdx
@@ -34,6 +34,16 @@ npx libretto cloud auth login
 
 This stores a new Libretto Cloud session in `~/.libretto/auth.json`. If the account is not verified yet, the CLI re-sends the verification email.
 
+### Reset a forgotten password
+
+Use `auth forgot-password` to request a password reset email:
+
+```bash theme={null}
+npx libretto cloud auth forgot-password
+```
+
+After you choose a new password from the reset link, run `auth login` again to save a fresh local session.
+
 To clear local credentials:
 
 ```bash theme={null}

--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -375,18 +375,17 @@ export const forgotPasswordCommand = SimpleCLI.command({
   .handle(async () => {
     const apiUrl = resolveHostedApiUrl();
     const email = await prompt("Email:");
-    await betterAuthCall({
+    const result = await orpcCall<{ status: "sent" | "not_found" }>({
       apiUrl,
-      path: "/api/auth/request-password-reset",
-      input: {
-        email,
-        redirectTo: `${apiUrl}/auth/reset-password`,
-      },
+      path: "/v1/auth/requestPasswordReset",
+      input: { email },
       unauthenticated: true,
     });
-    console.log(
-      "If an account exists for that email, a password reset link has been sent.",
-    );
+    if (result.status === "not_found") {
+      console.log(`No Libretto account exists for ${email}.`);
+      return;
+    }
+    console.log(`Password reset link sent to ${email}.`);
   });
 
 // ---------------------------------------------------------------------------

--- a/packages/libretto/src/cli/commands/auth.ts
+++ b/packages/libretto/src/cli/commands/auth.ts
@@ -3,6 +3,7 @@
  *
  *   libretto cloud auth signup
  *   libretto cloud auth login
+ *   libretto cloud auth forgot-password
  *   libretto cloud auth logout
  *   libretto cloud auth invite <email> [--role member|admin|owner]
  *   libretto cloud auth accept-invite <tenantSlug> <invitationId>
@@ -365,6 +366,27 @@ export const loginCommand = SimpleCLI.command({
         );
       }
     }
+  });
+
+export const forgotPasswordCommand = SimpleCLI.command({
+  description: "Send a password reset email",
+})
+  .input(SimpleCLI.input({ positionals: [], named: {} }))
+  .handle(async () => {
+    const apiUrl = resolveHostedApiUrl();
+    const email = await prompt("Email:");
+    await betterAuthCall({
+      apiUrl,
+      path: "/api/auth/request-password-reset",
+      input: {
+        email,
+        redirectTo: `${apiUrl}/auth/reset-password`,
+      },
+      unauthenticated: true,
+    });
+    console.log(
+      "If an account exists for that email, a password reset link has been sent.",
+    );
   });
 
 // ---------------------------------------------------------------------------
@@ -762,6 +784,7 @@ export const authCommands = SimpleCLI.group({
   routes: {
     signup: signupCommand,
     login: loginCommand,
+    "forgot-password": forgotPasswordCommand,
     logout: logoutCommand,
     invite: inviteCommand,
     "accept-invite": acceptInviteCommand,


### PR DESCRIPTION
## Summary
- Adds `libretto cloud auth forgot-password`
- Calls Better Auth's password reset request endpoint
- Uses the API reset page as the reset callback target

## Verification
- `pnpm -s type-check`
- `pnpm -s build`
- `node dist/cli/index.js cloud auth --help`