### PR TITLE
Add experimental HTML search command

### DIFF
--- a/packages/libretto/src/cli/commands/search.ts
+++ b/packages/libretto/src/cli/commands/search.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { DaemonClient } from "../core/daemon/ipc.js";
 import { resolveExperiments } from "../core/experiments.js";
-import { librettoCommand } from "../../shared/package-manager.js";
 import {
   formatHtmlForSearch,
   searchFormattedHtml,
@@ -21,7 +20,7 @@ export const searchInput = SimpleCLI.input({
   },
 }).refine(
   (input) => input.pattern !== undefined,
-  `Usage: ${librettoCommand("search <regex> --session <name> [--page <id>]")}`,
+  "Usage: libretto search <regex> --session <name> [--page <id>]",
 );
 
 export const searchCommand = SimpleCLI.command({
@@ -34,14 +33,14 @@ export const searchCommand = SimpleCLI.command({
       throw new Error(
         [
           'The "search" experiment is disabled.',
-          `Enable it with: ${librettoCommand("experiments enable search")}`,
+          "Enable it with: libretto experiments enable search",
         ].join("\n"),
       );
     }
 
     if (!ctx.sessionState.daemonSocketPath) {
       throw new Error(
-        `Session "${ctx.session}" has no daemon socket. Close and reopen it with: ${librettoCommand(`open <url> --session ${ctx.session}`)}`,
+        `Session "${ctx.session}" has no daemon socket. Close and reopen it with: libretto open <url> --session ${ctx.session}`,
       );
     }
 

--- a/packages/libretto/src/cli/commands/search.ts
+++ b/packages/libretto/src/cli/commands/search.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { DaemonClient } from "../core/daemon/ipc.js";
+import { resolveExperiments } from "../core/experiments.js";
+import { librettoCommand } from "../../shared/package-manager.js";
+import {
+  formatHtmlForSearch,
+  searchFormattedHtml,
+} from "../../shared/html-search/search-html.js";
+import { pageOption, sessionOption, withRequiredSession } from "./shared.js";
+import { SimpleCLI } from "affordance";
+
+export const searchInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("pattern", z.string().optional(), {
+      help: "JavaScript regex pattern to search for in the formatted HTML snapshot",
+    }),
+  ],
+  named: {
+    session: sessionOption(),
+    page: pageOption(),
+  },
+}).refine(
+  (input) => input.pattern !== undefined,
+  `Usage: ${librettoCommand("search <regex> --session <name> [--page <id>]")}`,
+);
+
+export const searchCommand = SimpleCLI.command({
+  description: "Search the current page HTML snapshot",
+})
+  .input(searchInput)
+  .use(withRequiredSession())
+  .handle(async ({ input, ctx }) => {
+    if (!resolveExperiments().search) {
+      throw new Error(
+        [
+          'The "search" experiment is disabled.',
+          `Enable it with: ${librettoCommand("experiments enable search")}`,
+        ].join("\n"),
+      );
+    }
+
+    if (!ctx.sessionState.daemonSocketPath) {
+      throw new Error(
+        `Session "${ctx.session}" has no daemon socket. Close and reopen it with: ${librettoCommand(`open <url> --session ${ctx.session}`)}`,
+      );
+    }
+
+    const client = await DaemonClient.connect(ctx.sessionState.daemonSocketPath);
+    try {
+      const response = await client.readonlyExec({
+        code: "return await page.content()",
+        pageId: input.page,
+      });
+      if (!response.ok) {
+        throw new Error(response.message);
+      }
+      if (typeof response.data.result !== "string") {
+        throw new Error("Expected page.content() to return an HTML string.");
+      }
+
+      const formattedHtml = formatHtmlForSearch(response.data.result);
+      const matches = searchFormattedHtml(formattedHtml, input.pattern!);
+      if (matches.length === 0) {
+        console.log(`No matches for /${input.pattern}/.`);
+        return;
+      }
+
+      for (const [index, match] of matches.entries()) {
+        if (index > 0) console.log("--");
+        console.log(match.lines.join("\n"));
+      }
+    } finally {
+      client.destroy();
+    }
+  });

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -3,7 +3,6 @@ import {
   type LibrettoConfig,
   writeLibrettoConfig,
 } from "./config.js";
-import { librettoCommand } from "../../shared/package-manager.js";
 
 export type ExperimentMetadata = {
   title: string;
@@ -20,9 +19,9 @@ export const EXPERIMENTS: Readonly<Record<string, ExperimentMetadata>> = {
     docs: [
       "Adds a search command for inspecting the current page's HTML snapshot with a JavaScript regex.",
       "",
-      `Usage: ${librettoCommand("search <regex> --session <name> [--page <id>]")}`,
+      "Usage: libretto search <regex> --session <name> [--page <id>]",
       "",
-      "The command captures page HTML through read-only execution, condenses and formats it, then prints matching regions with up to five lines of surrounding context.",
+      "The command captures page HTML through read-only execution, condenses and formats it, then prints matching regions with up to four lines of surrounding context.",
     ].join("\n"),
     defaultValue: false,
   },

--- a/packages/libretto/src/cli/core/experiments.ts
+++ b/packages/libretto/src/cli/core/experiments.ts
@@ -3,6 +3,7 @@ import {
   type LibrettoConfig,
   writeLibrettoConfig,
 } from "./config.js";
+import { librettoCommand } from "../../shared/package-manager.js";
 
 export type ExperimentMetadata = {
   title: string;
@@ -11,7 +12,21 @@ export type ExperimentMetadata = {
   defaultValue: boolean;
 };
 
-export const EXPERIMENTS: Readonly<Record<string, ExperimentMetadata>> = {};
+export const EXPERIMENTS: Readonly<Record<string, ExperimentMetadata>> = {
+  search: {
+    title: "HTML Search",
+    oneSentenceDescription:
+      "Adds a search command that greps the current page's formatted HTML snapshot.",
+    docs: [
+      "Adds a search command for inspecting the current page's HTML snapshot with a JavaScript regex.",
+      "",
+      `Usage: ${librettoCommand("search <regex> --session <name> [--page <id>]")}`,
+      "",
+      "The command captures page HTML through read-only execution, condenses and formats it, then prints matching regions with up to five lines of surrounding context.",
+    ].join("\n"),
+    defaultValue: false,
+  },
+};
 
 export type ExperimentName = string;
 export type Experiments = Record<ExperimentName, boolean>;

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -7,6 +7,7 @@ import { experimentsCommand } from "./commands/experiments.js";
 import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
+import { searchCommand } from "./commands/search.js";
 import { librettoCommand } from "../shared/package-manager.js";
 import { SimpleCLI } from "affordance";
 
@@ -22,6 +23,7 @@ export const cliRoutes = {
   }),
   experiments: experimentsCommand,
   ...executionCommands,
+  search: searchCommand,
   setup: setupCommand,
   status: statusCommand,
   snapshot: snapshotCommand,

--- a/packages/libretto/src/shared/html-search/search-html.spec.ts
+++ b/packages/libretto/src/shared/html-search/search-html.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { formatHtmlForSearch, searchFormattedHtml } from "./search-html.js";
+
+describe("HTML search", () => {
+  test("formats condensed HTML before searching", () => {
+    const formatted = formatHtmlForSearch(
+      '<!doctype html><html><body><main><p data-testid="target">Needle</p></main></body></html>',
+    );
+
+    expect(formatted).toContain('<p data-testid="target">');
+    expect(formatted).toContain("Needle");
+  });
+
+  test("returns merged matching regions with context", () => {
+    const formatted = [
+      "<html>",
+      "<body>",
+      "<main>",
+      "<section>",
+      "<h1>Heading</h1>",
+      '<p class="target">Needle</p>',
+      "<p>More content</p>",
+      "</section>",
+      "</main>",
+      "</body>",
+      "</html>",
+    ].join("\n");
+
+    const matches = searchFormattedHtml(formatted, "Needle", 2);
+
+    expect(matches).toEqual([
+      {
+        startLine: 4,
+        endLine: 8,
+        lines: [
+          "<section>",
+          "<h1>Heading</h1>",
+          '<p class="target">Needle</p>',
+          "<p>More content</p>",
+          "</section>",
+        ],
+      },
+    ]);
+  });
+
+  test("limits matching regions before adding context", () => {
+    const formatted = Array.from(
+      { length: 12 },
+      (_value, index) => `<p>Needle ${index}</p>`,
+    ).join("\n");
+
+    const matches = searchFormattedHtml(formatted, "Needle", 0, 8);
+
+    expect(matches).toEqual([
+      {
+        startLine: 1,
+        endLine: 8,
+        lines: Array.from(
+          { length: 8 },
+          (_value, index) => `<p>Needle ${index}</p>`,
+        ),
+      },
+    ]);
+  });
+});

--- a/packages/libretto/src/shared/html-search/search-html.ts
+++ b/packages/libretto/src/shared/html-search/search-html.ts
@@ -1,0 +1,75 @@
+import { condenseDom } from "../condense-dom/condense-dom.js";
+
+const DEFAULT_CONTEXT_LINES = 4;
+const DEFAULT_MATCH_LIMIT = 8;
+
+export type SearchHtmlMatch = {
+  startLine: number;
+  endLine: number;
+  lines: string[];
+};
+
+export function formatHtmlForSearch(html: string): string {
+  const condensed = condenseDom(html).html;
+  const separated = condensed
+    .replace(/>\s+</g, ">\n<")
+    .replace(/(<[^/!][^>]*>)([^<\n][\s\S]*?)(<\/[^>]+>)/g, "$1\n$2\n$3");
+
+  const lines = separated
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let indent = 0;
+  return lines
+    .map((line) => {
+      if (/^<\//.test(line)) indent = Math.max(0, indent - 1);
+      const formatted = `${"  ".repeat(indent)}${line}`;
+      if (isOpeningTag(line)) indent += 1;
+      return formatted;
+    })
+    .join("\n");
+}
+
+export function searchFormattedHtml(
+  formattedHtml: string,
+  pattern: string,
+  contextLines = DEFAULT_CONTEXT_LINES,
+  matchLimit = DEFAULT_MATCH_LIMIT,
+): SearchHtmlMatch[] {
+  const regex = new RegExp(pattern);
+  const lines = formattedHtml.split("\n");
+  const matchingIndexes = lines
+    .map((line, index) => (regex.test(line) ? index : -1))
+    .filter((index) => index >= 0)
+    .slice(0, matchLimit);
+
+  const matches: SearchHtmlMatch[] = [];
+  for (const matchingIndex of matchingIndexes) {
+    const startLine = Math.max(0, matchingIndex - contextLines);
+    const endLine = Math.min(lines.length - 1, matchingIndex + contextLines);
+    const previous = matches.at(-1);
+    if (previous && startLine <= previous.endLine + 1) {
+      previous.endLine = Math.max(previous.endLine, endLine + 1);
+      previous.lines = lines.slice(previous.startLine - 1, previous.endLine);
+      continue;
+    }
+    matches.push({
+      startLine: startLine + 1,
+      endLine: endLine + 1,
+      lines: lines.slice(startLine, endLine + 1),
+    });
+  }
+  return matches;
+}
+
+function isOpeningTag(line: string): boolean {
+  return (
+    /^<[^/!?][^>]*>$/.test(line) &&
+    !/\/>$/.test(line) &&
+    !/^<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b/i.test(
+      line,
+    ) &&
+    !/^<[^>]+>.*<\/[^>]+>$/.test(line)
+  );
+}

--- a/packages/libretto/src/shared/html-search/search-html.ts
+++ b/packages/libretto/src/shared/html-search/search-html.ts
@@ -49,7 +49,7 @@ export function searchFormattedHtml(
     const startLine = Math.max(0, matchingIndex - contextLines);
     const endLine = Math.min(lines.length - 1, matchingIndex + contextLines);
     const previous = matches.at(-1);
-    if (previous && startLine <= previous.endLine + 1) {
+    if (previous && startLine <= previous.endLine) {
       previous.endLine = Math.max(previous.endLine, endLine + 1);
       previous.lines = lines.slice(previous.startLine - 1, previous.endLine);
       continue;

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -326,12 +326,25 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
-  test("experiments reports no registered experiments", async ({
+  test("experiments reports registered experiment status", async ({
     librettoCli,
   }) => {
     const initial = await librettoCli("experiments");
     expect(initial.stdout).toContain("Libretto experiments:");
+    expect(initial.stdout).toContain("search: disabled");
     expect(initial.stderr).toBe("");
+  });
+
+  test("search points users to its experiment flag when disabled", async ({
+    librettoCli,
+    seedSessionState,
+  }) => {
+    const session = "search-disabled";
+    await seedSessionState({ session });
+
+    const result = await librettoCli(`search Needle --session ${session}`);
+    expect(result.stderr).toContain('The "search" experiment is disabled.');
+    expect(result.stderr).toContain("libretto experiments enable search");
   });
 
   test("experiments rejects missing and unknown experiment names with usage", async ({

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -339,6 +339,37 @@ throw new Error('expected late exec failure');
     expect(result.stdout).toContain("snapshot <ref> --session");
   }, 45_000);
 
+  test("experimental search prints matching HTML context", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-search";
+    const url = await writeFixturePage(
+      workspacePath,
+      "search",
+      "Search Test",
+      [
+        "<main>",
+        "<h1>Search Heading</h1>",
+        '<section data-testid="billing-card">',
+        "<p>Invoice total is ready</p>",
+        "</section>",
+        "</main>",
+      ].join(""),
+    );
+    await librettoCli("experiments enable search");
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const result = await librettoCli(
+      `search "billing-card|Invoice total" --session ${session}`,
+    );
+
+    expect(result.stdout).toContain('data-testid="billing-card"');
+    expect(result.stdout).toContain("Invoice total is ready");
+    expect(result.stdout).not.toContain("Lines ");
+    expect(result.stderr).toBe("");
+  }, 45_000);
+
   test("compact snapshot ref uses cached full snapshot and scopes output", async ({
     librettoCli,
     workspacePath,


### PR DESCRIPTION
## Summary
- add a disabled-by-default `search` experiment and top-level `search` CLI command
- capture page HTML through readonly daemon execution, condense/format it, and regex-search with four lines of context
- cap search output at the first eight matching lines and omit line numbers for cleaner agent use

## Testing
- `pnpm -s --dir packages/libretto test:vitest src/shared/html-search/search-html.spec.ts`
- `pnpm -s --dir packages/libretto test:vitest test/daemon-ipc.spec.ts -t "experimental search"`
- `pnpm -s type-check`
