### PR TITLE
Add Zod input/output schemas to workflow() + publish:experimental script

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -142,6 +142,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ### `run`
 
 - Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
+- The hosted platform extracts both schemas at build time and exposes them via `POST /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -6,25 +6,27 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Import `workflow` and its types from `"libretto"`:
+Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+
+Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
 ```typescript
+import { z } from "zod";
 import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
 
-type Input = {
-  // Define the expected input shape — passed via --params JSON
-  query: string;
-  maxResults?: number;
-};
+const inputSchema = z.object({
+  query: z.string(),
+  maxResults: z.number().int().positive().optional(),
+});
 
-type Output = {
-  // Define what the workflow returns
-  results: Array<{ name: string; value: string }>;
-};
+const outputSchema = z.object({
+  results: z.array(z.object({ name: z.string(), value: z.string() })),
+});
 
-export default workflow<Input, Output>(
+export default workflow(
   "myWorkflow",
-  async (ctx: LibrettoWorkflowContext, input): Promise<Output> => {
+  { input: inputSchema, output: outputSchema },
+  async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
@@ -38,10 +40,12 @@ export default workflow<Input, Output>(
 
 Key points:
 
-- `workflow(name, handler)` takes a unique workflow name and returns the workflow object that Libretto can run.
+- `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
+- At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
+- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
-- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
+- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.
 - After validation is complete and the workflow is confirmed working end to end, remove all `pause()` calls and pause-only workflow params unless the user explicitly says to keep them.
 - The browser is launched and closed automatically by the CLI. Do not launch or close it in the handler.

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -142,6 +142,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ### `run`
 
 - Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
+- The hosted platform extracts both schemas at build time and exposes them via `POST /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -6,25 +6,27 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Import `workflow` and its types from `"libretto"`:
+Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+
+Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
 ```typescript
+import { z } from "zod";
 import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
 
-type Input = {
-  // Define the expected input shape — passed via --params JSON
-  query: string;
-  maxResults?: number;
-};
+const inputSchema = z.object({
+  query: z.string(),
+  maxResults: z.number().int().positive().optional(),
+});
 
-type Output = {
-  // Define what the workflow returns
-  results: Array<{ name: string; value: string }>;
-};
+const outputSchema = z.object({
+  results: z.array(z.object({ name: z.string(), value: z.string() })),
+});
 
-export default workflow<Input, Output>(
+export default workflow(
   "myWorkflow",
-  async (ctx: LibrettoWorkflowContext, input): Promise<Output> => {
+  { input: inputSchema, output: outputSchema },
+  async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
@@ -38,10 +40,12 @@ export default workflow<Input, Output>(
 
 Key points:
 
-- `workflow(name, handler)` takes a unique workflow name and returns the workflow object that Libretto can run.
+- `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
+- At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
+- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
-- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
+- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.
 - After validation is complete and the workflow is confirmed working end to end, remove all `pause()` calls and pause-only workflow params unless the user explicitly says to keep them.
 - The browser is launched and closed automatically by the CLI. Do not launch or close it in the handler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ pnpm -s cli
 
 ## **FORBIDDEN** Actions
 
-- NEVER manually edit the `version` field in `packages/libretto/package.json`. Use `pnpm prepare-release`.
+- For stable releases on `main`: NEVER manually edit the `version` field in `packages/libretto/package.json`. Use `pnpm prepare-release` — that script opens a release PR, and CI publishes to npm under the `latest` dist-tag on merge.
+- For experimental pre-releases (e.g. validating a new API on a downstream consumer before promoting it to a stable release): manually edit `packages/libretto/package.json` `version` to a pre-release identifier like `0.6.16-experimental-<feature>.0`, then run `pnpm publish:experimental` from this repo root. That script derives the npm dist-tag from the pre-release identifier (between `-` and `.N`) and publishes locally — it does NOT touch `main` and does NOT use the GitHub Actions release workflow. Refuses to publish if the version isn't a pre-release.
 - NEVER hand-edit mirrored files in `.agents/skills/` or `.claude/skills/`. Edit the source in `packages/libretto/skills/` and run `pnpm sync:mirrors`.
 - NEVER run `pnpm build` just to type-check. Use `pnpm type-check` instead.
 - NEVER use `git add -A` or `git add .` — only stage the files you changed.

--- a/docs/libretto-cloud-api/deployments-and-workflows.mdx
+++ b/docs/libretto-cloud-api/deployments-and-workflows.mdx
@@ -100,7 +100,7 @@ Each `in_progress_builds` entry includes:
 
 #### POST `/v1/workflows/get`
 
-Return the deployment backing a single workflow name.
+Return the deployment backing a single workflow name, plus the JSON Schemas derived from the workflow's Zod input/output schemas.
 
 Request fields:
 
@@ -115,6 +115,42 @@ Response fields:
 - `deployment_built_at`
 - `created_at`
 - `updated_at`
+- `input_schema`: JSON Schema (Draft 2020-12) serialized from the workflow's Zod input schema at build time. `null` when the workflow was built without Zod schemas — either a pre-Zod-support deployment or a workflow that uses the 2-arg `workflow(name, handler)` form.
+- `output_schema`: JSON Schema serialized from the workflow's Zod output schema. `null` under the same conditions as `input_schema`.
+
+Example response for a Zod-schema workflow:
+
+```json
+{
+  "json": {
+    "workflow": "getExampleTitleAndUrl",
+    "deployment_id": "062874fc-4714-4bd5-932f-0ae61ed8d0f6",
+    "deployment_status": "ready",
+    "deployment_created_at": "2026-05-17T01:15:26.670Z",
+    "deployment_built_at": "2026-05-17T01:17:08.730Z",
+    "created_at": "2026-05-17T01:15:28.167Z",
+    "updated_at": "2026-05-17T01:17:31.314Z",
+    "input_schema": {
+      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "url": { "type": "string", "format": "uri" }
+      },
+      "additionalProperties": false
+    },
+    "output_schema": {
+      "type": "object",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": ["title", "currentUrl"],
+      "properties": {
+        "title": { "type": "string" },
+        "currentUrl": { "type": "string", "format": "uri" }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
 
 #### POST `/v1/workflows/delete`
 

--- a/docs/libretto-cloud-api/deployments-and-workflows.mdx
+++ b/docs/libretto-cloud-api/deployments-and-workflows.mdx
@@ -115,8 +115,8 @@ Response fields:
 - `deployment_built_at`
 - `created_at`
 - `updated_at`
-- `input_schema`: JSON Schema (Draft 2020-12) serialized from the workflow's Zod input schema at build time. `null` when the workflow was built without Zod schemas — either a pre-Zod-support deployment or a workflow that uses the 2-arg `workflow(name, handler)` form.
-- `output_schema`: JSON Schema serialized from the workflow's Zod output schema. `null` under the same conditions as `input_schema`.
+- `input_schema`: JSON Schema (Draft 2020-12) serialized from the workflow's Zod input schema at build time. `null` for legacy deployments built before Zod-schema workflows were supported.
+- `output_schema`: JSON Schema serialized from the workflow's Zod output schema. `null` for legacy deployments.
 
 Example response for a Zod-schema workflow:
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "type-check": "turbo run type-check",
     "test": "turbo run test:vitest --log-order=grouped",
     "prepare-release": "bash ./scripts/prepare-release.sh",
+    "publish:experimental": "bash ./scripts/publish-experimental.sh",
     "evals": "node evals/run.mjs",
     "benchmarks": "turbo run benchmarks --filter=@libretto/benchmarks --",
     "google-login": "gcloud auth login --update-adc && gcloud auth configure-docker us-central1-docker.pkg.dev --quiet",

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -142,6 +142,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ### `run`
 
 - Use `run` to verify a workflow file after creating it or editing it. Use the same headed or headless mode for validation that the workflow run is already using.
+- Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Plain `run` defaults to headed mode. Do not use `--headless` unless the user asks for headless mode or the existing workflow run already uses it.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
+- The hosted platform extracts both schemas at build time and exposes them via `POST /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -6,25 +6,27 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Import `workflow` and its types from `"libretto"`:
+Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+
+Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
 ```typescript
+import { z } from "zod";
 import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
 
-type Input = {
-  // Define the expected input shape — passed via --params JSON
-  query: string;
-  maxResults?: number;
-};
+const inputSchema = z.object({
+  query: z.string(),
+  maxResults: z.number().int().positive().optional(),
+});
 
-type Output = {
-  // Define what the workflow returns
-  results: Array<{ name: string; value: string }>;
-};
+const outputSchema = z.object({
+  results: z.array(z.object({ name: z.string(), value: z.string() })),
+});
 
-export default workflow<Input, Output>(
+export default workflow(
   "myWorkflow",
-  async (ctx: LibrettoWorkflowContext, input): Promise<Output> => {
+  { input: inputSchema, output: outputSchema },
+  async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
@@ -38,10 +40,12 @@ export default workflow<Input, Output>(
 
 Key points:
 
-- `workflow(name, handler)` takes a unique workflow name and returns the workflow object that Libretto can run.
+- `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
+- At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
+- The hosted platform extracts both schemas at build time and exposes them via `GET /v1/workflows/get`, so API consumers can introspect the shape of any deployed workflow.
 - `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
-- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI
+- `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.
 - After validation is complete and the workflow is confirmed working end to end, remove all `pause()` calls and pause-only workflow params unless the user explicitly says to keep them.
 - The browser is launched and closed automatically by the CLI. Do not launch or close it in the handler.

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -98,11 +98,13 @@ export {
   getWorkflowsFromModuleExports,
   isLibrettoWorkflow,
   LibrettoWorkflow,
+  LibrettoWorkflowInputError,
   LIBRETTO_WORKFLOW_BRAND,
   workflow,
   type ExportedLibrettoWorkflow,
   type LibrettoWorkflowContext,
   type LibrettoWorkflowHandler,
+  type LibrettoWorkflowSchemas,
 } from "./shared/workflow/workflow.js";
 const isDirectExecution = (): boolean => {
   const entryArg = process.argv[1];

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { z } from "zod";
 
 export const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
@@ -12,24 +13,98 @@ export type LibrettoWorkflowHandler<Input = unknown, Output = unknown> = (
   input: Input,
 ) => Promise<Output>;
 
-export class LibrettoWorkflow<Input = unknown, Output = unknown> {
+export type LibrettoWorkflowSchemas<
+  InputSchema extends z.ZodType,
+  OutputSchema extends z.ZodType,
+> = {
+  input: InputSchema;
+  output: OutputSchema;
+};
+
+// Thrown when input fails Zod validation. The runner surfaces `.message`
+// directly to the user, so we format issues into a single readable block.
+export class LibrettoWorkflowInputError extends Error {
+  public readonly workflowName: string;
+  public readonly zodError: z.ZodError;
+
+  constructor(workflowName: string, zodError: z.ZodError) {
+    super(formatZodErrorMessage(workflowName, zodError));
+    this.name = "LibrettoWorkflowInputError";
+    this.workflowName = workflowName;
+    this.zodError = zodError;
+  }
+}
+
+function formatZodErrorMessage(
+  workflowName: string,
+  zodError: z.ZodError,
+): string {
+  const lines = zodError.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    return `  - ${path}: ${issue.message}`;
+  });
+  return [
+    `Invalid input for workflow "${workflowName}":`,
+    ...lines,
+  ].join("\n");
+}
+
+export class LibrettoWorkflow<
+  InputSchema extends z.ZodType = z.ZodType<unknown>,
+  OutputSchema extends z.ZodType = z.ZodType<unknown>,
+> {
   public readonly [LIBRETTO_WORKFLOW_BRAND] = true;
   public readonly name: string;
-  private readonly handler: LibrettoWorkflowHandler<Input, Output>;
+  // Optional so the legacy 2-arg `workflow(name, handler)` form still works
+  // for deployments that were built before Zod schemas were a thing.
+  public readonly inputSchema?: InputSchema;
+  // Metadata only — `run()` validates `input` against `inputSchema` but does
+  // not parse the handler's return value. The hosted platform serializes
+  // this schema to JSON Schema at build time and exposes it via
+  // /v1/workflows/get so API consumers know the workflow's output shape.
+  public readonly outputSchema?: OutputSchema;
+  private readonly handler: LibrettoWorkflowHandler<
+    z.infer<InputSchema>,
+    z.infer<OutputSchema>
+  >;
 
-  constructor(name: string, handler: LibrettoWorkflowHandler<Input, Output>) {
+  constructor(
+    name: string,
+    schemas: LibrettoWorkflowSchemas<InputSchema, OutputSchema> | undefined,
+    handler: LibrettoWorkflowHandler<
+      z.infer<InputSchema>,
+      z.infer<OutputSchema>
+    >,
+  ) {
     this.name = name;
+    this.inputSchema = schemas?.input;
+    this.outputSchema = schemas?.output;
     this.handler = handler;
   }
 
-  async run(ctx: LibrettoWorkflowContext, input: Input): Promise<Output> {
-    return this.handler(ctx, input);
+  async run(
+    ctx: LibrettoWorkflowContext,
+    input: unknown,
+  ): Promise<z.infer<OutputSchema>> {
+    let parsed: z.infer<InputSchema>;
+    if (this.inputSchema) {
+      const result = this.inputSchema.safeParse(input);
+      if (!result.success) {
+        throw new LibrettoWorkflowInputError(this.name, result.error);
+      }
+      parsed = result.data;
+    } else {
+      parsed = input as z.infer<InputSchema>;
+    }
+    return this.handler(ctx, parsed);
   }
 }
 
 export type ExportedLibrettoWorkflow = {
   readonly [LIBRETTO_WORKFLOW_BRAND]: true;
   readonly name: string;
+  readonly inputSchema?: z.ZodType;
+  readonly outputSchema?: z.ZodType;
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
 
@@ -120,9 +195,41 @@ export function getWorkflowFromModuleExports(
   return null;
 }
 
+// Recommended 3-arg form: pass Zod schemas so input is validated at run time
+// and the hosted platform can expose typed I/O metadata via /v1/workflows/get.
+export function workflow<
+  InputSchema extends z.ZodType,
+  OutputSchema extends z.ZodType,
+>(
+  name: string,
+  schemas: LibrettoWorkflowSchemas<InputSchema, OutputSchema>,
+  handler: LibrettoWorkflowHandler<
+    z.infer<InputSchema>,
+    z.infer<OutputSchema>
+  >,
+): LibrettoWorkflow<InputSchema, OutputSchema>;
+
+// Legacy 2-arg form kept so deployments built before Zod schemas existed
+// continue to load. New code should always pass schemas.
 export function workflow<Input = unknown, Output = unknown>(
   name: string,
   handler: LibrettoWorkflowHandler<Input, Output>,
-): LibrettoWorkflow<Input, Output> {
-  return new LibrettoWorkflow(name, handler);
+): LibrettoWorkflow<z.ZodType<Input>, z.ZodType<Output>>;
+
+export function workflow(
+  name: string,
+  schemasOrHandler:
+    | LibrettoWorkflowSchemas<z.ZodType, z.ZodType>
+    | LibrettoWorkflowHandler,
+  maybeHandler?: LibrettoWorkflowHandler,
+): LibrettoWorkflow {
+  if (typeof schemasOrHandler === "function") {
+    return new LibrettoWorkflow(name, undefined, schemasOrHandler);
+  }
+  if (!maybeHandler) {
+    throw new Error(
+      `workflow("${name}") called with schemas but no handler. Pass the handler as the third argument.`,
+    );
+  }
+  return new LibrettoWorkflow(name, schemasOrHandler, maybeHandler);
 }

--- a/packages/libretto/test/workflow-zod-schema.spec.ts
+++ b/packages/libretto/test/workflow-zod-schema.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { Page } from "playwright";
+
+import {
+  LibrettoWorkflowInputError,
+  workflow,
+} from "../src/shared/workflow/workflow.js";
+
+// The Page methods touched by these tests are never actually called — we only
+// need `.run()` to type-check, and validation rejects bad input before the
+// handler runs. Cast through unknown to dodge Playwright's huge surface area.
+const fakePage = {} as unknown as Page;
+const fakeCtx = { session: "test-session", page: fakePage };
+
+describe("workflow() with Zod schemas", () => {
+  const inputSchema = z.object({
+    url: z.string().url(),
+    shouldFail: z.boolean().optional(),
+  });
+  const outputSchema = z.object({
+    pageTitle: z.string(),
+    finalUrl: z.string(),
+  });
+
+  it("exposes the schemas on the workflow object so the build manifest can serialize them", () => {
+    const wf = workflow(
+      "exposes",
+      { input: inputSchema, output: outputSchema },
+      async (_ctx, input) => ({
+        pageTitle: "x",
+        finalUrl: input.url,
+      }),
+    );
+
+    expect(wf.inputSchema).toBe(inputSchema);
+    expect(wf.outputSchema).toBe(outputSchema);
+  });
+
+  it("passes parsed input through to the handler when input is valid", async () => {
+    const wf = workflow(
+      "valid",
+      { input: inputSchema, output: outputSchema },
+      async (_ctx, input) => ({
+        pageTitle: "ok",
+        finalUrl: input.url,
+      }),
+    );
+
+    const result = await wf.run(fakeCtx, {
+      url: "https://example.com",
+    });
+    expect(result).toEqual({ pageTitle: "ok", finalUrl: "https://example.com" });
+  });
+
+  it("throws LibrettoWorkflowInputError with a field-by-field message when input is invalid", async () => {
+    let handlerCalled = false;
+    const wf = workflow(
+      "invalid",
+      { input: inputSchema, output: outputSchema },
+      async () => {
+        handlerCalled = true;
+        return { pageTitle: "should not run", finalUrl: "" };
+      },
+    );
+
+    // Missing required `url`.
+    await expect(wf.run(fakeCtx, { shouldFail: true })).rejects.toMatchObject({
+      name: "LibrettoWorkflowInputError",
+      workflowName: "invalid",
+    });
+    expect(handlerCalled).toBe(false);
+
+    // The error message names the workflow and lists the failing field so a
+    // user can see exactly what went wrong.
+    try {
+      await wf.run(fakeCtx, { shouldFail: "not a boolean" });
+      throw new Error("expected validation error");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LibrettoWorkflowInputError);
+      const msg = (err as LibrettoWorkflowInputError).message;
+      expect(msg).toContain('Invalid input for workflow "invalid"');
+      expect(msg).toContain("url");
+      expect(msg).toContain("shouldFail");
+    }
+  });
+
+  it("still accepts the legacy 2-arg form so old deployed bundles keep loading", async () => {
+    const wf = workflow("legacy", async (_ctx, input) => {
+      return { echoed: input };
+    });
+
+    expect(wf.inputSchema).toBeUndefined();
+    expect(wf.outputSchema).toBeUndefined();
+
+    const result = await wf.run(fakeCtx, { anything: "goes" });
+    expect(result).toEqual({ echoed: { anything: "goes" } });
+  });
+});

--- a/scripts/publish-experimental.sh
+++ b/scripts/publish-experimental.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   1. Manually edit packages/libretto/package.json `version` to a pre-release
-#      identifier, e.g. "0.6.16-experimental-zod.0". The pre-release identifier
+#      identifier, e.g. "0.6.16-experimental-zod.1". The pre-release identifier
 #      (the bit between "-" and ".N") becomes the npm dist-tag.
 #   2. Run `pnpm publish:experimental` from the libretto repo root.
 #
@@ -26,7 +26,7 @@ version="$(node -p "require('./${package_json_path}').version")"
 if [[ ! "$version" =~ -([^.]+)\.[0-9]+$ ]]; then
   echo "Refusing to publish: version '${version}' is not a pre-release." >&2
   echo "Manually set packages/libretto/package.json version to something like" >&2
-  echo "  0.6.16-experimental-zod.0" >&2
+  echo "  0.6.16-experimental-zod.1" >&2
   echo "before running this script, or use 'pnpm prepare-release' for stable releases." >&2
   exit 1
 fi

--- a/scripts/publish-experimental.sh
+++ b/scripts/publish-experimental.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Publish an experimental pre-release of libretto from this machine.
+#
+# Usage:
+#   1. Manually edit packages/libretto/package.json `version` to a pre-release
+#      identifier, e.g. "0.6.16-experimental-zod.0". The pre-release identifier
+#      (the bit between "-" and ".N") becomes the npm dist-tag.
+#   2. Run `pnpm publish:experimental` from the libretto repo root.
+#
+# Stable releases (no pre-release suffix) MUST go through `pnpm prepare-release`
+# instead — this script will refuse to publish a non-pre-release version because
+# that would overwrite the `latest` dist-tag without going through the normal
+# release PR + CI flow.
+set -euo pipefail
+
+package_json_path="packages/libretto/package.json"
+package_dir="packages/libretto"
+
+if [ ! -f "$package_json_path" ]; then
+  echo "Run this script from the libretto repo root (cannot find ${package_json_path})." >&2
+  exit 1
+fi
+
+version="$(node -p "require('./${package_json_path}').version")"
+
+if [[ ! "$version" =~ -([^.]+)\.[0-9]+$ ]]; then
+  echo "Refusing to publish: version '${version}' is not a pre-release." >&2
+  echo "Manually set packages/libretto/package.json version to something like" >&2
+  echo "  0.6.16-experimental-zod.0" >&2
+  echo "before running this script, or use 'pnpm prepare-release' for stable releases." >&2
+  exit 1
+fi
+dist_tag="${BASH_REMATCH[1]}"
+
+echo "Publishing libretto@${version} under dist-tag '${dist_tag}'."
+
+# Build the package so dist/ is fresh (npm publish ships dist/).
+pnpm --filter libretto build
+
+(
+  cd "$package_dir"
+  # --otp is requested interactively by npm if 2FA is enabled. If you have it
+  # ready, run with NPM_CONFIG_OTP=<code> pnpm publish:experimental.
+  npm publish --access public --tag "$dist_tag"
+)
+
+echo
+echo "Published libretto@${version} (dist-tag: ${dist_tag})."
+echo "Consumers can pin to it with:"
+echo "  \"libretto\": \"${version}\""
+echo "or install the latest experimental with:"
+echo "  npm install libretto@${dist_tag}"


### PR DESCRIPTION
## Summary

- Adds a Zod-required `workflow(name, { input, output }, handler)` form. Input is validated against the schema at runtime; bad input throws `LibrettoWorkflowInputError` with a field-by-field message. Handler's `input` parameter is inferred from `z.infer<typeof inputSchema>`.
- Preserves the legacy 2-arg `workflow(name, handler)` form so already-deployed bundles keep loading after the executor upgrades. The new behavior is opt-in.
- Surfaces `inputSchema` / `outputSchema` on the exported workflow object so downstream platforms (browser-automations) can serialize them with `z.toJSONSchema()` and surface typed I/O metadata via their own APIs.
- Adds `pnpm publish:experimental` (script in `scripts/publish-experimental.sh`) for trying unreleased library changes on a downstream consumer without going through the GitHub Actions release flow. Refuses to publish if the version isn't a pre-release; derives the npm dist-tag from the pre-release identifier so pre-releases never overwrite `latest`.
- AGENTS.md updated to reflect the stable-vs-experimental publishing policy.

## Already published

The first experimental cut was published from this branch to npm before opening this PR:

- `libretto@0.6.16-experimental-zod.0` under the `experimental-zod` dist-tag (`latest` is still `0.6.15`).

The browser-automations companion PR pins to this exact version for staging validation. This PR does **not** bump the version in `package.json` — that's part of the local publish flow, not part of the merge.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm test` (200 passed, 1 skipped) — includes 4 new tests in `test/workflow-zod-schema.spec.ts` covering schema attachment, valid-input pass-through, invalid-input ZodError message, and legacy 2-arg compatibility
- [x] End-to-end smoke: `libretto run` of a Zod-schema workflow rejects bad params with the expected per-field error and runs cleanly with valid params
- [x] End-to-end smoke: legacy 2-arg workflow still runs unchanged
- [x] `pnpm publish:experimental` published `libretto@0.6.16-experimental-zod.0` to npm under the `experimental-zod` dist-tag (latest unaffected)
- [ ] Staging validation against the browser-automations companion PR (workflowBuild emits Zod-schema workflows; bad input gets clear Zod error; legacy deployments still run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)