### PR TITLE
Update website prompt copy CTA

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -4,10 +4,10 @@ import {
   useKonamiPane,
   KonamiOverlay,
 } from "./components/CanvasAsciihedron";
-import { Button } from "./components/Button";
 import { Text } from "./components/Text";
 import { TerminalDemo } from "./components/TerminalDemo";
 import { InstallSnippet } from "./components/InstallSnippet";
+import { AppLink } from "./routing";
 import {
   OrchestrationContainer,
   AnimationTarget,
@@ -104,9 +104,17 @@ function Hero({
           reverse-engineer APIs and build fast, cheap, and reliable automation
           scripts
         </Text>
-        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }} className="mb-16 flex flex-wrap items-center justify-center gap-6">
+        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }} className="mb-16 flex flex-col items-center justify-center gap-3">
           <InstallSnippet />
-          <Button href="/docs/get-started/quickstart" variant="secondary">Go to docs</Button>
+          <div className="text-xs text-muted">
+            or{" "}
+            <AppLink
+              href="/docs/get-started/quickstart"
+              className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
+            >
+              go to docs
+            </AppLink>
+          </div>
         </div>
         <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
           <TerminalDemo />

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -80,7 +80,7 @@ function Hero({
           as="h1"
           size="5xl"
           style="serif"
-          className="crt-glow mx-auto mb-8 max-w-[1000px] text-center tracking-[-0.04em] text-ink [text-wrap:balance]"
+          className="crt-glow mx-auto mb-8 max-w-[720px] text-center tracking-[-0.04em] text-ink [text-wrap:balance]"
         >
           <AnimatedTitle
             className=""
@@ -90,7 +90,7 @@ function Hero({
               lineHeight: 1.05,
             }}
           >
-            Don't make browser agents do a script's job
+            Turn website workflows into reliable APIs
           </AnimatedTitle>
         </Text>
         <Text
@@ -98,11 +98,10 @@ function Hero({
           size="lg"
           data-animate={AnimationTarget.Content}
           htmlStyle={{ opacity: 0 }}
-          className="mx-auto mb-8 max-w-[580px] text-center leading-relaxed text-muted [text-wrap:balance]"
+          className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:balance]"
         >
-          Libretto is a CLI that lets coding agents inspect web pages,
-          reverse-engineer APIs and build fast, cheap, and reliable automation
-          scripts
+          Libretto is an open-source CLI that lets agents turn website
+          workflows into fast, reusable scripts you can deploy
         </Text>
         <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }} className="mb-16 flex flex-col items-center justify-center gap-3">
           <InstallSnippet />

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -1,48 +1,9 @@
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { Button } from "./Button";
 
 const PROMPT =
   "Fetch and follow https://libretto.sh/start.md to set up Libretto and create a new browser automation.";
-
-function ClaudeCodeIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" clipRule="evenodd" aria-hidden="true" className="size-3.5">
-      <path d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z" />
-    </svg>
-  );
-}
-
-function OpenAIIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" aria-hidden="true" className="size-3.5">
-      <path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
-    </svg>
-  );
-}
-
-function CursorIcon() {
-  return (
-    <svg viewBox="82.65 82.65 634.71 634.71" fill="currentColor" fillRule="evenodd" aria-hidden="true" className="size-3.5">
-      <path d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z" />
-      <path d="M517.36 400H634.72V634.72H517.36Z" />
-    </svg>
-  );
-}
-
-function CodexIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" aria-hidden="true" className="size-3.5">
-      <path d="M16 6H8v12h8V6zm4 16H4V2h16v20z" />
-    </svg>
-  );
-}
-
-const AGENTS: Array<{ name: string; icon: ReactNode }> = [
-  { name: "Claude Code", icon: <ClaudeCodeIcon /> },
-  { name: "Codex", icon: <OpenAIIcon /> },
-  { name: "Cursor", icon: <CursorIcon /> },
-  { name: "Agent CLI", icon: <CodexIcon /> },
-];
+const PROMPT_SNIPPET = "Fetch and follow https://libretto.sh/start.md";
 
 export function InstallSnippet() {
   const [copied, setCopied] = useState(false);
@@ -54,20 +15,18 @@ export function InstallSnippet() {
   }
 
   return (
-    <Button onClick={handleCopy} aria-label="Copy Libretto setup prompt" className="gap-3">
-      <span className="flex w-[94px] items-center justify-start text-ink" aria-hidden="true">
-        {AGENTS.map((agent, index) => (
-          <span
-            key={agent.name}
-            title={agent.name}
-            className="flex size-5 items-center justify-center text-ink transition-transform duration-200 ease-out hover:-translate-y-0.5"
-            style={{ marginLeft: index === 0 ? 0 : 4 }}
-          >
-            {agent.icon}
-          </span>
-        ))}
+    <div className="install-prompt inline-flex max-w-full items-stretch overflow-hidden rounded-lg">
+      <span className="install-prompt__snippet" aria-hidden="true">
+        <span className="truncate">{PROMPT_SNIPPET}</span>
+        <span className="shrink-0 text-faint">...</span>
       </span>
-      <span>{copied ? "Copied" : "Copy prompt"}</span>
-    </Button>
+      <Button
+        onClick={handleCopy}
+        aria-label="Copy Libretto setup prompt"
+        className="install-prompt__button"
+      >
+        {copied ? "Copied" : "Copy prompt"}
+      </Button>
+    </div>
   );
 }

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -3,7 +3,6 @@ import { Button } from "./Button";
 
 const PROMPT =
   "Fetch and follow https://libretto.sh/start.md to set up Libretto and create a new browser automation.";
-const PROMPT_SNIPPET = "Fetch and follow https://libretto.sh/start.md";
 
 export function InstallSnippet() {
   const [copied, setCopied] = useState(false);
@@ -17,8 +16,7 @@ export function InstallSnippet() {
   return (
     <div className="install-prompt inline-flex max-w-full items-stretch overflow-hidden rounded-lg">
       <span className="install-prompt__snippet" aria-hidden="true">
-        <span className="truncate">{PROMPT_SNIPPET}</span>
-        <span className="shrink-0 text-faint">...</span>
+        <span className="install-prompt__snippet-text">{PROMPT}</span>
       </span>
       <Button
         onClick={handleCopy}

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -14,7 +14,7 @@ export function InstallSnippet() {
   }
 
   return (
-    <div className="install-prompt inline-flex max-w-full items-stretch overflow-hidden rounded-lg">
+    <div className="install-prompt inline-flex max-w-full items-stretch overflow-hidden">
       <span className="install-prompt__snippet" aria-hidden="true">
         <span className="install-prompt__snippet-text">{PROMPT}</span>
       </span>

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -280,6 +280,52 @@ body {
   text-decoration-color: var(--color-accent);
 }
 
+.install-prompt {
+  min-height: 2.5rem;
+  border: 1px solid color-mix(in oklch, var(--color-gray-8) 64%, transparent);
+  background: color-mix(in oklch, var(--color-gray-3) 86%, black);
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.08),
+    0 2px 8px rgba(0, 0, 0, 0.24);
+}
+
+.install-prompt__snippet {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: min(58vw, 27rem);
+  padding-inline: 0.875rem;
+  border-right: 1px solid color-mix(in oklch, var(--color-gray-8) 62%, transparent);
+  color: var(--color-gray-12);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.install-prompt__button.libretto-button {
+  min-height: auto;
+  border-radius: 0;
+  padding-inline: 1rem;
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.18),
+    inset 0 0 0 1px color-mix(in oklch, var(--color-green-9) 34%, transparent);
+}
+
+.install-prompt__button.libretto-button:hover {
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.22),
+    inset 0 0 0 1px color-mix(in oklch, var(--color-green-11) 46%, transparent);
+}
+
+.install-prompt__button.libretto-button:focus-visible {
+  z-index: 1;
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.2),
+    inset 0 0 0 1px color-mix(in oklch, var(--color-green-9) 58%, transparent),
+    0 0 0 3px color-mix(in oklch, var(--color-green-9) 30%, transparent);
+}
+
 @keyframes blink {
   0%,
   100% {

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -282,6 +282,7 @@ body {
 
 .install-prompt {
   min-height: 2.5rem;
+  border-radius: 8px;
   border: 1px solid color-mix(in oklch, var(--color-gray-8) 64%, transparent);
   background: color-mix(in oklch, var(--color-gray-3) 86%, black);
   box-shadow:
@@ -293,6 +294,7 @@ body {
   display: inline-flex;
   align-items: center;
   min-width: 0;
+  flex: 1 1 auto;
   max-width: min(58vw, 27rem);
   padding-inline: 0.875rem;
   border-right: 1px solid color-mix(in oklch, var(--color-gray-8) 62%, transparent);
@@ -301,6 +303,14 @@ body {
   font-size: 0.75rem;
   letter-spacing: 0;
   line-height: 1;
+}
+
+.install-prompt__snippet-text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .install-prompt__button.libretto-button {

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -296,7 +296,7 @@ body {
   max-width: min(58vw, 27rem);
   padding-inline: 0.875rem;
   border-right: 1px solid color-mix(in oklch, var(--color-gray-8) 62%, transparent);
-  color: var(--color-gray-12);
+  color: var(--color-faint);
   font-family: var(--font-mono);
   font-size: 0.75rem;
   letter-spacing: 0;


### PR DESCRIPTION
## Summary
- Update the hero headline and subheader copy around turning website workflows into reliable APIs.
- Replace the hero prompt CTA with a segmented prompt preview plus green copy action.
- Stack the docs fallback under the prompt control as `or go to docs`.
- Add responsive styling for the joined prompt/button control, including native prompt truncation.

## Test Plan
- `pnpm -s --filter @libretto/website type-check`
- Checked the hero CTA locally at desktop and mobile widths.
