### PR TITLE
Replace npx libretto with libretto in docs; restructure start.md to install globally first

### DIFF
--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -6,7 +6,7 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+Generated files must default-export a `workflow()` instance so they can be run via `libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
 
 Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
+- `libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -6,7 +6,7 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+Generated files must default-export a `workflow()` instance so they can be run via `libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
 
 Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
+- `libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.

--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -2,15 +2,15 @@
 
 Install Libretto and verify that it runs end to end.
 
-## 1. Install the Libretto command
+## 1. Install the Libretto CLI
 
-Before anything else, install the global `libretto` command. This is required for every path below and must be run first. It is safe to rerun if Libretto is already installed. Requires Node.js and npm:
+Before anything else, install the global `libretto` CLI. This is required for every path below and must be run first. It is safe to rerun if Libretto is already installed. Requires Node.js and npm:
 
 ```bash
 curl -fsSL https://libretto.sh/install.sh | bash
 ```
 
-Verify the command is on PATH by running `libretto --help` before continuing.
+Verify the CLI is on PATH by running `libretto --help` before continuing.
 
 ## 2. Choose the target
 

--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -2,7 +2,17 @@
 
 Install Libretto and verify that it runs end to end.
 
-## 1. Choose the target
+## 1. Install the Libretto command
+
+Before anything else, install the global `libretto` command. This is required for every path below and must be run first. It is safe to rerun if Libretto is already installed. Requires Node.js and npm:
+
+```bash
+curl -fsSL https://libretto.sh/install.sh | bash
+```
+
+Verify the command is on PATH by running `libretto --help` before continuing.
+
+## 2. Choose the target
 
 Inspect the current directory. Ask only for missing information:
 
@@ -11,7 +21,7 @@ Inspect the current directory. Ask only for missing information:
 
 Use the target project's package manager conventions. If the user already chose a path, location, name, or package manager, treat that as binding.
 
-## 2. Install
+## 3. Set up the package
 
 For a new package:
 
@@ -22,12 +32,6 @@ cd <package-name>
 
 After creating a new package, do all remaining setup and verification inside the created package directory.
 
-Install the Libretto command once if it is not already available. This requires Node.js and npm:
-
-```bash
-curl -fsSL https://libretto.sh/install.sh | bash
-```
-
 For an existing package:
 
 ```bash
@@ -37,7 +41,7 @@ libretto setup
 
 Use equivalent pnpm, yarn, or bun commands when appropriate.
 
-## 3. Read installed guidance
+## 4. Read installed guidance
 
 After installation, make sure your current directory is the package directory. Then read the installed skill before creating or editing workflow code:
 
@@ -47,7 +51,7 @@ node_modules/libretto/skills/libretto/SKILL.md
 
 The package also includes docs under `node_modules/libretto/docs/`; use them only when the skill or task requires more detail.
 
-## 4. Verify
+## 5. Verify
 
 For this smoke check, copy the workflow below directly; do not inspect the scaffolded example or read additional references unless validation fails.
 
@@ -71,7 +75,7 @@ Run it:
 libretto run src/workflows/scrape-page.ts --headless
 ```
 
-## 5. Finish
+## 6. Finish
 
 After verifying Libretto is setup and working properly, summarize the steps taken and offer some sample browser automations you could build next, such as:
 

--- a/docs/libretto-cloud-hosting/authentication.mdx
+++ b/docs/libretto-cloud-hosting/authentication.mdx
@@ -39,7 +39,7 @@ This stores a new Libretto Cloud session in `~/.libretto/auth.json`. If the acco
 Use `auth forgot-password` to request a password reset email:
 
 ```bash theme={null}
-npx libretto cloud auth forgot-password
+libretto cloud auth forgot-password
 ```
 
 After you choose a new password from the reset link, run `auth login` again to save a fresh local session.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -6,7 +6,7 @@ Follow the user's existing codebase conventions, abstractions, and patterns when
 
 ## Workflow File Structure
 
-Generated files must default-export a `workflow()` instance so they can be run via `npx libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
+Generated files must default-export a `workflow()` instance so they can be run via `libretto run <file>`. Workflows declare their input and output shapes as Zod schemas, which both type the handler and validate runtime input.
 
 Add `zod` (`^4.0.0`) to the workflow's `package.json` dependencies. Then import `workflow` from `"libretto"` and `z` from `"zod"`:
 
@@ -42,7 +42,7 @@ Key points:
 
 - `workflow(name, { input, output }, handler)` takes a unique workflow name, a pair of Zod schemas describing input and output, and the async handler. The handler's `input` parameter is inferred from the input schema — do not redeclare it with a separate `type Input = ...`.
 - At run time, Libretto validates `input` against `inputSchema` before calling the handler. Invalid input throws a clear error listing each failing field; the workflow handler never sees malformed input.
-- `npx libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
+- `libretto run ./file.ts` executes the file's default-exported workflow, so always use `export default workflow(...)`.
 - `ctx` provides `session` and `page`. Use `console.log`/`console.warn`/`console.error` for logging — the runtime wraps these with structured metadata automatically.
 - `input` comes from `--params '{"query":"foo"}'` or `--params-file params.json` on the CLI, then gets parsed through `inputSchema`.
 - Use `await pause(ctx.session)` (or `await pause(session)`) to pause the workflow for debugging. It is a no-op in production.


### PR DESCRIPTION
## Summary

- Replace remaining `npx libretto` references in user-facing docs and the `code-generation-rules` skill source with the native `libretto` command, matching the convention used everywhere else in the docs.
- Restructure `apps/website/public/start.md` so the global install (`curl -fsSL https://libretto.sh/install.sh | bash`) is step 1 and the agent verifies with `libretto --help` before moving on. The scaffold / `npm install libretto` step is now step 3, which prevents an agent from running scaffolded commands before the binary is on PATH.
- Resync the `.agents/skills/libretto/` and `.claude/skills/libretto/` mirrors of `code-generation-rules.md` via `pnpm sync:mirrors`.

## Test plan

- [ ] `pnpm check:mirrors` passes (verified locally).
- [ ] `libretto --help` still renders correctly (no source code changed; only docs / skill markdown).
- [ ] Read through `start.md` to confirm steps 1–6 flow correctly and the install step is unambiguously first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)