### PR TITLE
Add libretto update command

### DIFF
--- a/packages/libretto/src/cli/commands/update.ts
+++ b/packages/libretto/src/cli/commands/update.ts
@@ -1,0 +1,149 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { SimpleCLI } from "affordance";
+
+const UPDATE_COMMAND = "curl -fsSL https://libretto.sh/install.sh | bash";
+
+type PackageManifest = {
+  version?: string;
+};
+
+function readCurrentCliVersion(): string {
+  const packageJsonPath = fileURLToPath(
+    new URL("../../../package.json", import.meta.url),
+  );
+  const manifest = JSON.parse(
+    readFileSync(packageJsonPath, "utf8"),
+  ) as PackageManifest;
+
+  if (!manifest.version) {
+    throw new Error(
+      `Unable to determine current libretto version from ${packageJsonPath}.`,
+    );
+  }
+
+  return manifest.version;
+}
+
+function readLatestNpmVersion(): string {
+  const result = spawnSync("npm", ["view", "libretto@latest", "version"], {
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new Error(
+      [
+        "Error: failed to check the latest Libretto version on npm.",
+        `Known state: ${result.error.message}`,
+        "Try: npm view libretto@latest version",
+        "Help: libretto help update",
+      ].join("\n"),
+    );
+  }
+
+  if (result.status !== 0) {
+    const detail = result.stderr.trim();
+    throw new Error(
+      [
+        "Error: failed to check the latest Libretto version on npm.",
+        `Known state: npm exited with status ${result.status}.`,
+        ...(detail ? [`npm stderr: ${detail}`] : []),
+        "Try: npm view libretto@latest version",
+        "Help: libretto help update",
+      ].join("\n"),
+    );
+  }
+
+  const version = result.stdout.trim();
+  if (!version) {
+    throw new Error(
+      [
+        "Error: failed to check the latest Libretto version on npm.",
+        "Known state: npm did not print a version.",
+        "Try: npm view libretto@latest version",
+        "Help: libretto help update",
+      ].join("\n"),
+    );
+  }
+
+  return version;
+}
+
+export const updateInput = SimpleCLI.input({
+  positionals: [],
+  named: {
+    dryRun: SimpleCLI.flag({
+      name: "dry-run",
+      help: "Print the update command without running it",
+    }),
+  },
+});
+
+function formatUpdateFailure(
+  status: number | null,
+  signal: string | null,
+): string {
+  const knownState =
+    status === null
+      ? `installer was interrupted${signal ? ` by ${signal}` : ""}.`
+      : `installer exited with status ${status}.`;
+
+  return [
+    "Error: failed to update Libretto to the latest version.",
+    `Known state: ${knownState}`,
+    `Try: ${UPDATE_COMMAND}`,
+    "Help: libretto help update",
+  ].join("\n");
+}
+
+export const updateCommand = SimpleCLI.command({
+  description: "Update Libretto to the latest version",
+})
+  .input(updateInput)
+  .handle(async ({ input }) => {
+    if (input.dryRun) {
+      console.log("Update command:");
+      console.log(`  ${UPDATE_COMMAND}`);
+      console.log("No changes made.");
+      return;
+    }
+
+    const currentVersion = readCurrentCliVersion();
+    const latestVersion = readLatestNpmVersion();
+    console.log(`Current version: ${currentVersion}`);
+    console.log(`Latest version: ${latestVersion}`);
+
+    if (currentVersion === latestVersion) {
+      console.log(`Libretto is already up to date (${currentVersion}).`);
+      console.log("No further action required.");
+      return;
+    }
+
+    console.log("Updating Libretto to latest...");
+    const result = spawnSync("bash", ["-lc", UPDATE_COMMAND], {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        LIBRETTO_VERSION: "latest",
+      },
+    });
+
+    if (result.error) {
+      throw new Error(
+        [
+          "Error: failed to start the Libretto installer.",
+          `Known state: ${result.error.message}`,
+          `Try: ${UPDATE_COMMAND}`,
+          "Help: libretto help update",
+        ].join("\n"),
+      );
+    }
+
+    if (result.status !== 0) {
+      throw new Error(formatUpdateFailure(result.status, result.signal));
+    }
+
+    console.log("Libretto updated to latest.");
+    console.log("No further action required.");
+  });

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -8,6 +8,7 @@ import { setupCommand } from "./commands/setup.js";
 import { statusCommand } from "./commands/status.js";
 import { snapshotCommand } from "./commands/snapshot.js";
 import { searchCommand } from "./commands/search.js";
+import { updateCommand } from "./commands/update.js";
 import { SimpleCLI } from "affordance";
 
 export const cliRoutes = {
@@ -26,6 +27,7 @@ export const cliRoutes = {
   setup: setupCommand,
   status: statusCommand,
   snapshot: snapshotCommand,
+  update: updateCommand,
 };
 
 export function createCLIApp() {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import outdent from "outdent";
@@ -99,6 +99,7 @@ function expectedRootHelp(): string {
       setup  Set up libretto in the current project
       status  Show workspace status and open sessions
       snapshot  Capture a screenshot and compact accessibility snapshot
+      update  Update Libretto to the latest version
 
     Options:
       --session <name>  Required for session-scoped commands
@@ -261,6 +262,52 @@ describe("basic CLI subprocess behavior", () => {
     const result = await librettoCli("help status");
     expect(result.stdout).toContain("Show workspace status");
     expect(result.stdout).toContain("open sessions");
+    expect(result.stderr).toBe("");
+  });
+
+  test("prints scoped help for update command", async ({ librettoCli }) => {
+    const result = await librettoCli("help update");
+    expect(result.stdout).toContain("Update Libretto to the latest version");
+    expect(result.stdout).toContain("--dry-run");
+    expect(result.stderr).toBe("");
+  });
+
+  test("update dry-run prints the installer command", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli("update --dry-run");
+    expect(result.stdout).toContain("Update command:");
+    expect(result.stdout).toContain(
+      "curl -fsSL https://libretto.sh/install.sh | bash",
+    );
+    expect(result.stdout).toContain("No changes made.");
+    expect(result.stderr).toBe("");
+  });
+
+  test("update skips installer when already on the latest version", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    const binDir = workspacePath("bin");
+    await mkdir(binDir, { recursive: true });
+    const npmPath = workspacePath("bin", "npm");
+    await writeFile(
+      npmPath,
+      `#!/usr/bin/env bash\nprintf '%s\\n' '${cliVersion}'\n`,
+      "utf8",
+    );
+    await chmod(npmPath, 0o755);
+
+    const result = await librettoCli("update", {
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    });
+
+    expect(result.stdout).toContain(`Current version: ${cliVersion}`);
+    expect(result.stdout).toContain(`Latest version: ${cliVersion}`);
+    expect(result.stdout).toContain("Libretto is already up to date");
+    expect(result.stdout).toContain("No further action required.");
+    expect(result.stdout).not.toContain("Updating Libretto to latest");
     expect(result.stderr).toBe("");
   });
 


### PR DESCRIPTION
## Summary
- add a `libretto update` command that checks npm for the latest published version before updating
- skip the installer when the current CLI is already on the latest version
- use the official installer path for actual updates and add dry-run/help coverage

## Verification
- `pnpm -s type-check`
- `pnpm -s --filter libretto test:vitest test/basic.spec.ts`
- `pnpm -s lint`
