### PR TITLE
ci(release): build workspace deps before type-check and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
         run: |
           pnpm check:mirrors
-          pnpm --filter libretto build
+          pnpm --filter libretto... build
           pnpm --filter libretto type-check
           pnpm --filter libretto test
     outputs:
@@ -160,7 +160,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build publish artifacts
-        run: pnpm --filter libretto build
+        run: pnpm --filter libretto... build
 
       - name: Publish libretto to npm
         if: needs.verify.outputs.npm_exists != 'true'


### PR DESCRIPTION
## Summary
- Release workflow run [26057795414](https://github.com/saffron-health/libretto/actions/runs/26057795414) failed at `Verify release build` with dozens of `TS2307: Cannot find module 'affordance'` errors because libretto's `tsc --noEmit` ran before the `affordance` workspace package's `dist/index.d.ts` was generated.
- Switched both `pnpm --filter libretto build` invocations (verify job and publish job) to `pnpm --filter libretto... build` so workspace dependencies are built first.

## Test plan
- [x] Reproduced the CI failure locally by deleting `packages/affordance/dist/` and running the old command sequence — `pnpm --filter libretto type-check` failed with the same TS2307 errors.
- [x] Repeated with the fixed command (`pnpm --filter libretto... build`) on a clean dist — affordance was built first, then libretto, and `pnpm --filter libretto type-check` exited 0.
- [x] Full verify sequence locally: `pnpm check:mirrors`, build, type-check, and `pnpm --filter libretto test` (3/3 tasks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)