### PR TITLE
Test eval installs from packed tarballs

### DIFF
--- a/packages/dev-tools/src/tmp-workspace.ts
+++ b/packages/dev-tools/src/tmp-workspace.ts
@@ -5,7 +5,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 export type CreateTmpWorkspaceOptions = {
@@ -24,6 +25,13 @@ export type CreateTmpWorkspaceOptions = {
    *  parallel eval/benchmark runs where a prior step handles the build. */
   skipBuild?: boolean;
 };
+
+type PackageManifest = Record<string, unknown> & {
+  name: string;
+  version: string;
+};
+
+let packedPackageTarballsPromise: Promise<string[]> | null = null;
 
 function findRepoRoot(): string {
   const override = process.env.LIBRETTO_REPO_ROOT?.trim();
@@ -54,6 +62,57 @@ function run(
     stdio: quiet ? ["ignore", "pipe", "pipe"] : ["ignore", "inherit", "pipe"],
     encoding: "utf8",
   });
+}
+
+function parseManifest(raw: string, source: string): PackageManifest {
+  const parsed = JSON.parse(raw) as unknown;
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { name?: unknown }).name !== "string" ||
+    typeof (parsed as { version?: unknown }).version !== "string"
+  ) {
+    throw new Error(`Invalid package manifest: ${source}`);
+  }
+  return parsed as PackageManifest;
+}
+
+function packageTarballName(manifest: PackageManifest): string {
+  return `${manifest.name.replace(/^@/, "").replace("/", "-")}-${manifest.version}.tgz`;
+}
+
+function packPackage(
+  packagePath: string,
+  destination: string,
+  quiet: boolean,
+): string {
+  const sourceManifest = parseManifest(
+    readFileSync(join(packagePath, "package.json"), "utf8"),
+    join(packagePath, "package.json"),
+  );
+
+  run(packagePath, "pnpm", ["pack", "--pack-destination", destination], quiet);
+
+  return join(destination, packageTarballName(sourceManifest));
+}
+
+async function getPackedPackageTarballs(
+  repoRoot: string,
+  quiet: boolean,
+): Promise<string[]> {
+  packedPackageTarballsPromise ??= Promise.resolve().then(() => {
+    const packDir = resolve(
+      tmpdir(),
+      `libretto-packed-packages-${process.pid}-${Date.now()}`,
+    );
+    mkdirSync(packDir, { recursive: true });
+
+    return [
+      packPackage(resolve(repoRoot, "packages", "affordance"), packDir, quiet),
+      packPackage(resolve(repoRoot, "packages", "libretto"), packDir, quiet),
+    ];
+  });
+  return packedPackageTarballsPromise;
 }
 
 export async function createTmpWorkspace(
@@ -117,11 +176,13 @@ export async function createTmpWorkspace(
   );
 
   // Install local libretto plus any caller-requested packages.
+  const packageTarballs = await getPackedPackageTarballs(repoRoot, quiet);
+
   const installArgs = [
     "add",
     "--lockfile=false",
     "--ignore-scripts",
-    `file:${librettoPackageRoot}`,
+    ...packageTarballs,
     ...(options.extraPackages ?? []),
   ];
   log(`  Installing packages: pnpm ${installArgs.join(" ")}`);

--- a/packages/libretto/docs/releasing.md
+++ b/packages/libretto/docs/releasing.md
@@ -28,17 +28,19 @@ GitHub Actions needs these repository secrets:
 
 The release workflow uses a GitHub Actions environment named `release`. Create that environment in the repository settings (no required reviewers — access is controlled by branch protection on `main` instead).
 
-On npm, configure `libretto` to trust this repository and workflow for publishing. The trusted publisher fields should match:
+On npm, configure each published package to trust this repository and workflow for publishing:
 
 - Organization or user: `saffron-health`
 - Repository: `libretto`
 - Workflow filename: `release.yml`
 - Environment name: `release`
 
-If you prefer the CLI, the setup command is:
+If you prefer the CLI, run one setup command per package:
 
 ```bash
 npm trust github libretto --repo saffron-health/libretto --file release.yml --env release
+npm trust github affordance --repo saffron-health/libretto --file release.yml --env release
+npm trust github create-libretto --repo saffron-health/libretto --file release.yml --env release
 ```
 
 Trusted publishing only works on supported cloud-hosted runners. This workflow uses `ubuntu-latest`, which satisfies that requirement. npm also requires a recent toolchain for trusted publishing, so the publish job runs on Node 24.
@@ -80,7 +82,7 @@ The workflow:
 1. Reads the version from `packages/libretto/package.json`.
 2. Checks whether that version already exists on npm and in GitHub Releases.
 3. Runs install, type-check, and tests for the `libretto` package in a verification job.
-4. Publishes `libretto@X.Y.Z` to npm from `packages/libretto` with trusted publishing if it is not already published.
+4. Publishes `affordance` first, then `libretto@X.Y.Z`, then `create-libretto@X.Y.Z` with trusted publishing.
 5. Creates GitHub release `vX.Y.Z` with generated release notes if it does not already exist.
 
 This makes the workflow safe to re-run after partial failures. For example, if npm publish succeeds but GitHub release creation fails, a re-run will skip npm and only create the missing release.

--- a/packages/libretto/docs/releasing.md
+++ b/packages/libretto/docs/releasing.md
@@ -35,12 +35,12 @@ On npm, configure each published package to trust this repository and workflow f
 - Workflow filename: `release.yml`
 - Environment name: `release`
 
-If you prefer the CLI, run one setup command per package:
+If you prefer the CLI, run one setup command per package with npm 11.10.0 or newer:
 
 ```bash
-npm trust github libretto --repo saffron-health/libretto --file release.yml --env release
-npm trust github affordance --repo saffron-health/libretto --file release.yml --env release
-npm trust github create-libretto --repo saffron-health/libretto --file release.yml --env release
+npx --yes npm@11.13.0 trust github libretto --repo saffron-health/libretto --file release.yml --env release --yes
+npx --yes npm@11.13.0 trust github affordance --repo saffron-health/libretto --file release.yml --env release --yes
+npx --yes npm@11.13.0 trust github create-libretto --repo saffron-health/libretto --file release.yml --env release --yes
 ```
 
 Trusted publishing only works on supported cloud-hosted runners. This workflow uses `ubuntu-latest`, which satisfies that requirement. npm also requires a recent toolchain for trusted publishing, so the publish job runs on Node 24.


### PR DESCRIPTION
## Summary
- pack local `affordance` and `libretto` artifacts before creating eval temp workspaces
- install those tarballs into the temp workspace instead of the raw `packages/libretto` directory
- keep the temp workspace consumer install on `--ignore-scripts`

## Verification
- `pnpm -s --filter @libretto/dev-tools run type-check`
- `pnpm -s --filter @libretto/dev-tools run lint`
- `pnpm -s --filter @libretto/dev-tools run build`
- smoke-created a temp workspace with `createTmpWorkspace({ skipBuild: true, skipBrowsers: true })`
