### PR TITLE
release: v0.6.18 + fix workspace: protocol in publish flow

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Read-Only Works

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Works

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Read-Only Works

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,16 +162,26 @@ jobs:
       - name: Build publish artifacts
         run: pnpm --filter libretto... build
 
+      - name: Publish affordance to npm
+        working-directory: packages/affordance
+        run: |
+          affordance_version="$(node -p "require('./package.json').version")"
+          if ! npm view "affordance@${affordance_version}" version >/dev/null 2>&1; then
+            pnpm publish --access public --no-git-checks
+          else
+            echo "affordance@${affordance_version} already published, skipping."
+          fi
+
       - name: Publish libretto to npm
         if: needs.verify.outputs.npm_exists != 'true'
         working-directory: packages/libretto
-        run: npm publish --access public
+        run: pnpm publish --access public --no-git-checks
 
       - name: Publish create-libretto to npm
         working-directory: packages/create-libretto
         run: |
           if ! npm view "create-libretto@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then
-            npm publish --access public
+            pnpm publish --access public --no-git-checks
           else
             echo "create-libretto@${{ needs.verify.outputs.version }} already published, skipping."
           fi

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -37,6 +37,13 @@ const faqs: FAQItem[] = [
       "Tools like Stagehand and Browser-Use use AI at runtime to handle edge cases without human involvement. They also rely entirely on UI interactions, which makes them slow, expensive, and nondeterministic.\n\nLibretto generates deterministic scripts that can use both UI automation and direct network requests. When a script breaks, you use Libretto to diagnose and fix it. You can still add AI runtime logic since it's all just TypeScript, but it's not the default.",
   },
   {
+    id: "diff-playwright",
+    question:
+      "How is it different from tools like playwright-cli, agent-browser, and dev-browser?",
+    answer:
+      "Libretto is both a runtime and a CLI, built around the workflow of writing reusable automation scripts.\n\nIt's optimized for that loop: a script validation loop that checks scripts run end-to-end, debugging with pause statements you can drop into your code, and the ability to record workflows in a real browser and turn them into scripts.\n\nWhen you're happy with a script, you can deploy it to the cloud and run it as a type-safe API with one command.",
+  },
+  {
     id: "providers",
     question: "What cloud providers do you support?",
     answer: (

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -41,7 +41,7 @@ const faqs: FAQItem[] = [
     question:
       "How is it different from tools like playwright-cli, agent-browser, and dev-browser?",
     answer:
-      "Libretto is both a runtime and a CLI, built around the workflow of writing reusable automation scripts.\n\nIt's optimized for that loop: a script validation loop that checks scripts run end-to-end, debugging with pause statements you can drop into your code, and the ability to record workflows in a real browser and turn them into scripts.\n\nWhen you're happy with a script, you can deploy it to the cloud and run it as a type-safe API with one command.",
+      "Libretto is both a runtime and a CLI, built specifically for writing reusable automation scripts.\n\nIt comes out of the box with a script validation loop that checks scripts run end-to-end when you generate them or make edits, pause statements you drop into your code for step-through debugging, and a workflow recorder that captures actions in a real browser and turns them into scripts.\n\nWhen you're happy with a script, you deploy it to the cloud and run it as a type-safe API with one command.",
   },
   {
     id: "providers",

--- a/packages/affordance/package.json
+++ b/packages/affordance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affordance",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A TypeScript framework for building agent-friendly CLIs",
   "license": "MIT",
   "homepage": "https://libretto.sh",

--- a/packages/create-libretto/package.json
+++ b/packages/create-libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-libretto",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Create and set up a Libretto project",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "homepage": "https://libretto.sh",

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Read-Only Works

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.17"
+  version: "0.6.18"
 ---
 
 ## How Libretto Works


### PR DESCRIPTION
## Summary

- **Fix:** libretto@0.6.17 on npm is unresolvable by npm/pnpm-outside-workspace because its `dependencies.affordance` was published as `workspace:^` literally. Root cause: the release job uses `npm publish`, which does not rewrite workspace specifiers. Switching to `pnpm publish` makes pnpm rewrite `workspace:^` to a concrete `^x.y.z` at publish time.
- **Bump:** `affordance` 0.1.0 → 0.2.0. Its source has diverged from the published 0.1.0 (PR #334 added `appendHelpText` to the SimpleCLIApp API, which libretto uses in `cli/router.ts`). Without this bump, the rewritten `^0.2.0` constraint would point at a version that doesn't exist on npm.
- **Workflow:** Add an idempotent `affordance` publish step before `libretto` so the dep is on npm when libretto's tarball is fetched.
- **Release:** Bump `libretto` and `create-libretto` to 0.6.18, sync skill mirrors.
- **Website:** Add a new FAQ entry below the Stagehand/Browser-Use one explaining how Libretto compares to playwright-cli, agent-browser, and dev-browser.

Verified locally with `pnpm pack` from `packages/libretto`: the resulting tarball's `package.json` correctly shows `"affordance": "^0.2.0"` (rewritten from `workspace:^`).

## Test plan

- [ ] `pnpm --filter libretto type-check`
- [ ] `pnpm --filter libretto test`
- [ ] After merge, confirm `npm view libretto@0.6.18 dependencies` shows `affordance: '^0.2.0'` and not `workspace:^`
- [ ] `curl -fsSL https://libretto.sh/install.sh | bash` succeeds against 0.6.18
- [ ] FAQ entry renders on the website

🤖 Generated with [Claude Code](https://claude.com/claude-code)