### PR TITLE
Warn when Libretto CLI versions differ

### DIFF
--- a/packages/libretto/src/cli/cli.ts
+++ b/packages/libretto/src/cli/cli.ts
@@ -2,7 +2,7 @@ import { ensureLibrettoSetup } from "./core/context.js";
 import { createCLIApp } from "./router.js";
 import {
   readCurrentCliVersion,
-  warnIfInstalledSkillOutOfDate,
+  warnIfLibrettoVersionsDiffer,
 } from "./core/skill-version.js";
 import { loadEnv } from "../shared/env/load-env.js";
 
@@ -11,7 +11,7 @@ function renderVersion(): string {
 }
 
 function printSetupAudit(): void {
-  warnIfInstalledSkillOutOfDate();
+  warnIfLibrettoVersionsDiffer();
 }
 
 function isPackageManagerExec(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -18,7 +18,7 @@ import {
   setSessionMode,
   validateSessionName,
 } from "../core/session.js";
-import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
+import { warnIfLibrettoVersionsDiffer } from "../core/skill-version.js";
 import { SimpleCLI } from "affordance";
 import {
   sessionOption,
@@ -107,7 +107,7 @@ export const openCommand = SimpleCLI.command({
   .use(withAutoSession())
   .use(withExperiments())
   .handle(async ({ input, ctx }) => {
-    warnIfInstalledSkillOutOfDate();
+    warnIfLibrettoVersionsDiffer();
     assertSessionAvailableForStart(ctx.session, ctx.logger);
     const providerName = resolveProviderName(input.provider);
     if (providerName === "local") {
@@ -168,7 +168,7 @@ export const connectCommand = SimpleCLI.command({
   .use(withAutoSession())
   .use(withExperiments())
   .handle(async ({ input, ctx }) => {
-    warnIfInstalledSkillOutOfDate();
+    warnIfLibrettoVersionsDiffer();
     await runConnectWithLogger(
       input.cdpUrl!,
       ctx.session,

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -25,7 +25,7 @@ import {
   writeSessionState,
   type SessionState,
 } from "../core/session.js";
-import { warnIfInstalledSkillOutOfDate } from "../core/skill-version.js";
+import { warnIfLibrettoVersionsDiffer } from "../core/skill-version.js";
 import { readLibrettoConfig } from "../core/config.js";
 import { renderSnapshotDiff } from "../../shared/snapshot/diff-snapshots.js";
 import {
@@ -860,7 +860,7 @@ export const runCommand = SimpleCLI.command({
   .use(withAutoSession())
   .use(withExperiments())
   .handle(async ({ input, ctx }) => {
-    warnIfInstalledSkillOutOfDate();
+    warnIfLibrettoVersionsDiffer();
     await stopExistingFailedRunSession(ctx.session, ctx.logger);
     assertSessionAvailableForStart(ctx.session, ctx.logger);
 

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -89,24 +89,114 @@ function readInstalledSkillVersions(): string[] {
   return [...versions];
 }
 
-function formatObservedVersions(components: {
+function parseVersion(version: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+} | null {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  };
+}
+
+function compareVersions(left: string, right: string): number {
+  const parsedLeft = parseVersion(left);
+  const parsedRight = parseVersion(right);
+  if (!parsedLeft || !parsedRight) {
+    return left.localeCompare(right);
+  }
+
+  for (const key of ["major", "minor", "patch"] as const) {
+    const diff = parsedLeft[key] - parsedRight[key];
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  if (parsedLeft.prerelease === parsedRight.prerelease) {
+    return 0;
+  }
+  if (parsedLeft.prerelease === null) {
+    return 1;
+  }
+  if (parsedRight.prerelease === null) {
+    return -1;
+  }
+  return parsedLeft.prerelease.localeCompare(parsedRight.prerelease);
+}
+
+function selectTargetVersion(versions: string[]): string {
+  const counts = new Map<string, number>();
+  for (const version of versions) {
+    counts.set(version, (counts.get(version) ?? 0) + 1);
+  }
+
+  const byCountThenVersion = [...counts.entries()].sort(
+    ([leftVersion, leftCount], [rightVersion, rightCount]) =>
+      rightCount - leftCount || compareVersions(rightVersion, leftVersion),
+  );
+
+  return byCountThenVersion[0]?.[0] ?? versions[0] ?? "latest";
+}
+
+function formatVersion(version: string, targetVersion: string): string {
+  return version === targetVersion ? version : `${version}  (out of date)`;
+}
+
+function formatSkillVersions(
+  versions: string[],
+  targetVersion: string,
+): string {
+  if (versions.length === 0) {
+    return "not installed";
+  }
+
+  return versions
+    .map((version) => formatVersion(version, targetVersion))
+    .join(", ");
+}
+
+function formatVersionWarning(components: {
   cliVersion: string;
   localPackageVersion: string | null;
   skillVersions: string[];
 }): string {
-  const labels = [`global CLI ${components.cliVersion}`];
+  const targetVersion = selectTargetVersion([
+    components.cliVersion,
+    ...(components.localPackageVersion ? [components.localPackageVersion] : []),
+    ...components.skillVersions,
+  ]);
+  const skillLabel =
+    components.skillVersions.length > 1 ? "agent skills" : "agent skill";
 
-  if (components.localPackageVersion) {
-    labels.push(`local package ${components.localPackageVersion}`);
-  }
-
-  if (components.skillVersions.length === 1) {
-    labels.push(`agent skill ${components.skillVersions[0]}`);
-  } else if (components.skillVersions.length > 1) {
-    labels.push(`agent skills ${components.skillVersions.join(", ")}`);
-  }
-
-  return labels.join(", ");
+  return [
+    "WARNING: Libretto version mismatch detected.",
+    "",
+    `  global CLI:    ${formatVersion(components.cliVersion, targetVersion)}`,
+    `  local package: ${
+      components.localPackageVersion
+        ? formatVersion(components.localPackageVersion, targetVersion)
+        : "not installed"
+    }`,
+    `  ${skillLabel}:   ${formatSkillVersions(
+      components.skillVersions,
+      targetVersion,
+    )}`,
+    "",
+    "How to update:",
+    `  global CLI:    npm install -g libretto@${targetVersion}`,
+    `  local package: npm install libretto@${targetVersion}`,
+    "  agent skill:   libretto setup",
+  ].join("\n");
 }
 
 export function warnIfLibrettoVersionsDiffer(): void {
@@ -125,11 +215,11 @@ export function warnIfLibrettoVersionsDiffer(): void {
     }
 
     console.error(
-      `Warning: Libretto versions differ: ${formatObservedVersions({
+      formatVersionWarning({
         cliVersion,
         localPackageVersion,
         skillVersions,
-      })}. Use the same Libretto version globally and locally; run \`libretto setup\` after changing versions.`,
+      }),
     );
   } catch {
     // Never block command execution on a best-effort skill version check.

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -193,7 +193,7 @@ function formatVersionWarning(components: {
     )}`,
     "",
     "How to update:",
-    `  global CLI:    npm install -g libretto@${targetVersion}`,
+    `  global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${targetVersion} bash`,
     `  local package: npm install libretto@${targetVersion}`,
     "  agent skill:   libretto setup",
   ].join("\n");

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -14,6 +14,17 @@ const INSTALLED_SKILL_PATHS = [
 
 let cachedCliVersion: string | null = null;
 
+function readPackageVersion(packageJsonPath: string): string | null {
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+
+  const manifest = JSON.parse(
+    readFileSync(packageJsonPath, "utf8"),
+  ) as PackageManifest;
+  return manifest.version?.trim() || null;
+}
+
 export function readCurrentCliVersion(): string {
   if (cachedCliVersion) {
     return cachedCliVersion;
@@ -22,18 +33,22 @@ export function readCurrentCliVersion(): string {
   const packageJsonPath = fileURLToPath(
     new URL("../../../package.json", import.meta.url),
   );
-  const manifest = JSON.parse(
-    readFileSync(packageJsonPath, "utf8"),
-  ) as PackageManifest;
+  const version = readPackageVersion(packageJsonPath);
 
-  if (!manifest.version) {
+  if (!version) {
     throw new Error(
       `Unable to determine current libretto version from ${packageJsonPath}.`,
     );
   }
 
-  cachedCliVersion = manifest.version;
+  cachedCliVersion = version;
   return cachedCliVersion;
+}
+
+function readLocalPackageVersion(): string | null {
+  return readPackageVersion(
+    join(REPO_ROOT, "node_modules", "libretto", "package.json"),
+  );
 }
 
 function readInstalledSkillVersion(skillPath: string): string | null {
@@ -60,32 +75,61 @@ function readInstalledSkillVersion(skillPath: string): string | null {
   return versionMatch?.[1]?.trim() ?? null;
 }
 
-function findInstalledSkillVersionMismatch(): {
-  installedVersion: string;
-  cliVersion: string;
-} | null {
-  const cliVersion = readCurrentCliVersion();
+function readInstalledSkillVersions(): string[] {
+  const versions = new Set<string>();
 
   for (const relativePathParts of INSTALLED_SKILL_PATHS) {
     const skillPath = join(REPO_ROOT, ...relativePathParts);
     const installedVersion = readInstalledSkillVersion(skillPath);
-    if (installedVersion && installedVersion !== cliVersion) {
-      return { installedVersion, cliVersion };
+    if (installedVersion) {
+      versions.add(installedVersion);
     }
   }
 
-  return null;
+  return [...versions];
 }
 
-export function warnIfInstalledSkillOutOfDate(): void {
+function formatObservedVersions(components: {
+  cliVersion: string;
+  localPackageVersion: string | null;
+  skillVersions: string[];
+}): string {
+  const labels = [`global CLI ${components.cliVersion}`];
+
+  if (components.localPackageVersion) {
+    labels.push(`local package ${components.localPackageVersion}`);
+  }
+
+  if (components.skillVersions.length === 1) {
+    labels.push(`agent skill ${components.skillVersions[0]}`);
+  } else if (components.skillVersions.length > 1) {
+    labels.push(`agent skills ${components.skillVersions.join(", ")}`);
+  }
+
+  return labels.join(", ");
+}
+
+export function warnIfLibrettoVersionsDiffer(): void {
   try {
-    const mismatch = findInstalledSkillVersionMismatch();
-    if (!mismatch) {
+    const cliVersion = readCurrentCliVersion();
+    const localPackageVersion = readLocalPackageVersion();
+    const skillVersions = readInstalledSkillVersions();
+    const observedVersions = new Set([
+      cliVersion,
+      ...(localPackageVersion ? [localPackageVersion] : []),
+      ...skillVersions,
+    ]);
+
+    if (observedVersions.size <= 1) {
       return;
     }
 
     console.error(
-      `Warning: Your agent skill (${mismatch.installedVersion}) is out of date with your Libretto CLI (${mismatch.cliVersion}). Please run \`libretto setup\` to update your skills to the correct version.`,
+      `Warning: Libretto versions differ: ${formatObservedVersions({
+        cliVersion,
+        localPackageVersion,
+        skillVersions,
+      })}. Use the same Libretto version globally and locally; run \`libretto setup\` after changing versions.`,
     );
   } catch {
     // Never block command execution on a best-effort skill version check.

--- a/packages/libretto/src/cli/core/skill-version.ts
+++ b/packages/libretto/src/cli/core/skill-version.ts
@@ -165,6 +165,41 @@ function formatSkillVersions(
     .join(", ");
 }
 
+function formatUpdateInstructions(components: {
+  cliVersion: string;
+  localPackageVersion: string | null;
+  skillVersions: string[];
+  targetVersion: string;
+}): string[] {
+  const instructions: string[] = [];
+
+  if (components.cliVersion !== components.targetVersion) {
+    instructions.push(
+      `  global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${components.targetVersion} bash`,
+    );
+  }
+
+  if (
+    components.localPackageVersion &&
+    components.localPackageVersion !== components.targetVersion
+  ) {
+    instructions.push(
+      `  local package: npm install libretto@${components.targetVersion}`,
+    );
+  }
+
+  if (
+    components.skillVersions.length > 0 &&
+    components.skillVersions.some(
+      (skillVersion) => skillVersion !== components.targetVersion,
+    )
+  ) {
+    instructions.push("  agent skill:   libretto setup");
+  }
+
+  return instructions;
+}
+
 function formatVersionWarning(components: {
   cliVersion: string;
   localPackageVersion: string | null;
@@ -177,6 +212,10 @@ function formatVersionWarning(components: {
   ]);
   const skillLabel =
     components.skillVersions.length > 1 ? "agent skills" : "agent skill";
+  const updateInstructions = formatUpdateInstructions({
+    ...components,
+    targetVersion,
+  });
 
   return [
     "WARNING: Libretto version mismatch detected.",
@@ -193,9 +232,7 @@ function formatVersionWarning(components: {
     )}`,
     "",
     "How to update:",
-    `  global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${targetVersion} bash`,
-    `  local package: npm install libretto@${targetVersion}`,
-    "  agent skill:   libretto setup",
+    ...updateInstructions,
   ].join("\n");
 }
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -85,8 +85,22 @@ async function seedLocalLibrettoPackageVersion(
   );
 }
 
-function expectedVersionWarning(versions: string): string {
-  return `Warning: Libretto versions differ: ${versions}.`;
+function expectVersionWarningHeader(stderr: string): void {
+  expect(stderr).toContain("WARNING: Libretto version mismatch detected.");
+  expect(stderr).toContain("How to update:");
+}
+
+function expectVersionUpdateCommands(
+  stderr: string,
+  targetVersion: string,
+): void {
+  expect(stderr).toContain(
+    `global CLI:    npm install -g libretto@${targetVersion}`,
+  );
+  expect(stderr).toContain(
+    `local package: npm install libretto@${targetVersion}`,
+  );
+  expect(stderr).toContain("agent skill:   libretto setup");
 }
 
 function expectedRootHelp(): string {
@@ -635,12 +649,11 @@ export default workflow("main", async (ctx) => {
       PLAYWRIGHT_BROWSERS_PATH: "/definitely-not-real",
     });
 
-    expect(result.stderr).toContain(
-      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
-    );
-    expect(result.stderr).toContain(
-      `Use the same Libretto version globally and locally; run \`libretto setup\` after changing versions.`,
-    );
+    expectVersionWarningHeader(result.stderr);
+    expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
+    expect(result.stderr).toContain("local package: not installed");
+    expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
+    expectVersionUpdateCommands(result.stderr, cliVersion);
     expect(result.stderr).toContain("Daemon exited before startup");
   });
 
@@ -653,13 +666,15 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("connect not-a-url --session local");
 
-    expect(result.stderr).toContain(
-      expectedVersionWarning(`global CLI ${cliVersion}, local package 0.0.0`),
-    );
+    expectVersionWarningHeader(result.stderr);
+    expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
+    expect(result.stderr).toContain("local package: 0.0.0  (out of date)");
+    expect(result.stderr).toContain("agent skill:   not installed");
+    expectVersionUpdateCommands(result.stderr, cliVersion);
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
-  test("warns when the local libretto package and installed skill versions differ", async ({
+  test("warns when the local libretto package is out of date with the installed skill", async ({
     librettoCli,
     workspacePath,
   }) => {
@@ -669,11 +684,32 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("connect not-a-url --session skill-local");
 
+    expectVersionWarningHeader(result.stderr);
+    expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
+    expect(result.stderr).toContain("local package: 0.0.0  (out of date)");
+    expect(result.stderr).toContain(`agent skill:   ${cliVersion}`);
+    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
+  });
+
+  test("warns when the global CLI is out of date with the local project", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    const projectVersion = "9.9.9";
+    await seedLocalLibrettoPackageVersion(workspacePath, projectVersion);
+    await seedInstalledSkillVersion(workspacePath, ".agents", projectVersion);
+
+    const result = await librettoCli("connect not-a-url --session global-local");
+
+    expectVersionWarningHeader(result.stderr);
     expect(result.stderr).toContain(
-      expectedVersionWarning(
-        `global CLI ${cliVersion}, local package 0.0.0, agent skill ${cliVersion}`,
-      ),
+      `global CLI:    ${cliVersion}  (out of date)`,
     );
+    expect(result.stderr).toContain(`local package: ${projectVersion}`);
+    expect(result.stderr).toContain(`agent skill:   ${projectVersion}`);
+    expectVersionUpdateCommands(result.stderr, projectVersion);
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
@@ -772,9 +808,10 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("run ./integration.ts");
 
-    expect(result.stderr).toContain(
-      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
-    );
+    expectVersionWarningHeader(result.stderr);
+    expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
+    expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
+    expectVersionUpdateCommands(result.stderr, cliVersion);
     expect(result.stderr).toContain("Integration file does not exist:");
   });
 
@@ -787,9 +824,10 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("connect not-a-url --session mismatch");
 
-    expect(result.stderr).toContain(
-      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
-    );
+    expectVersionWarningHeader(result.stderr);
+    expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
+    expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
+    expectVersionUpdateCommands(result.stderr, cliVersion);
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
@@ -802,7 +840,9 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("connect not-a-url --session matching");
 
-    expect(result.stderr).not.toContain("Warning: Libretto versions differ:");
+    expect(result.stderr).not.toContain(
+      "WARNING: Libretto version mismatch detected.",
+    );
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -71,11 +71,22 @@ metadata:
   );
 }
 
-function expectedSkillVersionWarning(
-  skillVersion: string,
-  cliVersion: string,
-): string {
-  return `Warning: Your agent skill (${skillVersion}) is out of date with your Libretto CLI (${cliVersion}).`;
+async function seedLocalLibrettoPackageVersion(
+  workspacePath: (...parts: string[]) => string,
+  version: string,
+): Promise<void> {
+  await mkdir(workspacePath("node_modules", "libretto"), {
+    recursive: true,
+  });
+  await writeFile(
+    workspacePath("node_modules", "libretto", "package.json"),
+    JSON.stringify({ name: "libretto", version }),
+    "utf8",
+  );
+}
+
+function expectedVersionWarning(versions: string): string {
+  return `Warning: Libretto versions differ: ${versions}.`;
 }
 
 function expectedRootHelp(): string {
@@ -625,12 +636,45 @@ export default workflow("main", async (ctx) => {
     });
 
     expect(result.stderr).toContain(
-      expectedSkillVersionWarning("0.0.0", cliVersion),
+      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
     );
     expect(result.stderr).toContain(
-      `Please run \`libretto setup\` to update your skills to the correct version.`,
+      `Use the same Libretto version globally and locally; run \`libretto setup\` after changing versions.`,
     );
     expect(result.stderr).toContain("Daemon exited before startup");
+  });
+
+  test("warns when the local libretto package version differs from the global CLI", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedLocalLibrettoPackageVersion(workspacePath, "0.0.0");
+
+    const result = await librettoCli("connect not-a-url --session local");
+
+    expect(result.stderr).toContain(
+      expectedVersionWarning(`global CLI ${cliVersion}, local package 0.0.0`),
+    );
+    expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
+  });
+
+  test("warns when the local libretto package and installed skill versions differ", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const cliVersion = await readCliVersion();
+    await seedLocalLibrettoPackageVersion(workspacePath, "0.0.0");
+    await seedInstalledSkillVersion(workspacePath, ".agents", cliVersion);
+
+    const result = await librettoCli("connect not-a-url --session skill-local");
+
+    expect(result.stderr).toContain(
+      expectedVersionWarning(
+        `global CLI ${cliVersion}, local package 0.0.0, agent skill ${cliVersion}`,
+      ),
+    );
+    expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
   test("defaults sessioned browser commands to the default session", async ({
@@ -729,7 +773,7 @@ export default workflow("main", async (ctx) => {
     const result = await librettoCli("run ./integration.ts");
 
     expect(result.stderr).toContain(
-      expectedSkillVersionWarning("0.0.0", cliVersion),
+      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
     );
     expect(result.stderr).toContain("Integration file does not exist:");
   });
@@ -744,7 +788,7 @@ export default workflow("main", async (ctx) => {
     const result = await librettoCli("connect not-a-url --session mismatch");
 
     expect(result.stderr).toContain(
-      expectedSkillVersionWarning("0.0.0", cliVersion),
+      expectedVersionWarning(`global CLI ${cliVersion}, agent skill 0.0.0`),
     );
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
@@ -758,7 +802,7 @@ export default workflow("main", async (ctx) => {
 
     const result = await librettoCli("connect not-a-url --session matching");
 
-    expect(result.stderr).not.toContain("Warning: Your agent skill (");
+    expect(result.stderr).not.toContain("Warning: Libretto versions differ:");
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -90,17 +90,31 @@ function expectVersionWarningHeader(stderr: string): void {
   expect(stderr).toContain("How to update:");
 }
 
-function expectVersionUpdateCommands(
+function expectVersionUpdateCommand(
   stderr: string,
+  component: "global CLI" | "local package" | "agent skill",
   targetVersion: string,
 ): void {
-  expect(stderr).toContain(
-    `global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${targetVersion} bash`,
-  );
-  expect(stderr).toContain(
-    `local package: npm install libretto@${targetVersion}`,
-  );
-  expect(stderr).toContain("agent skill:   libretto setup");
+  const commands = {
+    "global CLI": `global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${targetVersion} bash`,
+    "local package": `local package: npm install libretto@${targetVersion}`,
+    "agent skill": "agent skill:   libretto setup",
+  };
+
+  expect(stderr).toContain(commands[component]);
+}
+
+function expectNoVersionUpdateCommand(
+  stderr: string,
+  component: "global CLI" | "local package" | "agent skill",
+): void {
+  const labels = {
+    "global CLI": "global CLI:    curl -fsSL",
+    "local package": "local package: npm install",
+    "agent skill": "agent skill:   libretto setup",
+  };
+
+  expect(stderr).not.toContain(labels[component]);
 }
 
 function expectedRootHelp(): string {
@@ -653,7 +667,9 @@ export default workflow("main", async (ctx) => {
     expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
     expect(result.stderr).toContain("local package: not installed");
     expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
-    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "global CLI");
+    expectNoVersionUpdateCommand(result.stderr, "local package");
+    expectVersionUpdateCommand(result.stderr, "agent skill", cliVersion);
     expect(result.stderr).toContain("Daemon exited before startup");
   });
 
@@ -670,7 +686,9 @@ export default workflow("main", async (ctx) => {
     expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
     expect(result.stderr).toContain("local package: 0.0.0  (out of date)");
     expect(result.stderr).toContain("agent skill:   not installed");
-    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "global CLI");
+    expectVersionUpdateCommand(result.stderr, "local package", cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "agent skill");
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
@@ -688,7 +706,9 @@ export default workflow("main", async (ctx) => {
     expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
     expect(result.stderr).toContain("local package: 0.0.0  (out of date)");
     expect(result.stderr).toContain(`agent skill:   ${cliVersion}`);
-    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "global CLI");
+    expectVersionUpdateCommand(result.stderr, "local package", cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "agent skill");
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
@@ -709,7 +729,9 @@ export default workflow("main", async (ctx) => {
     );
     expect(result.stderr).toContain(`local package: ${projectVersion}`);
     expect(result.stderr).toContain(`agent skill:   ${projectVersion}`);
-    expectVersionUpdateCommands(result.stderr, projectVersion);
+    expectVersionUpdateCommand(result.stderr, "global CLI", projectVersion);
+    expectNoVersionUpdateCommand(result.stderr, "local package");
+    expectNoVersionUpdateCommand(result.stderr, "agent skill");
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 
@@ -811,7 +833,9 @@ export default workflow("main", async (ctx) => {
     expectVersionWarningHeader(result.stderr);
     expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
     expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
-    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "global CLI");
+    expectNoVersionUpdateCommand(result.stderr, "local package");
+    expectVersionUpdateCommand(result.stderr, "agent skill", cliVersion);
     expect(result.stderr).toContain("Integration file does not exist:");
   });
 
@@ -827,7 +851,9 @@ export default workflow("main", async (ctx) => {
     expectVersionWarningHeader(result.stderr);
     expect(result.stderr).toContain(`global CLI:    ${cliVersion}`);
     expect(result.stderr).toContain("agent skill:   0.0.0  (out of date)");
-    expectVersionUpdateCommands(result.stderr, cliVersion);
+    expectNoVersionUpdateCommand(result.stderr, "global CLI");
+    expectNoVersionUpdateCommand(result.stderr, "local package");
+    expectVersionUpdateCommand(result.stderr, "agent skill", cliVersion);
     expect(result.stderr).toContain("Invalid CDP URL: not-a-url");
   });
 

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -95,7 +95,7 @@ function expectVersionUpdateCommands(
   targetVersion: string,
 ): void {
   expect(stderr).toContain(
-    `global CLI:    npm install -g libretto@${targetVersion}`,
+    `global CLI:    curl -fsSL https://libretto.sh/install.sh | LIBRETTO_VERSION=${targetVersion} bash`,
   );
   expect(stderr).toContain(
     `local package: npm install libretto@${targetVersion}`,


### PR DESCRIPTION
## Summary
- warn once when the global `libretto` CLI, local `node_modules/libretto` package, and installed agent skills report different versions
- keep the warning concise and point users to align versions and rerun `libretto setup`
- add CLI subprocess coverage for global/local, global/skill, and local/skill version mismatches

## Verification
- `pnpm -s --filter affordance build`
- `pnpm -s --filter libretto build`
- `pnpm -s --filter libretto type-check`
- `pnpm -s --filter libretto lint`
- `pnpm -s --filter libretto test:vitest test/basic.spec.ts`
