### PR TITLE
Add cloud observability docs and autorepair deploy flag

### DIFF
--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -41,7 +41,7 @@ const faqs: FAQItem[] = [
     question:
       "How is it different from tools like playwright-cli, agent-browser, and dev-browser?",
     answer:
-      "Libretto is both a runtime and a CLI, built specifically for writing reusable automation scripts.\n\nIt comes out of the box with a script validation loop that checks scripts run end-to-end when you generate them or make edits, pause statements you drop into your code for step-through debugging, and a workflow recorder that captures actions in a real browser and turns them into scripts.\n\nWhen you're happy with a script, you deploy it to the cloud and run it as a type-safe API with one command.",
+      "Libretto is both a runtime and a CLI, built specifically for writing reusable automation scripts.\n\nIt comes out of the box with a script validation loop that checks scripts run end-to-end when you generate them or make edits, pause statements agents can drop into your code for step-through debugging, and a workflow recorder that captures actions in a real browser and turns them into scripts.\n\nWhen you're happy with a script, you deploy it to the cloud and run it as a type-safe API with one command.",
   },
   {
     id: "providers",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,7 @@
               "libretto-cloud-hosting/overview",
               "libretto-cloud-hosting/authentication",
               "libretto-cloud-hosting/deployments",
+              "libretto-cloud-hosting/observability-and-debugging",
               "libretto-cloud-hosting/billing"
             ]
           },

--- a/docs/libretto-cloud-api/deployments-and-workflows.mdx
+++ b/docs/libretto-cloud-api/deployments-and-workflows.mdx
@@ -17,7 +17,7 @@ Request fields:
 - `description`: optional deployment description
 - `source`: base64-encoded gzip tarball
 - `entry_point`: optional entry file, default `index.ts`
-- `auto_repair`: optional boolean, default `false`
+- `auto_repair`: optional boolean, default `false`. When `true`, failed jobs for this deployment route to the autofix agent instead of the readonly debug agent.
 
 Response fields:
 
@@ -224,9 +224,9 @@ curl -X POST "https://api.libretto.sh/v1/deployments/sync" \
     Invoke workflows and inspect job state.
   </Card>
 
-  <Card title="Sessions" icon="browser" href="/libretto-cloud-api/sessions">
-    Create browser sessions directly.
-  </Card>
+<Card title="Sessions" icon="browser" href="/libretto-cloud-api/sessions">
+  Create browser sessions directly.
+</Card>
 
   <Card title="Libretto Cloud API overview" icon="book-open" href="/libretto-cloud-api/overview">
     See the shared request format.

--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -24,6 +24,14 @@ Request fields:
 
 If you set `callback_url`, you must also set `callback_secret`.
 
+Callback delivery order:
+
+1. If the job has `callback_url` and `callback_secret`, Libretto Cloud delivers only to that per-job callback.
+2. Otherwise, Libretto Cloud delivers to every active stored webhook endpoint for the tenant.
+3. If `skip_callbacks` is true, Libretto Cloud does not deliver callbacks or stored webhooks.
+
+Use `callback_url` for one-off or environment-specific result delivery. Use stored webhook endpoints for long-lived production destinations. See [Webhooks](/libretto-cloud-api/webhooks) for payload fields and signature headers.
+
 Response fields:
 
 - `success`
@@ -160,7 +168,9 @@ curl -X POST "https://api.libretto.sh/v1/jobs/create" \
       "params": {
         "memberId": "12345"
       },
-      "timeout_seconds": 300
+      "timeout_seconds": 300,
+      "callback_url": "https://example.com/libretto/job-callback",
+      "callback_secret": "replace-with-your-secret"
     }
   }'
 ```
@@ -172,6 +182,10 @@ curl -X POST "https://api.libretto.sh/v1/jobs/create" \
 
   <Card title="Deployments and Workflows" icon="rocket" href="/libretto-cloud-api/deployments-and-workflows">
     Deploy workflows and inspect build state.
+  </Card>
+
+  <Card title="Webhooks" icon="webhook" href="/libretto-cloud-api/webhooks">
+    Configure tenant-level job result webhooks.
   </Card>
 
   <Card title="Libretto Cloud API overview" icon="book-open" href="/libretto-cloud-api/overview">

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -83,10 +83,13 @@ If you want to deploy from a different entry file, keep the source directory as 
 ```bash theme={null}
 libretto cloud deploy my-automations \
   --description "payer portal workflows" \
-  --entry-point src/workflows/check-eligibility.ts
+  --entry-point src/workflows/check-eligibility.ts \
+  --auto-repair
 ```
 
 The CLI bundles the deploy artifact, uploads it to Libretto Cloud, then waits for the build to finish. When the build is ready, it prints the deployment id and the discovered workflow names.
+
+Use `--auto-repair` when failed jobs from this deployment should route to the autofix agent instead of the readonly debug agent.
 
 ### Run a deployed workflow
 
@@ -144,18 +147,6 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
 
 The `workflow` value must match the workflow name declared in code and discovered during deploy, not the deployment id, filename, or export alias.
 
-### Investigate cloud failures
-
-When a Libretto Cloud workflow job fails, the platform emails the configured debug recipient with:
-
-- A short diagnosis.
-- A handoff prompt for a local coding agent.
-- Links to the relevant debug context, such as screenshots or recordings when available.
-
-That email is designed to move the fix back into a local coding workflow quickly. After you receive it, use the local repo and Libretto tooling to inspect the failure and patch the workflow.
-
-For the local debugging flow, see [Debugging workflows](/guides/debugging-workflows).
-
 ### Hosting options
 
 Libretto Cloud is the managed path. If you would rather use a different browser or infrastructure provider, use the alternative providers docs instead:
@@ -168,7 +159,10 @@ Libretto Cloud is the managed path. If you would rather use a different browser 
 - [Deploy on AWS](/alternative-providers/aws)
 
 <Note>
-  This page covers the managed hosted-platform flow. The alternative provider pages are the right reference when you want a different managed browser provider or want to own the runtime, scheduler, and secrets infrastructure yourself.
+  This page covers the managed hosted-platform flow. The alternative provider
+  pages are the right reference when you want a different managed browser
+  provider or want to own the runtime, scheduler, and secrets infrastructure
+  yourself.
 </Note>
 
 <CardGroup cols={3}>
@@ -176,12 +170,24 @@ Libretto Cloud is the managed path. If you would rather use a different browser 
     Start with the high-level cloud workflow.
   </Card>
 
-  <Card title="Authentication" icon="key" href="/libretto-cloud-hosting/authentication">
-    Create accounts, join organizations, and issue API keys.
-  </Card>
+<Card
+  title="Authentication"
+  icon="key"
+  href="/libretto-cloud-hosting/authentication"
+>
+  Create accounts, join organizations, and issue API keys.
+</Card>
 
-  <Card title="Billing" icon="credit-card" href="/libretto-cloud-hosting/billing">
-    Manage plans and open the billing portal.
-  </Card>
+<Card title="Billing" icon="credit-card" href="/libretto-cloud-hosting/billing">
+  Manage plans and open the billing portal.
+</Card>
+
+<Card
+  title="Observability and Debugging"
+  icon="bug"
+  href="/libretto-cloud-hosting/observability-and-debugging"
+>
+  Debug workflow failures and investigate hosted workflow runs.
+</Card>
 
 </CardGroup>

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -83,8 +83,7 @@ If you want to deploy from a different entry file, keep the source directory as 
 ```bash theme={null}
 libretto cloud deploy my-automations \
   --description "payer portal workflows" \
-  --entry-point src/workflows/check-eligibility.ts \
-  --auto-repair
+  --entry-point src/workflows/check-eligibility.ts
 ```
 
 The CLI bundles the deploy artifact, uploads it to Libretto Cloud, then waits for the build to finish. When the build is ready, it prints the deployment id and the discovered workflow names.

--- a/docs/libretto-cloud-hosting/observability-and-debugging.mdx
+++ b/docs/libretto-cloud-hosting/observability-and-debugging.mdx
@@ -1,0 +1,55 @@
+---
+title: Observability and Debugging
+---
+
+> Debug workflow failures and investigate hosted workflow runs.
+
+### Recordings and debug context
+
+Every hosted workflow run captures a browser recording. Use it with job state, logs, screenshots, and failure reports to understand what happened during the run.
+
+Use `/v1/jobs/get` for status, params, timestamps, result or error, mapped stack, and `recording_url`.
+
+Use `/v1/jobs/debugReport` for failed-run diagnosis, fix instructions, artifact links, job error details, and auto-repair fields when available.
+
+Use `/v1/logs/list` for workflow logs and Libretto executor logs from the job, filtered by `jobId`, workflow, or severity.
+
+See [Jobs and Logs](/libretto-cloud-api/jobs-and-logs) for the full API reference.
+
+### Failure emails
+
+**By default**, when a Libretto Cloud workflow job fails, Libretto Cloud starts a debug agent to analyze the failed run. The agent emails the configured debug recipient with:
+
+- **A short diagnosis.** What failed and why.
+- **A handoff prompt for your local coding agent.** Includes the diagnosis and instructions for fixing the workflow.
+- **Links to relevant debug context.** Includes recordings, screenshots, and logs when available.
+
+The email is designed to move the fix back into a local coding workflow quickly. After you receive it, use the local repo and Libretto tooling to inspect the failure and patch the workflow.
+
+For the local debugging flow, see [Debugging workflows](/guides/debugging-workflows).
+
+### Auto-repair
+
+Auto-repair lets Libretto Cloud try to fix failed workflows for you. When a job fails, an autofix agent analyzes the run, edits the deployed workflow code, and publishes a replacement deployment when it has a fix.
+
+Use `--auto-repair` when deploying from the CLI:
+
+```bash theme={null}
+libretto cloud deploy my-automations --auto-repair
+```
+
+### Next steps
+
+<CardGroup cols={3}>
+  <Card title="Deployments" icon="rocket" href="/libretto-cloud-hosting/deployments">
+    Deploy workflow bundles and enable auto-repair.
+  </Card>
+
+  <Card title="Jobs and Logs" icon="terminal" href="/libretto-cloud-api/jobs-and-logs">
+    Invoke workflows and inspect job state.
+  </Card>
+
+  <Card title="Debugging workflows" icon="bug" href="/guides/debugging-workflows">
+    Use local tools to inspect and patch failed workflows.
+  </Card>
+</CardGroup>

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -17,7 +17,8 @@ Libretto Cloud is the easiest way to host and run workflows. Sign up, run one de
 Use Libretto Cloud when you want to ship and run workflows without owning the runtime infrastructure yourself.
 
 - Libretto Cloud runs the browser layer for you, so you do not have to manage proxies, browser sessions, or CAPTCHA handling yourself.
-- When a run fails, Libretto Cloud automatically analyzes the failure and emails you a summary, along with the recordings, screenshots, logs, and other debug context you need to understand what broke.
+- By default, when a run fails, Libretto Cloud automatically analyzes the failure and emails you a summary, along with the recordings, screenshots, logs, and other debug context you need to understand what broke.
+- Deployments can also enable auto-repair, which routes failed jobs to the autofix agent instead of only sending debug context.
 - You can build, debug, and deploy workflow packages from the same CLI instead of stitching together separate tools for local development, browsers, and hosting.
 
 ### Set up Libretto Cloud
@@ -139,7 +140,11 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
   </Card>
 
   <Card title="Deployments" icon="rocket" href="/libretto-cloud-hosting/deployments">
-    Deploy workflow bundles and investigate hosted failures.
+    Deploy workflow bundles to Libretto Cloud.
+  </Card>
+
+  <Card title="Observability and Debugging" icon="bug" href="/libretto-cloud-hosting/observability-and-debugging">
+    Debug workflow failures and investigate hosted workflow runs.
   </Card>
 
   <Card title="Billing" icon="credit-card" href="/libretto-cloud-hosting/billing">

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -125,6 +125,10 @@ export const deployInput = SimpleCLI.input({
       name: "entry-point",
       help: "Entry point file (default: index.ts)",
     }),
+    autoRepair: SimpleCLI.flag({
+      name: "auto-repair",
+      help: "Route failed jobs for this deployment to autofix",
+    }),
     external: SimpleCLI.option(
       z
         .string()
@@ -167,6 +171,7 @@ export const deployCommand = SimpleCLI.command({
       entry_point: entryPoint,
     };
     if (input.description) createPayload.description = input.description;
+    if (input.autoRepair) createPayload.auto_repair = true;
 
     console.log("Uploading deployment...");
     const body = await orpcCall<DeploymentResponse["json"]>({

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -89,6 +89,7 @@ import {
   loadDefaultWorkflow,
 } from "../workflow-runtime.js";
 import { WorkflowController } from "../workflow-runner/runner.js";
+import { validateWorkflowInput } from "../../../shared/workflow/workflow.js";
 
 function isOperationalPage(page: Page): boolean {
   const url = page.url();
@@ -941,6 +942,7 @@ async function main(): Promise<void> {
       loadedWorkflow = await loadDefaultWorkflow(
         getAbsoluteIntegrationPath(config.workflow.integrationPath),
       );
+      validateWorkflowInput(loadedWorkflow, config.workflow.params ?? {});
     } catch (error) {
       throw new UserFacingStartupError(
         error instanceof Error ? error.message : String(error),

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -100,11 +100,13 @@ export {
   LibrettoWorkflow,
   LibrettoWorkflowInputError,
   LIBRETTO_WORKFLOW_BRAND,
+  validateWorkflowInput,
   workflow,
   type ExportedLibrettoWorkflow,
   type LibrettoWorkflowContext,
   type LibrettoWorkflowHandler,
   type LibrettoWorkflowSchemas,
+  type WorkflowInputValidator,
 } from "./shared/workflow/workflow.js";
 const isDirectExecution = (): boolean => {
   const entryArg = process.argv[1];

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -49,6 +49,32 @@ function formatZodErrorMessage(
   ].join("\n");
 }
 
+function parseWorkflowInput<InputSchema extends z.ZodType>(
+  workflowName: string,
+  inputSchema: InputSchema | undefined,
+  input: unknown,
+): z.infer<InputSchema> {
+  if (!inputSchema) return input as z.infer<InputSchema>;
+
+  const result = inputSchema.safeParse(input);
+  if (!result.success) {
+    throw new LibrettoWorkflowInputError(workflowName, result.error);
+  }
+  return result.data;
+}
+
+export type WorkflowInputValidator = {
+  readonly name: string;
+  readonly inputSchema?: z.ZodType;
+};
+
+export function validateWorkflowInput(
+  workflow: WorkflowInputValidator,
+  input: unknown,
+): void {
+  parseWorkflowInput(workflow.name, workflow.inputSchema, input);
+}
+
 export class LibrettoWorkflow<
   InputSchema extends z.ZodType = z.ZodType<unknown>,
   OutputSchema extends z.ZodType = z.ZodType<unknown>,
@@ -86,16 +112,7 @@ export class LibrettoWorkflow<
     ctx: LibrettoWorkflowContext,
     input: unknown,
   ): Promise<z.infer<OutputSchema>> {
-    let parsed: z.infer<InputSchema>;
-    if (this.inputSchema) {
-      const result = this.inputSchema.safeParse(input);
-      if (!result.success) {
-        throw new LibrettoWorkflowInputError(this.name, result.error);
-      }
-      parsed = result.data;
-    } else {
-      parsed = input as z.infer<InputSchema>;
-    }
+    const parsed = parseWorkflowInput(this.name, this.inputSchema, input);
     return this.handler(ctx, parsed);
   }
 }

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -366,6 +366,22 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("prints deploy help with auto repair flag", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud deploy", {
+      npm_command: undefined,
+      npm_config_user_agent: undefined,
+    });
+    expect(result.stdout).toContain(
+      "Deploy workflows to the hosted platform",
+    );
+    expect(result.stdout).toContain("libretto cloud deploy [sourceDir]");
+    expect(result.stdout).toContain("--auto-repair");
+    expect(result.stdout).toContain(
+      "Route failed jobs for this deployment to autofix",
+    );
+    expect(result.stderr).toBe("");
+  });
+
   test("deploy requires an API key and points users to signup", async ({
     librettoCli,
     workspaceDir,
@@ -875,6 +891,39 @@ export default workflow("main", async (ctx) => {
   test("fails run with invalid JSON in --params", async ({ librettoCli }) => {
     const result = await librettoCli('run ./integration.ts --params "{not-json}"');
     expect(result.stderr).toContain("Invalid JSON in --params:");
+  });
+
+  test("validates workflow params before starting a browser session", async ({
+    librettoCli,
+    librettoRuntimePath,
+    writeWorkflowScript,
+  }) => {
+    await writeWorkflowScript(
+      "integration.ts",
+      outdent`
+        import { workflow } from "${librettoRuntimePath}";
+        import { z } from "zod";
+
+        export default workflow(
+          "main",
+          {
+            input: z.object({ url: z.string().url() }),
+            output: z.unknown(),
+          },
+          async () => "ok",
+        );
+      `,
+    );
+
+    const result = await librettoCli(
+      `run ./integration.ts --session validation-preflight --params '{"url":"not-url"}'`,
+    );
+    expect(result.stderr).toContain('Invalid input for workflow "main"');
+    expect(result.stderr).not.toContain("Browser is still open");
+    expect(result.stdout).not.toContain("Running workflow");
+
+    const pagesResult = await librettoCli("pages --session validation-preflight");
+    expectMissingSessionError(pagesResult.stderr, "validation-preflight");
   });
 
   test("fails fast for invalid session names before command execution", async ({


### PR DESCRIPTION
## Summary
- add `--auto-repair` to `libretto cloud deploy` and send `auto_repair` to deployment creation
- validate local workflow input before launching a browser session
- add Libretto Cloud observability/debugging docs and update related hosting/API copy

## Verification
- `CI=true pnpm -s type-check`
- `CI=true pnpm --filter libretto exec vitest run test/basic.spec.ts -t "validates workflow params|deploy help"`
- `pnpm -s docs:validate`
- manual local CLI run: extra input field completed; missing required `memberId` failed before creating a session