### PR TITLE
docs: fix billing price formatting

### DIFF
--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -58,7 +58,7 @@ Browser hours accrue when Libretto Cloud provisions a browser session for:
 
 Hosted usage is measured per browser session, from the time a session starts until Libretto records it as closed.
 
-Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at **$0.000069444 per second** (**$0.25 per browser hour**), which is reflected in the included hours on each plan.
+Each session is billed by the second and rounds up to the next whole second, with a one-second minimum per session. Browser seconds are priced at **\$0.000069444 per second** (**\$0.25 per browser hour**), which is reflected in the included hours on each plan.
 
 #### Plans and pricing
 


### PR DESCRIPTION
## Summary
- Escape billing price dollar signs so Mintlify does not parse the pricing sentence as inline math.
- Preserve the intended bold formatting for per-second and per-hour prices.

## Verification
- `pnpm -s docs:validate`
- Local Mintlify preview rendered the sentence as `<strong>$0.000069444 per second</strong> (<strong>$0.25 per browser hour</strong>)`.
