### PR TITLE
Document explicit recording URL endpoint

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -135,6 +135,7 @@
               "libretto-cloud-api/overview",
               "libretto-cloud-api/authentication",
               "libretto-cloud-api/sessions",
+              "libretto-cloud-api/recordings",
               "libretto-cloud-api/deployments-and-workflows",
               "libretto-cloud-api/jobs-and-logs",
               "libretto-cloud-api/credentials",

--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -87,7 +87,8 @@ Response fields:
 - `result`
 - `error`
 - `mapped_stack`
-- `recording_url`
+
+Use [Recordings](/libretto-cloud-api/recordings) when you need the job's recording URL.
 
 #### POST `/v1/jobs/debugReport`
 
@@ -107,7 +108,6 @@ Response fields:
 - `handoff_prompt`
 - `screenshot_url`
 - `dom_snapshot_url`
-- `recording_url`
 - `autofix_summary`
 - `autofix_deployment_id`
 - `email_sent_at`

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -51,6 +51,10 @@ This section documents the public `/v1/*` routes exposed by Libretto Cloud in th
     Create and close cloud browser sessions.
   </Card>
 
+  <Card title="Recordings" icon="video" href="/libretto-cloud-api/recordings">
+    Generate temporary recording URLs.
+  </Card>
+
   <Card title="Deployments and Workflows" icon="rocket" href="/libretto-cloud-api/deployments-and-workflows">
     Upload bundles, build workflows, and inspect workflow state.
   </Card>

--- a/docs/libretto-cloud-api/recordings.mdx
+++ b/docs/libretto-cloud-api/recordings.mdx
@@ -1,0 +1,54 @@
+---
+title: Recordings
+---
+
+> Use the recordings API to generate temporary browser links for hosted browser recordings.
+
+All routes on this page require `x-api-key`.
+
+### POST `/v1/recordings/get`
+
+Generate a recording URL for a job or browser session.
+
+Request fields:
+
+- `job_id`: optional job id
+- `session_id`: optional browser session id
+
+Provide exactly one of `job_id` or `session_id`.
+
+Response fields:
+
+- `recording_url`
+- `recording_url_expires_at`
+
+`recording_url` is `null` when no recording is available for the job or session. When Libretto returns a URL, treat it as an opaque browser link.
+
+Recording URLs are temporary. If a URL expires, call this route again with the same `job_id` or `session_id` to generate a fresh URL for the existing recording. The recording itself is not regenerated or deleted when a URL expires.
+
+Example:
+
+```bash
+curl -X POST "https://api.libretto.sh/v1/recordings/get" \
+  -H "x-api-key: $LIBRETTO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "json": {
+      "job_id": "<job-id>"
+    }
+  }'
+```
+
+<CardGroup cols={3}>
+  <Card title="Jobs and Logs" icon="terminal" href="/libretto-cloud-api/jobs-and-logs">
+    Run workflows and inspect job state.
+  </Card>
+
+  <Card title="Sessions" icon="browser" href="/libretto-cloud-api/sessions">
+    Create and close hosted browser sessions.
+  </Card>
+
+  <Card title="Libretto Cloud API overview" icon="book-open" href="/libretto-cloud-api/overview">
+    See the shared request format.
+  </Card>
+</CardGroup>

--- a/docs/libretto-cloud-api/sessions.mdx
+++ b/docs/libretto-cloud-api/sessions.mdx
@@ -2,7 +2,7 @@
 title: Sessions
 ---
 
-> Use the sessions API to create and close hosted browser sessions directly.
+> Use the sessions API to create, inspect, and close hosted browser sessions directly.
 
 All routes on this page require `x-api-key`.
 
@@ -18,9 +18,9 @@ Response fields:
 
 - `success`
 - `session_id`
+- `status`
 - `cdp_url`
 - `live_view_url`
-- `recording_url`
 
 Example:
 
@@ -35,9 +35,26 @@ curl -X POST "https://api.libretto.sh/v1/sessions/create" \
   }'
 ```
 
+### POST `/v1/sessions/get`
+
+Inspect a hosted browser session.
+
+Request fields:
+
+- `session_id`: session id returned from `sessions/create`
+
+Response fields:
+
+- `session_id`
+- `status`
+- `cdp_url`
+- `live_view_url`
+
+Use this route when `sessions/create` returned a queued or starting session and you need to poll for the CDP URL or live view URL.
+
 ### POST `/v1/sessions/close`
 
-Close a hosted browser session by provider session id.
+Close a hosted browser session by session id.
 
 Request fields:
 
@@ -47,7 +64,6 @@ Response fields:
 
 - `success`
 - `message`
-- `replay_url`
 
 Example:
 
@@ -69,6 +85,10 @@ curl -X POST "https://api.libretto.sh/v1/sessions/close" \
 
   <Card title="Jobs and Logs" icon="terminal" href="/libretto-cloud-api/jobs-and-logs">
     Run workflows and inspect results.
+  </Card>
+
+  <Card title="Recordings" icon="video" href="/libretto-cloud-api/recordings">
+    Generate recording URLs for jobs and browser sessions.
   </Card>
 
   <Card title="Deployments and Workflows" icon="rocket" href="/libretto-cloud-api/deployments-and-workflows">

--- a/docs/libretto-cloud-hosting/observability-and-debugging.mdx
+++ b/docs/libretto-cloud-hosting/observability-and-debugging.mdx
@@ -8,7 +8,9 @@ title: Observability and Debugging
 
 Every hosted workflow run captures a browser recording. Use it with job state, logs, screenshots, and failure reports to understand what happened during the run.
 
-Use `/v1/jobs/get` for status, params, timestamps, result or error, mapped stack, and `recording_url`.
+Use `/v1/jobs/get` for status, params, timestamps, result or error, and mapped stack.
+
+Use `/v1/recordings/get` with a `job_id` or `session_id` when you need a recording URL. Recording URLs are temporary; call the same endpoint again to generate a fresh URL after one expires.
 
 Use `/v1/jobs/debugReport` for failed-run diagnosis, fix instructions, artifact links, job error details, and auto-repair fields when available.
 

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -6,7 +6,6 @@ type CloudSessionResponse = {
   status: string;
   cdp_url: string | null;
   live_view_url: string | null;
-  recording_url: string | null;
 };
 
 const DEFAULT_POLL_INTERVAL_MS = 2_000;
@@ -77,8 +76,11 @@ export function createLibrettoCloudProvider(): ProviderApi {
       };
     },
     async closeSession(sessionId) {
-      const json = await closeCloudSession(endpoint, apiKey, sessionId);
-      return { replayUrl: json.replay_url ?? undefined };
+      await closeCloudSession(endpoint, apiKey, sessionId);
+      const replayUrl = await getCloudRecordingUrl(endpoint, apiKey, sessionId).catch(
+        () => undefined,
+      );
+      return { replayUrl };
     },
   };
 }
@@ -172,7 +174,7 @@ async function closeCloudSession(
   endpoint: string,
   apiKey: string,
   sessionId: string,
-): Promise<{ replay_url: string | null }> {
+): Promise<void> {
   const resp = await fetch(`${endpoint}/v1/sessions/close`, {
     method: "POST",
     headers: {
@@ -187,10 +189,31 @@ async function closeCloudSession(
       `Libretto Cloud API error closing session ${sessionId} (${resp.status}): ${body}`,
     );
   }
+}
+
+async function getCloudRecordingUrl(
+  endpoint: string,
+  apiKey: string,
+  sessionId: string,
+): Promise<string | undefined> {
+  const resp = await fetch(`${endpoint}/v1/recordings/get`, {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ json: { session_id: sessionId } }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(
+      `Libretto Cloud API error reading recording for session ${sessionId} (${resp.status}): ${body}`,
+    );
+  }
   const { json } = (await resp.json()) as {
-    json: { replay_url: string | null };
+    json: { recording_url: string | null };
   };
-  return json;
+  return json.recording_url ?? undefined;
 }
 
 function createStartupSessionCleanup(

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -297,7 +297,6 @@ describe("Libretto Cloud provider", () => {
               status: "open",
               cdp_url: "wss://cloud.example.test/devtools/session-ready",
               live_view_url: null,
-              recording_url: null,
             },
           });
         }
@@ -330,7 +329,6 @@ describe("Libretto Cloud provider", () => {
               status: "queued",
               cdp_url: null,
               live_view_url: null,
-              recording_url: null,
             },
           });
         }
@@ -346,7 +344,6 @@ describe("Libretto Cloud provider", () => {
                   : "wss://cloud.example.test/devtools/session-queued",
               live_view_url:
                 getCalls === 1 ? null : "https://cloud.example.test/live",
-              recording_url: null,
             },
           });
         }
@@ -388,7 +385,6 @@ describe("Libretto Cloud provider", () => {
               status: "queued",
               cdp_url: null,
               live_view_url: null,
-              recording_url: null,
             },
           });
         }
@@ -399,13 +395,12 @@ describe("Libretto Cloud provider", () => {
               status: "queued",
               cdp_url: null,
               live_view_url: null,
-              recording_url: null,
             },
           });
         }
         if (pathname === "/v1/sessions/close") {
           closeCallFinished = true;
-          return jsonResponse({ json: { replay_url: null } });
+          return jsonResponse({ json: { success: true, message: "closed" } });
         }
         return new Response("not found", { status: 404 });
       },
@@ -431,6 +426,40 @@ describe("Libretto Cloud provider", () => {
     } finally {
       process.send = originalSend;
     }
+  });
+
+  it("fetches a recording URL after closing a cloud session", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/close") {
+          return jsonResponse({ json: { success: true, message: "closed" } });
+        }
+        if (pathname === "/v1/recordings/get") {
+          expect(await readJsonBody(init)).toEqual({
+            json: { session_id: "session-closed" },
+          });
+          return jsonResponse({
+            json: {
+              recording_url: "https://api.example.test/recordings/session-closed?t=signed",
+              recording_url_expires_at: "2026-05-27T00:00:00.000Z",
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createLibrettoCloudProvider().closeSession("session-closed"),
+    ).resolves.toEqual({
+      replayUrl: "https://api.example.test/recordings/session-closed?t=signed",
+    });
+    expect(fetchMock.mock.calls.map(([url]) => new URL(String(url)).pathname))
+      .toEqual(["/v1/sessions/close", "/v1/recordings/get"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a dedicated Libretto Cloud API docs page for recordings
- document POST /v1/recordings/get with job_id or session_id inputs
- update the Libretto Cloud provider close flow to fetch recording URLs through the explicit endpoint

## Tests
- pnpm --dir packages/libretto/packages/libretto exec vitest run test/browser.spec.ts
- pnpm --dir packages/libretto/packages/libretto type-check