### PR TITLE
Add provider benchmarking eval support

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -19,7 +19,15 @@ pnpm evals
 pnpm evals run
 ```
 
-Cases run in parallel by default.
+Cases run in parallel by default, up to the CPU parallelism detected by Node.js.
+
+Repeat each selected case multiple times:
+
+```bash
+pnpm evals --repeat-count 3
+```
+
+Repeats run sequentially, with cases inside each repeat running up to the detected CPU parallelism. Run-level totals, infra counts, duration, and metrics are averaged per repeat so the aggregate fields stay comparable to a one-pass suite.
 
 Run only cases that do not declare an auth profile:
 

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -16,7 +16,7 @@ import { createEvalContext } from "./fixtures.js";
 import {
   takeRecordedScores,
   withScoreRecording,
-  type EvalInfraClassification,
+  type InfraClassification,
   type EvalScoreRecord,
 } from "./scoring.js";
 import {
@@ -68,10 +68,6 @@ type CliOptions =
   | ProfilesStatusCliOptions
   | ProfilesLoginCliOptions
   | SummaryCliOptions;
-
-type InfraClassification =
-  | EvalInfraClassification
-  | "recovered-anti-bot-pass";
 
 type CaseResult = {
   id: string;
@@ -1169,7 +1165,6 @@ function infraClassification(
   if (value == null) return fallback;
   if (
     value === "clean-pass" ||
-    value === "recovered-anti-bot-pass" ||
     value === "anti-bot-failure" ||
     value === "system-failure" ||
     value === "ordinary-failure"

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -741,19 +741,60 @@ async function readJson(path: string): Promise<unknown> {
   }
 }
 
-function collectStrings(value: unknown): string[] {
-  if (typeof value === "string") return [value];
-  if (Array.isArray(value)) return value.flatMap((item) => collectStrings(item));
-  if (isRecord(value)) {
-    return Object.values(value).flatMap((item) => collectStrings(item));
+function addRecordingUrlsFromValue(value: unknown, urls: Set<string>): void {
+  if (typeof value === "string") {
+    const urlPatterns = [
+      /View recording:\s*(https?:\/\/[^\s)"]+)/g,
+      /"recordingUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
+      /"replayUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
+      /"replayViewUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
+      /"replay_view_url"\s*:\s*"(https?:\/\/[^"]+)"/g,
+      /https?:\/\/\S*\/browser\/replays\?\S+/g,
+    ];
+    for (const pattern of urlPatterns) {
+      for (const match of value.matchAll(pattern)) {
+        urls.add(match[1] ?? match[0]);
+      }
+    }
+    return;
   }
-  return [];
+
+  if (Array.isArray(value)) {
+    for (const item of value) addRecordingUrlsFromValue(item, urls);
+    return;
+  }
+
+  if (!isRecord(value)) return;
+
+  for (const [key, child] of Object.entries(value)) {
+    if (
+      typeof child === "string" &&
+      ["recordingUrl", "replayUrl", "replayViewUrl", "replay_view_url"].includes(
+        key,
+      ) &&
+      /^https?:\/\//.test(child)
+    ) {
+      urls.add(child);
+    }
+    addRecordingUrlsFromValue(child, urls);
+  }
 }
 
 async function recordingUrlsFromTranscript(path: string): Promise<string[]> {
   const urls = new Set<string>();
-  const urlPattern = /https?:\/\/\S*\/browser\/replays\?\S+/g;
-  const content = await readFile(path, "utf8");
+  let content: string;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw error;
+  }
   for (const line of content.split("\n")) {
     if (line.trim().length === 0) continue;
     let event: unknown;
@@ -762,12 +803,7 @@ async function recordingUrlsFromTranscript(path: string): Promise<string[]> {
     } catch {
       continue;
     }
-    for (const text of collectStrings(event)) {
-      const matches = text.matchAll(urlPattern);
-      for (const match of matches) {
-        urls.add(match[0]);
-      }
-    }
+    addRecordingUrlsFromValue(event, urls);
   }
   return Array.from(urls);
 }

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { availableParallelism } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import {
@@ -15,6 +16,7 @@ import { createEvalContext } from "./fixtures.js";
 import {
   takeRecordedScores,
   withScoreRecording,
+  type EvalInfraClassification,
   type EvalScoreRecord,
 } from "./scoring.js";
 import {
@@ -43,6 +45,7 @@ type RunCliOptions = {
   model: string;
   provider: BrowserProviderName | null;
   noAuth: boolean;
+  repeatCount: number;
 };
 
 type ProfilesStatusCliOptions = {
@@ -66,8 +69,15 @@ type CliOptions =
   | ProfilesLoginCliOptions
   | SummaryCliOptions;
 
+type InfraClassification =
+  | EvalInfraClassification
+  | "recovered-anti-bot-pass";
+
 type CaseResult = {
   id: string;
+  baseId: string;
+  repeatIndex: number;
+  repeatCount: number;
   name: string;
   file: string | null;
   status: "completed" | "error" | "skipped";
@@ -81,6 +91,8 @@ type CaseResult = {
   };
   agentMetrics: EvalMetrics;
   judgeMetrics: EvalMetrics;
+  recordingUrls: string[];
+  infraClassification: InfraClassification;
   artifacts: {
     result: string;
     transcript: string;
@@ -100,18 +112,27 @@ type RunSummary = {
   startedAt: string;
   finishedAt: string;
   durationMs: number;
+  repeatCount: number;
   totalCaseDurationMs: number;
   averageCompletedDurationMs: number | null;
   selectedModel: string;
   selectedProvider: BrowserProviderName;
   totals: {
     cases: number;
+    attempts: number;
     completed: number;
     skipped: number;
     errored: number;
     scorePassed: number;
     scoreTotal: number;
     scorePercent: number;
+  };
+  infra: {
+    browserSystemErrorCount: number;
+    cleanPassCount: number;
+    antiBotFailureCount: number;
+    systemFailureCount: number;
+    ordinaryFailureCount: number;
   };
   metrics: {
     agent: EvalMetrics;
@@ -120,6 +141,9 @@ type RunSummary = {
   };
   cases: Array<{
     id: string;
+    baseId: string;
+    repeatIndex: number;
+    repeatCount: number;
     name: string;
     status: CaseResult["status"];
     durationMs: number;
@@ -127,6 +151,8 @@ type RunSummary = {
     agentMetrics: EvalMetrics;
     judgeMetrics: EvalMetrics;
     combinedMetrics: EvalMetrics;
+    recordingUrls: string[];
+    infraClassification: InfraClassification;
     artifacts: CaseResult["artifacts"];
     error?: string;
     skipReason?: string;
@@ -142,6 +168,7 @@ const BROWSER_PROVIDER_NAMES = [
   "local",
   "kernel",
   "browserbase",
+  "steel",
   "libretto-cloud",
 ] as const;
 type BrowserProviderName = (typeof BROWSER_PROVIDER_NAMES)[number];
@@ -197,6 +224,104 @@ function scorePercent(passed: number, total: number): number {
   return total > 0 ? Number(((passed / total) * 100).toFixed(2)) : 0;
 }
 
+function parsePositiveInteger(value: string, option: string): number {
+  const parsed = Number(value);
+  if (Number.isInteger(parsed) && parsed > 0 && String(parsed) === value) {
+    return parsed;
+  }
+  throw new Error(`${option} must be a positive integer.`);
+}
+
+function averageValue(value: number, repeatCount: number): number {
+  return value / repeatCount;
+}
+
+function averageDuration(value: number, repeatCount: number): number {
+  return Math.round(value / repeatCount);
+}
+
+function averageOptionalValue(
+  value: number | null,
+  repeatCount: number,
+): number | null {
+  return value == null ? null : averageValue(value, repeatCount);
+}
+
+function averageNumberMap(
+  value: Record<string, number>,
+  repeatCount: number,
+): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, count]) => [
+      key,
+      averageValue(count, repeatCount),
+    ]),
+  );
+}
+
+function averageMetrics(metrics: EvalMetrics, repeatCount: number): EvalMetrics {
+  if (repeatCount === 1) return metrics;
+  return {
+    ...metrics,
+    durationMs: averageOptionalValue(metrics.durationMs, repeatCount),
+    inputTokens: averageOptionalValue(metrics.inputTokens, repeatCount),
+    outputTokens: averageOptionalValue(metrics.outputTokens, repeatCount),
+    cacheReadTokens: averageOptionalValue(
+      metrics.cacheReadTokens,
+      repeatCount,
+    ),
+    cacheWriteTokens: averageOptionalValue(
+      metrics.cacheWriteTokens,
+      repeatCount,
+    ),
+    totalTokens: averageOptionalValue(metrics.totalTokens, repeatCount),
+    totalCostUsd: averageOptionalValue(metrics.totalCostUsd, repeatCount),
+    turns: averageValue(metrics.turns, repeatCount),
+    turnsWithUsage: averageValue(metrics.turnsWithUsage, repeatCount),
+    toolCalls: averageNumberMap(metrics.toolCalls, repeatCount),
+    totalToolCalls: averageValue(metrics.totalToolCalls, repeatCount),
+    failedToolCalls: averageValue(metrics.failedToolCalls, repeatCount),
+    failedToolCallsByName: averageNumberMap(
+      metrics.failedToolCallsByName,
+      repeatCount,
+    ),
+  };
+}
+
+function detectedEvalConcurrency(caseCount: number): {
+  availableParallelism: number;
+  maxParallelCases: number;
+} {
+  const detectedParallelism = Math.max(1, availableParallelism());
+  return {
+    availableParallelism: detectedParallelism,
+    maxParallelCases: Math.max(1, Math.min(caseCount, detectedParallelism)),
+  };
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) return;
+        results[index] = await mapper(items[index], index);
+      }
+    }),
+  );
+
+  return results;
+}
+
 function metricArtifactsForCase(
   outputDir: string,
   id: string,
@@ -223,7 +348,7 @@ function metricArtifactsForCase(
 function usage(): string {
   return [
     "Usage:",
-    "  pnpm evals [run] [file-filter ...] [-t <pattern>] [--output <dir>] [--model <provider/model>] [--provider <browser-provider>] [--no-auth]",
+    "  pnpm evals [run] [file-filter ...] [-t <pattern>] [--output <dir>] [--model <provider/model>] [--provider <browser-provider>] [--repeat-count <count>] [--no-auth]",
     "  pnpm evals summary [run-dir] [--allow-empty]",
     "  pnpm evals profiles status",
     "  pnpm evals profiles login <domain>",
@@ -232,6 +357,7 @@ function usage(): string {
     "  pnpm evals",
     "  pnpm evals --no-auth",
     "  pnpm evals run -t network --model openai/gpt-5.5 --provider kernel",
+    "  pnpm evals public-websites.eval.ts --provider kernel --repeat-count 3",
     "  pnpm evals basic.eval.ts --output temp/eval-run",
     "  pnpm evals summary",
     "  pnpm evals summary temp/eval-run",
@@ -293,6 +419,7 @@ function parseArgs(argv: string[]): CliOptions {
   let model = DEFAULT_EVAL_MODEL;
   let provider: BrowserProviderName | null = null;
   let noAuth = false;
+  let repeatCount = 1;
   const fileFilters: string[] = [];
 
   for (let index = 0; index < args.length; index += 1) {
@@ -354,6 +481,19 @@ function parseArgs(argv: string[]): CliOptions {
       provider = parseBrowserProviderName(value);
       continue;
     }
+    if (arg === "--repeat-count") {
+      const value = args[index + 1];
+      if (!value) throw new Error("--repeat-count requires a count.");
+      repeatCount = parsePositiveInteger(value, "--repeat-count");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--repeat-count=")) {
+      const value = arg.slice("--repeat-count=".length);
+      if (!value) throw new Error("--repeat-count requires a count.");
+      repeatCount = parsePositiveInteger(value, "--repeat-count");
+      continue;
+    }
     if (arg.startsWith("-")) {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -371,6 +511,7 @@ function parseArgs(argv: string[]): CliOptions {
     model,
     provider,
     noAuth,
+    repeatCount,
   };
 }
 
@@ -535,9 +676,10 @@ function ensureOpenAiApiKey(): void {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
       [
-        "OpenAI eval credentials are missing.",
+        "Could not load OpenAI eval credentials.",
+        "OPENAI_API_KEY is not set, and gcloud access to GCP Secret Manager failed.",
         `Tried GCP Secret Manager secret: ${secretName}`,
-        `Set OPENAI_API_KEY, grant access to ${secretName}, or set LIBRETTO_EVAL_OPENAI_SECRET_NAME to another secret name.`,
+        `Set OPENAI_API_KEY, grant gcloud access to ${secretName}, or set LIBRETTO_EVAL_OPENAI_SECRET_NAME to another secret name.`,
         `Original error: ${message}`,
       ].join("\n"),
     );
@@ -599,6 +741,51 @@ async function readJson(path: string): Promise<unknown> {
   }
 }
 
+function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap((item) => collectStrings(item));
+  if (isRecord(value)) {
+    return Object.values(value).flatMap((item) => collectStrings(item));
+  }
+  return [];
+}
+
+async function recordingUrlsFromTranscript(path: string): Promise<string[]> {
+  const urls = new Set<string>();
+  const urlPattern = /https?:\/\/\S*\/browser\/replays\?\S+/g;
+  const content = await readFile(path, "utf8");
+  for (const line of content.split("\n")) {
+    if (line.trim().length === 0) continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    for (const text of collectStrings(event)) {
+      const matches = text.matchAll(urlPattern);
+      for (const match of matches) {
+        urls.add(match[0]);
+      }
+    }
+  }
+  return Array.from(urls);
+}
+
+function classifyInfraResult(
+  status: CaseResult["status"],
+  score: CaseResult["score"],
+  scores: EvalScoreRecord[],
+): InfraClassification {
+  const passed = status === "completed" && score.total > 0 && score.passed === score.total;
+  if (status === "error") return "system-failure";
+  const explicitClassification = scores.find(
+    (record) => record.infraClassification,
+  )?.infraClassification;
+  if (explicitClassification) return explicitClassification;
+  return passed ? "clean-pass" : "ordinary-failure";
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -628,6 +815,18 @@ function requireNonNegativeInteger(value: unknown, label: string): number {
     return value;
   }
   throw new Error(`${label} must be a non-negative integer.`);
+}
+
+function optionalPositiveInteger(
+  value: unknown,
+  fallback: number,
+  label: string,
+): number {
+  if (value == null) return fallback;
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  throw new Error(`${label} must be a positive integer.`);
 }
 
 function optionalString(value: unknown, label: string): string | null {
@@ -751,15 +950,27 @@ function buildSummaryMarkdown(summary: RunSummary): string {
     `- Run ID: \`${summary.runId}\``,
     `- Model: \`${summary.selectedModel}\``,
     `- Browser provider: \`${summary.selectedProvider}\``,
+    `- Repeat count: \`${summary.repeatCount}\``,
     `- Duration: \`${formatDuration(summary.durationMs)}\``,
     `- Total case duration: \`${formatDuration(summary.totalCaseDurationMs)}\``,
     `- Average completed case duration: \`${formatDuration(summary.averageCompletedDurationMs)}\``,
+    `- Eval cases: \`${summary.totals.cases}\``,
+    `- Attempts: \`${summary.totals.attempts}\``,
     `- Cases completed: \`${summary.totals.completed}\``,
     `- Cases errored: \`${summary.totals.errored}\``,
     `- Cases skipped: \`${summary.totals.skipped}\``,
     `- Score: \`${score}\` criteria (\`${summary.totals.scorePercent}%\`)`,
+    `- Browser/system errors: \`${summary.infra.browserSystemErrorCount}\``,
+    `- Clean passes: \`${summary.infra.cleanPassCount}\``,
+    `- Anti-bot failures: \`${summary.infra.antiBotFailureCount}\``,
+    `- System failures: \`${summary.infra.systemFailureCount}\``,
     "",
     "Scoring is informational. Low scores do not fail the eval command; setup or runtime errors do.",
+    ...(summary.repeatCount > 1
+      ? [
+          "Suite-level totals, infra counts, duration, and metrics are averaged per repeat.",
+        ]
+      : []),
     "",
     "## Metrics",
     "",
@@ -773,14 +984,15 @@ function buildSummaryMarkdown(summary: RunSummary): string {
     "",
     "## Cases",
     "",
-    "| Case | Status | Score | Duration | Cost | Tokens | Tool calls | Artifacts |",
-    "|---|---|---:|---:|---:|---:|---:|---|",
+    "| Case | Attempt | Status | Infra | Score | Duration | Cost | Tokens | Tool calls | Artifacts |",
+    "|---|---:|---|---|---:|---:|---:|---:|---:|---|",
   ];
 
   for (const result of summary.cases) {
     const caseScore = `${result.score.passed}/${result.score.total}`;
+    const attempt = `${result.repeatIndex}/${result.repeatCount}`;
     lines.push(
-      `| \`${result.name}\` | ${result.status} | \`${caseScore}\` | \`${formatDuration(result.durationMs)}\` | \`${formatUsd(result.combinedMetrics.totalCostUsd)}\` | \`${formatInteger(result.combinedMetrics.totalTokens)}\` | \`${result.combinedMetrics.totalToolCalls}\` | \`${result.artifacts.result}\` |`,
+      `| \`${result.name}\` | \`${attempt}\` | ${result.status} | \`${result.infraClassification}\` | \`${caseScore}\` | \`${formatDuration(result.durationMs)}\` | \`${formatUsd(result.combinedMetrics.totalCostUsd)}\` | \`${formatInteger(result.combinedMetrics.totalTokens)}\` | \`${result.combinedMetrics.totalToolCalls}\` | \`${result.artifacts.result}\` |`,
     );
   }
 
@@ -790,6 +1002,9 @@ function buildSummaryMarkdown(summary: RunSummary): string {
 async function runCase(
   evalCase: EvalCaseRecord,
   id: string,
+  baseId: string,
+  repeatIndex: number,
+  repeatCount: number,
   outputDir: string,
   model: string,
   provider: BrowserProviderName | null,
@@ -857,21 +1072,28 @@ async function runCase(
   const combinedError = [errorMessage, cleanupErrorMessage]
     .filter((message) => message && message.length > 0)
     .join("\n\n");
+  const recordingUrls = await recordingUrlsFromTranscript(artifactPaths.transcript);
+  const score = {
+    passed: scorePassed,
+    total: scoreTotal,
+    percent: scorePercent(scorePassed, scoreTotal),
+  };
   const result: CaseResult = {
     id,
+    baseId,
+    repeatIndex,
+    repeatCount,
     name: evalCase.name,
     file: evalCase.filePath ? relative(repoRoot, evalCase.filePath) : null,
     status,
     startedAt,
     finishedAt: new Date(finishedMs).toISOString(),
     durationMs: finishedMs - startedMs,
-    score: {
-      passed: scorePassed,
-      total: scoreTotal,
-      percent: scorePercent(scorePassed, scoreTotal),
-    },
+    score,
     agentMetrics,
     judgeMetrics,
+    recordingUrls,
+    infraClassification: classifyInfraResult(status, score, scores),
     artifacts,
     calls,
     scores,
@@ -903,6 +1125,24 @@ function artifactRecord(value: unknown, label: string): CaseResult["artifacts"] 
   };
 }
 
+function infraClassification(
+  value: unknown,
+  fallback: InfraClassification,
+  label: string,
+): InfraClassification {
+  if (value == null) return fallback;
+  if (
+    value === "clean-pass" ||
+    value === "recovered-anti-bot-pass" ||
+    value === "anti-bot-failure" ||
+    value === "system-failure" ||
+    value === "ordinary-failure"
+  ) {
+    return value;
+  }
+  throw new Error(`${label} must be a valid infra classification.`);
+}
+
 function summaryCaseFromResult(
   value: unknown,
   label: string,
@@ -917,19 +1157,44 @@ function summaryCaseFromResult(
     result.judgeMetrics,
     `${label}.judgeMetrics`,
   );
+  const scoreRecord = {
+    passed: requireNonNegativeInteger(score.passed, `${label}.score.passed`),
+    total: requireNonNegativeInteger(score.total, `${label}.score.total`),
+    percent: requireFiniteNumber(score.percent, `${label}.score.percent`),
+  };
   return {
     id: requireString(result.id, `${label}.id`),
+    baseId:
+      typeof result.baseId === "string" && result.baseId.trim().length > 0
+        ? result.baseId
+        : requireString(result.id, `${label}.id`),
+    repeatIndex: optionalPositiveInteger(
+      result.repeatIndex,
+      1,
+      `${label}.repeatIndex`,
+    ),
+    repeatCount: optionalPositiveInteger(
+      result.repeatCount,
+      1,
+      `${label}.repeatCount`,
+    ),
     name: requireString(result.name, `${label}.name`),
     status: caseStatus(result.status, `${label}.status`),
     durationMs: requireFiniteNumber(result.durationMs, `${label}.durationMs`),
-    score: {
-      passed: requireNonNegativeInteger(score.passed, `${label}.score.passed`),
-      total: requireNonNegativeInteger(score.total, `${label}.score.total`),
-      percent: requireFiniteNumber(score.percent, `${label}.score.percent`),
-    },
+    score: scoreRecord,
     agentMetrics,
     judgeMetrics,
     combinedMetrics: aggregateMetrics([agentMetrics, judgeMetrics]),
+    recordingUrls: stringArray(result.recordingUrls, `${label}.recordingUrls`),
+    infraClassification: infraClassification(
+      result.infraClassification,
+      classifyInfraResult(
+        caseStatus(result.status, `${label}.status`),
+        scoreRecord,
+        [],
+      ),
+      `${label}.infraClassification`,
+    ),
     artifacts: artifactRecord(result.artifacts, `${label}.artifacts`),
     ...(typeof result.error === "string" ? { error: result.error } : {}),
     ...(typeof result.skipReason === "string"
@@ -956,7 +1221,30 @@ async function loadSummaryCases(
   );
   return cases
     .filter((result): result is RunSummary["cases"][number] => result !== null)
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) =>
+      a.baseId === b.baseId
+        ? a.repeatIndex - b.repeatIndex
+        : a.baseId.localeCompare(b.baseId),
+    );
+}
+
+function summarizeInfra(
+  cases: Array<{ infraClassification: InfraClassification }>,
+  repeatCount = 1,
+): RunSummary["infra"] {
+  const count = (classification: InfraClassification): number =>
+    averageValue(
+      cases.filter((result) => result.infraClassification === classification)
+        .length,
+      repeatCount,
+    );
+  return {
+    browserSystemErrorCount: count("system-failure"),
+    cleanPassCount: count("clean-pass"),
+    antiBotFailureCount: count("anti-bot-failure"),
+    systemFailureCount: count("system-failure"),
+    ordinaryFailureCount: count("ordinary-failure"),
+  };
 }
 
 async function readRunRecord(runDir: string): Promise<Record<string, unknown>> {
@@ -1008,24 +1296,59 @@ async function runSummary(options: SummaryCliOptions): Promise<number> {
   }
 
   const runRecord = await readRunRecord(runDir);
-  const scorePassed = cases.reduce(
-    (total, result) => total + result.score.passed,
-    0,
+  const repeatCount = optionalPositiveInteger(
+    runRecord.repeatCount,
+    cases[0]?.repeatCount ?? 1,
+    "run.json.repeatCount",
   );
-  const scoreTotal = cases.reduce(
-    (total, result) => total + result.score.total,
-    0,
+  const caseCount = new Set(cases.map((result) => result.baseId)).size;
+  const scorePassed = averageValue(
+    cases.reduce((total, result) => total + result.score.passed, 0),
+    repeatCount,
   );
-  const agentMetrics = aggregateMetrics(
-    cases.map((result) => result.agentMetrics),
+  const scoreTotal = averageValue(
+    cases.reduce((total, result) => total + result.score.total, 0),
+    repeatCount,
   );
-  const judgeMetrics = aggregateMetrics(
-    cases.map((result) => result.judgeMetrics),
+  const agentMetrics = averageMetrics(
+    aggregateMetrics(cases.map((result) => result.agentMetrics)),
+    repeatCount,
   );
-  const totalCaseDurationMs = cases.reduce(
-    (total, result) => total + result.durationMs,
-    0,
+  const judgeMetrics = averageMetrics(
+    aggregateMetrics(cases.map((result) => result.judgeMetrics)),
+    repeatCount,
   );
+  const totalCaseDurationMs = averageDuration(
+    cases.reduce((total, result) => total + result.durationMs, 0),
+    repeatCount,
+  );
+  const completedAttempts = completed.length;
+  const skippedAttempts = cases.filter(
+    (result) => result.status === "skipped",
+  ).length;
+  const erroredAttempts = cases.filter(
+    (result) => result.status === "error",
+  ).length;
+  const completedAverage = averageValue(completedAttempts, repeatCount);
+  const skippedAverage = averageValue(skippedAttempts, repeatCount);
+  const erroredAverage = averageValue(erroredAttempts, repeatCount);
+  const durationMs =
+    typeof runRecord.durationMs === "number" && Number.isFinite(runRecord.durationMs)
+      ? runRecord.durationMs
+      : typeof runRecord.wallDurationMs === "number" &&
+          Number.isFinite(runRecord.wallDurationMs)
+        ? averageDuration(runRecord.wallDurationMs, repeatCount)
+        : totalCaseDurationMs;
+  const averageCompletedDurationMs =
+    completedAttempts > 0
+      ? Math.round(
+          completed.reduce((total, result) => total + result.durationMs, 0) /
+            completedAttempts,
+        )
+      : null;
+  const combinedMetrics = aggregateMetrics([agentMetrics, judgeMetrics]);
+  const attempts = cases.length;
+  const selectedCaseCount = caseCount > 0 ? caseCount : attempts;
   const summary: RunSummary = {
     generatedAt: new Date().toISOString(),
     runId:
@@ -1036,18 +1359,10 @@ async function runSummary(options: SummaryCliOptions): Promise<number> {
       typeof runRecord.startedAt === "string" ? runRecord.startedAt : "",
     finishedAt:
       typeof runRecord.finishedAt === "string" ? runRecord.finishedAt : "",
-    durationMs:
-      typeof runRecord.durationMs === "number" && Number.isFinite(runRecord.durationMs)
-        ? runRecord.durationMs
-        : totalCaseDurationMs,
+    durationMs,
+    repeatCount,
     totalCaseDurationMs,
-    averageCompletedDurationMs:
-      completed.length > 0
-        ? Math.round(
-            completed.reduce((total, result) => total + result.durationMs, 0) /
-              completed.length,
-          )
-        : null,
+    averageCompletedDurationMs,
     selectedModel:
       typeof runRecord.selectedModel === "string" ? runRecord.selectedModel : "-",
     selectedProvider:
@@ -1055,18 +1370,20 @@ async function runSummary(options: SummaryCliOptions): Promise<number> {
         ? parseBrowserProviderName(runRecord.selectedProvider)
         : "local",
     totals: {
-      cases: cases.length,
-      completed: completed.length,
-      skipped: cases.filter((result) => result.status === "skipped").length,
-      errored: cases.filter((result) => result.status === "error").length,
+      cases: selectedCaseCount,
+      attempts,
+      completed: completedAverage,
+      skipped: skippedAverage,
+      errored: erroredAverage,
       scorePassed,
       scoreTotal,
       scorePercent: scorePercent(scorePassed, scoreTotal),
     },
+    infra: summarizeInfra(cases, repeatCount),
     metrics: {
       agent: agentMetrics,
       judge: judgeMetrics,
-      combined: aggregateMetrics([agentMetrics, judgeMetrics]),
+      combined: combinedMetrics,
     },
     cases,
   };
@@ -1082,35 +1399,50 @@ async function runSelectedCases(
   selectedCases: EvalCaseRecord[],
   ids: Map<EvalCaseRecord, string>,
   options: RunCliOptions,
+  repeatIndex: number,
+  maxParallelCases: number,
 ): Promise<CaseResult[]> {
-  return await Promise.all(
-    selectedCases.map(async (evalCase) => {
-      const id = ids.get(evalCase);
-      if (!id) {
+  return await mapWithConcurrency(
+    selectedCases,
+    maxParallelCases,
+    async (evalCase) => {
+      const baseId = ids.get(evalCase);
+      if (!baseId) {
         throw new Error(`Failed to allocate result ID for ${evalCase.name}`);
       }
+      const id =
+        options.repeatCount === 1
+          ? baseId
+          : `${baseId}-repeat-${repeatIndex}`;
+      const repeatLabel =
+        options.repeatCount === 1
+          ? ""
+          : ` (repeat ${repeatIndex}/${options.repeatCount})`;
 
-      process.stdout.write(`\n▶ ${evalCase.name}\n`);
+      process.stdout.write(`\n▶ ${evalCase.name}${repeatLabel}\n`);
       const result = await runCase(
         evalCase,
         id,
+        baseId,
+        repeatIndex,
+        options.repeatCount,
         options.outputDir,
         options.model,
         options.provider,
       );
       if (result.status === "completed") {
-        process.stdout.write(`✓ ${evalCase.name}\n`);
+        process.stdout.write(`✓ ${evalCase.name}${repeatLabel}\n`);
       } else if (result.status === "skipped") {
         process.stdout.write(
-          `- ${evalCase.name} skipped: ${result.skipReason ?? "No reason provided."}\n`,
+          `- ${evalCase.name}${repeatLabel} skipped: ${result.skipReason ?? "No reason provided."}\n`,
         );
       } else {
         process.stdout.write(
-          `✗ ${evalCase.name}\n${result.error ?? "Unknown error"}\n`,
+          `✗ ${evalCase.name}${repeatLabel}\n${result.error ?? "Unknown error"}\n`,
         );
       }
       return result;
-    }),
+    },
   );
 }
 
@@ -1150,67 +1482,133 @@ async function run(options: CliOptions): Promise<number> {
   ensureEvalModelCredentials(options.model);
 
   await mkdir(options.outputDir, { recursive: true });
-  process.stdout.write(`Running ${selectedCases.length} eval case(s)\n`);
-  process.stdout.write("Execution: parallel\n");
+  const selectedProvider = selectedProviderName(options.provider);
+  const { availableParallelism, maxParallelCases } =
+    detectedEvalConcurrency(selectedCases.length);
+  const attemptCount = selectedCases.length * options.repeatCount;
   process.stdout.write(
-    `Browser provider: ${selectedProviderName(options.provider)}\n`,
+    `Running ${selectedCases.length} eval case(s) x ${options.repeatCount} repeat(s) = ${attemptCount} attempt(s)\n`,
   );
+  process.stdout.write(
+    `Execution: up to ${maxParallelCases} parallel case(s), sequential repeats (detected ${availableParallelism} available CPU(s))\n`,
+  );
+  process.stdout.write(`Browser provider: ${selectedProvider}\n`);
+  if (selectedProvider === "kernel") {
+    process.stdout.write("Kernel stealth: true\n");
+    process.stdout.write("Kernel headful: true\n");
+  }
   process.stdout.write(`Output: ${options.outputDir}\n`);
 
   const ids = caseIds(selectedCases);
-  const results = await runSelectedCases(selectedCases, ids, options);
+  const previousKernelStealth = process.env.KERNEL_STEALTH;
+  const previousKernelHeadless = process.env.KERNEL_HEADLESS;
+  if (selectedProvider === "kernel") {
+    process.env.KERNEL_STEALTH = "true";
+    process.env.KERNEL_HEADLESS = "false";
+  }
 
-  const completed = results.filter(
+  let results: CaseResult[] = [];
+  try {
+    for (
+      let repeatIndex = 1;
+      repeatIndex <= options.repeatCount;
+      repeatIndex += 1
+    ) {
+      if (options.repeatCount > 1) {
+        process.stdout.write(
+          `\nRepeat ${repeatIndex}/${options.repeatCount}\n`,
+        );
+      }
+      results = results.concat(
+        await runSelectedCases(
+          selectedCases,
+          ids,
+          options,
+          repeatIndex,
+          maxParallelCases,
+        ),
+      );
+    }
+  } finally {
+    if (previousKernelStealth === undefined) {
+      delete process.env.KERNEL_STEALTH;
+    } else {
+      process.env.KERNEL_STEALTH = previousKernelStealth;
+    }
+    if (previousKernelHeadless === undefined) {
+      delete process.env.KERNEL_HEADLESS;
+    } else {
+      process.env.KERNEL_HEADLESS = previousKernelHeadless;
+    }
+  }
+
+  const completedAttempts = results.filter(
     (result) => result.status === "completed",
   ).length;
-  const skipped = results.filter((result) => result.status === "skipped").length;
-  const errored = results.filter((result) => result.status === "error").length;
-  const scorePassed = results.reduce(
+  const skippedAttempts = results.filter(
+    (result) => result.status === "skipped",
+  ).length;
+  const erroredAttempts = results.filter(
+    (result) => result.status === "error",
+  ).length;
+  const scorePassedAttempts = results.reduce(
     (total, result) => total + result.score.passed,
     0,
   );
-  const scoreTotal = results.reduce(
+  const scoreTotalAttempts = results.reduce(
     (total, result) => total + result.score.total,
     0,
   );
   const finishedAt = new Date().toISOString();
-  const durationMs = Date.now() - startedMs;
+  const wallDurationMs = Date.now() - startedMs;
+  const durationMs = averageDuration(wallDurationMs, options.repeatCount);
   const runId = relative(repoRoot, options.outputDir).startsWith("evals/runs/")
     ? toPosixPath(relative(join(repoRoot, "evals", "runs"), options.outputDir))
     : dirname(options.outputDir) === join(repoRoot, "evals", "runs")
       ? options.outputDir.split(sep).at(-1) ?? options.outputDir
       : options.outputDir.split(sep).at(-1) ?? options.outputDir;
-  const agentMetrics = aggregateMetrics(
-    results.map((result) => result.agentMetrics),
+  const agentMetrics = averageMetrics(
+    aggregateMetrics(results.map((result) => result.agentMetrics)),
+    options.repeatCount,
   );
-  const judgeMetrics = aggregateMetrics(
-    results.map((result) => result.judgeMetrics),
+  const judgeMetrics = averageMetrics(
+    aggregateMetrics(results.map((result) => result.judgeMetrics)),
+    options.repeatCount,
   );
   const combinedMetrics = aggregateMetrics([agentMetrics, judgeMetrics]);
-  const totalCaseDurationMs = results.reduce(
-    (total, result) => total + result.durationMs,
-    0,
+  const totalCaseDurationMs = averageDuration(
+    results.reduce((total, result) => total + result.durationMs, 0),
+    options.repeatCount,
   );
+  const completed = averageValue(completedAttempts, options.repeatCount);
+  const skipped = averageValue(skippedAttempts, options.repeatCount);
+  const errored = averageValue(erroredAttempts, options.repeatCount);
+  const scorePassed = averageValue(
+    scorePassedAttempts,
+    options.repeatCount,
+  );
+  const scoreTotal = averageValue(scoreTotalAttempts, options.repeatCount);
+  const completedAttemptDurationMs = results
+    .filter((result) => result.status === "completed")
+    .reduce((total, result) => total + result.durationMs, 0);
+  const averageCompletedDurationMs =
+    completedAttempts > 0
+      ? Math.round(completedAttemptDurationMs / completedAttempts)
+      : null;
   const summary: RunSummary = {
     generatedAt: finishedAt,
     runId,
     startedAt,
     finishedAt,
     durationMs,
+    repeatCount: options.repeatCount,
     totalCaseDurationMs,
-    averageCompletedDurationMs:
-      completed > 0
-        ? Math.round(
-            results
-              .filter((result) => result.status === "completed")
-              .reduce((total, result) => total + result.durationMs, 0) /
-              completed,
-          )
-        : null,
+    averageCompletedDurationMs,
     selectedModel: options.model,
-    selectedProvider: selectedProviderName(options.provider),
+    selectedProvider,
     totals: {
-      cases: results.length,
+      cases: selectedCases.length,
+      attempts: results.length,
       completed,
       skipped,
       errored,
@@ -1218,6 +1616,7 @@ async function run(options: CliOptions): Promise<number> {
       scoreTotal,
       scorePercent: scorePercent(scorePassed, scoreTotal),
     },
+    infra: summarizeInfra(results, options.repeatCount),
     metrics: {
       agent: agentMetrics,
       judge: judgeMetrics,
@@ -1225,6 +1624,9 @@ async function run(options: CliOptions): Promise<number> {
     },
     cases: results.map((result) => ({
       id: result.id,
+      baseId: result.baseId,
+      repeatIndex: result.repeatIndex,
+      repeatCount: result.repeatCount,
       name: result.name,
       status: result.status,
       durationMs: result.durationMs,
@@ -1235,6 +1637,8 @@ async function run(options: CliOptions): Promise<number> {
         result.agentMetrics,
         result.judgeMetrics,
       ]),
+      recordingUrls: result.recordingUrls,
+      infraClassification: result.infraClassification,
       artifacts: result.artifacts,
       ...(result.error ? { error: result.error } : {}),
       ...(result.skipReason ? { skipReason: result.skipReason } : {}),
@@ -1246,14 +1650,19 @@ async function run(options: CliOptions): Promise<number> {
     startedAt,
     finishedAt,
     durationMs,
+    wallDurationMs,
+    repeatCount: options.repeatCount,
     gitSha: gitSha(),
     outputDir: options.outputDir,
     fileFilters: options.fileFilters,
     testNamePattern: options.testNamePattern,
     selectedModel: options.model,
-    selectedProvider: selectedProviderName(options.provider),
+    selectedProvider,
     noAuth: options.noAuth,
+    availableParallelism,
+    maxParallelCases,
     totals: summary.totals,
+    infra: summary.infra,
     metrics: summary.metrics,
     cases: summary.cases,
   };
@@ -1267,9 +1676,9 @@ async function run(options: CliOptions): Promise<number> {
   );
 
   process.stdout.write(
-    `\nCompleted ${completed}/${results.length} eval case(s); score ${scorePassed}/${scoreTotal}; ${skipped} skipped; ${errored} error(s).\n`,
+    `\nCompleted ${completedAttempts}/${results.length} eval attempt(s); average score ${scorePassed}/${scoreTotal}; average skipped ${skipped}; average errors ${errored}.\n`,
   );
-  return errored > 0 ? 1 : 0;
+  return erroredAttempts > 0 ? 1 : 0;
 }
 
 async function profilesStatus(): Promise<number> {

--- a/evals/cli.ts
+++ b/evals/cli.ts
@@ -737,45 +737,6 @@ async function readJson(path: string): Promise<unknown> {
   }
 }
 
-function addRecordingUrlsFromValue(value: unknown, urls: Set<string>): void {
-  if (typeof value === "string") {
-    const urlPatterns = [
-      /View recording:\s*(https?:\/\/[^\s)"]+)/g,
-      /"recordingUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
-      /"replayUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
-      /"replayViewUrl"\s*:\s*"(https?:\/\/[^"]+)"/g,
-      /"replay_view_url"\s*:\s*"(https?:\/\/[^"]+)"/g,
-      /https?:\/\/\S*\/browser\/replays\?\S+/g,
-    ];
-    for (const pattern of urlPatterns) {
-      for (const match of value.matchAll(pattern)) {
-        urls.add(match[1] ?? match[0]);
-      }
-    }
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) addRecordingUrlsFromValue(item, urls);
-    return;
-  }
-
-  if (!isRecord(value)) return;
-
-  for (const [key, child] of Object.entries(value)) {
-    if (
-      typeof child === "string" &&
-      ["recordingUrl", "replayUrl", "replayViewUrl", "replay_view_url"].includes(
-        key,
-      ) &&
-      /^https?:\/\//.test(child)
-    ) {
-      urls.add(child);
-    }
-    addRecordingUrlsFromValue(child, urls);
-  }
-}
-
 async function recordingUrlsFromTranscript(path: string): Promise<string[]> {
   const urls = new Set<string>();
   let content: string;
@@ -793,15 +754,66 @@ async function recordingUrlsFromTranscript(path: string): Promise<string[]> {
   }
   for (const line of content.split("\n")) {
     if (line.trim().length === 0) continue;
-    let event: unknown;
+    let record: unknown;
     try {
-      event = JSON.parse(line);
-    } catch {
-      continue;
+      record = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse transcript JSON from ${path}: ${formatError(error)}`,
+      );
     }
-    addRecordingUrlsFromValue(event, urls);
+    for (const url of recordingUrlsFromTranscriptRecord(record)) urls.add(url);
   }
   return Array.from(urls);
+}
+
+function recordingUrlsFromTranscriptRecord(record: unknown): string[] {
+  if (!isRecord(record) || !isRecord(record.event)) return [];
+
+  const urls = new Set<string>();
+  addRecordingUrl(urls, recordingUrlField(record.event));
+  if (isRecord(record.event.result)) {
+    addRecordingUrl(urls, recordingUrlField(record.event.result));
+    for (const text of toolResultContentText(record.event.result)) {
+      addRecordingUrl(urls, recordingUrlFromCliOutput(text));
+    }
+  }
+  return Array.from(urls);
+}
+
+function recordingUrlField(record: Record<string, unknown>): string | null {
+  for (const key of ["recordingUrl", "replayUrl", "replayViewUrl", "replay_view_url"]) {
+    const value = record[key];
+    if (typeof value === "string" && isHttpUrl(value)) return value;
+  }
+  return null;
+}
+
+function toolResultContentText(result: Record<string, unknown>): string[] {
+  if (!Array.isArray(result.content)) return [];
+  return result.content.flatMap((item) => {
+    if (!isRecord(item) || typeof item.text !== "string") return [];
+    return [item.text];
+  });
+}
+
+function recordingUrlFromCliOutput(text: string): string | null {
+  for (const line of text.split("\n")) {
+    const prefix = "View recording:";
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(prefix)) continue;
+    const url = trimmed.slice(prefix.length).trim();
+    return isHttpUrl(url) ? url : null;
+  }
+  return null;
+}
+
+function addRecordingUrl(urls: Set<string>, url: string | null): void {
+  if (url) urls.add(url);
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\/\S+$/.test(value);
 }
 
 function classifyInfraResult(

--- a/evals/fixtures.ts
+++ b/evals/fixtures.ts
@@ -113,6 +113,7 @@ export async function createEvalContext(
   const harness = new PiEvalHarness({
     cwd: evalWorkspaceDir,
     model: options.model,
+    browserProvider: options.provider,
   });
 
   return {

--- a/evals/harness.ts
+++ b/evals/harness.ts
@@ -81,6 +81,7 @@ type PiUsageSummary = {
 export type PiEvalHarnessOptions = {
   cwd: string;
   model?: string;
+  browserProvider?: string | null;
   stopOnFinalResult?: boolean;
 };
 
@@ -738,6 +739,7 @@ export class EvalResponse {
 export class PiEvalHarness {
   private readonly cwd: string;
   private readonly model: EvalModelSelector;
+  readonly browserProvider: string;
   private readonly stopOnFinalResult: boolean;
   private session: AgentSession | null = null;
 
@@ -746,6 +748,7 @@ export class PiEvalHarness {
     this.model = options.model
       ? parseModelSelector(options.model)
       : DEFAULT_EVAL_MODEL;
+    this.browserProvider = options.browserProvider ?? "local";
     this.stopOnFinalResult = options.stopOnFinalResult === true;
   }
 

--- a/evals/public-websites.eval.ts
+++ b/evals/public-websites.eval.ts
@@ -1,6 +1,6 @@
 import { evalCase } from "./eval-case.js";
 import type { EvalScore } from "./harness.js";
-import { recordScore, type EvalInfraClassification } from "./scoring.js";
+import { recordScore, type InfraClassification } from "./scoring.js";
 
 type WebsiteEval = {
   name: string;
@@ -125,7 +125,7 @@ const ANTI_BOT_CRITERION =
 
 function infraClassificationForScore(
   score: EvalScore,
-): EvalInfraClassification {
+): InfraClassification {
   const antiBotCriterion = score.criteria[1];
   if (antiBotCriterion && !antiBotCriterion.pass) return "anti-bot-failure";
   return score.passed === score.total ? "clean-pass" : "ordinary-failure";

--- a/evals/public-websites.eval.ts
+++ b/evals/public-websites.eval.ts
@@ -1,0 +1,181 @@
+import { evalCase } from "./eval-case.js";
+import type { EvalScore } from "./harness.js";
+import { recordScore, type EvalInfraClassification } from "./scoring.js";
+
+type WebsiteEval = {
+  name: string;
+  task: string;
+};
+
+const WEBSITE_EVALS: WebsiteEval[] = [
+  {
+    name: "craigslist used bikes search",
+    task: "Search Craigslist for used bikes in San Francisco. Tell me the title and price of the first relevant listing.",
+  },
+  {
+    name: "apartments.com austin apartment search",
+    task: "Search Apartments.com for apartments in Austin under $2,000. Tell me the first listing name, price, and neighborhood.",
+  },
+  {
+    name: "apple newest iphone lookup",
+    task: "Find the newest iPhone on Apple.com. Tell me its starting price and available colors.",
+  },
+  {
+    name: "google official playwright docs result",
+    task: 'Search Google for "Playwright docs network mocking". Open the official docs result and tell me the page title.',
+  },
+  {
+    name: "youtube playwright tutorial search",
+    task: 'Search YouTube for "Playwright tutorial". Tell me the title of the first video result.',
+  },
+  {
+    name: "reddit browser automation thread",
+    task: 'Search Reddit for "browser automation". Open one relevant thread and summarize the top comment.',
+  },
+  {
+    name: "amazon wireless mouse search",
+    task: 'Search Amazon for "wireless mouse". Tell me the name and price of the first organic result.',
+  },
+  {
+    name: "walmart paper towels search",
+    task: 'Search Walmart for "paper towels". Tell me the first product name, price, and whether pickup is available.',
+  },
+  {
+    name: "target coffee maker search",
+    task: 'Search Target for "coffee maker". Tell me the first product name, price, and rating.',
+  },
+  {
+    name: "best buy headphones search",
+    task: 'Search Best Buy for "noise cancelling headphones". Tell me the first product name and price.',
+  },
+  {
+    name: "airbnb austin next weekend search",
+    task: "Search Airbnb for stays in Austin next weekend. Tell me the first listing name and nightly price.",
+  },
+  {
+    name: "booking.com chicago hotel search",
+    task: "Search Booking.com for hotels in Chicago next weekend. Tell me the first hotel name, rating, and price.",
+  },
+  {
+    name: "expedia sfo jfk flight search",
+    task: "Search Expedia for flights from SFO to JFK next Friday. Tell me the cheapest listed price.",
+  },
+  {
+    name: "doordash nyc pizza search",
+    task: "Search DoorDash for pizza near New York City. Tell me the first restaurant name and rating.",
+  },
+  {
+    name: "uber eats sf sushi search",
+    task: "Search Uber Eats for sushi near San Francisco. Tell me the first restaurant name and delivery estimate.",
+  },
+  {
+    name: "zillow seattle homes search",
+    task: "Search Zillow for homes in Seattle under $800k. Tell me the first listing price and address area.",
+  },
+  {
+    name: "realtor.com denver homes search",
+    task: "Search Realtor.com for homes in Denver. Tell me the first listing price and number of bedrooms.",
+  },
+  {
+    name: "yelp brooklyn coffee shops search",
+    task: "Search Yelp for coffee shops in Brooklyn. Tell me the first business name, rating, and review count.",
+  },
+  {
+    name: "linkedin public job search",
+    task: 'Search LinkedIn for "browser automation engineer". Tell me if public results are visible without signing in.',
+  },
+  {
+    name: "hacker news browser automation search",
+    task: 'Search Hacker News for "browser automation". Find one recent thread and tell me its title.',
+  },
+  {
+    name: "github playwright repo stats",
+    task: "Open the Playwright GitHub repo. Tell me how many stars it has and what language it mostly uses.",
+  },
+  {
+    name: "npm playwright package lookup",
+    task: "Look up the playwright package on npm. Tell me the latest version and weekly downloads.",
+  },
+  {
+    name: "pypi requests package lookup",
+    task: "Look up the requests package on PyPI. Tell me the latest version and supported Python versions.",
+  },
+  {
+    name: "mdn array map lookup",
+    task: "Find the MDN page for Array.prototype.map(). Tell me what the method returns.",
+  },
+  {
+    name: "wikipedia olympics medal table lookup",
+    task: "Open the Wikipedia page for the 2024 Summer Olympics medal table. Tell me the top three countries.",
+  },
+  {
+    name: "books to scrape five star cheapest book",
+    task: "Find the cheapest book with a 5-star rating on Books to Scrape. Tell me its title and price.",
+  },
+  {
+    name: "quotes to scrape einstein quote",
+    task: "Go through Quotes to Scrape and find the first quote by Albert Einstein. Tell me the quote.",
+  },
+];
+
+const LIVE_PAGE_EVIDENCE_CRITERION =
+  "The agent used Libretto with the configured browser provider to reach the requested website or task area, perform the requested search or lookup, and return a plausible answer grounded in live page evidence. Be lenient about ambiguous result choice, sorting, availability, prices, or dynamic website content. Mark false if the run failed to use Libretto, used a different browser provider than the configured one, went to the wrong site/task area, could not access the relevant page due to browser/provider issues, or returned an answer without evidence from the live page.";
+const ANTI_BOT_CRITERION =
+  "Mark false if the run encountered or reported an anti-bot block, including CAPTCHA, challenge, human verification, bot check, Access Denied, permission denied, blocked, 403/Forbidden, unusual traffic, or bot-detection pages, and the block was still present after the agent waited up to 3 minutes and checked the same intended site again. Mark false if the agent worked around an anti-bot block by opening another page, session, search result, mirror, API, cached copy, or fallback source. Mark true for a challenge if the configured browser provider visibly solved it automatically within the 3-minute wait and the agent continued directly on the intended site from that solved page.";
+
+function infraClassificationForScore(
+  score: EvalScore,
+): EvalInfraClassification {
+  const antiBotCriterion = score.criteria[1];
+  if (antiBotCriterion && !antiBotCriterion.pass) return "anti-bot-failure";
+  return score.passed === score.total ? "clean-pass" : "ordinary-failure";
+}
+
+function captchaInstruction(provider: string): string {
+  const providerName =
+    provider === "kernel"
+      ? "Kernel"
+      : provider === "browserbase"
+        ? "browserbase"
+        : provider === "steel"
+          ? "Steel"
+          : "local";
+  const otherProviders = ["local", "Kernel", "browserbase", "Steel"]
+    .filter((name) => name !== providerName)
+    .join(", ");
+
+  if (provider === "kernel") {
+    return [
+      `Use the configured Kernel browser provider; do not switch to ${otherProviders}, search-result snippets, mirrors, APIs, or unrelated fallback sources.`,
+      "The browser provider is Kernel, which is expected to auto-solve CAPTCHA, challenge, bot-check, and human-verification pages.",
+      "If you see a CAPTCHA, challenge, bot-check, human-verification page, Access Denied, permission denied, blocked, 403/Forbidden, unusual traffic, or bot-detection page, wait up to 3 minutes for the browser provider to solve it automatically, then check the same intended site again.",
+      "If the anti-bot page is gone, continue directly from the requested site. If the anti-bot page is still there after the 3-minute wait, report that the task failed immediately.",
+      "Do not work around anti-bot blocks by opening another page, session, search result, mirror, API, cached copy, or fallback source.",
+    ].join(" ");
+  }
+
+  return [
+    `Use the configured ${providerName} browser provider; do not switch to ${otherProviders}, search-result snippets, mirrors, APIs, or unrelated fallback sources.`,
+    `If you see a CAPTCHA, challenge, bot-check, human-verification page, Access Denied, permission denied, blocked, 403/Forbidden, unusual traffic, or bot-detection page, wait up to 3 minutes for the browser provider to solve it automatically, then check the same intended site again.`,
+    "If the anti-bot page is gone, continue directly from the requested site. If the anti-bot page is still there after the 3-minute wait, report that the task failed immediately.",
+    "Do not work around anti-bot blocks by opening another page, session, search result, mirror, API, cached copy, or fallback source.",
+  ].join(" ");
+}
+
+for (const websiteEval of WEBSITE_EVALS) {
+  evalCase({ name: websiteEval.name }, async ({ harness }) => {
+    const response = await harness.send(
+      `${websiteEval.task}. Use Libretto. ${captchaInstruction(
+        harness.browserProvider,
+      )}`,
+    );
+
+    const score = await response.score([
+      LIVE_PAGE_EVIDENCE_CRITERION,
+      ANTI_BOT_CRITERION,
+    ]);
+    recordScore(websiteEval.name, score, {
+      infraClassification: infraClassificationForScore(score),
+    });
+  });
+}

--- a/evals/scoring.ts
+++ b/evals/scoring.ts
@@ -4,6 +4,16 @@ import type { EvalMetrics } from "./artifacts.js";
 
 type EvalFailureRecord = Pick<ScoredCriterion, "criterion" | "reason">;
 
+export type EvalInfraClassification =
+  | "clean-pass"
+  | "anti-bot-failure"
+  | "system-failure"
+  | "ordinary-failure";
+
+export type EvalScoreMetadata = {
+  infraClassification?: EvalInfraClassification;
+};
+
 export type EvalScoreRecord = {
   name: string;
   passed: number;
@@ -18,6 +28,7 @@ export type EvalScoreRecord = {
     metrics: EvalMetrics;
   };
   judge: EvalJudgeRecord;
+  infraClassification?: EvalInfraClassification;
 };
 
 const recordedScores: EvalScoreRecord[] = [];
@@ -27,7 +38,11 @@ function currentRecordedScores(): EvalScoreRecord[] {
   return scoreStorage.getStore() ?? recordedScores;
 }
 
-function toRecord(name: string, score: EvalScore): EvalScoreRecord {
+function toRecord(
+  name: string,
+  score: EvalScore,
+  metadata: EvalScoreMetadata = {},
+): EvalScoreRecord {
   return {
     name,
     passed: score.passed,
@@ -39,11 +54,18 @@ function toRecord(name: string, score: EvalScore): EvalScoreRecord {
       .map(({ criterion, reason }) => ({ criterion, reason })),
     agent: score.agent,
     judge: score.judge,
+    ...(metadata.infraClassification
+      ? { infraClassification: metadata.infraClassification }
+      : {}),
   };
 }
 
-export function recordScore(name: string, score: EvalScore): EvalScoreRecord {
-  const record = toRecord(name, score);
+export function recordScore(
+  name: string,
+  score: EvalScore,
+  metadata: EvalScoreMetadata = {},
+): EvalScoreRecord {
+  const record = toRecord(name, score, metadata);
   currentRecordedScores().push(record);
   return record;
 }

--- a/evals/scoring.ts
+++ b/evals/scoring.ts
@@ -4,14 +4,14 @@ import type { EvalMetrics } from "./artifacts.js";
 
 type EvalFailureRecord = Pick<ScoredCriterion, "criterion" | "reason">;
 
-export type EvalInfraClassification =
+export type InfraClassification =
   | "clean-pass"
   | "anti-bot-failure"
   | "system-failure"
   | "ordinary-failure";
 
 export type EvalScoreMetadata = {
-  infraClassification?: EvalInfraClassification;
+  infraClassification?: InfraClassification;
 };
 
 export type EvalScoreRecord = {
@@ -28,7 +28,7 @@ export type EvalScoreRecord = {
     metrics: EvalMetrics;
   };
   judge: EvalJudgeRecord;
-  infraClassification?: EvalInfraClassification;
+  infraClassification?: InfraClassification;
 };
 
 const recordedScores: EvalScoreRecord[] = [];

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -628,13 +628,20 @@ async function runIntegrationFromFile(
       stayOpenOnSuccess: args.stayOpenOnSuccess,
       daemonSocketPath,
       provider: provider
-        ? { name: provider.name, sessionId: provider.sessionId }
+        ? {
+            name: provider.name,
+            sessionId: provider.sessionId,
+            recordingUrl: provider.recordingUrl,
+          }
         : undefined,
     },
     logger,
   );
   if (provider?.liveViewUrl) {
     console.log(`View live session: ${provider.liveViewUrl}`);
+  }
+  if (provider?.recordingUrl) {
+    console.log(`View recording: ${provider.recordingUrl}`);
   }
 
   let outcome: WorkflowOutcome;

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -568,10 +568,14 @@ export async function runOpenWithProvider(
     sessionId: providerSession.sessionId,
     cdpEndpoint: providerSession.cdpEndpoint,
     liveViewUrl: providerSession.liveViewUrl,
+    recordingUrl: providerSession.recordingUrl,
   });
 
   if (providerSession.liveViewUrl) {
     console.log(`View live session: ${providerSession.liveViewUrl}`);
+  }
+  if (providerSession.recordingUrl) {
+    console.log(`View recording: ${providerSession.recordingUrl}`);
   }
 
   writeSessionState(
@@ -587,6 +591,7 @@ export async function runOpenWithProvider(
       provider: {
         name: providerName,
         sessionId: providerSession.sessionId,
+        recordingUrl: providerSession.recordingUrl,
       },
     },
     logger,
@@ -867,7 +872,7 @@ async function waitForCloseAllTargets(
 
 async function closeProviderSessionDirectly(
   session: string,
-  providerState: { name: string; sessionId: string },
+  providerState: { name: string; sessionId: string; recordingUrl?: string },
   logger: LoggerApi,
 ): Promise<string | undefined> {
   try {
@@ -879,7 +884,7 @@ async function closeProviderSessionDirectly(
       sessionId: providerState.sessionId,
       replayUrl: result.replayUrl,
     });
-    return result.replayUrl;
+    return result.replayUrl ?? providerState.recordingUrl;
   } catch (error) {
     logger.warn("close-provider-direct-fallback-failed", {
       session,

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -182,6 +182,7 @@ class BrowserDaemon {
       provider: ProviderApi;
       name: string;
       sessionId: string;
+      recordingUrl?: string;
     },
   ) {
     this.logger = logger.withScope("child");
@@ -230,11 +231,13 @@ class BrowserDaemon {
       sessionId: string;
       cdpEndpoint: string;
       liveViewUrl?: string;
+      recordingUrl?: string;
     };
     providerSession?: {
       provider: ProviderApi;
       name: string;
       sessionId: string;
+      recordingUrl?: string;
     };
     beforeReady?: () => void;
   }): Promise<BrowserDaemon> {
@@ -516,11 +519,13 @@ class BrowserDaemon {
           sessionId: providerSession.sessionId,
           cdpEndpoint: providerSession.cdpEndpoint,
           liveViewUrl: providerSession.liveViewUrl,
+          recordingUrl: providerSession.recordingUrl,
         },
         providerSession: {
           provider,
           name: config.providerName,
           sessionId: providerSession.sessionId,
+          recordingUrl: providerSession.recordingUrl,
         },
         beforeReady: startupCleanup.dispose,
       });
@@ -593,13 +598,13 @@ class BrowserDaemon {
         const result = await this.providerSession.provider.closeSession(
           this.providerSession.sessionId,
         );
-        replayUrl = result.replayUrl;
-        if (result.replayUrl) {
+        replayUrl = result.replayUrl ?? this.providerSession.recordingUrl;
+        if (replayUrl) {
           this.logger.info("provider-recording", {
             session: this.session,
             provider: this.providerSession.name,
             sessionId: this.providerSession.sessionId,
-            replayUrl: result.replayUrl,
+            replayUrl,
           });
         }
         writeFileSync(
@@ -608,7 +613,7 @@ class BrowserDaemon {
             {
               provider: this.providerSession.name,
               sessionId: this.providerSession.sessionId,
-              replayUrl: result.replayUrl,
+              replayUrl,
             },
             null,
             2,

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -98,6 +98,7 @@ export type DaemonReadyMessage = {
     sessionId: string;
     cdpEndpoint: string;
     liveViewUrl?: string;
+    recordingUrl?: string;
   };
 };
 

--- a/packages/libretto/src/cli/core/providers/kernel.ts
+++ b/packages/libretto/src/cli/core/providers/kernel.ts
@@ -1,51 +1,167 @@
 import type { ProviderApi } from "./types.js";
 
-const KERNEL_API_ENDPOINT = "https://api.onkernel.com";
+export type KernelProviderOptions = {
+  apiKey?: string;
+  headless?: boolean;
+  stealth?: boolean;
+  timeoutSeconds?: number;
+  enableRecording?: boolean;
+};
 
-export function createKernelProvider(): ProviderApi {
-  const apiKey = process.env.KERNEL_API_KEY;
+type KernelBrowserResponse = {
+  session_id: string;
+  cdp_ws_url: string;
+  browser_live_view_url?: string | null;
+};
+
+type KernelReplayResponse = {
+  replay_id: string;
+  replay_view_url?: string | null;
+};
+
+function readBooleanEnv(name: string, defaultValue: boolean): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return defaultValue;
+  return value === "1" || value === "true" || value === "yes";
+}
+
+function readTimeoutSeconds(options: KernelProviderOptions): number {
+  if (options.timeoutSeconds !== undefined) return options.timeoutSeconds;
+  return Number(process.env.KERNEL_TIMEOUT_SECONDS ?? 300);
+}
+
+async function kernelFetchJson<T>(
+  endpoint: string,
+  apiKey: string,
+  path: string,
+  init: RequestInit,
+): Promise<T> {
+  const resp = await fetch(`${endpoint}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Kernel API error (${resp.status}): ${body}`);
+  }
+  return (await resp.json()) as T;
+}
+
+async function kernelFetchNoBody(
+  endpoint: string,
+  apiKey: string,
+  path: string,
+  init: RequestInit,
+): Promise<void> {
+  const resp = await fetch(`${endpoint}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      ...init.headers,
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Kernel API error (${resp.status}): ${body}`);
+  }
+}
+
+export function createKernelProvider(
+  options: KernelProviderOptions = {},
+): ProviderApi {
+  const apiKey = options.apiKey ?? process.env.KERNEL_API_KEY;
   if (!apiKey)
     throw new Error("KERNEL_API_KEY is required for Kernel provider.");
+  const endpoint = process.env.KERNEL_ENDPOINT ?? "https://api.onkernel.com";
+  const headless = options.headless ?? process.env.KERNEL_HEADLESS !== "false";
+  const stealth = options.stealth ?? readBooleanEnv("KERNEL_STEALTH", false);
+  const timeoutSeconds = readTimeoutSeconds(options);
+  const enableRecording =
+    options.enableRecording ?? readBooleanEnv("KERNEL_ENABLE_RECORDING", false);
+  const replays = new Map<
+    string,
+    {
+      replayId: string;
+      replayViewUrl?: string;
+    }
+  >();
 
   return {
     async createSession() {
-      const resp = await fetch(`${KERNEL_API_ENDPOINT}/browsers`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
+      const json = await kernelFetchJson<KernelBrowserResponse>(
+        endpoint,
+        apiKey,
+        "/browsers",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            headless,
+            stealth,
+            timeout_seconds: timeoutSeconds,
+          }),
         },
-        body: JSON.stringify({
-          headless: process.env.KERNEL_HEADLESS !== "false",
-          stealth: process.env.KERNEL_STEALTH === "true",
-          timeout_seconds: Number(process.env.KERNEL_TIMEOUT_SECONDS ?? 300),
-        }),
-      });
-      if (!resp.ok) {
-        const body = await resp.text();
-        throw new Error(`Kernel API error (${resp.status}): ${body}`);
+      );
+
+      let replay: KernelReplayResponse | undefined;
+      if (enableRecording) {
+        try {
+          replay = await kernelFetchJson<KernelReplayResponse>(
+            endpoint,
+            apiKey,
+            `/browsers/${json.session_id}/replays`,
+            { method: "POST", body: JSON.stringify({}) },
+          );
+          replays.set(json.session_id, {
+            replayId: replay.replay_id,
+            replayViewUrl: replay.replay_view_url ?? undefined,
+          });
+        } catch (error) {
+          await kernelFetchNoBody(
+            endpoint,
+            apiKey,
+            `/browsers/${json.session_id}`,
+            { method: "DELETE" },
+          ).catch(() => {});
+          throw error;
+        }
       }
-      const json = (await resp.json()) as {
-        session_id: string;
-        cdp_ws_url: string;
-      };
+
       return {
         sessionId: json.session_id,
         cdpEndpoint: json.cdp_ws_url,
+        liveViewUrl: json.browser_live_view_url ?? undefined,
+        recordingUrl: replay?.replay_view_url ?? undefined,
       };
     },
     async closeSession(sessionId) {
-      const resp = await fetch(`${KERNEL_API_ENDPOINT}/browsers/${sessionId}`, {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${apiKey}` },
-      });
-      if (!resp.ok) {
-        const body = await resp.text();
-        throw new Error(
-          `Kernel API error closing session ${sessionId} (${resp.status}): ${body}`,
-        );
+      const replay = replays.get(sessionId);
+      let replayStopError: unknown;
+      if (replay) {
+        try {
+          await kernelFetchNoBody(
+            endpoint,
+            apiKey,
+            `/browsers/${sessionId}/replays/${replay.replayId}/stop`,
+            { method: "POST" },
+          );
+        } catch (error) {
+          replayStopError = error;
+        }
       }
-      return {};
+
+      await kernelFetchNoBody(endpoint, apiKey, `/browsers/${sessionId}`, {
+        method: "DELETE",
+      });
+      replays.delete(sessionId);
+
+      if (replayStopError) {
+        throw replayStopError;
+      }
+      return { replayUrl: replay?.replayViewUrl };
     },
   };
 }

--- a/packages/libretto/src/cli/core/providers/types.ts
+++ b/packages/libretto/src/cli/core/providers/types.ts
@@ -5,6 +5,9 @@ export type ProviderSession = {
   // Only libretto-cloud surfaces this today; direct-SDK providers leave it
   // undefined.
   liveViewUrl?: string;
+  // Provider-hosted URL for watching the recording for this session. It may be
+  // available as soon as recording starts, before the provider has finalized it.
+  recordingUrl?: string;
 };
 
 export type ProviderCloseResult = {

--- a/packages/libretto/src/shared/state/index.ts
+++ b/packages/libretto/src/shared/state/index.ts
@@ -7,6 +7,7 @@ export {
   parseSessionStateContent,
   serializeSessionState,
   type SessionAccessMode,
+  type ProviderState,
   type SessionStatus,
   type SessionState,
   type SessionStateFile,

--- a/packages/libretto/src/shared/state/session-state.ts
+++ b/packages/libretto/src/shared/state/session-state.ts
@@ -19,6 +19,7 @@ export const SessionViewportSchema = z.object({
 export const ProviderStateSchema = z.object({
   name: z.string(),
   sessionId: z.string(),
+  recordingUrl: z.string().url().optional(),
 });
 
 export const SessionStateFileSchema = z.object({
@@ -38,6 +39,7 @@ export const SessionStateFileSchema = z.object({
 
 export type SessionStatus = z.infer<typeof SessionStatusSchema>;
 export type SessionAccessMode = z.infer<typeof SessionAccessModeSchema>;
+export type ProviderState = z.infer<typeof ProviderStateSchema>;
 export type SessionStateFile = z.infer<typeof SessionStateFileSchema>;
 export type SessionState = Omit<SessionStateFile, "version">;
 

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { openInput } from "../src/cli/commands/browser.js";
 import { normalizeDomain, normalizeUrl } from "../src/cli/core/browser.js";
 import { resolveProviderName } from "../src/cli/core/providers/index.js";
+import { createKernelProvider } from "../src/cli/core/providers/kernel.js";
 import { createLibrettoCloudProvider } from "../src/cli/core/providers/libretto-cloud.js";
 import { createSteelProvider } from "../src/cli/core/providers/steel.js";
 import { test } from "./fixtures.js";
@@ -275,6 +276,113 @@ describe("provider session guards", () => {
     );
     expect(result.stderr).toContain("already open");
     expect(result.stderr).toContain("kernel");
+  });
+});
+
+describe("Kernel provider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses constructor options before environment defaults", async () => {
+    vi.stubEnv("KERNEL_API_KEY", "env-key");
+    vi.stubEnv("KERNEL_HEADLESS", "false");
+    vi.stubEnv("KERNEL_STEALTH", "false");
+    vi.stubEnv("KERNEL_TIMEOUT_SECONDS", "111");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/browsers") {
+          return jsonResponse({
+            session_id: "kernel-session",
+            cdp_ws_url: "wss://kernel.example.test/cdp",
+            browser_live_view_url: "https://kernel.example.test/live",
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const session = await createKernelProvider({
+      apiKey: "constructor-key",
+      headless: true,
+      stealth: true,
+      timeoutSeconds: 222,
+    }).createSession();
+
+    expect(session).toEqual({
+      sessionId: "kernel-session",
+      cdpEndpoint: "wss://kernel.example.test/cdp",
+      liveViewUrl: "https://kernel.example.test/live",
+      recordingUrl: undefined,
+    });
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer constructor-key",
+    });
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      headless: true,
+      stealth: true,
+      timeout_seconds: 222,
+    });
+  });
+
+  it("starts and stops replay recording when enabled", async () => {
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        const method = init?.method;
+        if (pathname === "/browsers" && method === "POST") {
+          return jsonResponse({
+            session_id: "kernel-recorded",
+            cdp_ws_url: "wss://kernel.example.test/recorded",
+            browser_live_view_url: "https://kernel.example.test/live",
+          });
+        }
+        if (pathname === "/browsers/kernel-recorded/replays") {
+          return jsonResponse({
+            replay_id: "replay-123",
+            replay_view_url: "https://kernel.example.test/replay",
+          });
+        }
+        if (
+          pathname === "/browsers/kernel-recorded/replays/replay-123/stop"
+        ) {
+          return new Response(null, { status: 200 });
+        }
+        if (pathname === "/browsers/kernel-recorded" && method === "DELETE") {
+          return new Response(null, { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createKernelProvider({
+      apiKey: "test-key",
+      enableRecording: true,
+    });
+
+    const session = await provider.createSession();
+    expect(session).toEqual({
+      sessionId: "kernel-recorded",
+      cdpEndpoint: "wss://kernel.example.test/recorded",
+      liveViewUrl: "https://kernel.example.test/live",
+      recordingUrl: "https://kernel.example.test/replay",
+    });
+
+    await expect(provider.closeSession("kernel-recorded")).resolves.toEqual({
+      replayUrl: "https://kernel.example.test/replay",
+    });
+    expect(fetchMock.mock.calls.map(([url]) => new URL(String(url)).pathname))
+      .toEqual([
+        "/browsers",
+        "/browsers/kernel-recorded/replays",
+        "/browsers/kernel-recorded/replays/replay-123/stop",
+        "/browsers/kernel-recorded",
+      ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a public website eval suite for comparing browser providers on live websites and anti-bot behavior
- add eval CLI support for provider selection, repeat counts, bounded parallelism, averaged aggregate metrics, recording URLs, and infra classifications
- add Kernel provider constructor options and recording/live-view state plumbing, with tests for provider state persistence

## Validation
- `pnpm -s type-check`
- `pnpm -s test`
