### PR TITLE
Document CAPTCHA handling in Libretto skill

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -24,7 +24,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Workflow guides: [one-shot generation](https://libretto.sh/docs/guides/one-shot-workflow-generation), [interactive building](https://libretto.sh/docs/guides/interactive-workflow-building), [debugging workflows](https://libretto.sh/docs/guides/debugging-workflows), [convert to network requests](https://libretto.sh/docs/guides/convert-to-network-requests)
 - CLI reference: [open and connect](https://libretto.sh/docs/reference/cli/open-and-connect), [sessions](https://libretto.sh/docs/reference/cli/sessions), [profiles](https://libretto.sh/docs/reference/cli/profiles), [snapshot](https://libretto.sh/docs/reference/cli/snapshot), [exec](https://libretto.sh/docs/reference/cli/exec), [run and resume](https://libretto.sh/docs/reference/cli/run-and-resume), [session logs](https://libretto.sh/docs/reference/cli/session-logs), [pages](https://libretto.sh/docs/reference/cli/pages)
 - Library API: [workflow](https://libretto.sh/docs/reference/runtime/workflow), [AI extraction](https://libretto.sh/docs/reference/runtime/ai-extraction), [network requests](https://libretto.sh/docs/reference/runtime/network-requests), [file downloads](https://libretto.sh/docs/reference/runtime/file-downloads)
-- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments)
+- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments), [stealth](https://libretto.sh/docs/libretto-cloud-hosting/stealth)
 - Alternative providers: [overview](https://libretto.sh/docs/alternative-providers/overview), [Kernel](https://libretto.sh/docs/alternative-providers/kernel), [Browserbase](https://libretto.sh/docs/alternative-providers/browserbase), [Steel](https://libretto.sh/docs/alternative-providers/steel), [GCP](https://libretto.sh/docs/alternative-providers/gcp), [AWS](https://libretto.sh/docs/alternative-providers/aws)
 
 ## Default Integration Approach
@@ -40,8 +40,8 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 ## CAPTCHA Handling
 
 - If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
-- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
-- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+- If the same challenge appears while the session is using a hosted browser provider, wait up to 2 minutes for automatic CAPTCHA handling before deciding the workflow is blocked.
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a short comment linking to the hosted platform stealth docs. Follow `references/code-generation-rules.md` for the code shape.
 
 ## Setup
 

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -37,6 +37,12 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
+## CAPTCHA Handling
+
+- If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
+- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+
 ## Setup
 
 - Use the package manager convention for the target project. The examples use `npx libretto`; pnpm, yarn, and bun projects should use their equivalent package-manager execution form.

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -59,14 +59,10 @@ Before extracting data (for example text, rows, or field values), wait for the t
 
 ## CAPTCHA Waits
 
-If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit 2 minute timeout wait. Put a short comment immediately above the wait linking to the hosted platform stealth docs:
 
 ```typescript
-// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
-// CAPTCHA solving on self-hosted infra is unsupported.
-// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
-// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
-// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+// Wait for hosted CAPTCHA solving; see https://libretto.sh/docs/libretto-cloud-hosting/stealth.
 await page.waitForTimeout(120_000);
 ```
 

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -57,6 +57,21 @@ During the interactive `exec` phase, `page.evaluate` is fine for quick prototypi
 
 Before extracting data (for example text, rows, or field values), wait for the target content itself to be ready, not just its container.
 
+## CAPTCHA Waits
+
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+
+```typescript
+// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
+// CAPTCHA solving on self-hosted infra is unsupported.
+// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
+// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
+// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+await page.waitForTimeout(120_000);
+```
+
+Use the wait only where a challenge was actually observed or is expected from the site's normal flow. After the wait, continue with a concrete locator or URL assertion for the real page state so the workflow fails clearly if the challenge was not solved.
+
 ### Anti-Patterns
 
 These patterns come up frequently during interactive sessions and should not carry over into production code:

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -24,7 +24,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Workflow guides: [one-shot generation](https://libretto.sh/docs/guides/one-shot-workflow-generation), [interactive building](https://libretto.sh/docs/guides/interactive-workflow-building), [debugging workflows](https://libretto.sh/docs/guides/debugging-workflows), [convert to network requests](https://libretto.sh/docs/guides/convert-to-network-requests)
 - CLI reference: [open and connect](https://libretto.sh/docs/reference/cli/open-and-connect), [sessions](https://libretto.sh/docs/reference/cli/sessions), [profiles](https://libretto.sh/docs/reference/cli/profiles), [snapshot](https://libretto.sh/docs/reference/cli/snapshot), [exec](https://libretto.sh/docs/reference/cli/exec), [run and resume](https://libretto.sh/docs/reference/cli/run-and-resume), [session logs](https://libretto.sh/docs/reference/cli/session-logs), [pages](https://libretto.sh/docs/reference/cli/pages)
 - Library API: [workflow](https://libretto.sh/docs/reference/runtime/workflow), [AI extraction](https://libretto.sh/docs/reference/runtime/ai-extraction), [network requests](https://libretto.sh/docs/reference/runtime/network-requests), [file downloads](https://libretto.sh/docs/reference/runtime/file-downloads)
-- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments)
+- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments), [stealth](https://libretto.sh/docs/libretto-cloud-hosting/stealth)
 - Alternative providers: [overview](https://libretto.sh/docs/alternative-providers/overview), [Kernel](https://libretto.sh/docs/alternative-providers/kernel), [Browserbase](https://libretto.sh/docs/alternative-providers/browserbase), [Steel](https://libretto.sh/docs/alternative-providers/steel), [GCP](https://libretto.sh/docs/alternative-providers/gcp), [AWS](https://libretto.sh/docs/alternative-providers/aws)
 
 ## Default Integration Approach
@@ -40,8 +40,8 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 ## CAPTCHA Handling
 
 - If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
-- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
-- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+- If the same challenge appears while the session is using a hosted browser provider, wait up to 2 minutes for automatic CAPTCHA handling before deciding the workflow is blocked.
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a short comment linking to the hosted platform stealth docs. Follow `references/code-generation-rules.md` for the code shape.
 
 ## Setup
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -37,6 +37,12 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
+## CAPTCHA Handling
+
+- If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
+- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+
 ## Setup
 
 - Use the package manager convention for the target project. The examples use `npx libretto`; pnpm, yarn, and bun projects should use their equivalent package-manager execution form.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -59,14 +59,10 @@ Before extracting data (for example text, rows, or field values), wait for the t
 
 ## CAPTCHA Waits
 
-If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit 2 minute timeout wait. Put a short comment immediately above the wait linking to the hosted platform stealth docs:
 
 ```typescript
-// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
-// CAPTCHA solving on self-hosted infra is unsupported.
-// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
-// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
-// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+// Wait for hosted CAPTCHA solving; see https://libretto.sh/docs/libretto-cloud-hosting/stealth.
 await page.waitForTimeout(120_000);
 ```
 

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -57,6 +57,21 @@ During the interactive `exec` phase, `page.evaluate` is fine for quick prototypi
 
 Before extracting data (for example text, rows, or field values), wait for the target content itself to be ready, not just its container.
 
+## CAPTCHA Waits
+
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+
+```typescript
+// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
+// CAPTCHA solving on self-hosted infra is unsupported.
+// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
+// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
+// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+await page.waitForTimeout(120_000);
+```
+
+Use the wait only where a challenge was actually observed or is expected from the site's normal flow. After the wait, continue with a concrete locator or URL assertion for the real page state so the workflow fails clearly if the challenge was not solved.
+
 ### Anti-Patterns
 
 These patterns come up frequently during interactive sessions and should not carry over into production code:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -115,7 +115,8 @@
               "libretto-cloud-hosting/authentication",
               "libretto-cloud-hosting/deployments",
               "libretto-cloud-hosting/observability-and-debugging",
-              "libretto-cloud-hosting/billing"
+              "libretto-cloud-hosting/billing",
+              "libretto-cloud-hosting/stealth"
             ]
           },
           {

--- a/docs/libretto-cloud-hosting/stealth.mdx
+++ b/docs/libretto-cloud-hosting/stealth.mdx
@@ -1,0 +1,28 @@
+---
+title: Stealth
+sidebarTitle: Stealth
+---
+
+> Libretto's stealth browsers help hosted runs avoid bot detection.
+
+Every Libretto Cloud browser runs in stealth mode. Hosted runs use residential proxies and managed browser fingerprints, so sessions look more like normal user traffic than bare automation.
+
+Stealth also includes automatic CAPTCHA handling. Libretto Cloud cannot guarantee every challenge will clear, but common CAPTCHA and bot-check pages can resolve without a manual handoff.
+
+## Workflow behavior
+
+On Libretto Cloud, if a workflow reaches a CAPTCHA, Cloudflare check, or similar interstitial, wait up to 2 minutes before treating it as blocked. That gives the hosted browser time to finish the provider-side solve and continue to the page your workflow expects.
+
+After the wait, assert on the real page state with a URL or locator. This keeps failures clear when a challenge is not solved.
+
+```typescript theme={null}
+// Wait for hosted CAPTCHA solving; see https://libretto.sh/docs/libretto-cloud-hosting/stealth.
+await page.waitForTimeout(120_000);
+await page.getByRole("heading", { name: "Dashboard" }).waitFor();
+```
+
+## Local and self-hosted runs
+
+Stealth is included with Libretto Cloud and is also available through some other hosted browser providers. Local Chromium and self-hosted infrastructure do not include managed residential proxies or automatic CAPTCHA solving by default.
+
+For self-hosted runs, set up your own external proxy and CAPTCHA-solving services, or solve challenges manually in a visible browser and continue from that state.

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -24,7 +24,7 @@ Full documentation is published at [libretto.sh](https://libretto.sh). Available
 - Workflow guides: [one-shot generation](https://libretto.sh/docs/guides/one-shot-workflow-generation), [interactive building](https://libretto.sh/docs/guides/interactive-workflow-building), [debugging workflows](https://libretto.sh/docs/guides/debugging-workflows), [convert to network requests](https://libretto.sh/docs/guides/convert-to-network-requests)
 - CLI reference: [open and connect](https://libretto.sh/docs/reference/cli/open-and-connect), [sessions](https://libretto.sh/docs/reference/cli/sessions), [profiles](https://libretto.sh/docs/reference/cli/profiles), [snapshot](https://libretto.sh/docs/reference/cli/snapshot), [exec](https://libretto.sh/docs/reference/cli/exec), [run and resume](https://libretto.sh/docs/reference/cli/run-and-resume), [session logs](https://libretto.sh/docs/reference/cli/session-logs), [pages](https://libretto.sh/docs/reference/cli/pages)
 - Library API: [workflow](https://libretto.sh/docs/reference/runtime/workflow), [AI extraction](https://libretto.sh/docs/reference/runtime/ai-extraction), [network requests](https://libretto.sh/docs/reference/runtime/network-requests), [file downloads](https://libretto.sh/docs/reference/runtime/file-downloads)
-- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments)
+- Libretto Cloud Hosting: [overview](https://libretto.sh/docs/libretto-cloud-hosting/overview), [authentication](https://libretto.sh/docs/libretto-cloud-hosting/authentication), [deployments](https://libretto.sh/docs/libretto-cloud-hosting/deployments), [stealth](https://libretto.sh/docs/libretto-cloud-hosting/stealth)
 - Alternative providers: [overview](https://libretto.sh/docs/alternative-providers/overview), [Kernel](https://libretto.sh/docs/alternative-providers/kernel), [Browserbase](https://libretto.sh/docs/alternative-providers/browserbase), [Steel](https://libretto.sh/docs/alternative-providers/steel), [GCP](https://libretto.sh/docs/alternative-providers/gcp), [AWS](https://libretto.sh/docs/alternative-providers/aws)
 
 ## Default Integration Approach
@@ -40,8 +40,8 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 ## CAPTCHA Handling
 
 - If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
-- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
-- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+- If the same challenge appears while the session is using a hosted browser provider, wait up to 2 minutes for automatic CAPTCHA handling before deciding the workflow is blocked.
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a short comment linking to the hosted platform stealth docs. Follow `references/code-generation-rules.md` for the code shape.
 
 ## Setup
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -37,6 +37,12 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
+## CAPTCHA Handling
+
+- If a CAPTCHA, Cloudflare challenge, or similar bot check appears in a local Chromium session, try to solve it in the visible browser and continue from the solved state.
+- If the same challenge appears while the session is using an external browser provider, wait up to 2 minutes for the provider's automatic CAPTCHA handling before deciding the workflow is blocked. Kernel stealth mode and Browserbase browser settings both document automatic CAPTCHA solving; Libretto Cloud manages CAPTCHA handling for hosted browser runs. See [Kernel stealth mode](https://www.kernel.sh/docs/browsers/bot-detection/stealth), [Browserbase core features](https://docs.browserbase.com/platform/browser/core-features/overview), and [Libretto Cloud overview](https://libretto.sh/docs/libretto-cloud-hosting/overview).
+- When a CAPTCHA was observed during exploration, generated workflow code should include an explicit timeout wait at that point with a comment explaining that cloud browser providers may auto-solve the challenge. Follow `references/code-generation-rules.md` for the code shape.
+
 ## Setup
 
 - Use the package manager convention for the target project. The examples use `npx libretto`; pnpm, yarn, and bun projects should use their equivalent package-manager execution form.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -59,14 +59,10 @@ Before extracting data (for example text, rows, or field values), wait for the t
 
 ## CAPTCHA Waits
 
-If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit 2 minute timeout wait. Put a short comment immediately above the wait linking to the hosted platform stealth docs:
 
 ```typescript
-// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
-// CAPTCHA solving on self-hosted infra is unsupported.
-// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
-// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
-// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+// Wait for hosted CAPTCHA solving; see https://libretto.sh/docs/libretto-cloud-hosting/stealth.
 await page.waitForTimeout(120_000);
 ```
 

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -57,6 +57,21 @@ During the interactive `exec` phase, `page.evaluate` is fine for quick prototypi
 
 Before extracting data (for example text, rows, or field values), wait for the target content itself to be ready, not just its container.
 
+## CAPTCHA Waits
+
+If a CAPTCHA, Cloudflare challenge, or similar bot check appeared during exploration, preserve that recovery point in generated workflow code with an explicit timeout wait. Put a short comment immediately above the wait explaining that cloud browser providers can auto-solve these checks, and include links to the provider docs:
+
+```typescript
+// Cloud browser providers may auto-solve CAPTCHA or bot checks before the workflow can continue.
+// CAPTCHA solving on self-hosted infra is unsupported.
+// Libretto Cloud: https://libretto.sh/docs/libretto-cloud-hosting/overview
+// Kernel: https://www.kernel.sh/docs/browsers/bot-detection/stealth
+// Browserbase: https://docs.browserbase.com/platform/browser/core-features/overview
+await page.waitForTimeout(120_000);
+```
+
+Use the wait only where a challenge was actually observed or is expected from the site's normal flow. After the wait, continue with a concrete locator or URL assertion for the real page state so the workflow fails clearly if the challenge was not solved.
+
 ### Anti-Patterns
 
 These patterns come up frequently during interactive sessions and should not carry over into production code:


### PR DESCRIPTION
## Summary
- add Libretto skill guidance for handling CAPTCHA and bot-check pages in local versus external-provider sessions
- document generated workflow wait comments for provider auto-solving, including the self-hosted infra unsupported note
- sync `.agents` and `.claude` skill mirrors from the source skill files

## Verification
- `pnpm -s check:mirrors`
