### PR TITLE
Track website click events with Fathom

### DIFF
--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -16,12 +16,12 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Libretto | Don't make browser agents do a script's job</title>
+    <title>Libretto | Turn website workflows into reliable APIs</title>
     <meta name="description" content="Libretto is a CLI that lets coding agents inspect web pages, reverse-engineer APIs and build fast, cheap, and reliable automation scripts" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Libretto | Don't make browser agents do a script's job" />
+    <meta property="og:title" content="Libretto | Turn website workflows into reliable APIs" />
     <meta property="og:description" content="Libretto is a CLI that lets coding agents inspect web pages, reverse-engineer APIs and build fast, cheap, and reliable automation scripts" />
     <meta property="og:url" content="https://libretto.sh" />
     <meta property="og:image" content="https://libretto.sh/og-image.png" />
@@ -30,7 +30,7 @@
 
     <!-- Twitter / X -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Libretto | Don't make browser agents do a script's job" />
+    <meta name="twitter:title" content="Libretto | Turn website workflows into reliable APIs" />
     <meta name="twitter:description" content="Libretto is a CLI that lets coding agents inspect web pages, reverse-engineer APIs and build fast, cheap, and reliable automation scripts" />
     <meta name="twitter:image" content="https://libretto.sh/og-image.png" />
 

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -110,6 +110,7 @@ function Hero({
             <AppLink
               href="/docs/get-started/quickstart"
               className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
+              data-fathom-event="Hero docs click"
             >
               go to docs
             </AppLink>

--- a/apps/website/src/analytics.ts
+++ b/apps/website/src/analytics.ts
@@ -1,0 +1,42 @@
+type FathomOptions = {
+  _value?: number;
+};
+
+type FathomClient = {
+  trackEvent: (name: string, options?: FathomOptions) => void;
+};
+
+declare global {
+  interface Window {
+    fathom?: FathomClient;
+  }
+}
+
+const EVENT_ATTRIBUTE = "data-fathom-event";
+
+let isInitialized = false;
+
+export function initializeFathomClickTracking() {
+  if (isInitialized) {
+    return;
+  }
+
+  isInitialized = true;
+
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const trackedElement = target.closest<HTMLElement>(`[${EVENT_ATTRIBUTE}]`);
+    const eventName = trackedElement?.dataset.fathomEvent;
+
+    if (!eventName) {
+      return;
+    }
+
+    window.fathom?.trackEvent(eventName);
+  });
+}

--- a/apps/website/src/blog/BlogPage.tsx
+++ b/apps/website/src/blog/BlogPage.tsx
@@ -38,7 +38,11 @@ function BlogShell({ children }: { children: React.ReactNode }) {
 function BlogPostPreview({ post }: { post: BlogPost }) {
   return (
     <article className="border-t border-rule py-8">
-      <AppLink href={`/blog/${post.slug}`} className="group block no-underline">
+      <AppLink
+        href={`/blog/${post.slug}`}
+        className="group block no-underline"
+        data-fathom-event="Blog post click"
+      >
         <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2">
           <Text as="time" size="xs" className="text-muted/70">
             {formatPostDate(post.publishedAt)}
@@ -166,7 +170,7 @@ export function BlogPostPage({ slug }: { slug: string }) {
           >
             Post not found.
           </Text>
-          <Button href="/blog" variant="secondary">
+          <Button href="/blog" variant="secondary" data-fathom-event="Blog back click">
             Back to blog
           </Button>
         </section>
@@ -180,6 +184,7 @@ export function BlogPostPage({ slug }: { slug: string }) {
         <AppLink
           href="/blog"
           className="mb-10 inline-block text-sm text-muted/70 no-underline transition-colors hover:text-accent-bright"
+          data-fathom-event="Blog back click"
         >
           Back to blog
         </AppLink>

--- a/apps/website/src/components/CTA.tsx
+++ b/apps/website/src/components/CTA.tsx
@@ -16,10 +16,18 @@ export function CTA() {
           minutes.
         </Text>
         <div className="flex flex-col items-center gap-3">
-          <Button href="/docs/get-started/quickstart">Go to docs</Button>
+          <Button href="/docs/get-started/quickstart" data-fathom-event="CTA docs click">
+            Go to docs
+          </Button>
           <div className="flex items-center gap-2">
             <span className="text-sm text-faint">or</span>
-            <Button href="https://cal.com/team/saffron-health/libretto-demo" variant="secondary">book a demo</Button>
+            <Button
+              href="https://cal.com/team/saffron-health/libretto-demo"
+              variant="secondary"
+              data-fathom-event="CTA demo click"
+            >
+              book a demo
+            </Button>
           </div>
         </div>
       </div>

--- a/apps/website/src/components/CloudProviders.tsx
+++ b/apps/website/src/components/CloudProviders.tsx
@@ -35,6 +35,7 @@ function CommandBox({ command }: { command: string }) {
         type="button"
         onClick={handleCopy}
         className="copy-icon-btn absolute right-2.5 top-2.5 size-7 flex items-center justify-center rounded-lg"
+        data-fathom-event="Cloud deploy command copy"
       >
         <div className="relative size-[18px] shrink-0">
           <div
@@ -150,6 +151,7 @@ export function CloudProviders() {
             <a
               href="/docs/libretto-cloud-hosting/overview"
               className={`${linkClass} mt-4 inline-block font-mono text-xs`}
+              data-fathom-event="Cloud docs click"
             >
               cloud docs →
             </a>
@@ -187,6 +189,7 @@ export function CloudProviders() {
             <a
               href="/docs/alternative-providers/overview"
               className={`${linkClass} mt-4 inline-block font-mono text-xs`}
+              data-fathom-event="Provider setup click"
             >
               provider setup →
             </a>

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -22,7 +22,7 @@ const faqs: FAQItem[] = [
         gives your coding agent a live browser and a CLI to inspect pages,
         capture network traffic, record user actions, and turn them into
         deterministic automation scripts. Check out the{" "}
-        <a href="/docs/get-started/quickstart" className={linkClass}>
+        <a href="/docs/get-started/quickstart" className={linkClass} data-fathom-event="FAQ docs click">
           docs
         </a>{" "}
         to get started.
@@ -49,15 +49,15 @@ const faqs: FAQItem[] = [
     answer: (
       <>
         The CLI has built-in support for{" "}
-        <a href="https://www.browserbase.com/" className={linkClass}>
+        <a href="https://www.browserbase.com/" className={linkClass} data-fathom-event="FAQ Browserbase click">
           Browserbase
         </a>{" "}
         and{" "}
-        <a href="https://www.kernel.computer/" className={linkClass}>
+        <a href="https://www.kernel.computer/" className={linkClass} data-fathom-event="FAQ Kernel click">
           Kernel
         </a>
         , and{" "}
-        <a href="https://steel.dev/" className={linkClass}>
+        <a href="https://steel.dev/" className={linkClass} data-fathom-event="FAQ Steel click">
           Steel
         </a>
         {" "}to spin up browser sessions directly. Libretto can also connect to any
@@ -73,7 +73,7 @@ const faqs: FAQItem[] = [
     answer: (
       <>
         Yes, fully open source under the MIT license. You can find the code on{" "}
-        <a href={REPO_URL} className={linkClass}>
+        <a href={REPO_URL} className={linkClass} data-fathom-event="FAQ github click">
           GitHub
         </a>
         .
@@ -86,15 +86,15 @@ const faqs: FAQItem[] = [
     answer: (
       <>
         Jump into our{" "}
-        <a href={DISCORD_URL} className={linkClass}>
+        <a href={DISCORD_URL} className={linkClass} data-fathom-event="FAQ discord click">
           Discord
         </a>{" "}
         for quick help, open an issue on{" "}
-        <a href={REPO_URL} className={linkClass}>
+        <a href={REPO_URL} className={linkClass} data-fathom-event="FAQ github click">
           GitHub
         </a>
         , or read through the{" "}
-        <a href="/docs/get-started/quickstart" className={linkClass}>
+        <a href="/docs/get-started/quickstart" className={linkClass} data-fathom-event="FAQ docs click">
           docs
         </a>
         .
@@ -137,6 +137,7 @@ function FAQAccordionItem({ item }: { item: FAQItem }) {
         className="flex w-full cursor-pointer items-center justify-between py-5 text-left outline-none focus-visible:ring-2 focus-visible:ring-accent/30 rounded-sm"
         onClick={() => setIsExpanded(!isExpanded)}
         aria-expanded={isExpanded}
+        data-fathom-event="FAQ toggle click"
       >
         <Text size="md" className="font-medium text-ink">
           {item.question}

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -55,10 +55,14 @@ export function Footer() {
             © {new Date().getFullYear()} Saffron Health
           </Text>
           <div className="flex gap-6">
-            <a href="/blog" className={linkClass}>
+            <a href="/blog" className={linkClass} data-fathom-event="Footer blog click">
               Blog
             </a>
-            <a href="/docs/get-started/quickstart" className={linkClass}>
+            <a
+              href="/docs/get-started/quickstart"
+              className={linkClass}
+              data-fathom-event="Footer docs click"
+            >
               Docs
             </a>
             <a
@@ -66,10 +70,17 @@ export function Footer() {
               target="_blank"
               rel="noopener noreferrer"
               className={linkClass}
+              data-fathom-event="Footer forum click"
             >
               Forum
             </a>
-            <a href={RELEASES_URL} target="_blank" rel="noopener noreferrer" className={linkClass}>
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linkClass}
+              data-fathom-event="Footer changelog click"
+            >
               Changelog
             </a>
           </div>
@@ -83,6 +94,7 @@ export function Footer() {
             rel="noopener noreferrer"
             aria-label="Libretto on npm"
             className="text-muted/50 transition-colors hover:text-muted"
+            data-fathom-event="Footer npm click"
           >
             <NpmIcon width={28} height={12} />
           </a>
@@ -92,6 +104,7 @@ export function Footer() {
             rel="noopener noreferrer"
             aria-label="Libretto on Discord"
             className="text-muted/50 transition-colors hover:text-muted"
+            data-fathom-event="Footer discord click"
           >
             <DiscordIcon width={14} height={14} />
           </a>
@@ -101,6 +114,7 @@ export function Footer() {
             rel="noopener noreferrer"
             aria-label="Libretto on GitHub"
             className="text-muted/50 transition-colors hover:text-muted"
+            data-fathom-event="Footer github click"
           >
             <GitHubIcon width={14} height={14} />
           </a>

--- a/apps/website/src/components/InstallSnippet.tsx
+++ b/apps/website/src/components/InstallSnippet.tsx
@@ -22,6 +22,7 @@ export function InstallSnippet() {
         onClick={handleCopy}
         aria-label="Copy Libretto setup prompt"
         className="install-prompt__button"
+        data-fathom-event="Hero copy prompt click"
       >
         {copied ? "Copied" : "Copy prompt"}
       </Button>

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -77,6 +77,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
       <AriaButton
         aria-label="Menu"
         className="relative flex size-9 items-center justify-center rounded-lg text-ink outline-none hover:bg-ink/[0.06] focus-visible:ring-2 focus-visible:ring-ink/20"
+        data-fathom-event="Mobile menu click"
       >
         <CrossfadeIcon
           activeKey={animation === "visible" ? "close" : "hamburger"}
@@ -107,7 +108,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
           className="min-w-[180px] origin-top-right rounded-xl border border-accent/20 bg-panel p-1.5 shadow-lg shadow-black/30"
         >
           <Menu className="outline-none">
-            <MenuItem href="/blog" className={itemClass}>
+            <MenuItem href="/blog" className={itemClass} data-fathom-event="Mobile nav blog click">
               Blog
             </MenuItem>
             <MenuItem
@@ -115,6 +116,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
               target="_blank"
               rel="noopener noreferrer"
               className={itemClass}
+              data-fathom-event="Mobile nav forum click"
             >
               Forum
             </MenuItem>
@@ -123,6 +125,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
               target="_blank"
               rel="noopener noreferrer"
               className={itemClass}
+              data-fathom-event="Mobile nav changelog click"
             >
               Changelog
             </MenuItem>
@@ -131,6 +134,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
               target="_blank"
               rel="noopener noreferrer"
               className={itemClass}
+              data-fathom-event="Mobile nav npm click"
             >
               <NpmIcon width={28} height={12} />
               npm
@@ -140,6 +144,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
               target="_blank"
               rel="noopener noreferrer"
               className={itemClass}
+              data-fathom-event="Mobile nav github click"
             >
               <GitHubStarIcon width={15} height={15} />
               GitHub{stars !== null && ` (${stars})`}

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -69,10 +69,12 @@ function GlitchNavLink({
   href,
   children,
   external = true,
+  fathomEvent,
 }: {
   href: string;
   children: string;
   external?: boolean;
+  fathomEvent: string;
 }) {
   const { display, isScrambling, hovered, onEnter, onLeave } = useGlitchText(children);
 
@@ -82,6 +84,7 @@ function GlitchNavLink({
       target={external ? "_blank" : undefined}
       rel={external ? "noopener noreferrer" : undefined}
       className="no-underline"
+      data-fathom-event={fathomEvent}
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
     >
@@ -139,11 +142,15 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             </Text>
           </AppLink>
           <div className="absolute left-1/2 hidden -translate-x-1/2 gap-7 md:flex">
-            <GlitchNavLink href="/blog" external={false}>
+            <GlitchNavLink href="/blog" external={false} fathomEvent="Nav blog click">
               Blog
             </GlitchNavLink>
-            <GlitchNavLink href={DISCUSSIONS_URL}>Forum</GlitchNavLink>
-            <GlitchNavLink href={RELEASES_URL}>Changelog</GlitchNavLink>
+            <GlitchNavLink href={DISCUSSIONS_URL} fathomEvent="Nav forum click">
+              Forum
+            </GlitchNavLink>
+            <GlitchNavLink href={RELEASES_URL} fathomEvent="Nav changelog click">
+              Changelog
+            </GlitchNavLink>
           </div>
         </div>
         <div className="flex items-center gap-4">
@@ -153,6 +160,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             rel="noopener noreferrer"
             aria-label="Libretto on npm"
             className="hidden text-ink/70 transition-colors hover:text-ink md:flex"
+            data-fathom-event="Nav npm click"
           >
             <NpmIcon width={36} height={14} />
           </a>
@@ -161,11 +169,12 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             target="_blank"
             rel="noopener noreferrer"
             className="hidden items-center gap-1.5 text-ink/70 transition-colors hover:text-ink md:flex"
+            data-fathom-event="Nav github click"
           >
             <GitHubStarIcon width={15} height={15} />
             {stars !== null && <span className="text-sm font-medium">{formatStars(stars)}</span>}
           </a>
-          <Button href="/docs/get-started/quickstart" size="sm">
+          <Button href="/docs/get-started/quickstart" size="sm" data-fathom-event="Nav docs click">
             Go to docs
           </Button>
           <div className="md:hidden">

--- a/apps/website/src/main.tsx
+++ b/apps/website/src/main.tsx
@@ -1,10 +1,12 @@
 import { StrictMode, Suspense, lazy } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import { initializeFathomClickTracking } from "./analytics";
 import { App } from "./App";
 import { IcosahedronDebug } from "./IcosahedronDebug";
 
 const path = window.location.pathname;
+initializeFathomClickTracking();
 
 // Dev-only lazy imports — fully tree-shaken from production builds
 const DevAgentation = import.meta.env.DEV


### PR DESCRIPTION
## Summary
- add a small typed Fathom click tracking helper that delegates from `data-fathom-event` attributes
- mark important website click targets, including docs CTAs, prompt copy, demo booking, navigation, social/community links, cloud/provider docs, FAQ links, and blog navigation
- update the browser, Open Graph, and Twitter title metadata to "Libretto | Turn website workflows into reliable APIs"

## Verification
- `pnpm -s type-check`
- `pnpm -s --filter @libretto/website type-check`
- `pnpm -s --filter @libretto/website lint`
