### PR TITLE
docs: update workflow Zod schema guidance

### DIFF
--- a/docs/get-started/first-workflow.mdx
+++ b/docs/get-started/first-workflow.mdx
@@ -20,14 +20,24 @@ Create `src/workflows/scrape-page.ts`:
 
 ```ts src/workflows/scrape-page.ts
 import { workflow } from "libretto";
+import { z } from "zod";
 
-export default workflow("scrape-page", async ({ page }) => {
-  await page.goto("https://example.com");
-  const title = await page.title();
-  console.log(`Page title: ${title}`);
+export default workflow(
+  "scrape-page",
+  {
+    input: z.object({}),
+    output: z.object({
+      title: z.string(),
+    }),
+  },
+  async ({ page }) => {
+    await page.goto("https://example.com");
+    const title = await page.title();
+    console.log(`Page title: ${title}`);
 
-  return { title };
-});
+    return { title };
+  },
+);
 ```
   </Step>
 

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -62,15 +62,27 @@ If you already have a Node.js package that you plan to use for Libretto automati
 
     ```ts src/workflows/scrape-page.ts
     import { workflow } from "libretto";
+    import { z } from "zod";
 
-    export default workflow("scrape-page", async ({ page }) => {
-      await page.goto("https://example.com");
-      const title = await page.title();
-      console.log(`Page title: ${title}`);
-    });
+    export default workflow(
+      "scrape-page",
+      {
+        input: z.object({}),
+        output: z.object({
+          title: z.string(),
+        }),
+      },
+      async ({ page }) => {
+        await page.goto("https://example.com");
+        const title = await page.title();
+        console.log(`Page title: ${title}`);
+
+        return { title };
+      },
+    );
     ```
 
-    The `workflow()` function wraps your automation with browser lifecycle management, error handling, and session recording.
+    The `workflow()` function wraps your automation with browser lifecycle management, input validation, error handling, and session recording.
 
   </Step>
 

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -42,9 +42,9 @@ Use this if you want Libretto to scaffold a new package with directory structure
 If you already have a Node.js package that you plan to use for Libretto automations, you can skip the scaffolding and just install Libretto directly.
 
 <Steps>
-  <Step title="Install Libretto">
+  <Step title="Install Libretto and Zod">
     ```bash
-    npm install libretto
+    npm install libretto zod
     ```
   </Step>
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -58,14 +58,24 @@ Create `src/workflows/scrape-page.ts` in the package you set up:
 
 ```ts src/workflows/scrape-page.ts
 import { workflow } from "libretto";
+import { z } from "zod";
 
-export default workflow("scrape-page", async ({ page }) => {
-  await page.goto("https://example.com");
-  const title = await page.title();
-  console.log(`Page title: ${title}`);
+export default workflow(
+  "scrape-page",
+  {
+    input: z.object({}),
+    output: z.object({
+      title: z.string(),
+    }),
+  },
+  async ({ page }) => {
+    await page.goto("https://example.com");
+    const title = await page.title();
+    console.log(`Page title: ${title}`);
 
-  return { title };
-});
+    return { title };
+  },
+);
 ```
 
 Run it headless:

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -45,7 +45,7 @@ This scaffolds a package, installs dependencies, runs setup, and downloads Chrom
 From the existing package directory, add Libretto as a dependency and run setup:
 
 ```bash theme={null}
-npm install libretto
+npm install libretto zod
 npx libretto setup
 ```
 

--- a/docs/guides/debugging-workflows.mdx
+++ b/docs/guides/debugging-workflows.mdx
@@ -101,9 +101,16 @@ If you need the workflow to stop at a specific point (not at failure, but at a k
 
 ```typescript theme={null}
 import { workflow, pause } from "libretto";
+import { z } from "zod";
 
 export default workflow(
   "eligibilityCheck",
+  {
+    input: z.object({
+      memberId: z.string(),
+    }),
+    output: z.object({}),
+  },
   async (ctx, input) => {
     const { session, page } = ctx;
 

--- a/docs/guides/debugging-workflows.mdx
+++ b/docs/guides/debugging-workflows.mdx
@@ -109,7 +109,7 @@ export default workflow(
     input: z.object({
       memberId: z.string(),
     }),
-    output: z.object({}),
+    output: z.void(),
   },
   async (ctx, input) => {
     const { session, page } = ctx;

--- a/docs/guides/interactive-workflow-building.mdx
+++ b/docs/guides/interactive-workflow-building.mdx
@@ -57,7 +57,7 @@ This approach combines your knowledge of the application (you drive the browser 
   <Step title="Review the generated workflow file">
     The agent writes a TypeScript file that exports a `workflow()`. Things to check:
 
-    - **Output type** matches what you asked for
+    - **Input/output schemas** match what you asked for
     - **Selectors** look reasonable (class names, data attributes, or ARIA roles, not brittle positional selectors)
     - **Parameterization**: values you typed during the demo should be replaced with input parameters, not hardcoded
     - **Wait logic**: if you mentioned something takes time to load, make sure there's a `waitForSelector` or similar

--- a/docs/guides/one-shot-workflow-generation.mdx
+++ b/docs/guides/one-shot-workflow-generation.mdx
@@ -10,7 +10,7 @@ One-shot generation is the fastest way to go from an idea to a working automatio
 
 <Steps>
   <Step title="Prompt your agent">
-    Describe the **site**, the **data or action** you want, and the **shape of the output**. The more specific you are, the better your results.
+    Describe the **site**, the **data or action** you want, and the **input/output shape** you want the workflow to expose as Zod schemas. The more specific you are, the better your results.
 
     ```text Example prompt
     Use the Libretto skill. Go on https://sfbay.craigslist.org and scrape the first 10 "free stuff" listings for title, location, and link.
@@ -48,18 +48,23 @@ One-shot generation is the fastest way to go from an idea to a working automatio
 
     ```typescript  theme={null}
     import { workflow } from "libretto";
+    import { z } from "zod";
 
-    type Output = {
-      listings: Array<{
-        title: string;
-        location: string;
-        link: string;
-      }>;
-    };
+    const outputSchema = z.object({
+      listings: z.array(z.object({
+        title: z.string(),
+        location: z.string(),
+        link: z.string().url(),
+      })),
+    });
 
-    export default workflow<{}, Output>(
+    export default workflow(
       "freeStuff",
-      async (ctx): Promise<Output> => {
+      {
+        input: z.object({}),
+        output: outputSchema,
+      },
+      async (ctx) => {
         const { page } = ctx;
 
         await page.goto("https://sfbay.craigslist.org/search/zip");
@@ -80,7 +85,7 @@ One-shot generation is the fastest way to go from an idea to a working automatio
     ```
 
     Things to check:
-    - **Output type** matches what you asked for
+    - **Input/output schemas** match what you asked for
     - **Selectors** look reasonable (class names, data attributes, or ARIA roles, not brittle positional selectors)
     - **Pagination** logic is present if you asked for more items than fit on one page
 

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -97,13 +97,18 @@ After the deployment finishes, call the hosted jobs endpoint with the workflow n
 ```ts theme={null}
 // src/workflows/check-eligibility.ts
 import { workflow } from "libretto";
+import { z } from "zod";
 
-type Input = {
-  memberId: string;
-};
-
-export default workflow<Input, { status: string }>(
+export default workflow(
   "check-eligibility",
+  {
+    input: z.object({
+      memberId: z.string(),
+    }),
+    output: z.object({
+      status: z.string(),
+    }),
+  },
   async ({ page }, input) => {
     await page.goto("https://example.com/eligibility");
 
@@ -114,7 +119,7 @@ export default workflow<Input, { status: string }>(
 );
 ```
 
-then hit the endpoint with `workflow: "check-eligibility"`:
+then hit the endpoint with `workflow: "check-eligibility"`. The `params` object must match the workflow input schema:
 
 ```bash theme={null}
 curl -X POST "https://api.libretto.sh/v1/jobs/create" \

--- a/docs/reference/cli/run-and-resume.mdx
+++ b/docs/reference/cli/run-and-resume.mdx
@@ -39,12 +39,16 @@ npx libretto run <file> [flags]
 </ParamField>
 
 <ParamField path="--params" type="string">
-  Inline JSON input for the workflow, passed as a quoted string. Example: `--params '{"status":"open"}'`.
+  Inline JSON input for the workflow, passed as a quoted string. When the
+  workflow uses Zod schemas, Libretto validates this input against
+  `schemas.input` before the handler runs. Example:
+  `--params '{"status":"open"}'`.
 </ParamField>
 
 <ParamField path="--params-file" type="string">
   Path to a JSON file to use as workflow input. Cannot be used together with
-  `--params`.
+  `--params`. When the workflow uses Zod schemas, the file contents are
+  validated against `schemas.input`.
 </ParamField>
 
 <ParamField path="--auth-profile" type="string">
@@ -149,22 +153,32 @@ Insert `await pause(session)` calls in your workflow file to create interactive 
 
 ```typescript theme={null}
 import { workflow, pause } from "libretto";
+import { z } from "zod";
 
-export default workflow("myWorkflow", async (ctx, input) => {
-  const { session, page } = ctx;
+export default workflow(
+  "myWorkflow",
+  {
+    input: z.object({}),
+    output: z.object({
+      done: z.boolean(),
+    }),
+  },
+  async (ctx) => {
+    const { session, page } = ctx;
 
-  await page.goto("https://linkedin.com");
+    await page.goto("https://linkedin.com");
 
-  // Pause here for inspection
-  await pause(session);
+    // Pause here for inspection
+    await pause(session);
 
-  await page.locator("#submit").click();
+    await page.locator("#submit").click();
 
-  // Pause again before the final step
-  await pause(session);
+    // Pause again before the final step
+    await pause(session);
 
-  return { done: true };
-});
+    return { done: true };
+  },
+);
 ```
 
 <Note>

--- a/docs/reference/runtime/workflow.mdx
+++ b/docs/reference/runtime/workflow.mdx
@@ -4,20 +4,30 @@ title: Workflow
 
 > Define and run reusable browser automation workflows.
 
-The `workflow()` factory is the entry point for every Libretto automation. You wrap your Playwright logic in a typed handler, export the result, and the CLI (or your own runner) takes care of launching a browser, wiring up context, and invoking your handler.
+The `workflow()` factory is the entry point for every Libretto automation. You wrap your Playwright logic in a typed handler, define Zod schemas for the workflow input and output, export the result, and the CLI (or your own runner) takes care of launching a browser, validating input, wiring up context, and invoking your handler.
 
 ### `workflow()`
 
-Creates a named `LibrettoWorkflow` from a handler function.
+Creates a named `LibrettoWorkflow` from input/output Zod schemas and a handler function.
 
 ```typescript theme={null}
-function workflow<Input = unknown, Output = unknown>(
+function workflow<
+  InputSchema extends z.ZodType,
+  OutputSchema extends z.ZodType,
+>(
   name: string,
-  handler: LibrettoWorkflowHandler<Input, Output>,
-): LibrettoWorkflow<Input, Output>;
+  schemas: {
+    input: InputSchema;
+    output: OutputSchema;
+  },
+  handler: LibrettoWorkflowHandler<
+    z.infer<InputSchema>,
+    z.infer<OutputSchema>
+  >,
+): LibrettoWorkflow<InputSchema, OutputSchema>;
 ```
 
-The handler receives a `LibrettoWorkflowContext` and typed `input`, and must return a `Promise<Output>`.
+The handler receives a `LibrettoWorkflowContext` and typed `input`, and must return a `Promise<Output>`. The input type is inferred from `schemas.input`; the output type is inferred from `schemas.output`.
 
 ```typescript theme={null}
 type LibrettoWorkflowHandler<Input, Output> = (
@@ -25,6 +35,12 @@ type LibrettoWorkflowHandler<Input, Output> = (
   input: Input,
 ) => Promise<Output>;
 ```
+
+Libretto validates `--params` and `--params-file` input against `schemas.input` before the workflow handler runs. The CLI passes the parsed input to the handler, so Zod transforms and defaults are reflected in `input`.
+
+`schemas.output` describes the returned value for TypeScript and hosted workflow metadata. Local `run()` does not validate the handler return value at runtime. Libretto Cloud serializes the output schema to JSON Schema during deploy and exposes it through `/v1/workflows/get`.
+
+The older `workflow(name, handler)` form is still supported for existing workflows, but new workflows should use the schema form.
 
 #### `LibrettoWorkflowContext`
 
@@ -41,9 +57,20 @@ type LibrettoWorkflowHandler<Input, Output> = (
 
 ```typescript theme={null}
 import { workflow, launchBrowser, pause } from "libretto";
+import { z } from "zod";
 
-export default workflow<{ query: string }, string[]>(
+const inputSchema = z.object({
+  query: z.string(),
+});
+
+const outputSchema = z.array(z.string());
+
+export default workflow(
   "main",
+  {
+    input: inputSchema,
+    output: outputSchema,
+  },
   async (ctx, input) => {
     const { page } = ctx;
 
@@ -184,9 +211,14 @@ npx libretto resume --session <session-name>
 
 ```typescript theme={null}
 import { workflow, pause } from "libretto";
+import { z } from "zod";
 
-export default workflow<{ id: string }, void>(
+export default workflow(
   "main",
+  {
+    input: z.object({ id: z.string() }),
+    output: z.void(),
+  },
   async (ctx, input) => {
     const { page, session } = ctx;
 

--- a/docs/reference/runtime/workflow.mdx
+++ b/docs/reference/runtime/workflow.mdx
@@ -36,12 +36,6 @@ type LibrettoWorkflowHandler<Input, Output> = (
 ) => Promise<Output>;
 ```
 
-Libretto validates `--params` and `--params-file` input against `schemas.input` before the workflow handler runs. The CLI passes the parsed input to the handler, so Zod transforms and defaults are reflected in `input`.
-
-`schemas.output` describes the returned value for TypeScript and hosted workflow metadata. Local `run()` does not validate the handler return value at runtime. Libretto Cloud serializes the output schema to JSON Schema during deploy and exposes it through `/v1/workflows/get`.
-
-The older `workflow(name, handler)` form is still supported for existing workflows, but new workflows should use the schema form.
-
 #### `LibrettoWorkflowContext`
 
 <ResponseField name="session" type="string">

--- a/docs/understand-libretto/core-concepts.mdx
+++ b/docs/understand-libretto/core-concepts.mdx
@@ -9,7 +9,7 @@ title: Core concepts
 Libretto ships two interfaces:
 
 - **CLI** (`npx libretto <command>`): the primary interface for both agents and humans. Commands open browsers, take snapshots, execute Playwright code, run workflow files, and manage sessions. Every command accepts `--session <name>` to target a specific browser session.
-- **Library API** (`import { workflow } from "libretto"`): used inside workflow files you run with `npx libretto run`. The `workflow()` function wraps your automation handler and gives it typed access to `page` and `session`.
+- **Library API** (`import { workflow } from "libretto"`): used inside workflow files you run with `npx libretto run`. The `workflow()` function wraps your automation handler, validates input with a Zod schema, and gives the handler typed access to `page`, `session`, and parsed input.
 
 ### The `.libretto/` directory
 

--- a/docs/understand-libretto/how-workflow-generation-works.mdx
+++ b/docs/understand-libretto/how-workflow-generation-works.mdx
@@ -32,7 +32,7 @@ Prototyping against the live page is what separates Libretto from writing a Play
 
 ### 4. Code generation and validation
 
-Once the agent has validated all the interactions, it writes a TypeScript file that exports a `workflow()`. The workflow uses the same Playwright selectors the agent already tested, so the script is grounded in what actually worked on the live page.
+Once the agent has validated all the interactions, it writes a TypeScript file that exports a `workflow()` with Zod input and output schemas. The workflow uses the same Playwright selectors the agent already tested, so the script is grounded in what actually worked on the live page.
 
 The agent then runs the workflow headless to verify it works end-to-end without any manual intervention. If the run fails, the agent re-enters the snapshot-and-prototype loop (phases 2 and 3) to diagnose and fix the issue, then tries the headless run again.
 

--- a/docs/understand-libretto/website-authentication.mdx
+++ b/docs/understand-libretto/website-authentication.mdx
@@ -11,20 +11,25 @@ Most real automation targets sit behind a login. There are two patterns for gett
 
 ### Passing credentials into a workflow
 
-Workflows receive a typed `input` object. Credentials are just fields on that input, and your Playwright code fills them into the page the same way it fills any other form. If the site also requires a TOTP (Google Authenticator style) code, store the **shared secret** alongside the other credentials and derive a fresh code each run with a library like [`otplib`](https://www.npmjs.com/package/otplib):
+Workflows receive a typed `input` object inferred from the workflow's Zod input schema. Credentials are just fields on that input, and your Playwright code fills them into the page the same way it fills any other form. If the site also requires a TOTP (Google Authenticator style) code, store the **shared secret** alongside the other credentials and derive a fresh code each run with a library like [`otplib`](https://www.npmjs.com/package/otplib):
 
 ```typescript theme={null}
 import { authenticator } from "otplib";
 import { workflow } from "libretto";
+import { z } from "zod";
 
-type Input = {
-  username: string;
-  password: string;
-  totpSecret: string;
-};
-
-export const main = workflow<Input, { success: boolean }>(
+export const main = workflow(
   "portal-login",
+  {
+    input: z.object({
+      username: z.string(),
+      password: z.string(),
+      totpSecret: z.string(),
+    }),
+    output: z.object({
+      success: z.boolean(),
+    }),
+  },
   async (ctx, input) => {
     const { page } = ctx;
 
@@ -48,7 +53,7 @@ Invoke the workflow with credentials sourced from your environment:
 
 ```bash theme={null}
 npx libretto run ./portal-login.ts \
-  --input '{"username":"'"$PORTAL_USERNAME"'","password":"'"$PORTAL_PASSWORD"'","totpSecret":"'"$PORTAL_TOTP_SECRET"'"}'
+  --params '{"username":"'"$PORTAL_USERNAME"'","password":"'"$PORTAL_PASSWORD"'","totpSecret":"'"$PORTAL_TOTP_SECRET"'"}'
 ```
 
 <Warning>


### PR DESCRIPTION
## Summary
- Document the current `workflow(name, schemas, handler)` signature with Zod input and output schemas.
- Update workflow examples across get-started, runtime, CLI, cloud hosting, and workflow-generation docs.
- Clarify that `--params` and `--params-file` are validated against `schemas.input`, while `schemas.output` is used for typing and hosted metadata.

## Validation
- `pnpm -s docs:validate`
- `pnpm -s docs:broken-links`
