### PR TITLE
Add Libretto Cloud pricing section

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -22,6 +22,7 @@ import { BattleTestedBanner } from "./components/BattleTestedBanner";
 import { Benchmarks } from "./components/Benchmarks";
 import { MaintainingFeatures } from "./components/MaintainingFeatures";
 import { CloudProviders } from "./components/CloudProviders";
+import { Pricing } from "./components/Pricing.js";
 import { FAQ } from "./components/FAQ";
 import { CTA } from "./components/CTA";
 import { SectionDivider } from "./components/SectionDivider.js";
@@ -135,6 +136,8 @@ export function HomePage() {
         <MaintainingFeatures />
         <SectionDivider />
         <CloudProviders />
+        <SectionDivider />
+        <Pricing />
         <SectionDivider />
         <FAQ />
         <SectionDivider />

--- a/apps/website/src/components/CloudProviders.tsx
+++ b/apps/website/src/components/CloudProviders.tsx
@@ -1,17 +1,13 @@
-import classnames from "classnames";
-import { useState } from "react";
 import { Text } from "./Text.js";
 import { Kicker } from "./Kicker.js";
-import { Panel } from "./Panel.js";
 import { SiteSection } from "./SiteSection.js";
+import { ShellCommand } from "./ShellCommand.js";
 import {
   AWSLogo,
   KernelLogo,
   BrowserbaseLogo,
   SteelLogo,
   GCPLogo,
-  CheckIcon,
-  CopyIcon,
 } from "../icons";
 
 const linkClass = "underline text-ink/70 transition-colors hover:text-ink";
@@ -24,53 +20,6 @@ const LOGOS = [
   <AWSLogo key="aws" className="h-9 w-auto text-ink/35" />,
   <GCPLogo key="gcp" className="h-8 w-auto text-ink/35" />,
 ];
-
-function CommandBox({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-  function handleCopy() {
-    void navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  }
-  return (
-    <Panel
-      padding="none"
-      radius="xl"
-      tone="accent"
-      className="relative px-5 py-4 pr-12 font-mono text-[13px] text-ink/80 shadow-sm"
-    >
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="copy-icon-btn absolute right-2.5 top-2.5 size-7 flex items-center justify-center rounded-lg"
-        data-fathom-event="Cloud deploy command copy"
-      >
-        <div className="relative size-[18px] shrink-0">
-          <div
-            className={classnames(
-              "absolute inset-0 flex items-center justify-center text-ink/50 transition-[opacity,filter,scale] duration-240 ease-in-out",
-              copied ? "scale-100 opacity-100" : "scale-[0.25] opacity-0",
-            )}
-          >
-            <CheckIcon width={18} height={18} />
-          </div>
-          <div
-            className={classnames(
-              "absolute inset-0 flex items-center justify-center text-ink/50 transition-[opacity,filter,scale] duration-240 ease-in-out",
-              copied ? "scale-[0.25] opacity-0" : "scale-100 opacity-100",
-            )}
-          >
-            <CopyIcon width={18} height={18} className="translate-y-px" />
-          </div>
-        </div>
-      </button>
-      <div className="flex items-center">
-        <span className="w-4 select-none text-ink/20">$</span>
-        <span className="pl-2">{command}</span>
-      </div>
-    </Panel>
-  );
-}
 
 function LogoTile({
   children,
@@ -152,7 +101,11 @@ export function CloudProviders() {
             </li>
             <li>→ No browser pool to manage</li>
           </ul>
-          <CommandBox command={DEPLOY_COMMAND} />
+          <ShellCommand
+            ariaLabel="Copy cloud deploy command"
+            command={DEPLOY_COMMAND}
+            fathomEvent="Cloud deploy command copy"
+          />
           <a
             href="/docs/libretto-cloud-hosting/overview"
             className={`${linkClass} mt-4 inline-block font-mono text-xs`}

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -111,7 +111,7 @@ export function MobileMenu({ stars }: { stars: string | null }) {
             <MenuItem href="/blog" className={itemClass} data-fathom-event="Mobile nav blog click">
               Blog
             </MenuItem>
-            <MenuItem href="#pricing" className={itemClass} data-fathom-event="Mobile nav pricing click">
+            <MenuItem href="/#pricing" className={itemClass} data-fathom-event="Mobile nav pricing click">
               Pricing
             </MenuItem>
             <MenuItem

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -111,6 +111,9 @@ export function MobileMenu({ stars }: { stars: string | null }) {
             <MenuItem href="/blog" className={itemClass} data-fathom-event="Mobile nav blog click">
               Blog
             </MenuItem>
+            <MenuItem href="#pricing" className={itemClass} data-fathom-event="Mobile nav pricing click">
+              Pricing
+            </MenuItem>
             <MenuItem
               href={DISCUSSIONS_URL}
               target="_blank"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -145,6 +145,9 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             <GlitchNavLink href="/blog" external={false} fathomEvent="Nav blog click">
               Blog
             </GlitchNavLink>
+            <GlitchNavLink href="#pricing" external={false} fathomEvent="Nav pricing click">
+              Pricing
+            </GlitchNavLink>
             <GlitchNavLink href={DISCUSSIONS_URL} fathomEvent="Nav forum click">
               Forum
             </GlitchNavLink>

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -145,7 +145,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             <GlitchNavLink href="/blog" external={false} fathomEvent="Nav blog click">
               Blog
             </GlitchNavLink>
-            <GlitchNavLink href="#pricing" external={false} fathomEvent="Nav pricing click">
+            <GlitchNavLink href="/#pricing" external={false} fathomEvent="Nav pricing click">
               Pricing
             </GlitchNavLink>
             <GlitchNavLink href={DISCUSSIONS_URL} fathomEvent="Nav forum click">

--- a/apps/website/src/components/Pricing.tsx
+++ b/apps/website/src/components/Pricing.tsx
@@ -1,0 +1,147 @@
+import { ArrowRightIcon } from "../icons/index.js";
+import { AppLink } from "../routing.js";
+import { SectionIntro } from "./SectionIntro.js";
+import { ShellCommand } from "./ShellCommand.js";
+import { SiteSection } from "./SiteSection.js";
+import { Text } from "./Text.js";
+
+const BILLING_DOCS_URL = "/docs/libretto-cloud-hosting/billing";
+const BILLING_COMMAND = "npx libretto cloud billing portal";
+
+const plans = [
+  {
+    name: "Free",
+    price: "$0",
+    cadence: "per month",
+    hours: "1",
+    note: "Try a hosted browser session before connecting billing.",
+  },
+  {
+    name: "Pro",
+    price: "$20",
+    cadence: "per month",
+    hours: "80",
+    note: "For solo builders and small production workflows.",
+    featured: true,
+  },
+  {
+    name: "Team",
+    price: "$100",
+    cadence: "per month",
+    hours: "400",
+    note: "Shared capacity for teams running regular cloud jobs.",
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    cadence: "team@libretto.sh",
+    note: "BAA support, custom capacity, and deployment guidance.",
+  },
+];
+
+function PlanCard({ plan }: { plan: (typeof plans)[number] }) {
+  return (
+    <div
+      className={[
+        "relative flex min-h-[260px] flex-col rounded-lg border p-5",
+        plan.featured
+          ? "border-accent/45 bg-green-3/35 shadow-[0_0_28px_color-mix(in_oklch,var(--color-green-9)_12%,transparent)]"
+          : "border-ink/10 bg-panel",
+      ].join(" ")}
+    >
+      {plan.featured ? (
+        <div className="absolute right-5 top-5 font-mono text-[10px] uppercase text-accent-bright">
+          POPULAR
+        </div>
+      ) : null}
+      <Text as="h3" size="xl" className="mb-4 font-medium text-ink">
+        {plan.name}
+      </Text>
+      <div className="mb-5">
+        <Text
+          as="div"
+          size="4xl"
+          style="serif"
+          className="text-ink"
+          htmlStyle={{ fontWeight: 300, lineHeight: 1 }}
+        >
+          {plan.price}
+        </Text>
+        <Text as="div" size="xs" className="mt-2 text-muted">
+          {plan.cadence}
+        </Text>
+      </div>
+      {plan.hours ? (
+        <div className="mb-4 flex items-baseline gap-2 border-t border-ink/10 pt-4">
+          <Text as="span" size="2xl" className="font-medium text-accent-bright">
+            {plan.hours}
+          </Text>
+          <Text as="span" size="xs" className="text-muted">
+            browser {plan.hours === "1" ? "hour" : "hours"} included
+          </Text>
+        </div>
+      ) : null}
+      <Text as="p" size="sm" className="mt-auto leading-relaxed text-muted">
+        {plan.note}
+      </Text>
+    </div>
+  );
+}
+
+function CloudOnlyNote() {
+  return (
+    <>
+      <Text as="p" size="sm" className="leading-relaxed text-muted [text-wrap:pretty]">
+        Pricing applies to Libretto Cloud, the hosted browser platform for
+        deployed workflows. The Libretto CLI is open-source and will always be
+        free to use locally or with infrastructure you control.
+      </Text>
+    </>
+  );
+}
+
+export function Pricing() {
+  return (
+    <SiteSection id="pricing" width="lg">
+      <SectionIntro
+        kicker="// PRICING --"
+        title="Libretto Cloud pricing"
+        copyClassName="max-w-[680px]"
+      >
+        Start free, then pay for managed hosted browser time when you deploy
+        workflows to Libretto Cloud.
+      </SectionIntro>
+
+      <div className="mt-12 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {plans.map((plan) => (
+          <PlanCard key={plan.name} plan={plan} />
+        ))}
+      </div>
+
+      <div className="mx-auto mt-12 grid max-w-[860px] gap-6 text-left md:grid-cols-[1fr_360px] md:items-center">
+        <div className="space-y-4">
+          <CloudOnlyNote />
+          <Text as="p" size="sm" className="leading-relaxed text-muted [text-wrap:pretty]">
+            Usage is measured by hosted browser session time. Manage plans,
+            invoices, and payment methods from the Libretto billing portal.
+          </Text>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-3">
+          <ShellCommand
+            ariaLabel="Copy billing portal command"
+            command={BILLING_COMMAND}
+            fathomEvent="Pricing billing command copy"
+          />
+          <AppLink
+            href={BILLING_DOCS_URL}
+            className="inline-flex items-center gap-1.5 font-mono text-xs text-accent underline decoration-accent/60 underline-offset-4 transition-colors hover:text-accent-bright"
+            data-fathom-event="Pricing billing docs click"
+          >
+            Billing docs
+            <ArrowRightIcon width={15} height={15} />
+          </AppLink>
+        </div>
+      </div>
+    </SiteSection>
+  );
+}

--- a/apps/website/src/components/ShellCommand.tsx
+++ b/apps/website/src/components/ShellCommand.tsx
@@ -1,0 +1,86 @@
+import classnames from "classnames";
+import { useState } from "react";
+import { CheckIcon, CopyIcon } from "../icons/index.js";
+
+interface ShellCommandProps {
+  ariaLabel: string;
+  className?: string;
+  command: string;
+  fathomEvent: string;
+}
+
+function CopyButton({
+  ariaLabel,
+  className,
+  copied,
+  fathomEvent,
+  onCopy,
+}: {
+  ariaLabel: string;
+  className: string;
+  copied: boolean;
+  fathomEvent: string;
+  onCopy: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      aria-label={ariaLabel}
+      className={`copy-icon-btn absolute flex size-7 items-center justify-center rounded-lg ${className}`}
+      data-fathom-event={fathomEvent}
+    >
+      <div className="relative size-[18px] shrink-0">
+        <div
+          className={classnames(
+            "absolute inset-0 flex items-center justify-center text-ink/50 transition-[opacity,filter,scale] duration-240 ease-in-out",
+            copied ? "scale-100 opacity-100" : "scale-[0.25] opacity-0",
+          )}
+        >
+          <CheckIcon width={18} height={18} />
+        </div>
+        <div
+          className={classnames(
+            "absolute inset-0 flex items-center justify-center text-ink/50 transition-[opacity,filter,scale] duration-240 ease-in-out",
+            copied ? "scale-[0.25] opacity-0" : "scale-100 opacity-100",
+          )}
+        >
+          <CopyIcon width={18} height={18} />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function ShellCommand({
+  ariaLabel,
+  className = "",
+  command,
+  fathomEvent,
+}: ShellCommandProps) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div
+      className={`relative rounded-lg border border-ink/10 bg-panel-hi px-4 py-3 pr-11 font-mono text-[13px] text-ink shadow-sm ${className}`.trim()}
+    >
+      <CopyButton
+        ariaLabel={ariaLabel}
+        className="right-2.5 top-1/2 -translate-y-1/2"
+        copied={copied}
+        fathomEvent={fathomEvent}
+        onCopy={handleCopy}
+      />
+      <div className="flex items-center">
+        <span className="w-4 select-none text-ink/20">$</span>
+        <span className="pl-2">{command}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/SiteSection.tsx
+++ b/apps/website/src/components/SiteSection.tsx
@@ -10,6 +10,7 @@ const widthClasses: Record<SiteSectionWidth, string> = {
 
 interface SiteSectionProps {
   className?: string;
+  id?: string;
   innerClassName?: string;
   width?: SiteSectionWidth;
 }
@@ -17,6 +18,7 @@ interface SiteSectionProps {
 export function SiteSection({
   children,
   className = "",
+  id,
   innerClassName = "",
   width = "md",
 }: PropsWithChildren<SiteSectionProps>) {
@@ -25,7 +27,7 @@ export function SiteSection({
     .join(" ");
 
   return (
-    <section className={`section-crt px-8 py-24 ${className}`.trim()}>
+    <section id={id} className={`section-crt px-8 py-24 ${className}`.trim()}>
       <div className={innerClasses}>{children}</div>
     </section>
   );

--- a/apps/website/src/icons/index.ts
+++ b/apps/website/src/icons/index.ts
@@ -1,4 +1,5 @@
 export { AWSLogo } from "./AWSLogo";
+export { ArrowRightIcon } from "./ArrowRightIcon";
 export { BrowserbaseLogo } from "./BrowserbaseLogo";
 export { GCPLogo } from "./GCPLogo";
 export { CheckIcon } from "./CheckIcon";

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -59,18 +59,15 @@ function shouldUseSpaNavigation({
       return false;
     }
 
+    if (url.hash) {
+      return false;
+    }
+
     if (!isAppOwnedPathname(url.pathname)) {
       return false;
     }
 
-    const currentPathname = normalizeAppPathname(window.location.pathname);
-    const nextPathname = normalizeAppPathname(url.pathname);
-    const isSameDocumentHashNavigation =
-      nextPathname === currentPathname &&
-      url.search === window.location.search &&
-      Boolean(url.hash);
-
-    return !isSameDocumentHashNavigation;
+    return true;
   } catch {
     return false;
   }

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
-  server: { allowedHosts: ["codybot.exe.xyz"] },
+  server: { allowedHosts: ["codybot.exe.xyz", "cody.tail14d4f7.ts.net"] },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- add a Libretto Cloud pricing section to the homepage with Free, Pro, Team, and Enterprise tiers
- add Pricing links to desktop and mobile navigation that scroll to the section
- extract a reusable copyable `ShellCommand` component and reuse it for cloud deploy and billing commands
- allow the Tailscale preview hostname in the website Vite dev server config

## Verification
- `pnpm -s --filter @libretto/website type-check`
