### PR TITLE
Publish recovery docs to Mintlify

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,7 +74,8 @@
               "understand-libretto/how-workflow-generation-works",
               "understand-libretto/configuration",
               "understand-libretto/automation-and-bot-detection",
-              "understand-libretto/website-authentication"
+              "understand-libretto/website-authentication",
+              "understand-libretto/error-handling-and-recovery"
             ]
           }
         ]
@@ -101,7 +102,8 @@
               "reference/runtime/workflow",
               "reference/runtime/ai-extraction",
               "reference/runtime/network-requests",
-              "reference/runtime/file-downloads"
+              "reference/runtime/file-downloads",
+              "reference/runtime/page-fallbacks"
             ]
           }
         ]

--- a/docs/reference/runtime/page-fallbacks.mdx
+++ b/docs/reference/runtime/page-fallbacks.mdx
@@ -1,0 +1,87 @@
+---
+title: Runtime recovery actions
+---
+
+`recoveryAction` lets a workflow recover from a supported Playwright Page or Locator failure. When a supported action fails, Libretto runs the recovery action and retries the original action once.
+
+```typescript theme={null}
+export default workflow("reviewOrder", {
+  input,
+  output,
+  recoveryAction,
+  handler: async ({ page }, params) => {
+    await page.goto(params.url);
+    await page.locator("#review").click();
+    return { complete: true };
+  },
+});
+```
+
+## computerUseRecoveryAction
+
+`computerUseRecoveryAction()` runs a small vision agent with your instruction. It screenshots the viewport, asks the model for a browser action, executes it with Playwright coordinates, and stops when the model returns `done` or `maxSteps` is reached.
+
+One step is one screenshot, one model decision, and one browser action. The default `maxSteps` is `3`, which covers the common popup flow of close, confirm, then done.
+
+```typescript theme={null}
+import { computerUseRecoveryAction } from "libretto";
+
+const recoveryAction = computerUseRecoveryAction({
+  provider: "openai",
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: "gpt-5.5",
+  instruction: "Close any visible blocker that prevents submitting the form.",
+  maxSteps: 3,
+});
+```
+
+Supported provider shortcuts:
+
+```typescript theme={null}
+{ provider: "openai", apiKey, model?: "gpt-5.5" }
+{ provider: "anthropic", apiKey, model?: "claude-sonnet-4-6" }
+```
+
+Advanced callers can pass a preconfigured AI SDK `LanguageModel` with `languageModel`.
+
+## popupRecoveryAction
+
+`popupRecoveryAction()` is a preset for the common popup case. It uses Libretto's default instruction for closing popups, cookie banners, modals, overlays, and similar blockers.
+
+```typescript theme={null}
+import { popupRecoveryAction } from "libretto";
+
+const recoveryAction = popupRecoveryAction({
+  provider: "anthropic",
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: "claude-sonnet-4-6",
+  maxSteps: 3,
+});
+```
+
+## Custom recovery logic
+
+Use a custom `RecoveryAction` when the site needs deterministic recovery logic, or when it needs to combine `popupRecoveryAction()` with other steps such as reloading the page.
+
+```typescript theme={null}
+import {
+  popupRecoveryAction,
+  type RecoveryAction,
+} from "libretto";
+
+const popupRecoveryAgent = popupRecoveryAction({
+  provider: "openai",
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: "gpt-5.5",
+});
+
+const recoveryAction: RecoveryAction = async (context) => {
+  const result = await popupRecoveryAgent(context);
+  if (result.status === "incomplete") {
+    await context.page.reload();
+  }
+  return result;
+};
+```
+
+If the recovery action returns without throwing, Libretto retries the original failed method once.

--- a/docs/understand-libretto/error-handling-and-recovery.mdx
+++ b/docs/understand-libretto/error-handling-and-recovery.mdx
@@ -1,0 +1,47 @@
+---
+title: Error recovery
+---
+
+Libretto helps your agent handle failures in two ways: inspect failed runs so it can fix the deterministic workflow, or add a narrow runtime recovery action for expected nondeterminism.
+
+Most workflow failures should be fixed with better selectors, waits, or assertions. Runtime recovery is for cases where the workflow is on the right path but the site sometimes shows unexpected UI that blocks the next action.
+
+## Debugging failed runs
+
+When a workflow fails during development, the Libretto CLI helps your agent debug the code by preserving the browser session. The agent can run headed, add `pause(ctx.session)` at useful checkpoints, inspect the page state, iterate on code, and use `resume` to continue from the pause before redeploying.
+
+For deployed workflows on the hosted platform, a failed run automatically starts an analysis agent. It reviews the error, logs, recording, screenshots, and browser state so it can explain what went wrong and suggest the code change.
+
+## Runtime recovery actions
+
+Add `recoveryAction` to a workflow when you want Libretto to recover after a supported Page or Locator action fails. Libretto calls the recovery action, then retries the original action once.
+
+```typescript theme={null}
+export default workflow("reviewOrder", {
+  input,
+  output,
+  recoveryAction: popupRecoveryAction({
+    provider: "openai",
+    apiKey: process.env.OPENAI_API_KEY!,
+    model: "gpt-5.5",
+    maxSteps: 3,
+  }),
+  handler: async ({ page }, params) => {
+    await page.goto(params.url);
+    await page.locator("#review").click();
+    return { complete: true };
+  },
+});
+```
+
+## AI vision recovery
+
+The computer use recovery action looks at the current screen and takes one or more browser actions to get back to the expected path. It is useful for nondeterministic blockers such as cookie banners, popups, modals, interstitials, and overlays that intercept clicks.
+
+It uses a viewport screenshot, asks the model for an action, scales the returned screenshot coordinates to Playwright coordinates, and executes the action.
+
+`popupRecoveryAction()` is the built-in preset for closing popups and other blockers. Use `computerUseRecoveryAction()` when you want to provide your own instruction.
+
+Simple sites without nondeterministic UI usually do not need AI vision recovery. For complicated sites automated through the DOM, add it when exploration shows blockers across sessions, accounts, or time. Do not use it to make business decisions that belong in the workflow handler.
+
+Supported provider shortcut models are `gpt-5.5` and `claude-sonnet-4-6`.


### PR DESCRIPTION
## Summary
- add the runtime recovery action docs to the public Mintlify docs tree
- add the error recovery overview page to the public docs tree
- register both pages in docs navigation so libretto.sh/docs publishes them

## Testing
- pnpm -s docs:validate
- git diff --check -- docs/docs.json docs/reference/runtime/page-fallbacks.mdx docs/understand-libretto/error-handling-and-recovery.mdx