### PR TITLE
Show release age in website badge

### DIFF
--- a/apps/website/src/components/VersionBadge.tsx
+++ b/apps/website/src/components/VersionBadge.tsx
@@ -2,7 +2,41 @@ import { useEffect, useState } from "react";
 
 interface ReleaseInfo {
   tagName: string;
+  publishedAt: Date;
   url: string;
+}
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat("en", {
+  numeric: "always",
+});
+
+const relativeTimeUnits = [
+  { unit: "year", seconds: 60 * 60 * 24 * 365 },
+  { unit: "month", seconds: 60 * 60 * 24 * 30 },
+  { unit: "week", seconds: 60 * 60 * 24 * 7 },
+  { unit: "day", seconds: 60 * 60 * 24 },
+  { unit: "hour", seconds: 60 * 60 },
+  { unit: "minute", seconds: 60 },
+] as const;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatRelativeTime(date: Date) {
+  const elapsedSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const absoluteSeconds = Math.abs(elapsedSeconds);
+
+  for (const { unit, seconds } of relativeTimeUnits) {
+    if (absoluteSeconds >= seconds) {
+      return relativeTimeFormatter.format(
+        Math.round(elapsedSeconds / seconds),
+        unit,
+      );
+    }
+  }
+
+  return "less than 1 minute ago";
 }
 
 function useLatestRelease(repo: string) {
@@ -12,9 +46,20 @@ function useLatestRelease(repo: string) {
     fetch(`https://api.github.com/repos/${repo}/releases/latest`)
       .then((r) => r.json())
       .then((data) => {
-        if (typeof data.tag_name === "string" && typeof data.html_url === "string") {
+        if (
+          isObject(data) &&
+          typeof data.tag_name === "string" &&
+          typeof data.html_url === "string" &&
+          typeof data.published_at === "string"
+        ) {
+          const publishedAt = new Date(data.published_at);
+          if (Number.isNaN(publishedAt.getTime())) {
+            return;
+          }
+
           setRelease({
             tagName: data.tag_name,
+            publishedAt,
             url: data.html_url,
           });
         }
@@ -40,7 +85,9 @@ export function VersionBadge() {
         rel="noopener noreferrer"
         className="inline-flex items-center gap-2 rounded-full border border-accent/25 bg-accent/[0.08] px-3 py-1 font-mono text-[11px] text-accent/70 backdrop-blur-sm transition-colors hover:text-accent-bright"
       >
-        <span className="tabular-nums">{release.tagName} now available</span>
+        <span className="tabular-nums">
+          {release.tagName} released {formatRelativeTime(release.publishedAt)}
+        </span>
       </a>
     </div>
   );


### PR DESCRIPTION
## Summary
- Read the latest GitHub release `published_at` timestamp in the website version badge.
- Render badge copy as `<version> released <relative time>`.
- Guard malformed release responses before updating badge state.

## Verification
- `pnpm -s --filter @libretto/website type-check`
