### PR TITLE
Add cloud workflow code sharing command

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,7 +93,8 @@
               "reference/cli/exec",
               "reference/cli/run-and-resume",
               "reference/cli/session-logs",
-              "reference/cli/pages"
+              "reference/cli/pages",
+              "reference/cli/share"
             ]
           },
           {

--- a/docs/reference/cli/share.mdx
+++ b/docs/reference/cli/share.mdx
@@ -1,0 +1,111 @@
+---
+title: share
+---
+
+> Make hosted workflow source code public through Libretto Cloud.
+
+The `cloud share` command creates a public code share for a workflow that is already deployed to Libretto Cloud. Use it when you want anyone with the generated URL to fork your automation code and use it as the starting point for their own automation.
+
+<Info>
+  Workflow sharing requires a Libretto Cloud account, API key, and tenant-level
+  code sharing. Code sharing is disabled by default for new tenants. If you have
+  not set up Libretto Cloud yet, start with [Libretto Cloud
+  Hosting](/libretto-cloud-hosting/overview).
+</Info>
+
+### cloud share
+
+```bash theme={null}
+npx libretto cloud share check-eligibility
+```
+
+#### Syntax
+
+```bash theme={null}
+npx libretto cloud share <workflow> [flags]
+```
+
+<ParamField path="workflow" type="string" required>
+  The hosted workflow name to share. This is the workflow name declared in code
+  and deployed with `npx libretto cloud deploy`.
+</ParamField>
+
+<ParamField path="--refresh" type="boolean">
+  Refresh an existing share from the workflow's current deployment.
+</ParamField>
+
+#### Prerequisites
+
+<Steps>
+  <Step title="Create a Libretto Cloud account">
+    Sign up for Libretto Cloud before sharing workflows:
+
+    ```bash theme={null}
+    npx libretto cloud auth signup
+    ```
+
+    See [Libretto Cloud Hosting](/libretto-cloud-hosting/overview) for the full
+    hosted setup flow.
+  </Step>
+
+  <Step title="Issue an API key">
+    Create an API key and expose it as `LIBRETTO_API_KEY`:
+
+    ```bash theme={null}
+    npx libretto cloud auth api-key issue --label laptop-dev
+    export LIBRETTO_API_KEY=<issued-key>
+    ```
+  </Step>
+
+  <Step title="Enable code sharing">
+    Code sharing is disabled by default for each tenant. Enable it before
+    creating public workflow links:
+
+    ```bash theme={null}
+    npx libretto cloud sharing enable
+    ```
+  </Step>
+
+  <Step title="Deploy the workflow">
+    Share works on hosted workflows. Deploy the package that contains the
+    workflow before sharing it:
+
+    ```bash theme={null}
+    npx libretto cloud deploy .
+    ```
+  </Step>
+</Steps>
+
+#### Output
+
+When sharing succeeds, Libretto prints the public marketplace URL and code URL:
+
+```bash theme={null}
+Shared workflow: check-eligibility
+Marketplace URL: https://libretto.sh/...
+Code URL: https://libretto.sh/...
+```
+
+If the workflow is already shared, rerun the command with `--refresh` to update the shared code from the current deployment:
+
+```bash theme={null}
+npx libretto cloud share check-eligibility --refresh
+```
+
+### cloud sharing
+
+Use the `cloud sharing` commands to inspect or change whether public workflow code sharing is enabled for the current Libretto Cloud tenant. New tenants start with code sharing disabled.
+
+```bash theme={null}
+npx libretto cloud sharing status
+npx libretto cloud sharing enable
+npx libretto cloud sharing disable
+```
+
+All `cloud sharing` commands require `LIBRETTO_API_KEY`.
+
+<Warning>
+  Shared workflow code is public. Review the deployed source before sharing, and
+  keep credentials in Libretto Cloud credentials or environment configuration
+  instead of hard-coding them in workflow files.
+</Warning>

--- a/packages/libretto/src/cli/commands/cloud-sharing.ts
+++ b/packages/libretto/src/cli/commands/cloud-sharing.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { SimpleCLI } from "affordance";
+import { orpcCall, resolveApiUrl } from "../core/auth-fetch.js";
+
+type CodeSharingStatusResponse = {
+  enabled: boolean;
+};
+
+type ShareWorkflowResponse = {
+  id: string;
+  status: "created" | "existing" | "refreshed";
+  workflow: string;
+  marketplace_url: string;
+  code_url: string;
+};
+
+function requireCloudApiKey() {
+  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "LIBRETTO_API_KEY is required to share Libretto Cloud workflow code. Issue one with `libretto cloud auth api-key issue --label <label>`.",
+    );
+  }
+  return {
+    apiUrl: resolveApiUrl(null),
+    credential: { source: "env-api-key" as const, apiKey },
+  };
+}
+
+export const shareWorkflowCommand = SimpleCLI.command({
+  description: "Share one hosted workflow's code publicly",
+})
+  .input(SimpleCLI.input({
+    positionals: [
+      SimpleCLI.positional("workflow", z.string().min(1), {
+        help: "Hosted workflow name to share",
+      }),
+    ],
+    named: {
+      refresh: SimpleCLI.flag({
+        help: "Refresh an existing share from the workflow's current deployment",
+      }),
+    },
+  }))
+  .handle(async ({ input }) => {
+    const { apiUrl, credential } = requireCloudApiKey();
+    const response = await orpcCall<ShareWorkflowResponse>({
+      apiUrl,
+      path: "/v1/workflows/share",
+      input: { workflow: input.workflow, refresh: input.refresh },
+      credential,
+    });
+
+    if (response.status === "existing") {
+      console.log(`Workflow is already shared: ${response.workflow}`);
+      console.log("Use --refresh to update the shared code from the current deployment.");
+    } else if (response.status === "refreshed") {
+      console.log(`Refreshed shared workflow: ${response.workflow}`);
+    } else {
+      console.log(`Shared workflow: ${response.workflow}`);
+    }
+    console.log(`Marketplace URL: ${response.marketplace_url}`);
+    console.log(`Code URL: ${response.code_url}`);
+    return response.marketplace_url;
+  });
+
+export const codeSharingStatusCommand = SimpleCLI.command({
+  description: "Show whether tenant code sharing is enabled",
+})
+  .input(SimpleCLI.input({ positionals: [], named: {} }))
+  .handle(async () => {
+    const { apiUrl, credential } = requireCloudApiKey();
+    const response = await orpcCall<CodeSharingStatusResponse>({
+      apiUrl,
+      path: "/v1/tenant/codeSharing",
+      input: {},
+      credential,
+    });
+    console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+    return response.enabled;
+  });
+
+async function updateCodeSharing(enabled: boolean): Promise<boolean> {
+  const { apiUrl, credential } = requireCloudApiKey();
+  const response = await orpcCall<CodeSharingStatusResponse>({
+    apiUrl,
+    path: "/v1/tenant/updateCodeSharing",
+    input: { enabled },
+    credential,
+  });
+  console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+  return response.enabled;
+}
+
+export const enableCodeSharingCommand = SimpleCLI.command({
+  description: "Enable public workflow code sharing for this tenant",
+})
+  .input(SimpleCLI.input({ positionals: [], named: {} }))
+  .handle(async () => updateCodeSharing(true));
+
+export const disableCodeSharingCommand = SimpleCLI.command({
+  description: "Disable public workflow code sharing for this tenant",
+})
+  .input(SimpleCLI.input({ positionals: [], named: {} }))
+  .handle(async () => updateCodeSharing(false));
+
+export const codeSharingCommands = SimpleCLI.group({
+  description: "Manage tenant workflow code sharing",
+  routes: {
+    status: codeSharingStatusCommand,
+    enable: enableCodeSharingCommand,
+    disable: disableCodeSharingCommand,
+  },
+});

--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { createRequire, Module } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 import { build } from "esbuild";
@@ -57,6 +57,8 @@ export type WorkflowDeployMetadata = {
   credentialNames: string[];
   authProfileName?: string;
   authProfileRefresh?: boolean;
+  sourceFile?: string;
+  sourceFiles?: string[];
 };
 
 type BuildHostedDeployTarballArgs = {
@@ -473,13 +475,17 @@ function resolveWorkspaceSourcePath(
 function workspaceSourcePlugin(
   workspacePackages: Map<string, WorkspacePackage>,
   externalPackages: ReadonlySet<string>,
+  unresolvedWorkspaceImports?: Map<string, string>,
 ) {
   return {
     name: "workspace-source-resolver",
     setup(buildApi: {
       onResolve: (
         options: { filter: RegExp },
-        callback: (args: { path: string }) => { path: string } | null,
+        callback: (args: { path: string }) =>
+          | { path: string }
+          | { path: string; external: true }
+          | null,
       ) => void;
     }) {
       // Workspace imports are treated as bundle input, so their code is
@@ -503,9 +509,8 @@ function workspaceSourcePlugin(
           match.subpath,
         );
         if (!resolvedPath) {
-          throw new Error(
-            `Unable to resolve workspace import "${args.path}" from ${match.info.dir}.`,
-          );
+          unresolvedWorkspaceImports?.set(args.path, match.info.dir);
+          return { path: args.path, external: true };
         }
 
         return { path: resolvedPath };
@@ -616,6 +621,40 @@ function writeDeployMetadata(args: {
     join(args.outputDir, DEPLOY_METADATA_FILENAME),
     JSON.stringify({ workflows: args.workflows }, null, 2) + "\n",
   );
+}
+
+function toPortableRelativePath(args: {
+  absSourceDir: string;
+  absPath: string;
+}): string {
+  const relPath = relative(args.absSourceDir, args.absPath).replaceAll("\\", "/");
+  if (relPath.startsWith("../") || relPath === ".." || relPath.startsWith("/")) {
+    throw new Error(
+      `Deploy entry point must be inside the source directory to support cloud code sharing: ${args.absPath}`,
+    );
+  }
+  return relPath;
+}
+
+function writeShareableSourceFiles(args: {
+  absSourceDir: string;
+  absSourcePaths: readonly string[];
+  outputDir: string;
+}): string[] {
+  const relPaths = [...new Set(args.absSourcePaths.map((absPath) =>
+    toPortableRelativePath({
+      absPath,
+      absSourceDir: args.absSourceDir,
+    }),
+  ))].sort();
+
+  for (const relPath of relPaths) {
+    const targetPath = join(args.outputDir, ".libretto-share", "source", relPath);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    cpSync(resolve(args.absSourceDir, relPath), targetPath);
+  }
+
+  return relPaths;
 }
 
 function shouldVendorCurrentLibretto(versionSpec: string): boolean {
@@ -963,8 +1002,12 @@ async function writeBundledDeployEntrypoint(args: {
   externalPackages: ReadonlySet<string>;
   outputDir: string;
   workspacePackages: Map<string, WorkspacePackage>;
-}): Promise<WorkflowDeployMetadata[]> {
+}): Promise<{
+  shareableSourceFiles: string[];
+  workflows: WorkflowDeployMetadata[];
+}> {
   try {
+    const unresolvedWorkspaceImports = new Map<string, string>();
     // The implementation bundle is CommonJS so the bootstrap can load it lazily
     // with createRequire() after workflow discovery, while external packages
     // continue to load through normal Node module resolution.
@@ -976,13 +1019,25 @@ async function writeBundledDeployEntrypoint(args: {
       format: "cjs",
       outfile: "prebundled.cjs",
       platform: "node",
+      metafile: true,
       plugins: [
-        workspaceSourcePlugin(args.workspacePackages, args.externalPackages),
+        workspaceSourcePlugin(
+          args.workspacePackages,
+          args.externalPackages,
+          unresolvedWorkspaceImports,
+        ),
       ],
       splitting: false,
       target: "node20",
       write: false,
     });
+    const [unresolvedImport] = unresolvedWorkspaceImports;
+    if (unresolvedImport) {
+      const [importPath, packageDir] = unresolvedImport;
+      throw new Error(
+        `Unable to resolve workspace import "${importPath}" from ${packageDir}.`,
+      );
+    }
 
     const bundledImplementation = implementationBuild.outputFiles?.find(
       (file) => file.path.endsWith("prebundled.cjs"),
@@ -1008,7 +1063,22 @@ async function writeBundledDeployEntrypoint(args: {
         workflows,
       }),
     );
-    return workflows;
+    const shareableSourceFiles = Object.keys(implementationBuild.metafile?.inputs ?? {})
+      .map((inputPath) =>
+        isAbsolute(inputPath)
+          ? resolve(inputPath)
+          : resolve(args.absSourceDir, inputPath),
+      )
+      .filter((absPath) => {
+        const relPath = relative(args.absSourceDir, absPath);
+        return (
+          relPath !== "" &&
+          !relPath.startsWith("../") &&
+          relPath !== ".." &&
+          !isAbsolute(relPath)
+        );
+      });
+    return { shareableSourceFiles, workflows };
   } catch (error) {
     throw new Error(
       `Failed to bundle deploy entry point ${args.absEntryPoint}.\n${formatBuildError(error)}`,
@@ -1040,7 +1110,7 @@ export async function createHostedDeployPackage(
   let callerOwnsTempRoot = false;
 
   try {
-    const workflows = await writeBundledDeployEntrypoint({
+    const { shareableSourceFiles, workflows } = await writeBundledDeployEntrypoint({
       absEntryPoint,
       absSourceDir,
       deploymentName: args.deploymentName,
@@ -1048,6 +1118,20 @@ export async function createHostedDeployPackage(
       outputDir,
       workspacePackages,
     });
+    const sourceFiles = writeShareableSourceFiles({
+      absSourceDir,
+      absSourcePaths: [...shareableSourceFiles, absEntryPoint],
+      outputDir,
+    });
+    const sourceFile = toPortableRelativePath({
+      absPath: absEntryPoint,
+      absSourceDir,
+    });
+    const workflowsWithShareableSource = workflows.map((workflow) => ({
+      ...workflow,
+      sourceFile,
+      sourceFiles,
+    }));
 
     if (librettoDependency === "file:./libretto") {
       copyCurrentLibrettoPackage(outputDir);
@@ -1063,7 +1147,7 @@ export async function createHostedDeployPackage(
       outputDir,
       sourceDir: absSourceDir,
     });
-    writeDeployMetadata({ outputDir, workflows });
+    writeDeployMetadata({ outputDir, workflows: workflowsWithShareableSource });
 
     // Success transfers ownership of the temp directory to the caller, who is
     // responsible for invoking cleanup() after the tarball/upload step.
@@ -1074,7 +1158,7 @@ export async function createHostedDeployPackage(
         },
         entryPoint: "index.js",
         outputDir,
-        workflows,
+        workflows: workflowsWithShareableSource,
       };
   } finally {
     // On any failure before we return, this function still owns the temp dir

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -2,6 +2,7 @@ import { authCommands } from "./commands/auth.js";
 import { billingCommands } from "./commands/billing.js";
 import { browserCommands } from "./commands/browser.js";
 import { cloudCredentialCommands } from "./commands/cloud-credentials.js";
+import { codeSharingCommands, shareWorkflowCommand } from "./commands/cloud-sharing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
 import { experimentsCommand } from "./commands/experiments.js";
@@ -25,6 +26,8 @@ export const cliRoutes = {
       billing: billingCommands,
       credentials: cloudCredentialCommands,
       profiles: profileCommands,
+      share: shareWorkflowCommand,
+      sharing: codeSharingCommands,
     },
   }),
   experiments: experimentsCommand,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -603,6 +603,8 @@ export default workflow("main", async (ctx) => {
         billing <subcommand>  Hosted-platform subscription + usage commands
         credentials <subcommand>  Manage hosted credentials
         profiles <subcommand>  Manage hosted browser auth profiles
+        share  Share one hosted workflow's code publicly
+        sharing <subcommand>  Manage tenant workflow code sharing
     `}\n`);
     expect(result.stdout).toBe("");
   });

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -361,7 +361,28 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("deploy");
     expect(result.stdout).toContain("auth");
     expect(result.stdout).toContain("billing");
+    expect(result.stdout).toContain("share");
+    expect(result.stdout).toContain("sharing");
     expect(result.stderr).toBe("");
+  });
+
+  test("prints cloud share help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud share");
+    expect(result.stdout).toContain("Share one hosted workflow's code publicly");
+    expect(result.stdout).toContain("libretto cloud share <workflow>");
+    expect(result.stdout).toContain("--refresh");
+    expect(result.stderr).toBe("");
+  });
+
+  test("cloud share requires an API key", async ({ librettoCli }) => {
+    const result = await librettoCli("cloud share testWorkflow", {
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to share Libretto Cloud workflow code.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
   });
 
   test("prints deploy help with auto repair flag", async ({ librettoCli }) => {

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -161,14 +161,24 @@ describe("createHostedDeployPackage", () => {
       'export const workspaceMessage = "bundled from workspace source";\n',
     );
     writeFileSync(
+      join(sourceDir, "src", "format.ts"),
+      [
+        "export function formatMessage(value: string): string {",
+        '  return `formatted ${value}`;',
+        "}",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
       entryPoint,
       [
         'import { workflow } from "libretto";',
         'import { workspaceMessage } from "@repo/config/message";',
+        'import { formatMessage } from "./format";',
         "",
         "export const testWorkflow = workflow(",
         '  "testWorkflow",',
-        "  async () => workspaceMessage,",
+        "  async () => formatMessage(workspaceMessage),",
         ");",
         "",
       ].join("\n"),
@@ -187,6 +197,11 @@ describe("createHostedDeployPackage", () => {
     ) as {
       dependencies?: Record<string, string>;
     };
+    const deployMetadata = JSON.parse(
+      readFileSync(join(deployPackage.outputDir, ".libretto-workflows.json"), "utf8"),
+    ) as {
+      workflows: Array<{ name: string; sourceFile?: string; sourceFiles?: string[] }>;
+    };
     const bundle = readFileSync(
       join(deployPackage.outputDir, "index.js"),
       "utf8",
@@ -196,9 +211,30 @@ describe("createHostedDeployPackage", () => {
     expect(deployManifest.dependencies).toEqual({
       libretto: "0.5.4",
     });
+    expect(deployMetadata.workflows).toEqual([
+      {
+        name: "testWorkflow",
+        credentialNames: [],
+        sourceFile: "src/workflow.ts",
+        sourceFiles: ["src/format.ts", "src/workflow.ts"],
+      },
+    ]);
+    expect(
+      readFileSync(
+        join(deployPackage.outputDir, ".libretto-share", "source", "src", "workflow.ts"),
+        "utf8",
+      ),
+    ).toContain("testWorkflow");
+    expect(
+      readFileSync(
+        join(deployPackage.outputDir, ".libretto-share", "source", "src", "format.ts"),
+        "utf8",
+      ),
+    ).toContain("formatMessage");
     expect(bundle).toContain('createWorkflowProxy("testWorkflow", {"credentialNames":[]})');
     expect(bundle).toContain("return workflow(workflowName, {");
     expect(implementation).toContain("bundled from workspace source");
+    expect(implementation).toContain("formatted");
     expect(implementation).not.toContain("@repo/config/message");
     expect(bundle).not.toContain("workspace:*");
     expect(
@@ -354,6 +390,8 @@ describe("createHostedDeployPackage", () => {
         authProfileRefresh: true,
         credentialNames: ["openai_api_key"],
         name: "testWorkflow",
+        sourceFile: "src/workflow.ts",
+        sourceFiles: ["src/workflow.ts"],
       },
     ]);
 


### PR DESCRIPTION
## Summary
- adds `libretto cloud share <workflow>` for user-initiated hosted workflow code sharing
- adds `libretto cloud sharing status|enable|disable` tenant controls
- includes shareable source metadata in hosted deploy artifacts without adding the command to the Libretto skill file

## Tests
- `pnpm -s --filter libretto type-check`
- `pnpm -s --filter libretto build`
- `pnpm -s --filter libretto exec vitest run test/basic.spec.ts -t "cloud"`
- `pnpm -s --filter libretto exec vitest run test/deploy-artifact.spec.ts`