### PR TITLE
Add CLI telemetry version metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, and an error boolean. Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`packages/libretto/src/cli/core/telemetry.ts`](packages/libretto/src/cli/core/telemetry.ts).
 

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -95,7 +95,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, and an error boolean. Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`src/cli/core/telemetry.ts`](src/cli/core/telemetry.ts).
 

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -93,7 +93,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, and an error boolean. Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`{{LIBRETTO_PATH_PREFIX}}src/cli/core/telemetry.ts`]({{LIBRETTO_PATH_PREFIX}}src/cli/core/telemetry.ts).
 

--- a/packages/libretto/src/cli/core/telemetry.ts
+++ b/packages/libretto/src/cli/core/telemetry.ts
@@ -1,13 +1,17 @@
 import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { SimpleCLICommandMeta, SimpleCLIMiddleware } from "affordance";
 import { resolveHostedApiUrl } from "./auth-fetch.js";
 
 const TELEMETRY_FILE_NAME = "telemetry.json";
 const TELEMETRY_ENDPOINT_PATH = "/v1/telemetry/recordCliEvent";
 const TELEMETRY_TIMEOUT_MS = 250;
+
+type BuildChannel = "node_modules" | "source" | "unknown";
 
 type StoredTelemetryState = {
   installId?: string;
@@ -19,7 +23,47 @@ type CliTelemetryPayload = {
   timestamp: string;
   event: string;
   error: boolean;
+  packageVersion: string;
+  buildChannel: BuildChannel;
 };
+
+type PackageJson = {
+  version?: unknown;
+};
+
+function packageRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "../../..");
+}
+
+function readPackageVersion(): string {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(join(packageRoot(), "package.json"), "utf8"),
+    ) as PackageJson;
+    return typeof parsed.version === "string" ? parsed.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function resolveBuildChannel(): BuildChannel {
+  const root = packageRoot();
+  const workspaceRoot = join(root, "../..");
+  if (
+    basename(dirname(root)) === "packages" &&
+    existsSync(join(workspaceRoot, "pnpm-workspace.yaml"))
+  ) {
+    return "source";
+  }
+
+  const pathSegments = root.split(/[\\/]+/);
+  if (pathSegments.includes("node_modules")) return "node_modules";
+
+  return "unknown";
+}
+
+const packageVersion = readPackageVersion();
+const buildChannel = resolveBuildChannel();
 
 function telemetryDir(): string {
   return join(homedir(), ".libretto");
@@ -65,7 +109,7 @@ function writeTelemetryNotice(): void {
   if (!process.stderr.isTTY) return;
   process.stderr.write(
     [
-      "Libretto collects anonymous CLI telemetry: install id, timestamp, command event, and error status only.",
+      "Libretto collects anonymous CLI telemetry: install id, timestamp, command event, error status, package version, and build channel only.",
       "Set LIBRETTO_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1 to disable it, or set enabled:false in ~/.libretto/telemetry.json.",
     ].join(" ") + "\n",
   );
@@ -92,6 +136,8 @@ async function recordCliTelemetryEvent(
     timestamp: new Date().toISOString(),
     event: `libretto ${command.path.join(" ")}`,
     error,
+    packageVersion,
+    buildChannel,
   });
 }
 

--- a/packages/libretto/test/fixtures.ts
+++ b/packages/libretto/test/fixtures.ts
@@ -124,6 +124,7 @@ async function execProcess(
   stdinText?: string,
 ): Promise<SpawnResult> {
   const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  childEnv.LIBRETTO_TELEMETRY_DISABLED = "1";
   for (const [key, value] of Object.entries(env ?? {})) {
     if (value === undefined) {
       delete childEnv[key];

--- a/packages/libretto/test/telemetry.spec.ts
+++ b/packages/libretto/test/telemetry.spec.ts
@@ -63,6 +63,8 @@ describe("CLI telemetry", () => {
         json: {
           event: "libretto status",
           error: false,
+          packageVersion: expect.stringMatching(/^\d+\.\d+\.\d+/),
+          buildChannel: "source",
         },
       },
     });


### PR DESCRIPTION
## Summary
- add package version and build channel to CLI telemetry payloads
- classify source checkout vs npm/unknown builds for telemetry analysis
- disable prod telemetry by default in CLI test fixtures while telemetry tests explicitly opt back in to their local server
- update telemetry disclosure docs

## Verification
- pnpm -s --filter libretto type-check
- pnpm -s --filter libretto build
- pnpm -s --filter libretto test -- test/telemetry.spec.ts