### PR TITLE
Add npm bugs metadata for libretto

### DIFF
--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/saffron-health/libretto"
   },
+  "bugs": {
+    "url": "https://github.com/saffron-health/libretto/issues"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- add package-level `bugs.url` metadata pointing to this repository's issue tracker
- leave runtime code, dependencies, entrypoints, and generated output unchanged

## Verification
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/libretto/package.json','utf8')); if (p.name !== 'libretto' || p.bugs?.url !== 'https://github.com/saffron-health/libretto/issues') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs}))"`
- `npm pack --dry-run --json --ignore-scripts` from `packages/libretto`
- `git diff --check`