### PR TITLE
docs: clarify libretto shipped docs reference

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 ## Shipped Source & Documentation
 
-For shipped source details and published documentation links, read `references/shipped-source-and-documentation.md`.
+Read `references/shipped-source-and-documentation.md` for shipped source details, published documentation links, and implementation context beyond what this skill file covers.
 
 ## Default Integration Approach
 

--- a/.agents/skills/libretto/references/shipped-source-and-documentation.md
+++ b/.agents/skills/libretto/references/shipped-source-and-documentation.md
@@ -1,6 +1,6 @@
 # Shipped Source & Documentation
 
-The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Read these when you need implementation context beyond what the main skill file covers. Resolve paths from the package root, such as `node_modules/libretto/`.
+The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Resolve paths from the package root, such as `node_modules/libretto/`.
 
 Full documentation is published at [libretto.sh](https://libretto.sh). Available pages:
 

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 ## Shipped Source & Documentation
 
-For shipped source details and published documentation links, read `references/shipped-source-and-documentation.md`.
+Read `references/shipped-source-and-documentation.md` for shipped source details, published documentation links, and implementation context beyond what this skill file covers.
 
 ## Default Integration Approach
 

--- a/.claude/skills/libretto/references/shipped-source-and-documentation.md
+++ b/.claude/skills/libretto/references/shipped-source-and-documentation.md
@@ -1,6 +1,6 @@
 # Shipped Source & Documentation
 
-The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Read these when you need implementation context beyond what the main skill file covers. Resolve paths from the package root, such as `node_modules/libretto/`.
+The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Resolve paths from the package root, such as `node_modules/libretto/`.
 
 Full documentation is published at [libretto.sh](https://libretto.sh). Available pages:
 

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 ## Shipped Source & Documentation
 
-For shipped source details and published documentation links, read `references/shipped-source-and-documentation.md`.
+Read `references/shipped-source-and-documentation.md` for shipped source details, published documentation links, and implementation context beyond what this skill file covers.
 
 ## Default Integration Approach
 

--- a/packages/libretto/skills/libretto/references/shipped-source-and-documentation.md
+++ b/packages/libretto/skills/libretto/references/shipped-source-and-documentation.md
@@ -1,6 +1,6 @@
 # Shipped Source & Documentation
 
-The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Read these when you need implementation context beyond what the main skill file covers. Resolve paths from the package root, such as `node_modules/libretto/`.
+The npm package includes `src/` (full TypeScript source) and `docs/` for deeper understanding of internals and design decisions. Resolve paths from the package root, such as `node_modules/libretto/`.
 
 Full documentation is published at [libretto.sh](https://libretto.sh). Available pages:
 


### PR DESCRIPTION
## Summary
- Move the instruction about when to read the shipped docs reference back into the main Libretto skill
- Keep `references/shipped-source-and-documentation.md` focused on source/package facts and documentation links
- Sync `.agents` and `.claude` skill mirrors

## Validation
- pnpm check:mirrors
- git diff --check