### PR TITLE
Bump Affordance when release includes source changes

### DIFF
--- a/packages/affordance/package.json
+++ b/packages/affordance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affordance",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A TypeScript framework for building agent-friendly CLIs",
   "license": "MIT",
   "homepage": "https://libretto.sh",

--- a/packages/libretto/docs/releasing.md
+++ b/packages/libretto/docs/releasing.md
@@ -66,10 +66,13 @@ The root `scripts/prepare-release.sh` script does the following:
 1. Checks that the working tree is clean.
 2. Updates local `main` from `origin/main`.
 3. Runs `pnpm install --frozen-lockfile`, `pnpm --filter libretto type-check`, and `pnpm --filter libretto test`.
-4. Bumps the version in `packages/libretto/package.json`.
-5. Creates a release branch.
-6. Commits the version bump.
-7. Pushes the branch and opens a PR to `main` with the `release` label.
+4. Checks whether `packages/affordance` changed since the current Libretto release tag. If it changed, the script runs Affordance type-check/tests and bumps `packages/affordance/package.json` by one patch version when the current Affordance version is already published to npm.
+5. Bumps the version in `packages/libretto/package.json`.
+6. Creates a release branch.
+7. Commits the version bump.
+8. Pushes the branch and opens a PR to `main` with the `release` label.
+
+Affordance is published before Libretto in `.github/workflows/release.yml`. Keeping this automatic patch bump in the release PR prevents Libretto from depending on unpublished Affordance APIs while still avoiding unnecessary Affordance releases when its package contents did not change.
 
 Release PRs also run the eval workflow. That workflow records score, duration, token, cost, and tool-call metrics for review. Scores are informational: low scores do not fail the workflow, but setup/runtime failures and zero completed records do.
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -6,7 +6,9 @@ usage() {
 Usage: scripts/prepare-release.sh [patch|minor|major]
 
 Creates a release PR branch from main, bumps packages/libretto/package.json,
-pushes the branch, and opens a pull request targeting main.
+bumps packages/affordance/package.json when affordance changed since the last
+Libretto release and its current version is already published, pushes the
+branch, and opens a pull request targeting main.
 EOF
 }
 
@@ -14,6 +16,8 @@ bump="${1:-patch}"
 package_json_path="packages/libretto/package.json"
 package_dir="packages/libretto"
 skill_path="packages/libretto/skills/libretto/SKILL.md"
+affordance_package_json_path="packages/affordance/package.json"
+affordance_dir="packages/affordance"
 
 case "$bump" in
   patch|minor|major)
@@ -66,6 +70,32 @@ process.stdout.write(next.join("."))
 ' "$current_version" "$bump")"
 branch_name="release-v${next_version}"
 
+affordance_changed=false
+affordance_current_version="$(node -p "require('./${affordance_package_json_path}').version")"
+affordance_next_version=""
+
+if git rev-parse --verify --quiet "v${current_version}" >/dev/null; then
+  if ! git diff --quiet "v${current_version}..HEAD" -- "$affordance_dir"; then
+    affordance_changed=true
+  fi
+else
+  echo "Warning: v${current_version} tag not found; skipping automatic affordance change detection." >&2
+fi
+
+if [ "$affordance_changed" = true ]; then
+  pnpm --filter affordance type-check
+  pnpm --filter affordance test
+
+  if npm view "affordance@${affordance_current_version}" version >/dev/null 2>&1; then
+    affordance_next_version="$(node -e '
+const [major, minor, patch] = process.argv[1].split(".").map(Number)
+process.stdout.write([major, minor, patch + 1].join("."))
+' "$affordance_current_version")"
+  else
+    echo "Affordance changed, but affordance@${affordance_current_version} is not published; keeping current affordance version."
+  fi
+fi
+
 if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
   echo "Local branch ${branch_name} already exists." >&2
   exit 1
@@ -83,6 +113,13 @@ git checkout -b "$branch_name"
   npm version "$next_version" --no-git-tag-version >/dev/null
 )
 
+if [ -n "$affordance_next_version" ]; then
+  (
+    cd "$affordance_dir"
+    npm version "$affordance_next_version" --no-git-tag-version >/dev/null
+  )
+fi
+
 node packages/dev-tools/scripts/set-libretto-skill-version.mjs "$next_version"
 
 pnpm sync:mirrors
@@ -90,6 +127,7 @@ pnpm check:mirrors
 
 git add \
   "$package_json_path" \
+  "$affordance_package_json_path" \
   packages/libretto/skills/libretto/SKILL.md \
   packages/libretto/skills/libretto-readonly/SKILL.md \
   .agents/skills/libretto \
@@ -111,10 +149,12 @@ gh pr create \
 ## Summary
 
 - release libretto v${next_version}
+$(if [ -n "$affordance_next_version" ]; then echo "- release affordance v${affordance_next_version}"; elif [ "$affordance_changed" = true ]; then echo "- include affordance changes already versioned at v${affordance_current_version}"; fi)
 
 ## Verification
 
 - pnpm --filter libretto type-check
 - pnpm --filter libretto test
+$(if [ "$affordance_changed" = true ]; then echo "- pnpm --filter affordance type-check"; echo "- pnpm --filter affordance test"; fi)
 EOF
 )"


### PR DESCRIPTION
## Summary
- update `prepare-release` to detect changes under `packages/affordance` since the current Libretto release tag
- run Affordance verification and patch-bump Affordance when its current version is already published
- document the Affordance bump behavior in the release guide

## Verification
- bash -n scripts/prepare-release.sh
- pnpm -s --filter affordance type-check
