### PR TITLE
Check Affordance publish state in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,12 @@ jobs:
           set -euo pipefail
           package_name="$(node -p "require('./packages/libretto/package.json').name")"
           version="$(node -p "require('./packages/libretto/package.json').version")"
+          affordance_version="$(node -p "require('./packages/affordance/package.json').version")"
+          create_libretto_package_name="$(node -p "require('./packages/create-libretto/package.json').name")"
           echo "package_name=${package_name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "affordance_version=${affordance_version}" >> "$GITHUB_OUTPUT"
+          echo "create_libretto_package_name=${create_libretto_package_name}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
       - name: Check release state
@@ -46,6 +50,9 @@ jobs:
 
           release_exists=false
           npm_exists=false
+          affordance_npm_exists=false
+          create_libretto_npm_exists=false
+          publish_needed=false
 
           if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
             release_exists=true
@@ -55,16 +62,31 @@ jobs:
             npm_exists=true
           fi
 
+          if npm view "affordance@${{ steps.version.outputs.affordance_version }}" version >/dev/null 2>&1; then
+            affordance_npm_exists=true
+          fi
+
+          if npm view "${{ steps.version.outputs.create_libretto_package_name }}@${{ steps.version.outputs.version }}" version >/dev/null 2>&1; then
+            create_libretto_npm_exists=true
+          fi
+
+          if [ "$release_exists" != true ] || [ "$npm_exists" != true ] || [ "$affordance_npm_exists" != true ] || [ "$create_libretto_npm_exists" != true ]; then
+            publish_needed=true
+          fi
+
           echo "release_exists=${release_exists}" >> "$GITHUB_OUTPUT"
           echo "npm_exists=${npm_exists}" >> "$GITHUB_OUTPUT"
+          echo "affordance_npm_exists=${affordance_npm_exists}" >> "$GITHUB_OUTPUT"
+          echo "create_libretto_npm_exists=${create_libretto_npm_exists}" >> "$GITHUB_OUTPUT"
+          echo "publish_needed=${publish_needed}" >> "$GITHUB_OUTPUT"
 
       - name: Skip already published version
-        if: steps.state.outputs.release_exists == 'true' && steps.state.outputs.npm_exists == 'true'
+        if: steps.state.outputs.publish_needed != 'true'
         run: |
-          echo "Version ${{ steps.version.outputs.version }} is already published to npm and GitHub."
+          echo "Version ${{ steps.version.outputs.version }} and affordance@${{ steps.version.outputs.affordance_version }} are already published to npm and GitHub."
 
       - name: Configure gcloud secret access for evaluator
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.publish_needed == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -105,7 +127,7 @@ jobs:
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Restore evaluator cache
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.publish_needed == 'true'
         uses: actions/cache@v4
         with:
           path: temp/libretto-cli-evaluate-cache
@@ -114,15 +136,15 @@ jobs:
             libretto-evaluate-cache-${{ runner.os }}-
 
       - name: Install dependencies
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.publish_needed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.publish_needed == 'true'
         run: npx playwright install chromium
 
       - name: Verify release build
-        if: steps.state.outputs.release_exists != 'true' || steps.state.outputs.npm_exists != 'true'
+        if: steps.state.outputs.publish_needed == 'true'
         run: |
           pnpm check:mirrors
           pnpm --filter libretto... build
@@ -133,10 +155,13 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       release_exists: ${{ steps.state.outputs.release_exists }}
       npm_exists: ${{ steps.state.outputs.npm_exists }}
+      affordance_npm_exists: ${{ steps.state.outputs.affordance_npm_exists }}
+      create_libretto_npm_exists: ${{ steps.state.outputs.create_libretto_npm_exists }}
+      publish_needed: ${{ steps.state.outputs.publish_needed }}
 
   release:
     needs: verify
-    if: needs.verify.outputs.release_exists != 'true' || needs.verify.outputs.npm_exists != 'true'
+    if: needs.verify.outputs.publish_needed == 'true'
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -163,6 +188,7 @@ jobs:
         run: pnpm --filter libretto... build
 
       - name: Publish affordance to npm
+        if: needs.verify.outputs.affordance_npm_exists != 'true'
         working-directory: packages/affordance
         run: |
           affordance_version="$(node -p "require('./package.json').version")"
@@ -178,6 +204,7 @@ jobs:
         run: pnpm publish --access public --no-git-checks
 
       - name: Publish create-libretto to npm
+        if: needs.verify.outputs.create_libretto_npm_exists != 'true'
         working-directory: packages/create-libretto
         run: |
           if ! npm view "create-libretto@${{ needs.verify.outputs.version }}" version >/dev/null 2>&1; then

--- a/packages/libretto/docs/releasing.md
+++ b/packages/libretto/docs/releasing.md
@@ -83,12 +83,12 @@ After the release PR merges, `.github/workflows/release.yml` runs on `main`.
 The workflow:
 
 1. Reads the version from `packages/libretto/package.json`.
-2. Checks whether that version already exists on npm and in GitHub Releases.
+2. Checks whether that version already exists on npm and in GitHub Releases. It also checks whether the current `packages/affordance/package.json` version and matching `create-libretto` version already exist on npm.
 3. Runs install, type-check, and tests for the `libretto` package in a verification job.
 4. Publishes `affordance` first, then `libretto@X.Y.Z`, then `create-libretto@X.Y.Z` with trusted publishing.
 5. Creates GitHub release `vX.Y.Z` with generated release notes if it does not already exist.
 
-This makes the workflow safe to re-run after partial failures. For example, if npm publish succeeds but GitHub release creation fails, a re-run will skip npm and only create the missing release.
+This makes the workflow safe to re-run after partial failures. For example, if npm publish succeeds but GitHub release creation fails, a re-run will skip npm and only create the missing release. It also means Affordance can still be published if its version is missing even when the Libretto npm package and GitHub release for the current Libretto version already exist.
 
 ## Eval gating on release PRs
 


### PR DESCRIPTION
## Summary
- include Affordance and create-libretto npm state in the release workflow's publish decision
- run the release job when Affordance is missing even if the Libretto version and GitHub release already exist
- document partial-release recovery for Affordance

## Verification
- simulated the release-state shell logic locally; with current versions it reports `publish_needed=true` because `affordance@0.2.1` is not on npm
