### PR TITLE
release: v0.6.28

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Read-Only Works

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Works

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Read-Only Works

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Works

--- a/packages/create-libretto/package.json
+++ b/packages/create-libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-libretto",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "Create and set up a Libretto project",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "homepage": "https://libretto.sh",

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Read-Only Works

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.27"
+  version: "0.6.28"
 ---
 
 ## How Libretto Works


### PR DESCRIPTION
## Summary

- release libretto v0.6.28
- publish libretto with `affordance: ^0.2.1` so fresh installs use the fixed Affordance middleware support

## Verification

- pnpm --filter libretto type-check
- pnpm --filter libretto test
- pnpm --filter affordance type-check
- pnpm --filter affordance test
- packed packages/libretto and verified package dependency `affordance: ^0.2.1`
