### PR TITLE
Ignore Affordance version-only changes in release prep

### DIFF
--- a/packages/libretto/docs/releasing.md
+++ b/packages/libretto/docs/releasing.md
@@ -66,7 +66,7 @@ The root `scripts/prepare-release.sh` script does the following:
 1. Checks that the working tree is clean.
 2. Updates local `main` from `origin/main`.
 3. Runs `pnpm install --frozen-lockfile`, `pnpm --filter libretto type-check`, and `pnpm --filter libretto test`.
-4. Checks whether `packages/affordance` changed since the current Libretto release tag. If it changed, the script runs Affordance type-check/tests and bumps `packages/affordance/package.json` by one patch version when the current Affordance version is already published to npm.
+4. Checks whether `packages/affordance` changed since the current Libretto release tag, excluding `packages/affordance/package.json` version-only changes. If source/package contents changed, the script runs Affordance type-check/tests and bumps `packages/affordance/package.json` by one patch version when the current Affordance version is already published to npm.
 5. Bumps the version in `packages/libretto/package.json`.
 6. Creates a release branch.
 7. Commits the version bump.

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -75,7 +75,9 @@ affordance_current_version="$(node -p "require('./${affordance_package_json_path
 affordance_next_version=""
 
 if git rev-parse --verify --quiet "v${current_version}" >/dev/null; then
-  if ! git diff --quiet "v${current_version}..HEAD" -- "$affordance_dir"; then
+  if ! git diff --quiet "v${current_version}..HEAD" -- \
+    "$affordance_dir" \
+    ":(exclude)$affordance_package_json_path"; then
     affordance_changed=true
   fi
 else

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -79,6 +79,29 @@ if git rev-parse --verify --quiet "v${current_version}" >/dev/null; then
     "$affordance_dir" \
     ":(exclude)$affordance_package_json_path"; then
     affordance_changed=true
+  else
+    previous_affordance_package_json="$(mktemp)"
+    git show "v${current_version}:${affordance_package_json_path}" > "$previous_affordance_package_json"
+    if ! node - "$previous_affordance_package_json" "$affordance_package_json_path" <<'NODE'
+const fs = require("node:fs");
+const [previousPath, currentPath] = process.argv.slice(2);
+
+function comparablePackageJson(path) {
+  const packageJson = JSON.parse(fs.readFileSync(path, "utf8"));
+  delete packageJson.version;
+  return JSON.stringify(packageJson);
+}
+
+process.exit(
+  comparablePackageJson(previousPath) === comparablePackageJson(currentPath)
+    ? 0
+    : 1,
+);
+NODE
+    then
+      affordance_changed=true
+    fi
+    rm "$previous_affordance_package_json"
   fi
 else
   echo "Warning: v${current_version} tag not found; skipping automatic affordance change detection." >&2


### PR DESCRIPTION
## Summary
- update `prepare-release` so Affordance auto-bump detection ignores only the `version` field in `packages/affordance/package.json`
- still treat Affordance source changes and non-version package metadata changes as release-relevant
- clarify release docs to distinguish Affordance source/package contents from release metadata

## Verification
- bash -n scripts/prepare-release.sh
- simulated current release state: Affordance `version`-only delta reports `affordance_changed=false`
- simulated non-version `packages/affordance/package.json` metadata delta reports as changed
