### PR TITLE
Remove website pricing section

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -22,7 +22,6 @@ import { BattleTestedBanner } from "./components/BattleTestedBanner";
 import { Benchmarks } from "./components/Benchmarks";
 import { MaintainingFeatures } from "./components/MaintainingFeatures";
 import { CloudProviders } from "./components/CloudProviders";
-import { Pricing } from "./components/Pricing.js";
 import { FAQ } from "./components/FAQ";
 import { CTA } from "./components/CTA";
 import { SectionDivider } from "./components/SectionDivider.js";
@@ -136,8 +135,6 @@ export function HomePage() {
         <MaintainingFeatures />
         <SectionDivider />
         <CloudProviders />
-        <SectionDivider />
-        <Pricing />
         <SectionDivider />
         <FAQ />
         <SectionDivider />

--- a/apps/website/src/components/CloudProviders.tsx
+++ b/apps/website/src/components/CloudProviders.tsx
@@ -115,7 +115,7 @@ export function CloudProviders() {
               cloud docs →
             </a>
             <a
-              href="/docs/libretto-cloud-hosting/billing"
+              href="/docs/libretto-cloud-hosting/billing#plans-and-pricing"
               className={linkClass}
               data-fathom-event="Cloud pricing click"
             >

--- a/apps/website/src/components/CloudProviders.tsx
+++ b/apps/website/src/components/CloudProviders.tsx
@@ -106,13 +106,22 @@ export function CloudProviders() {
             command={DEPLOY_COMMAND}
             fathomEvent="Cloud deploy command copy"
           />
-          <a
-            href="/docs/libretto-cloud-hosting/overview"
-            className={`${linkClass} mt-4 inline-block font-mono text-xs`}
-            data-fathom-event="Cloud docs click"
-          >
-            cloud docs →
-          </a>
+          <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs">
+            <a
+              href="/docs/libretto-cloud-hosting/overview"
+              className={linkClass}
+              data-fathom-event="Cloud docs click"
+            >
+              cloud docs →
+            </a>
+            <a
+              href="/docs/libretto-cloud-hosting/billing"
+              className={linkClass}
+              data-fathom-event="Cloud pricing click"
+            >
+              pricing →
+            </a>
+          </div>
         </div>
 
         <OrBadge className="-my-4 self-center md:hidden" />

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -111,9 +111,6 @@ export function MobileMenu({ stars }: { stars: string | null }) {
             <MenuItem href="/blog" className={itemClass} data-fathom-event="Mobile nav blog click">
               Blog
             </MenuItem>
-            <MenuItem href="/#pricing" className={itemClass} data-fathom-event="Mobile nav pricing click">
-              Pricing
-            </MenuItem>
             <MenuItem
               href={DISCUSSIONS_URL}
               target="_blank"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -144,9 +144,6 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             <GlitchNavLink href="/blog" external={false} fathomEvent="Nav blog click">
               Blog
             </GlitchNavLink>
-            <GlitchNavLink href="/#pricing" external={false} fathomEvent="Nav pricing click">
-              Pricing
-            </GlitchNavLink>
             <GlitchNavLink href={DISCUSSIONS_URL} fathomEvent="Nav forum click">
               Forum
             </GlitchNavLink>

--- a/apps/website/src/components/Pricing.tsx
+++ b/apps/website/src/components/Pricing.tsx
@@ -102,7 +102,7 @@ function CloudOnlyNote() {
   );
 }
 
-export function Pricing() {
+export function _Pricing() {
   return (
     <SiteSection id="pricing" width="lg">
       <SectionIntro

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -80,8 +80,8 @@ Run `billing portal`, open the printed plans page, and use it to change plans or
 ### BAA and Enterprise
 
 The hosted Libretto Cloud platform is fully HIPAA compliant. If you need a BAA
-or want to discuss an Enterprise plan, please reach out to us at
-`team@libretto.sh`.
+(which does not require an Enterprise plan) or want to discuss an Enterprise
+plan, please reach out to us at `team@libretto.sh`.
 
 ### Troubleshooting
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -79,8 +79,9 @@ Run `billing portal`, open the printed plans page, and use it to change plans or
 
 ### BAA and Enterprise
 
-The hosted Libretto Cloud platform is fully HIPAA compliant. For BAA and
-Enterprise, please reach out to us at `team@libretto.sh`.
+The hosted Libretto Cloud platform is fully HIPAA compliant. If you need a BAA
+or want to discuss an Enterprise plan, please reach out to us at
+`team@libretto.sh`.
 
 ### Troubleshooting
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -79,7 +79,7 @@ Run `billing portal`, open the printed plans page, and use it to change plans or
 
 ### BAA and Enterprise
 
-For BAA and Enterprise, please reach out to us at `team@saffron.health`.
+For BAA and Enterprise, please reach out to us at `team@libretto.sh`.
 
 ### Troubleshooting
 

--- a/docs/libretto-cloud-hosting/billing.mdx
+++ b/docs/libretto-cloud-hosting/billing.mdx
@@ -79,7 +79,8 @@ Run `billing portal`, open the printed plans page, and use it to change plans or
 
 ### BAA and Enterprise
 
-For BAA and Enterprise, please reach out to us at `team@libretto.sh`.
+The hosted Libretto Cloud platform is fully HIPAA compliant. For BAA and
+Enterprise, please reach out to us at `team@libretto.sh`.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- remove the pricing section from the website homepage while keeping the component available as `_Pricing`
- remove pricing links from the desktop and mobile header navigation
- add a pricing docs link next to the cloud docs link in the deployment section

## Verification
- `pnpm -s --filter @libretto/website type-check`
