### PR TITLE
Encourage closing Libretto sessions

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - Prefer `snapshot` first when the visible page state is unclear.
 - Use `readonly-exec` for focused inspection: titles, HTML, locator text, counts, visibility checks, and GET requests.
 - Keep snippets small and purpose-built. Do not run multiple `readonly-exec` commands at the same time.
+- Close disposable sessions before your final response once inspection is complete. Open browsers keep consuming local or hosted resources.
 - End with diagnosis and handoff guidance, not an attempted in-browser repair.
 
 ## Commands
@@ -81,7 +82,7 @@ libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 
 ### `close`
 
-- Use `close` when the inspection session is no longer needed.
+- Use `close` when the inspection session is no longer needed, unless the user explicitly asks to keep the browser open.
 
 ```bash
 libretto close --session failed-job-debug

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -54,6 +54,7 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 - Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
 - After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, or `--headless` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
+- Close disposable sessions before your final response once exploration, debugging, or validation is complete. Open browsers keep consuming local or hosted resources.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
@@ -179,6 +180,7 @@ npx libretto save app.example.com
 ### `close`
 
 - Use `close` when the user is done with the session or an exploration session is no longer helping progress (unless the user asked to keep watching that browser).
+- Prefer closing sessions promptly after successful validation or diagnosis so unused browsers do not keep consuming resources.
 - `close --all` is available for workspace cleanup.
 
 ```bash

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - Prefer `snapshot` first when the visible page state is unclear.
 - Use `readonly-exec` for focused inspection: titles, HTML, locator text, counts, visibility checks, and GET requests.
 - Keep snippets small and purpose-built. Do not run multiple `readonly-exec` commands at the same time.
+- Close disposable sessions before your final response once inspection is complete. Open browsers keep consuming local or hosted resources.
 - End with diagnosis and handoff guidance, not an attempted in-browser repair.
 
 ## Commands
@@ -81,7 +82,7 @@ libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 
 ### `close`
 
-- Use `close` when the inspection session is no longer needed.
+- Use `close` when the inspection session is no longer needed, unless the user explicitly asks to keep the browser open.
 
 ```bash
 libretto close --session failed-job-debug

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -54,6 +54,7 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 - Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
 - After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, or `--headless` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
+- Close disposable sessions before your final response once exploration, debugging, or validation is complete. Open browsers keep consuming local or hosted resources.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
@@ -179,6 +180,7 @@ npx libretto save app.example.com
 ### `close`
 
 - Use `close` when the user is done with the session or an exploration session is no longer helping progress (unless the user asked to keep watching that browser).
+- Prefer closing sessions promptly after successful validation or diagnosis so unused browsers do not keep consuming resources.
 - `close --all` is available for workspace cleanup.
 
 ```bash

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - Prefer `snapshot` first when the visible page state is unclear.
 - Use `readonly-exec` for focused inspection: titles, HTML, locator text, counts, visibility checks, and GET requests.
 - Keep snippets small and purpose-built. Do not run multiple `readonly-exec` commands at the same time.
+- Close disposable sessions before your final response once inspection is complete. Open browsers keep consuming local or hosted resources.
 - End with diagnosis and handoff guidance, not an attempted in-browser repair.
 
 ## Commands
@@ -81,7 +82,7 @@ libretto readonly-exec "await scrollBy(0, 500)" --session failed-job-debug
 
 ### `close`
 
-- Use `close` when the inspection session is no longer needed.
+- Use `close` when the inspection session is no longer needed, unless the user explicitly asks to keep the browser open.
 
 ```bash
 libretto close --session failed-job-debug

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -54,6 +54,7 @@ Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first 
 - Validation requires a successful clean `run` with confirmation of the actual returned output, not just process success. Use the same headed or headless mode that the workflow run is already using.
 - After validation, always show the user: (1) the output/results from the validation run, and (2) the same command so they can re-run it themselves. Include any `--params`, `--headed`, or `--headless` flags the workflow needs.
 - Treat exploration sessions as disposable unless the user explicitly wants one kept open.
+- Close disposable sessions before your final response once exploration, debugging, or validation is complete. Open browsers keep consuming local or hosted resources.
 - Get explicit user confirmation before mutating actions or replaying network requests that may have side effects.
 - Never run multiple `exec` commands at the same time.
 - If the browser must remain read-only, switch to the `libretto-readonly` skill and use `readonly-exec` instead of `exec`.
@@ -179,6 +180,7 @@ npx libretto save app.example.com
 ### `close`
 
 - Use `close` when the user is done with the session or an exploration session is no longer helping progress (unless the user asked to keep watching that browser).
+- Prefer closing sessions promptly after successful validation or diagnosis so unused browsers do not keep consuming resources.
 - `close --all` is available for workspace cleanup.
 
 ```bash


### PR DESCRIPTION
## Summary
- Update the interactive Libretto skill to close disposable sessions after exploration, debugging, or validation.
- Update the read-only Libretto skill to close inspection sessions unless the user asks to keep the browser open.
- Sync generated skill mirrors.

## Verification
- `pnpm -s check:mirrors`
