### PR TITLE
fix: resolve playwright from libretto's own deps in setup

### DIFF
--- a/packages/libretto/src/cli/commands/setup.ts
+++ b/packages/libretto/src/cli/commands/setup.ts
@@ -1,4 +1,5 @@
 import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { spawnSync } from "node:child_process";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,10 +12,24 @@ import { SimpleCLI } from "affordance";
 
 function installBrowsers(): void {
   console.log("Installing Playwright Chromium...");
-  const result = spawnSync("npx", ["playwright", "install", "chromium"], {
-    stdio: "inherit",
-    shell: true,
-  });
+  const require = createRequire(import.meta.url);
+  let playwrightCLI: string;
+  try {
+    playwrightCLI = join(
+      dirname(require.resolve("playwright/package.json")),
+      "cli.js",
+    );
+  } catch {
+    console.error(
+      "Could not resolve playwright. Run manually: npx playwright install chromium",
+    );
+    return;
+  }
+  const result = spawnSync(
+    process.execPath,
+    [playwrightCLI, "install", "chromium"],
+    { stdio: "inherit" },
+  );
   if (result.status === 0) {
     console.log("✓ Playwright Chromium installed");
   } else {


### PR DESCRIPTION
## Summary
  - `npx libretto setup` was installing Chromium for the system PATH playwright via `npx playwright install chromium`
  - The daemon uses libretto's bundled playwright which expects Chromium at a different path → silent crash
  - Fix: resolve playwright CLI from libretto's own module graph using `createRequire(import.meta.url)` so setup always
  installs for the exact playwright the daemon will use

  Fixes #410