### PR TITLE
Bundle workflow libretto in deploy artifacts

### DIFF
--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -71,7 +71,6 @@ type BuildHostedDeployTarballArgs = {
 type CreateHostedDeployPackageArgs = BuildHostedDeployTarballArgs;
 
 const DEFAULT_RUNTIME_EXTERNALS = [
-  "libretto",
   "playwright",
   "playwright-core",
   "chromium-bidi",
@@ -580,22 +579,79 @@ function resolveDependencyVersion(
   );
 }
 
+function resolveLibrettoDependencyVersion(
+  sourceDir: string,
+  packageName: string,
+): string | null {
+  try {
+    const librettoManifestPath = require.resolve("libretto/package.json", {
+      paths: [sourceDir],
+    });
+    const version = readDependencyVersionFromManifest(
+      readPackageManifest(librettoManifestPath),
+      packageName,
+    );
+    if (version) {
+      return version;
+    }
+  } catch {
+    // Fall through to the current CLI install. Source installs are optional in
+    // tests that only exercise manifest construction.
+  }
+
+  const version = readDependencyVersionFromManifest(
+    readPackageManifest(join(CURRENT_LIBRETTO_PACKAGE_DIR, "package.json")),
+    packageName,
+  );
+  if (version) {
+    return version;
+  }
+
+  try {
+    const manifestPath = require.resolve(`${packageName}/package.json`, {
+      paths: [CURRENT_LIBRETTO_PACKAGE_DIR],
+    });
+    return readPackageManifest(manifestPath).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function writeDeployManifest(args: {
   additionalExternals: readonly string[];
   deploymentName: string;
   librettoDependency: string;
   outputDir: string;
+  runtimeExternals: readonly string[];
   sourceDir: string;
 }): void {
+  const dependencyPackages = [
+    ...new Set([
+      ...BUILT_IN_MANIFEST_DEPENDENCIES,
+      ...args.runtimeExternals.filter((packageName) =>
+        resolveLibrettoDependencyVersion(args.sourceDir, packageName),
+      ),
+      ...args.additionalExternals,
+    ]),
+  ];
   const dependencies = Object.fromEntries(
-    [...BUILT_IN_MANIFEST_DEPENDENCIES, ...args.additionalExternals].map(
-      (packageName) => [
+    dependencyPackages.map((packageName) => {
+      const fallbackVersion =
+        packageName === "libretto"
+          ? args.librettoDependency
+          : (resolveLibrettoDependencyVersion(args.sourceDir, packageName) ??
+            undefined);
+      return [
         packageName,
         packageName === "libretto"
           ? args.librettoDependency
-          : resolveDependencyVersion(args.sourceDir, packageName),
-      ],
-    ),
+          : resolveDependencyVersion(
+              args.sourceDir,
+              packageName,
+              fallbackVersion,
+            ),
+      ];
+    }),
   );
 
   writeFileSync(
@@ -930,7 +986,7 @@ function createBootstrapSource(args: {
   // to discover workflow exports. The implementation bundle stays embedded in
   // the file, while external packages are resolved from node_modules when the
   // deployed code loads them.
-  return `import { createRequire } from "node:module";
+  return `import { createRequire, Module } from "node:module";
 import { existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -946,6 +1002,45 @@ const BUNDLE_FILENAME = join(
 const nativeRequire = createRequire(
   join(tmpdir(), ${JSON.stringify("libretto-deploy-bootstrap.cjs")}),
 );
+const packageRequire = createRequire(import.meta.url || __filename);
+
+function isBarePackageSpecifier(specifier) {
+  return (
+    !specifier.startsWith(".") &&
+    !specifier.startsWith("/") &&
+    !specifier.startsWith("node:") &&
+    !/^[A-Za-z]:[\\\\/]/.test(specifier)
+  );
+}
+
+function loadImplementation() {
+  const originalRequire = Module.prototype.require;
+  function patchedRequire(specifier) {
+    try {
+      return originalRequire.call(this, specifier);
+    } catch (error) {
+      if (
+        error?.code === "MODULE_NOT_FOUND" &&
+        isBarePackageSpecifier(specifier)
+      ) {
+        Module.prototype.require = originalRequire;
+        try {
+          return packageRequire(specifier);
+        } finally {
+          Module.prototype.require = patchedRequire;
+        }
+      }
+      throw error;
+    }
+  }
+  Module.prototype.require = patchedRequire;
+
+  try {
+    return nativeRequire(ensureBundleFile());
+  } finally {
+    Module.prototype.require = originalRequire;
+  }
+}
 
 function ensureBundleFile() {
   if (!existsSync(BUNDLE_FILENAME)) {
@@ -960,7 +1055,7 @@ function ensureBundleFile() {
 
 function createWorkflowProxy(workflowName, metadata) {
   const handler = async (ctx, input) => {
-    const impl = nativeRequire(ensureBundleFile());
+    const impl = loadImplementation();
     const target = getWorkflowFromModuleExports(impl, workflowName);
     if (!target || typeof target.run !== "function") {
       throw new Error(
@@ -1008,6 +1103,11 @@ async function writeBundledDeployEntrypoint(args: {
 }> {
   try {
     const unresolvedWorkspaceImports = new Map<string, string>();
+    const discoveryExternalPackages = new Set<string>([
+      ...args.externalPackages,
+      "libretto",
+    ]);
+    const unresolvedDiscoveryWorkspaceImports = new Map<string, string>();
     // The implementation bundle is CommonJS so the bootstrap can load it lazily
     // with createRequire() after workflow discovery, while external packages
     // continue to load through normal Node module resolution.
@@ -1031,9 +1131,37 @@ async function writeBundledDeployEntrypoint(args: {
       target: "node20",
       write: false,
     });
+    // Discovery intentionally keeps libretto external so the local discovery
+    // shim can observe workflow(...) calls without executing the full library.
+    const discoveryBuild = await build({
+      absWorkingDir: args.absSourceDir,
+      bundle: true,
+      entryPoints: [args.absEntryPoint],
+      external: [...discoveryExternalPackages],
+      format: "cjs",
+      outfile: "prebundled-discovery.cjs",
+      platform: "node",
+      plugins: [
+        workspaceSourcePlugin(
+          args.workspacePackages,
+          discoveryExternalPackages,
+          unresolvedDiscoveryWorkspaceImports,
+        ),
+      ],
+      splitting: false,
+      target: "node20",
+      write: false,
+    });
     const [unresolvedImport] = unresolvedWorkspaceImports;
     if (unresolvedImport) {
       const [importPath, packageDir] = unresolvedImport;
+      throw new Error(
+        `Unable to resolve workspace import "${importPath}" from ${packageDir}.`,
+      );
+    }
+    const [unresolvedDiscoveryImport] = unresolvedDiscoveryWorkspaceImports;
+    if (unresolvedDiscoveryImport) {
+      const [importPath, packageDir] = unresolvedDiscoveryImport;
       throw new Error(
         `Unable to resolve workspace import "${importPath}" from ${packageDir}.`,
       );
@@ -1047,12 +1175,18 @@ async function writeBundledDeployEntrypoint(args: {
         "Bundler did not produce a deployment implementation file.",
       );
     }
+    const bundledDiscovery = discoveryBuild.outputFiles?.find((file) =>
+      file.path.endsWith("prebundled-discovery.cjs"),
+    );
+    if (!bundledDiscovery) {
+      throw new Error("Bundler did not produce a deployment discovery file.");
+    }
 
     const workflows = discoverBundledWorkflows({
       absEntryPoint: args.absEntryPoint,
       absSourceDir: args.absSourceDir,
-      bundleBuffer: Buffer.from(bundledImplementation.contents),
-      externalPackages: args.externalPackages,
+      bundleBuffer: Buffer.from(bundledDiscovery.contents),
+      externalPackages: discoveryExternalPackages,
     });
 
     writeFileSync(
@@ -1145,6 +1279,7 @@ export async function createHostedDeployPackage(
       deploymentName: args.deploymentName,
       librettoDependency,
       outputDir,
+      runtimeExternals: [...DEFAULT_RUNTIME_EXTERNALS],
       sourceDir: absSourceDir,
     });
     writeDeployMetadata({ outputDir, workflows: workflowsWithShareableSource });

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -32,11 +32,32 @@ function extractBundledImplementation(indexSource: string): string {
 
 const require = createRequire(import.meta.url);
 const currentLibrettoPackageDir = fileURLToPath(new URL("..", import.meta.url));
-const currentLibrettoVersion = JSON.parse(
+const currentLibrettoManifest = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as {
+  dependencies?: Record<string, string>;
   version: string;
 };
+const expectedRuntimeExternalDependencies = Object.fromEntries(
+  ["playwright", "playwright-core", "chromium-bidi"].flatMap((packageName) => {
+    let version = currentLibrettoManifest.dependencies?.[packageName];
+    if (!version) {
+      try {
+        const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+          paths: [currentLibrettoPackageDir],
+        });
+        version = (
+          JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+            version?: string;
+          }
+        ).version;
+      } catch {
+        version = undefined;
+      }
+    }
+    return version ? [[packageName, version]] : [];
+  }),
+);
 
 describe("createHostedDeployPackage", () => {
   const cleanups: Array<() => void> = [];
@@ -57,6 +78,19 @@ describe("createHostedDeployPackage", () => {
 
   function createWorkspaceRoot(): string {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "libretto-deploy-test-"));
+    const nodeModulesDir = join(workspaceRoot, "node_modules");
+    mkdirSync(nodeModulesDir, { recursive: true });
+    symlinkSync(
+      currentLibrettoPackageDir,
+      join(nodeModulesDir, "libretto"),
+      "dir",
+    );
+    for (const packageName of Object.keys(expectedRuntimeExternalDependencies)) {
+      const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+        paths: [currentLibrettoPackageDir],
+      });
+      symlinkSync(dirname(packageJsonPath), join(nodeModulesDir, packageName), "dir");
+    }
     registerCleanup(() => {
       rmSync(workspaceRoot, { force: true, recursive: true });
     });
@@ -93,7 +127,9 @@ describe("createHostedDeployPackage", () => {
     const nodeModulesDir = join(dirname(args.outfile), "node_modules");
     mkdirSync(nodeModulesDir, { recursive: true });
     const linkedPackageDir = join(nodeModulesDir, "libretto");
-    symlinkSync(currentLibrettoPackageDir, linkedPackageDir, "dir");
+    if (!existsSync(linkedPackageDir)) {
+      symlinkSync(currentLibrettoPackageDir, linkedPackageDir, "dir");
+    }
 
     await build({
       bundle: true,
@@ -210,6 +246,7 @@ describe("createHostedDeployPackage", () => {
 
     expect(deployManifest.dependencies).toEqual({
       libretto: "0.5.4",
+      ...expectedRuntimeExternalDependencies,
     });
     expect(deployMetadata.workflows).toEqual([
       {
@@ -256,7 +293,7 @@ describe("createHostedDeployPackage", () => {
       private: true,
       type: "module",
       dependencies: {
-        libretto: currentLibrettoVersion.version,
+        libretto: currentLibrettoManifest.version,
       },
     });
 
@@ -339,7 +376,8 @@ describe("createHostedDeployPackage", () => {
     const implementation = extractBundledImplementation(bundle);
 
     expect(deployManifest.dependencies).toEqual({
-      libretto: currentLibrettoVersion.version,
+      libretto: currentLibrettoManifest.version,
+      ...expectedRuntimeExternalDependencies,
       lodash: "^4.17.21",
     });
     expect(bundle).toContain('createWorkflowProxy("testWorkflow", {"credentialNames":[]})');
@@ -358,7 +396,7 @@ describe("createHostedDeployPackage", () => {
       private: true,
       type: "module",
       dependencies: {
-        libretto: currentLibrettoVersion.version,
+        libretto: currentLibrettoManifest.version,
       },
     });
 
@@ -452,6 +490,7 @@ describe("createHostedDeployPackage", () => {
 
     expect(deployManifest.dependencies).toEqual({
       libretto: "file:./libretto",
+      ...expectedRuntimeExternalDependencies,
     });
     expect(
       existsSync(join(deployPackage.outputDir, "libretto", "package.json")),
@@ -531,6 +570,52 @@ describe("createHostedDeployPackage", () => {
         {},
       ),
     ).resolves.toEqual({ ok: true });
+  });
+
+  it("bundles workflow libretto imports into the embedded implementation", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    const entryPoint = join(sourceDir, "src", "index.ts");
+
+    mkdirSync(join(sourceDir, "src"), { recursive: true });
+
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      type: "module",
+      dependencies: {
+        libretto: currentLibrettoManifest.version,
+      },
+    });
+    writeFileSync(
+      entryPoint,
+      [
+        'import { librettoAuthenticate, workflow } from "libretto";',
+        "",
+        "export const testWorkflow = workflow(",
+        '  "testWorkflow",',
+        "  async () => ({ hasAuthenticate: typeof librettoAuthenticate === \"function\" }),",
+        ");",
+        "",
+      ].join("\n"),
+    );
+
+    const deployPackage = trackDeployPackage(
+      await createHostedDeployPackage({
+        deploymentName: "embedded-libretto-worker",
+        entryPoint,
+        sourceDir,
+      }),
+    );
+
+    const bundle = readFileSync(
+      join(deployPackage.outputDir, "index.js"),
+      "utf8",
+    );
+    const implementation = extractBundledImplementation(bundle);
+
+    expect(implementation).toContain("librettoAuthenticate");
+    expect(implementation).not.toContain('require("libretto")');
   });
 
   it("does not resolve bare workspace imports through subpath-only exports", async () => {


### PR DESCRIPTION
## Summary
- bundle workflow source's `libretto` into hosted deploy implementations instead of resolving the executor's installed version at runtime
- keep a separate discovery bundle with `libretto` externalized so workflow metadata discovery still uses the lightweight discovery shim
- declare default runtime externals in the generated deployment manifest and resolve embedded `/tmp` implementation bare imports through the deployed package root
- add deploy-artifact regression coverage for embedded `libretto` imports

## Validation
- `pnpm --dir packages/libretto --filter libretto lint`
- `pnpm --dir packages/libretto --filter libretto type-check`
- `pnpm --dir packages/libretto/packages/libretto exec vitest run test/deploy-artifact.spec.ts`
- `pnpm --dir packages/libretto --filter libretto build`
- staged with patched CLI against browser-automations staging:
  - `stagingLibretto024RuntimeCheck` completed with `{ expected: "0.6.24", hasLibrettoAuthenticate: false }` on deployment `949c82bc-b1fa-4824-ac4d-6456e70b571a`
  - `stagingLibretto029RuntimeCheck` completed with `{ expected: "0.6.29", hasLibrettoAuthenticate: true }` on deployment `faa87200-7af0-4d35-a80c-aa2ca6db1a35`

## Notes
- Publishing an experimental npm prerelease from this machine is blocked by npm auth (`npm whoami` returns E401), so staging validation used the patched local CLI directly.
