### PR TITLE
Add comparison pages for browser automation tools

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Switch } from "wouter";
 import { HomePage } from "./HomePage";
 import { BlogIndexPage, BlogPostPage } from "./blog/BlogPage";
 import { BrowserUsePage } from "./vs/BrowserUsePage";
+import { StagehandPage } from "./vs/StagehandPage";
 
 export function App() {
   return (
@@ -9,6 +10,7 @@ export function App() {
       <Route path="/blog" component={BlogIndexPage} />
       <Route path="/blog/:slug">{(params) => <BlogPostPage slug={params.slug ?? ""} />}</Route>
       <Route path="/vs/browser-use" component={BrowserUsePage} />
+      <Route path="/vs/stagehand" component={StagehandPage} />
       <Route path="*" component={HomePage} />
     </Switch>
   );

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -1,19 +1,15 @@
-import { useLocation } from "wouter";
+import { Route, Switch } from "wouter";
 import { HomePage } from "./HomePage";
 import { BlogIndexPage, BlogPostPage } from "./blog/BlogPage";
-import { normalizeAppPathname } from "./routing";
+import { BrowserUsePage } from "./vs/BrowserUsePage";
 
 export function App() {
-  const [location] = useLocation();
-  const pathname = normalizeAppPathname(location);
-
-  if (pathname === "/blog") {
-    return <BlogIndexPage />;
-  }
-
-  if (pathname.startsWith("/blog/")) {
-    return <BlogPostPage slug={pathname.slice("/blog/".length)} />;
-  }
-
-  return <HomePage />;
+  return (
+    <Switch>
+      <Route path="/blog" component={BlogIndexPage} />
+      <Route path="/blog/:slug">{(params) => <BlogPostPage slug={params.slug ?? ""} />}</Route>
+      <Route path="/vs/browser-use" component={BrowserUsePage} />
+      <Route path="*" component={HomePage} />
+    </Switch>
+  );
 }

--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -2,15 +2,28 @@ import { Route, Switch } from "wouter";
 import { HomePage } from "./HomePage";
 import { BlogIndexPage, BlogPostPage } from "./blog/BlogPage";
 import { BrowserUsePage } from "./vs/BrowserUsePage";
+import { PlaywrightCodegenPage } from "./vs/PlaywrightCodegenPage";
 import { StagehandPage } from "./vs/StagehandPage";
+
+function VsRoutes() {
+  return (
+    <Switch>
+      <Route path="/browser-use" component={BrowserUsePage} />
+      <Route path="/playwright-codegen" component={PlaywrightCodegenPage} />
+      <Route path="/stagehand" component={StagehandPage} />
+      <Route path="*" component={HomePage} />
+    </Switch>
+  );
+}
 
 export function App() {
   return (
     <Switch>
       <Route path="/blog" component={BlogIndexPage} />
-      <Route path="/blog/:slug">{(params) => <BlogPostPage slug={params.slug ?? ""} />}</Route>
-      <Route path="/vs/browser-use" component={BrowserUsePage} />
-      <Route path="/vs/stagehand" component={StagehandPage} />
+      <Route path="/blog/:slug">
+        {(params) => <BlogPostPage slug={params.slug ?? ""} />}
+      </Route>
+      <Route path="/vs" nest component={VsRoutes} />
       <Route path="*" component={HomePage} />
     </Switch>
   );

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -7,7 +7,6 @@ import {
 import { Text } from "./components/Text";
 import { TerminalDemo } from "./components/TerminalDemo";
 import { InstallSnippet } from "./components/InstallSnippet";
-import { AppLink } from "./routing";
 import {
   OrchestrationContainer,
   AnimationTarget,
@@ -96,13 +95,13 @@ function Hero({
           <InstallSnippet />
           <div className="text-xs text-muted">
             or{" "}
-            <AppLink
+            <a
               href="/docs/get-started/quickstart"
               className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
               data-fathom-event="Hero docs click"
             >
               go to docs
-            </AppLink>
+            </a>
           </div>
         </div>
         <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>

--- a/apps/website/src/components/Button.tsx
+++ b/apps/website/src/components/Button.tsx
@@ -1,5 +1,4 @@
 import type * as React from "react";
-import { AppLink } from "../routing";
 
 type ButtonSize = "default" | "sm";
 type ButtonVariant = "primary" | "secondary";
@@ -42,7 +41,7 @@ export function Button({
 
   if (typeof props.href === "string") {
     const anchorProps = props as ButtonAsAnchorProps;
-    return <AppLink className={classes} {...anchorProps} />;
+    return <a className={classes} {...anchorProps} />;
   }
 
   const buttonProps = props as ButtonAsButtonProps;

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -52,7 +52,11 @@ function shouldUseSpaNavigation({
 }
 
 function isDocumentPath(pathname: string): boolean {
-  return pathname === "/docs" || pathname.startsWith("/docs/");
+  return (
+    pathname === "/docs" ||
+    pathname.startsWith("/docs/") ||
+    /\.[^/]+$/.test(pathname)
+  );
 }
 
 export function AppLink({ href, target, download, ...props }: AppLinkProps) {

--- a/apps/website/src/routing.tsx
+++ b/apps/website/src/routing.tsx
@@ -5,24 +5,6 @@ type AppLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;
 };
 
-export function normalizeAppPathname(pathname: string): string {
-  if (pathname === "/") {
-    return pathname;
-  }
-
-  return pathname.replace(/\/+$/, "");
-}
-
-export function isAppOwnedPathname(pathname: string): boolean {
-  const normalizedPathname = normalizeAppPathname(pathname);
-
-  return (
-    normalizedPathname === "/" ||
-    normalizedPathname === "/blog" ||
-    normalizedPathname.startsWith("/blog/")
-  );
-}
-
 function shouldUseSpaNavigation({
   href,
   target,
@@ -59,11 +41,7 @@ function shouldUseSpaNavigation({
       return false;
     }
 
-    if (url.hash) {
-      return false;
-    }
-
-    if (!isAppOwnedPathname(url.pathname)) {
+    if (url.hash || isDocumentPath(url.pathname)) {
       return false;
     }
 
@@ -71,6 +49,10 @@ function shouldUseSpaNavigation({
   } catch {
     return false;
   }
+}
+
+function isDocumentPath(pathname: string): boolean {
+  return pathname === "/docs" || pathname.startsWith("/docs/");
 }
 
 export function AppLink({ href, target, download, ...props }: AppLinkProps) {

--- a/apps/website/src/vs/BrowserUsePage.tsx
+++ b/apps/website/src/vs/BrowserUsePage.tsx
@@ -1,0 +1,404 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { AppLink } from "../routing";
+import { AsciiLibretto } from "../brand";
+import { Button } from "../components/Button";
+import { Footer } from "../components/Footer";
+import { Kicker } from "../components/Kicker";
+import { Navbar } from "../components/Navbar";
+import { Panel } from "../components/Panel";
+import { SectionHeading } from "../components/SectionHeading";
+import { Text } from "../components/Text";
+
+const linkClass =
+  "text-accent-bright underline decoration-accent/40 underline-offset-4 transition-colors hover:text-ink";
+
+interface ComparisonRow {
+  label: string;
+  browserUse: ReactNode;
+  browserUseMark?: "positive" | "tradeoff";
+  libretto: ReactNode;
+  librettoMark?: "positive" | "tradeoff";
+}
+
+const comparisonRows: ComparisonRow[] = [
+  {
+    label: "Execution model",
+    browserUse:
+      "An LLM-driven agent observes the page, reasons, and decides actions at runtime.",
+    libretto:
+      "A workflow is recorded once, then compiled into a deterministic Playwright-plus-API script.",
+  },
+  {
+    label: "Reliability across runs",
+    browserUse:
+      "Flexible, but the agent can choose different actions when page state or model output shifts.",
+    browserUseMark: "tradeoff",
+    libretto:
+      "The generated script follows the same inspected code path unless you change the script.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Speed",
+    browserUse:
+      "~79.5s in Libretto's internal benchmark of the same multi-step workflow.",
+    browserUseMark: "tradeoff",
+    libretto:
+      "~16.3s in the same Libretto internal benchmark, about 5x faster.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Debuggability",
+    browserUse:
+      "You inspect agent traces and model decisions after the run.",
+    browserUseMark: "tradeoff",
+    libretto:
+      "You debug plain code, recorded actions, network calls, and normal Playwright failures.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Token cost per run",
+    browserUse:
+      "Runtime reasoning consumes tokens on every execution.",
+    browserUseMark: "tradeoff",
+    libretto:
+      "The generated workflow runs as code, so LLM reasoning is not required on every execution.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Output you can inspect and own",
+    browserUse:
+      "The durable artifact is usually the prompt, task definition, and trace.",
+    browserUseMark: "tradeoff",
+    libretto:
+      "The durable artifact is a readable script teams can inspect, debug, version, and deploy.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Unknown or changing pages",
+    browserUse:
+      "Strong fit: the runtime agent can adapt while exploring a page it has not seen before.",
+    browserUseMark: "positive",
+    libretto:
+      "Better after the workflow is known and stable enough to encode as a maintained script.",
+    librettoMark: "tradeoff",
+  },
+  {
+    label: "Deployment",
+    browserUse:
+      "Deploy an agent runtime, model access, browser infrastructure, and task prompts.",
+    libretto:
+      "Deploy the generated automation code as part of your normal codebase or Libretto workflow runtime.",
+  },
+];
+
+interface FAQItem {
+  question: string;
+  answer: ReactNode;
+}
+
+const faqItems: FAQItem[] = [
+  {
+    question: "Can I migrate a Browser Use task to Libretto?",
+    answer:
+      "Yes, when the task has become a known repeatable workflow. Use Browser Use-style exploration to understand the path, then record and compile the workflow in Libretto so future runs execute as deterministic code.",
+  },
+  {
+    question: "Is Libretto open source?",
+    answer: (
+      <>
+        Yes. Libretto is an open-source CLI. You can start from the docs or the
+        project website at{" "}
+        <a href="https://libretto.sh" className={linkClass}>
+          libretto.sh
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    question: "Does Libretto use an LLM at runtime?",
+    answer:
+      "Not by default for the workflow execution path described here. Libretto uses a coding agent while building and maintaining the workflow, then runs the generated script directly instead of asking an LLM to re-reason through every run.",
+  },
+  {
+    question: "Is Browser Use the wrong tool for production?",
+    answer:
+      "Not categorically. It can be the right tool when flexibility matters more than repeatability, especially for open-ended tasks. Libretto is a better fit when a known workflow needs to run many times with predictable behavior, lower per-run cost, and inspectable code.",
+  },
+  {
+    question: "What kinds of sites is Libretto designed for?",
+    answer:
+      "Libretto has been battle-tested on complex healthcare and legacy portals: messy, fragile, real-world sites where teams need durable automation rather than one-off exploration.",
+  },
+];
+
+function setMetaContent(selector: string, content: string) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement("meta");
+    const property = selector.match(/\[property="([^"]+)"\]/)?.[1];
+    const name = selector.match(/\[name="([^"]+)"\]/)?.[1];
+
+    if (property) {
+      element.setAttribute("property", property);
+    }
+    if (name) {
+      element.setAttribute("name", name);
+    }
+
+    document.head.append(element);
+  }
+
+  element.content = content;
+}
+
+function setCanonicalHref(href: string) {
+  let element = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!element) {
+    element = document.createElement("link");
+    element.rel = "canonical";
+    document.head.append(element);
+  }
+
+  element.href = href;
+}
+
+function BrowserUsePageMeta() {
+  useEffect(() => {
+    const title = "Libretto vs Browser Use: deterministic scripts vs a runtime agent";
+    const description =
+      "A developer-focused comparison of Libretto and Browser Use for AI browser automation: runtime agents, deterministic scripts, speed, debuggability, and production trade-offs.";
+    const url = "https://libretto.sh/vs/browser-use";
+
+    document.title = title;
+    setCanonicalHref(url);
+    setMetaContent('meta[name="description"]', description);
+    setMetaContent('meta[property="og:type"]', "article");
+    setMetaContent('meta[property="og:title"]', title);
+    setMetaContent('meta[property="og:description"]', description);
+    setMetaContent('meta[property="og:url"]', url);
+    setMetaContent('meta[name="twitter:card"]', "summary");
+    setMetaContent('meta[name="twitter:title"]', title);
+    setMetaContent('meta[name="twitter:description"]', description);
+  }, []);
+
+  return null;
+}
+
+function ArticleSection({
+  children,
+  kicker,
+  title,
+}: {
+  children: ReactNode;
+  kicker: string;
+  title: ReactNode;
+}) {
+  return (
+    <section className="border-t border-rule py-14">
+      <Kicker className="mb-3 text-sm text-accent">{kicker}</Kicker>
+      <SectionHeading size="sm" className="mb-7 normal-case">
+        {title}
+      </SectionHeading>
+      {children}
+    </section>
+  );
+}
+
+function PositiveMark() {
+  return <span className="font-medium text-accent-bright">✓</span>;
+}
+
+function TradeoffMark() {
+  return <span className="font-medium text-muted/60">—</span>;
+}
+
+function ComparisonMark({ kind }: { kind?: "positive" | "tradeoff" }) {
+  if (kind === "positive") {
+    return <PositiveMark />;
+  }
+
+  if (kind === "tradeoff") {
+    return <TradeoffMark />;
+  }
+
+  return null;
+}
+
+function ComparisonTable() {
+  return (
+    <div className="overflow-x-auto rounded-[3.75px] border border-rule bg-panel/80">
+      <table className="w-full min-w-[760px] border-collapse border border-rule text-left text-sm leading-relaxed text-muted">
+        <thead>
+          <tr className="border-b border-rule">
+            <th className="w-[22%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Dimension
+            </th>
+            <th className="w-[39%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Browser Use
+            </th>
+            <th className="w-[39%] border border-rule bg-green-3/35 px-4 py-3 font-medium uppercase tracking-[0.08em] text-accent-bright">
+              Libretto
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {comparisonRows.map((row) => (
+            <tr key={row.label} className="border-b border-rule last:border-b-0">
+              <th className="border border-rule px-4 py-4 align-top font-medium text-ink">
+                {row.label}
+              </th>
+              <td className="border border-rule px-4 py-4 align-top">
+                <ComparisonMark kind={row.browserUseMark} /> <span>{row.browserUse}</span>
+              </td>
+              <td className="border border-rule bg-green-3/20 px-4 py-4 align-top text-ink">
+                <ComparisonMark kind={row.librettoMark} /> <span>{row.libretto}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function FAQList() {
+  return (
+    <div className="border-t border-rule">
+      {faqItems.map((item) => (
+        <details key={item.question} className="group border-b border-rule py-5">
+          <summary className="cursor-pointer list-none text-base font-medium text-ink outline-none transition-colors hover:text-accent-bright focus-visible:ring-2 focus-visible:ring-accent/30 [&::-webkit-details-marker]:hidden">
+            <span className="mr-3 text-accent group-open:hidden">+</span>
+            <span className="mr-3 hidden text-muted group-open:inline">−</span>
+            {item.question}
+          </summary>
+          <Text as="p" size="sm" className="mt-4 max-w-[700px] leading-relaxed text-muted">
+            {item.answer}
+          </Text>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export function BrowserUsePage() {
+  return (
+    <div className="crt-page flex min-h-screen flex-col bg-bg text-ink">
+      <BrowserUsePageMeta />
+      <Navbar />
+      <main className="section-rails relative mx-auto mt-16 w-full max-w-[1100px] flex-1 px-8">
+        <article className="mx-auto max-w-[820px] pb-20">
+          <header className="pb-16">
+            <div className="mb-8 overflow-hidden">
+              <AsciiLibretto decorative className="text-[4px] text-accent sm:text-[5px] md:text-[6px]" />
+            </div>
+            <Kicker className="mb-4 text-accent">// COMPARISON --</Kicker>
+            <Text
+              as="h1"
+              size="5xl"
+              style="serif"
+              className="crt-glow mb-7 max-w-[780px] font-[300] leading-[1.05] tracking-[-0.04em] text-ink [text-wrap:balance]"
+              htmlStyle={{ fontSize: "clamp(40px, 6vw, 72px)" }}
+            >
+              Libretto vs Browser Use: deterministic scripts vs a runtime agent.
+            </Text>
+            <Text as="p" size="lg" className="max-w-[720px] leading-relaxed text-muted">
+              Browser Use is a strong fit when you want an agent to figure out a browser task at runtime. Libretto is for the moment after that: when the workflow is known, needs to run reliably, and should become fast, inspectable code your team owns.
+            </Text>
+          </header>
+
+          <Panel padding="lg" radius="md" className="mb-12 border-accent/20 bg-green-2/35">
+            <Kicker className="mb-3 text-sm text-accent">// SHORT VERSION --</Kicker>
+            <ul className="space-y-3 leading-relaxed text-muted">
+              <li>
+                Use Browser Use for open-ended exploration, one-off tasks, rapidly changing pages, and prototypes where maintaining a script would be premature.
+              </li>
+              <li>
+                Use Libretto when a workflow is repeated enough that speed, determinism, debuggability, and per-run cost matter.
+              </li>
+              <li>
+                In Libretto's own internal benchmark on the same multi-step workflow, a Libretto-generated script completed in ~16.3 seconds versus ~79.5 seconds for the runtime-agent approach.
+              </li>
+            </ul>
+          </Panel>
+
+          <ArticleSection kicker="// HOW IT WORKS --" title="Browser Use runs an agent at execution time">
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Browser Use is a popular open-source library for giving an LLM-driven agent control of a browser. On each run, the agent observes the page, reasons about the current state, decides the next action, and continues until the task is complete or stuck.
+              </p>
+              <p>
+                That runtime-agent model is useful precisely because it is flexible. If the page is unfamiliar, the task is exploratory, or the target keeps changing, you may not want to encode a maintained script yet. You can point the agent at the task and let it adapt.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// HOW LIBRETTO WORKS --" title="Libretto records once, then compiles to code">
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto takes a different path. A coding agent uses the CLI with a live browser to inspect pages, record a workflow, capture useful network calls, and turn the result into a deterministic script. The script can combine Playwright interactions with direct in-session API calls when the browser reveals a cleaner underlying request.
+              </p>
+              <p>
+                The important shift is ownership. The output is plain code: readable, inspectable, debuggable, versionable, and deployable. Instead of asking a model to rediscover the workflow every time, you run the script you have already inspected.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// HEAD TO HEAD --" title="Comparison table">
+            <ComparisonTable />
+          </ArticleSection>
+
+          <ArticleSection kicker="// USE BROWSER USE WHEN --" title="When to use Browser Use instead">
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Browser Use is the more natural choice when the browser task is not yet well understood. If you are exploring a new site, asking an agent to gather information once, or working with pages that change faster than you can justify maintaining automation code, runtime reasoning is a feature, not a bug.
+              </p>
+              <p>
+                It is also a good prototyping tool. You can learn whether a workflow is possible before investing in selectors, API-call extraction, error handling, and deployment. For many internal or one-off tasks, that trade-off is entirely reasonable.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// USE LIBRETTO WHEN --" title="When Libretto is the better choice">
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto is better once the workflow is known and repeated. At that point, you usually want the browser automation to behave like production code: predictable across runs, cheap to execute, easy to debug, and reviewable in pull requests.
+              </p>
+              <p>
+                This matters most on fragile real-world sites. Libretto has been battle-tested on complex healthcare and legacy portals where small UI changes, hidden network calls, and brittle state can make pure runtime interaction slow and hard to reason about. Recording the workflow and compiling it into code gives teams something concrete to maintain.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// FAQ --" title="Short FAQ">
+            <FAQList />
+          </ArticleSection>
+
+          <section className="border-t border-rule py-14">
+            <Kicker className="mb-3 text-sm text-accent">// NEXT STEP --</Kicker>
+            <Text as="h2" size="3xl" style="serif" className="mb-5 font-[300] leading-tight text-ink">
+              Try turning one known workflow into a script.
+            </Text>
+            <Text as="p" size="md" className="mb-7 max-w-[640px] leading-relaxed text-muted">
+              Start with a workflow you already understand, record it with Libretto, then inspect the generated code before you run it again.
+            </Text>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button href="/docs/get-started/quickstart" data-fathom-event="Browser Use comparison docs click">
+                Go to docs
+              </Button>
+              <AppLink
+                href="https://libretto.sh"
+                className="text-sm text-muted underline decoration-muted underline-offset-4 transition-colors hover:text-accent-bright"
+                data-fathom-event="Browser Use comparison homepage click"
+              >
+                libretto.sh
+              </AppLink>
+            </div>
+          </section>
+        </article>
+        <Footer />
+      </main>
+    </div>
+  );
+}

--- a/apps/website/src/vs/PlaywrightCodegenPage.tsx
+++ b/apps/website/src/vs/PlaywrightCodegenPage.tsx
@@ -1,0 +1,535 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript.js";
+import { AppLink } from "../routing";
+import { AsciiLibretto } from "../brand";
+import { Button } from "../components/Button";
+import { Footer } from "../components/Footer";
+import { Kicker } from "../components/Kicker";
+import { Navbar } from "../components/Navbar";
+import { Panel } from "../components/Panel";
+import { SectionHeading } from "../components/SectionHeading";
+import { Text } from "../components/Text";
+
+interface ComparisonRow {
+  label: string;
+  playwright: ReactNode;
+  playwrightMark?: "positive" | "tradeoff";
+  libretto: ReactNode;
+  librettoMark?: "positive" | "tradeoff";
+}
+
+const comparisonRows: ComparisonRow[] = [
+  {
+    label: "Core model",
+    playwright:
+      "A mature browser automation framework plus a recorder that generates Playwright test code from browser interactions.",
+    playwrightMark: "positive",
+    libretto:
+      "An open-source CLI for coding agents that turns website workflows into deterministic automation scripts.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Generated artifact",
+    playwright:
+      "A Playwright test skeleton built from recorded clicks, fills, assertions, and locators; often needs cleanup before it is reliable.",
+    playwrightMark: "tradeoff",
+    libretto:
+      "A workflow script that can combine Playwright actions with direct in-session API calls captured from the browser.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Workflow understanding",
+    playwright:
+      "Codegen records what you do; the developer still supplies intent, data setup, cleanup, and maintainable structure.",
+    playwrightMark: "tradeoff",
+    libretto:
+      "A coding agent inspects the site, records the workflow, and helps turn the observed path into maintained automation code.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Selectors and locators",
+    playwright:
+      "Tries to choose resilient role, text, and test-id locators, but recorded flows can still become brittle selector soup on real apps.",
+    playwrightMark: "tradeoff",
+    libretto:
+      "Uses Playwright locators where UI automation is right, but can avoid some UI fragility by replacing steps with API calls.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Network/API shortcuts",
+    playwright:
+      "Playwright has excellent network and API APIs, but codegen is documented around UI actions, assertions, and locators.",
+    playwrightMark: "tradeoff",
+    libretto:
+      "Designed to capture useful in-session requests and turn slow UI sequences into direct calls when appropriate.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Debugging",
+    playwright:
+      "Best-in-class developer tooling: Inspector, UI Mode, Trace Viewer, action logs, screenshots, console, and network tabs.",
+    playwrightMark: "positive",
+    libretto:
+      "Debugs generated workflow code with browser/session context, action logs, network observations, and normal Playwright failures.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Runtime determinism",
+    playwright:
+      "Fast and deterministic when the test code, state, data, and locators are well maintained.",
+    playwrightMark: "positive",
+    libretto:
+      "Also fast and deterministic, with the additional goal of moving known workflow work out of UI steps when possible.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Maintenance burden",
+    playwright:
+      "Your team owns fixtures, data setup, auth, abstractions, retries, CI, and repair when generated code breaks.",
+    playwrightMark: "tradeoff",
+    libretto:
+      "The agent-assisted CLI is built around exploring, generating, validating, and repairing reusable workflow scripts.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Best fit",
+    playwright:
+      "Simple frontend tests and teams that want a quick starting point before hand-maintaining the Playwright code.",
+    playwrightMark: "positive",
+    libretto:
+      "Teams building reliable browser automations, especially against portals or third-party apps without clean APIs.",
+    librettoMark: "positive",
+  },
+];
+
+interface FAQItem {
+  question: string;
+  answer: ReactNode;
+}
+
+const faqItems: FAQItem[] = [
+  {
+    question: "Is Libretto replacing Playwright?",
+    answer:
+      "No. Libretto uses Playwright where browser automation is the right layer. The difference is workflow construction: Libretto gives coding agents a CLI for discovering, recording, validating, and maintaining scripts, and it can use direct in-session API calls when the browser reveals a better path.",
+  },
+  {
+    question: "Is Playwright codegen bad?",
+    answer:
+      "No. Playwright codegen is a useful recorder and locator generator, especially for simple frontend tests. The problem is using raw generated output as a reliable browser automation. Engineers usually still need to add intent, assertions, fixtures, data handling, better waits, and long-term structure.",
+  },
+  {
+    question: "Can Libretto output normal TypeScript?",
+    answer:
+      "Yes. Libretto workflows are plain code that teams can read, inspect, debug, version, and deploy.",
+  },
+  {
+    question: "Does Playwright codegen capture API calls?",
+    answer:
+      "Playwright itself has strong network monitoring, request mocking, and API testing APIs. But the official codegen workflow is documented as recording browser actions, assertions, and locators, not as automatically converting observed network traffic into API-level workflow steps.",
+  },
+  {
+    question: "When should I just use Playwright directly?",
+    answer:
+      "Use Playwright directly when your team already knows the app, controls the environment, and wants hand-authored browser tests or scripts. Use Libretto when the hard part is building and maintaining a reliable automation against a third-party or legacy website.",
+  },
+];
+
+const playwrightExample = String.raw`import { test, expect } from "@playwright/test";
+
+test("authorization status", async ({ page }) => {
+  await page.goto("https://portal.example.com/authorizations");
+  await page.getByRole("textbox", { name: "Authorization ID" }).fill("A-123");
+  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("link", { name: "A-123" }).click();
+
+  await expect(page.getByText("Approved")).toBeVisible();
+});`;
+
+const librettoExample = String.raw`import { workflow } from "libretto";
+import { z } from "zod";
+
+export default workflow("readAuthorizationStatus", {
+  input: z.object({ authorizationId: z.string() }),
+  output: z.object({ memberName: z.string(), status: z.string() }),
+  async handler({ page }, input) {
+    await page.goto("https://portal.example.com/authorizations");
+
+    const response = await page.request.post(
+      "https://portal.example.com/api/authorizations/detail",
+      { data: { id: input.authorizationId } },
+    );
+
+    const authorization = await response.json();
+    return {
+      memberName: authorization.member.name,
+      status: authorization.status,
+    };
+  },
+});`;
+
+function setMetaContent(selector: string, content: string) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement("meta");
+    const property = selector.match(/\[property="([^"]+)"\]/)?.[1];
+    const name = selector.match(/\[name="([^"]+)"\]/)?.[1];
+
+    if (property) {
+      element.setAttribute("property", property);
+    }
+    if (name) {
+      element.setAttribute("name", name);
+    }
+
+    document.head.append(element);
+  }
+
+  element.content = content;
+}
+
+function setCanonicalHref(href: string) {
+  let element = document.head.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]',
+  );
+  if (!element) {
+    element = document.createElement("link");
+    element.rel = "canonical";
+    document.head.append(element);
+  }
+
+  element.href = href;
+}
+
+function PlaywrightCodegenPageMeta() {
+  useEffect(() => {
+    const title =
+      "Libretto vs Playwright codegen: workflow compiler vs browser recorder";
+    const description =
+      "A developer-focused comparison of Libretto and Playwright codegen for deterministic browser automation, generated code, network shortcuts, debugging, and maintenance.";
+    const url = "https://libretto.sh/vs/playwright-codegen";
+
+    document.title = title;
+    setCanonicalHref(url);
+    setMetaContent('meta[name="description"]', description);
+    setMetaContent('meta[property="og:type"]', "article");
+    setMetaContent('meta[property="og:title"]', title);
+    setMetaContent('meta[property="og:description"]', description);
+    setMetaContent('meta[property="og:url"]', url);
+    setMetaContent('meta[name="twitter:card"]', "summary");
+    setMetaContent('meta[name="twitter:title"]', title);
+    setMetaContent('meta[name="twitter:description"]', description);
+  }, []);
+
+  return null;
+}
+
+function ArticleSection({
+  children,
+  kicker,
+  title,
+}: {
+  children: ReactNode;
+  kicker: string;
+  title: ReactNode;
+}) {
+  return (
+    <section className="border-t border-rule py-14">
+      <Kicker className="mb-3 text-sm text-accent">{kicker}</Kicker>
+      <SectionHeading size="sm" className="mb-7 normal-case">
+        {title}
+      </SectionHeading>
+      {children}
+    </section>
+  );
+}
+
+function PositiveMark() {
+  return <span className="font-medium text-accent-bright">✓</span>;
+}
+
+function TradeoffMark() {
+  return <span className="font-medium text-muted/60">—</span>;
+}
+
+function ComparisonMark({ kind }: { kind?: "positive" | "tradeoff" }) {
+  if (kind === "positive") {
+    return <PositiveMark />;
+  }
+
+  if (kind === "tradeoff") {
+    return <TradeoffMark />;
+  }
+
+  return null;
+}
+
+function ComparisonTable() {
+  return (
+    <div className="overflow-x-auto rounded-[3.75px] border border-rule bg-panel/80">
+      <table className="w-full min-w-[760px] border-collapse border border-rule text-left text-sm leading-relaxed text-muted">
+        <thead>
+          <tr className="border-b border-rule">
+            <th className="w-[22%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Dimension
+            </th>
+            <th className="w-[39%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Playwright codegen
+            </th>
+            <th className="w-[39%] border border-rule bg-green-3/35 px-4 py-3 font-medium uppercase tracking-[0.08em] text-accent-bright">
+              Libretto
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {comparisonRows.map((row) => (
+            <tr
+              key={row.label}
+              className="border-b border-rule last:border-b-0"
+            >
+              <th className="border border-rule px-4 py-4 align-top font-medium text-ink">
+                {row.label}
+              </th>
+              <td className="border border-rule px-4 py-4 align-top">
+                <ComparisonMark kind={row.playwrightMark} />{" "}
+                <span>{row.playwright}</span>
+              </td>
+              <td className="border border-rule bg-green-3/20 px-4 py-4 align-top text-ink">
+                <ComparisonMark kind={row.librettoMark} />{" "}
+                <span>{row.libretto}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
+  const highlightedCode = Prism.highlight(
+    code,
+    Prism.languages.typescript,
+    "typescript",
+  );
+
+  return (
+    <div className="overflow-hidden rounded-[3.75px] border border-rule bg-[#0f120f]">
+      <div className="border-b border-rule bg-panel px-4 py-2">
+        <Text size="xs" className="uppercase tracking-[0.08em] text-muted/70">
+          {label}
+        </Text>
+      </div>
+      <pre className="overflow-x-auto p-4 text-xs leading-relaxed text-muted">
+        <code
+          className="font-mono text-[#e6edf3] [&_.token.boolean]:text-[#79c0ff] [&_.token.builtin]:text-[#ffa657] [&_.token.class-name]:text-[#ffa657] [&_.token.comment]:text-[#8b949e] [&_.token.function]:text-[#d2a8ff] [&_.token.keyword]:text-[#ff7b72] [&_.token.number]:text-[#79c0ff] [&_.token.operator]:text-[#ff7b72] [&_.token.property]:text-[#79c0ff] [&_.token.punctuation]:text-[#c9d1d9] [&_.token.string]:text-[#a5d6ff] [&_.token.variable]:text-[#ffa657]"
+          dangerouslySetInnerHTML={{ __html: highlightedCode }}
+        />
+      </pre>
+    </div>
+  );
+}
+
+function CodeComparison() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <CodeBlock code={playwrightExample} label="Playwright codegen: recorded UI test" />
+      <CodeBlock code={librettoExample} label="Libretto: generated workflow code" />
+    </div>
+  );
+}
+
+function FAQList() {
+  return (
+    <div className="border-t border-rule">
+      {faqItems.map((item) => (
+        <details
+          key={item.question}
+          className="group border-b border-rule py-5"
+        >
+          <summary className="cursor-pointer list-none text-base font-medium text-ink outline-none transition-colors hover:text-accent-bright focus-visible:ring-2 focus-visible:ring-accent/30 [&::-webkit-details-marker]:hidden">
+            <span className="mr-3 text-accent group-open:hidden">+</span>
+            <span className="mr-3 hidden text-muted group-open:inline">−</span>
+            {item.question}
+          </summary>
+          <Text
+            as="p"
+            size="sm"
+            className="mt-4 max-w-[700px] leading-relaxed text-muted"
+          >
+            {item.answer}
+          </Text>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export function PlaywrightCodegenPage() {
+  return (
+    <div className="crt-page flex min-h-screen flex-col bg-bg text-ink">
+      <PlaywrightCodegenPageMeta />
+      <Navbar />
+      <main className="section-rails relative mx-auto mt-16 w-full max-w-[1100px] flex-1 px-8">
+        <article className="mx-auto max-w-[820px] pb-20">
+          <header className="pb-16">
+            <div className="mb-8 overflow-hidden">
+              <AsciiLibretto
+                decorative
+                className="text-[4px] text-accent sm:text-[5px] md:text-[6px]"
+              />
+            </div>
+            <Kicker className="mb-4 text-accent">// COMPARISON --</Kicker>
+            <Text
+              as="h1"
+              size="5xl"
+              style="serif"
+              className="crt-glow mb-7 max-w-[780px] font-[300] leading-[1.05] tracking-[-0.04em] text-ink [text-wrap:balance]"
+              htmlStyle={{ fontSize: "clamp(40px, 6vw, 72px)" }}
+            >
+              Libretto vs Playwright codegen: workflow compiler vs browser recorder.
+            </Text>
+            <Text
+              as="p"
+              size="lg"
+              className="max-w-[720px] leading-relaxed text-muted"
+            >
+              Playwright is the standard for fast, deterministic browser automation, and codegen is a useful way to bootstrap tests. Libretto is for teams that want a coding agent to turn a real website workflow into a maintained script, including direct API-call shortcuts when the browser reveals them.
+            </Text>
+          </header>
+
+          <Panel
+            padding="lg"
+            radius="md"
+            className="mb-12 border-accent/20 bg-green-2/35"
+          >
+            <Kicker className="mb-3 text-sm text-accent">
+              // SHORT VERSION --
+            </Kicker>
+            <ul className="space-y-3 leading-relaxed text-muted">
+              <li>
+                Use Playwright directly when your team wants full control over browser tests or scripts and is ready to write the reliable parts by hand.
+              </li>
+              <li>
+                Use Playwright codegen for simple apps and straightforward frontend tests where a recorded flow is close to the final test.
+              </li>
+              <li>
+                Use Libretto when you are building browser automations that need to keep working, especially against third-party or legacy sites where naive recorded UI steps tend to break.
+              </li>
+            </ul>
+          </Panel>
+
+          <ArticleSection
+            kicker="// HOW IT WORKS --"
+            title="Playwright codegen records browser interactions"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Playwright is a mature open-source framework for browser automation and end-to-end testing. It supports Chromium, Firefox, and WebKit, has first-class TypeScript and JavaScript support, and also provides official Python, .NET, and Java bindings.
+              </p>
+              <p>
+                Playwright codegen opens a browser and the Playwright Inspector. As you click, type, and add assertions, it emits Playwright code. The generated locators follow Playwright's philosophy: prefer user-facing roles, text, labels, placeholders, and test IDs over brittle CSS or XPath when possible.
+              </p>
+              <p>
+                That output is plain code, which is a major strength. But codegen is still a recorder, and recorded browser flows are often not reliable automations by themselves. It does not know the business intent of the workflow, decide which network requests are the real abstraction, or design your fixtures, auth, data setup, cleanup, and retry strategy.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// HOW LIBRETTO WORKS --"
+            title="Libretto uses Playwright, but builds a workflow artifact"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto is not anti-Playwright. It uses Playwright where the browser is the right layer. The difference is that Libretto is built for browser automations, not just recorded frontend tests. It gives coding agents a purpose-built CLI for inspecting a live site, recording the workflow, observing network calls, and turning the path into a deterministic script.
+              </p>
+              <p>
+                The generated script can keep UI actions when they are necessary and replace slow or fragile UI sequences with direct in-session API calls when the portal exposes a cleaner request. That is the core wedge: Libretto is not just recording clicks; it is trying to produce automation code that survives real-world portal behavior.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// CODE SHAPE --"
+            title="What the difference looks like in code"
+          >
+            <div className="mb-7 space-y-6 leading-[1.85] text-muted">
+              <p>
+                A codegen test often mirrors the visible UI path. That can be fine for a simple frontend test, but it is a weak foundation for many operational automations. A Libretto workflow may start from the same path, then replace fragile steps with direct requests discovered during the browser session.
+              </p>
+            </div>
+            <CodeComparison />
+          </ArticleSection>
+
+          <ArticleSection kicker="// HEAD TO HEAD --" title="Comparison table">
+            <ComparisonTable />
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// USE PLAYWRIGHT WHEN --"
+            title="When to use Playwright codegen instead"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Use Playwright codegen when you are writing simple tests for an app your team controls and want a quick starting point. It is useful for discovering locators, recording a happy path, and producing code you can immediately edit in your repo.
+              </p>
+              <p>
+                Use Playwright directly when you need precise control over test structure, browser contexts, cross-browser coverage, API mocking, CI sharding, and debug artifacts. Playwright's Inspector, Trace Viewer, UI Mode, network tooling, and VS Code extension are hard to beat.
+              </p>
+              <p>
+                If the job is normal frontend testing and your engineers are comfortable rewriting the generated output into reliable tests, Playwright may be all you need.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// USE LIBRETTO WHEN --"
+            title="When Libretto is the better choice"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto is the better fit when you are building browser automations, especially against a third-party portal, legacy web app, or workflow your team does not fully control. In those cases, the hard part is often not writing one Playwright locator; it is discovering the stable path, understanding the hidden requests, and keeping the workflow working over time.
+              </p>
+              <p>
+                It is also useful when the workflow is operational rather than test-oriented. If you need to run the same portal task thousands of times, direct API-call shortcuts, typed inputs and outputs, deployment, and agent-assisted repair become more important than a recorded test skeleton.
+              </p>
+              <p>
+                Playwright gives you the low-level power. Libretto packages that power into an agent workflow for producing and maintaining deterministic scripts.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// FAQ --" title="Short FAQ">
+            <FAQList />
+          </ArticleSection>
+
+          <section className="border-t border-rule py-14">
+            <Kicker className="mb-3 text-sm text-accent">// NEXT STEP --</Kicker>
+            <Text as="h2" size="3xl" style="serif" className="mb-5 font-[300] leading-tight text-ink">
+              Try Libretto on a workflow codegen cannot simplify.
+            </Text>
+            <Text as="p" size="md" className="mb-7 max-w-[640px] leading-relaxed text-muted">
+              Pick a workflow with logins, fragile UI state, or hidden network calls, then record it with Libretto and inspect the generated script.
+            </Text>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button href="/docs/get-started/quickstart" data-fathom-event="Playwright codegen comparison docs click">
+                Go to docs
+              </Button>
+              <AppLink
+                href="https://libretto.sh"
+                className="text-sm text-muted underline decoration-muted underline-offset-4 transition-colors hover:text-accent-bright"
+                data-fathom-event="Playwright codegen comparison homepage click"
+              >
+                libretto.sh
+              </AppLink>
+            </div>
+          </section>
+        </article>
+        <Footer />
+      </main>
+    </div>
+  );
+}

--- a/apps/website/src/vs/StagehandPage.tsx
+++ b/apps/website/src/vs/StagehandPage.tsx
@@ -347,8 +347,14 @@ function CodeBlock({ code, label }: { code: string; label: string }) {
 function CodeComparison() {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
-      <CodeBlock code={stagehandExample} label="Stagehand: runtime AI primitive" />
-      <CodeBlock code={librettoExample} label="Libretto: generated workflow code" />
+      <CodeBlock
+        code={stagehandExample}
+        label="Stagehand: runtime AI primitive"
+      />
+      <CodeBlock
+        code={librettoExample}
+        label="Libretto: generated workflow code"
+      />
     </div>
   );
 }

--- a/apps/website/src/vs/StagehandPage.tsx
+++ b/apps/website/src/vs/StagehandPage.tsx
@@ -1,0 +1,623 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript.js";
+import { AppLink } from "../routing";
+import { AsciiLibretto } from "../brand";
+import { Button } from "../components/Button";
+import { Footer } from "../components/Footer";
+import { Kicker } from "../components/Kicker";
+import { Navbar } from "../components/Navbar";
+import { Panel } from "../components/Panel";
+import { SectionHeading } from "../components/SectionHeading";
+import { Text } from "../components/Text";
+
+interface ComparisonRow {
+  label: string;
+  stagehand: ReactNode;
+  stagehandMark?: "positive" | "tradeoff";
+  libretto: ReactNode;
+  librettoMark?: "positive" | "tradeoff";
+}
+
+const comparisonRows: ComparisonRow[] = [
+  {
+    label: "Core model",
+    stagehand:
+      "A TypeScript/JavaScript framework for mixing browser code with AI primitives like act(), observe(), extract(), and agent().",
+    stagehandMark: "positive",
+    libretto:
+      "An open-source CLI for coding agents that records known workflows and turns them into deterministic automation scripts.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Runtime execution",
+    stagehand:
+      "Natural-language actions and extraction generally call a model at runtime unless you are replaying cached or explicit actions.",
+    stagehandMark: "tradeoff",
+    libretto:
+      "The generated workflow runs as code; the agent helps build and maintain the script, not re-reason through every execution.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Artifact you own",
+    stagehand:
+      "Your app code plus Stagehand instructions, cached actions, traces, and Browserbase session context when you use the hosted path.",
+    stagehandMark: "tradeoff",
+    libretto:
+      "A plain script your team can read, inspect, debug, version, and deploy like the rest of your codebase.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Determinism",
+    stagehand:
+      "Strongest when replaying explicit observed actions; less deterministic when fresh natural-language act() or agent() calls are used.",
+    stagehandMark: "tradeoff",
+    libretto:
+      "Designed around repeatable script execution once the workflow has been recorded and reviewed.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Caching",
+    stagehand:
+      "Action caching can save tokens and replay prior actions; self-healing may call AI again when a page changes.",
+    stagehandMark: "positive",
+    libretto:
+      "Avoids the runtime cache question for known workflows by compiling the workflow into maintained code.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Playwright relationship",
+    stagehand:
+      "Works with Playwright-style browser control and can bridge to Playwright pages, but exposes its own AI action model.",
+    stagehandMark: "positive",
+    libretto:
+      "Combines Playwright with direct in-session API calls captured from the browser workflow.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Direct API-call shortcuts",
+    stagehand:
+      "Best known for browser actions, extraction, and agent primitives; direct API-call shortcutting is not the central abstraction.",
+    stagehandMark: "tradeoff",
+    libretto:
+      "Can replace slow UI steps with direct in-session API calls when the workflow exposes cleaner network requests.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Cloud story",
+    stagehand:
+      "Local mode exists, but Browserbase is the first-class cloud path and the natural production on-ramp.",
+    stagehandMark: "positive",
+    libretto:
+      "Generated scripts are plain code you can run in your own infrastructure, Libretto Cloud, or supported browser providers.",
+    librettoMark: "positive",
+  },
+  {
+    label: "Best fit",
+    stagehand:
+      "Apps that want runtime AI flexibility inside a TypeScript browser automation framework, especially on Browserbase.",
+    stagehandMark: "positive",
+    libretto:
+      "Known, repeated workflows that need to become fast, deterministic scripts with no inference on every run.",
+    librettoMark: "positive",
+  },
+];
+
+interface FAQItem {
+  question: string;
+  answer: ReactNode;
+}
+
+const faqItems: FAQItem[] = [
+  {
+    question: "Is Stagehand open source?",
+    answer: (
+      <>
+        Yes. Stagehand is open source and MIT-licensed in the Browserbase GitHub
+        repository. Libretto is also open source.
+      </>
+    ),
+  },
+  {
+    question: "Does Stagehand run without LLM inference?",
+    answer:
+      "Sometimes. Stagehand can replay cached or explicit observed actions, which can avoid model calls for those steps. But natural-language act(), observe(), extract(), and agent() workflows are runtime AI primitives, and self-healing can involve AI again when the page changes.",
+  },
+  {
+    question: "Is Libretto just a Stagehand alternative without Browserbase?",
+    answer:
+      "No. The bigger difference is the artifact. Stagehand gives you a framework for mixing code and AI primitives at runtime. Libretto uses a coding agent to turn a known workflow into a deterministic script your team owns. Libretto can still run against hosted browser providers when that is the right infrastructure choice.",
+  },
+  {
+    question: "Can I use both?",
+    answer:
+      "Yes. Stagehand can be useful while exploring dynamic flows or building TypeScript apps that need runtime AI actions. Libretto is a better fit when a workflow has graduated from exploration into code you want to run repeatedly.",
+  },
+  {
+    question: "Which one is better for legacy portals?",
+    answer:
+      "It depends on whether the workflow is known. Stagehand is useful when runtime adaptation is valuable. Libretto is built for repeated portal workflows where teams want deterministic scripts, inspectable code, and fewer model-dependent decisions in production.",
+  },
+];
+
+const stagehandExample = String.raw`import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod";
+
+const stagehand = new Stagehand({ env: "BROWSERBASE" });
+await stagehand.init();
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://portal.example.com");
+
+await stagehand.act("open the latest authorization request");
+
+const result = await stagehand.extract(
+  "extract the member name and current status",
+  z.object({
+    memberName: z.string(),
+    status: z.string(),
+  }),
+);`;
+
+const librettoExample = String.raw`import { workflow } from "libretto";
+import { z } from "zod";
+
+export default workflow("readAuthorizationStatus", {
+  input: z.object({ authorizationId: z.string() }),
+  output: z.object({ memberName: z.string(), status: z.string() }),
+  async handler({ page }, input) {
+    await page.goto("https://portal.example.com/authorizations");
+
+    const response = await page.request.post(
+      "https://portal.example.com/api/authorizations/detail",
+      { data: { id: input.authorizationId } },
+    );
+
+    const authorization = await response.json();
+    return {
+      memberName: authorization.member.name,
+      status: authorization.status,
+    };
+  },
+});`;
+
+function setMetaContent(selector: string, content: string) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (!element) {
+    element = document.createElement("meta");
+    const property = selector.match(/\[property="([^"]+)"\]/)?.[1];
+    const name = selector.match(/\[name="([^"]+)"\]/)?.[1];
+
+    if (property) {
+      element.setAttribute("property", property);
+    }
+    if (name) {
+      element.setAttribute("name", name);
+    }
+
+    document.head.append(element);
+  }
+
+  element.content = content;
+}
+
+function setCanonicalHref(href: string) {
+  let element = document.head.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]',
+  );
+  if (!element) {
+    element = document.createElement("link");
+    element.rel = "canonical";
+    document.head.append(element);
+  }
+
+  element.href = href;
+}
+
+function StagehandPageMeta() {
+  useEffect(() => {
+    const title =
+      "Libretto vs Stagehand: compiled scripts vs runtime AI primitives";
+    const description =
+      "A developer-focused comparison of Libretto and Browserbase Stagehand for AI browser automation: act(), observe(), caching, deterministic scripts, and runtime inference trade-offs.";
+    const url = "https://libretto.sh/vs/stagehand";
+
+    document.title = title;
+    setCanonicalHref(url);
+    setMetaContent('meta[name="description"]', description);
+    setMetaContent('meta[property="og:type"]', "article");
+    setMetaContent('meta[property="og:title"]', title);
+    setMetaContent('meta[property="og:description"]', description);
+    setMetaContent('meta[property="og:url"]', url);
+    setMetaContent('meta[name="twitter:card"]', "summary");
+    setMetaContent('meta[name="twitter:title"]', title);
+    setMetaContent('meta[name="twitter:description"]', description);
+  }, []);
+
+  return null;
+}
+
+function ArticleSection({
+  children,
+  kicker,
+  title,
+}: {
+  children: ReactNode;
+  kicker: string;
+  title: ReactNode;
+}) {
+  return (
+    <section className="border-t border-rule py-14">
+      <Kicker className="mb-3 text-sm text-accent">{kicker}</Kicker>
+      <SectionHeading size="sm" className="mb-7 normal-case">
+        {title}
+      </SectionHeading>
+      {children}
+    </section>
+  );
+}
+
+function PositiveMark() {
+  return <span className="font-medium text-accent-bright">✓</span>;
+}
+
+function TradeoffMark() {
+  return <span className="font-medium text-muted/60">—</span>;
+}
+
+function ComparisonMark({ kind }: { kind?: "positive" | "tradeoff" }) {
+  if (kind === "positive") {
+    return <PositiveMark />;
+  }
+
+  if (kind === "tradeoff") {
+    return <TradeoffMark />;
+  }
+
+  return null;
+}
+
+function ComparisonTable() {
+  return (
+    <div className="overflow-x-auto rounded-[3.75px] border border-rule bg-panel/80">
+      <table className="w-full min-w-[760px] border-collapse border border-rule text-left text-sm leading-relaxed text-muted">
+        <thead>
+          <tr className="border-b border-rule">
+            <th className="w-[22%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Dimension
+            </th>
+            <th className="w-[39%] border border-rule px-4 py-3 font-medium uppercase tracking-[0.08em] text-muted/80">
+              Stagehand
+            </th>
+            <th className="w-[39%] border border-rule bg-green-3/35 px-4 py-3 font-medium uppercase tracking-[0.08em] text-accent-bright">
+              Libretto
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {comparisonRows.map((row) => (
+            <tr
+              key={row.label}
+              className="border-b border-rule last:border-b-0"
+            >
+              <th className="border border-rule px-4 py-4 align-top font-medium text-ink">
+                {row.label}
+              </th>
+              <td className="border border-rule px-4 py-4 align-top">
+                <ComparisonMark kind={row.stagehandMark} />{" "}
+                <span>{row.stagehand}</span>
+              </td>
+              <td className="border border-rule bg-green-3/20 px-4 py-4 align-top text-ink">
+                <ComparisonMark kind={row.librettoMark} />{" "}
+                <span>{row.libretto}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
+  const highlightedCode = Prism.highlight(
+    code,
+    Prism.languages.typescript,
+    "typescript",
+  );
+
+  return (
+    <div className="overflow-hidden rounded-[3.75px] border border-rule bg-[#0f120f]">
+      <div className="border-b border-rule bg-panel px-4 py-2">
+        <Text size="xs" className="uppercase tracking-[0.08em] text-muted/70">
+          {label}
+        </Text>
+      </div>
+      <pre className="overflow-x-auto p-4 text-xs leading-relaxed text-muted">
+        <code
+          className="font-mono text-[#e6edf3] [&_.token.boolean]:text-[#79c0ff] [&_.token.builtin]:text-[#ffa657] [&_.token.class-name]:text-[#ffa657] [&_.token.comment]:text-[#8b949e] [&_.token.function]:text-[#d2a8ff] [&_.token.keyword]:text-[#ff7b72] [&_.token.number]:text-[#79c0ff] [&_.token.operator]:text-[#ff7b72] [&_.token.property]:text-[#79c0ff] [&_.token.punctuation]:text-[#c9d1d9] [&_.token.string]:text-[#a5d6ff] [&_.token.variable]:text-[#ffa657]"
+          dangerouslySetInnerHTML={{ __html: highlightedCode }}
+        />
+      </pre>
+    </div>
+  );
+}
+
+function CodeComparison() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <CodeBlock code={stagehandExample} label="Stagehand: runtime AI primitive" />
+      <CodeBlock code={librettoExample} label="Libretto: generated workflow code" />
+    </div>
+  );
+}
+
+function FAQList() {
+  return (
+    <div className="border-t border-rule">
+      {faqItems.map((item) => (
+        <details
+          key={item.question}
+          className="group border-b border-rule py-5"
+        >
+          <summary className="cursor-pointer list-none text-base font-medium text-ink outline-none transition-colors hover:text-accent-bright focus-visible:ring-2 focus-visible:ring-accent/30 [&::-webkit-details-marker]:hidden">
+            <span className="mr-3 text-accent group-open:hidden">+</span>
+            <span className="mr-3 hidden text-muted group-open:inline">−</span>
+            {item.question}
+          </summary>
+          <Text
+            as="p"
+            size="sm"
+            className="mt-4 max-w-[700px] leading-relaxed text-muted"
+          >
+            {item.answer}
+          </Text>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+export function StagehandPage() {
+  return (
+    <div className="crt-page flex min-h-screen flex-col bg-bg text-ink">
+      <StagehandPageMeta />
+      <Navbar />
+      <main className="section-rails relative mx-auto mt-16 w-full max-w-[1100px] flex-1 px-8">
+        <article className="mx-auto max-w-[820px] pb-20">
+          <header className="pb-16">
+            <div className="mb-8 overflow-hidden">
+              <AsciiLibretto
+                decorative
+                className="text-[4px] text-accent sm:text-[5px] md:text-[6px]"
+              />
+            </div>
+            <Kicker className="mb-4 text-accent">// COMPARISON --</Kicker>
+            <Text
+              as="h1"
+              size="5xl"
+              style="serif"
+              className="crt-glow mb-7 max-w-[780px] font-[300] leading-[1.05] tracking-[-0.04em] text-ink [text-wrap:balance]"
+              htmlStyle={{ fontSize: "clamp(40px, 6vw, 72px)" }}
+            >
+              Libretto vs Stagehand: compiled scripts vs runtime AI primitives.
+            </Text>
+            <Text
+              as="p"
+              size="lg"
+              className="max-w-[720px] leading-relaxed text-muted"
+            >
+              Stagehand is a strong developer framework when you want to mix
+              Playwright-style browser code with AI actions at runtime. Libretto
+              is better when a known workflow should become a deterministic
+              script your team owns, deploys, and runs without inference on
+              every execution.
+            </Text>
+          </header>
+
+          <Panel
+            padding="lg"
+            radius="md"
+            className="mb-12 border-accent/20 bg-green-2/35"
+          >
+            <Kicker className="mb-3 text-sm text-accent">
+              // SHORT VERSION --
+            </Kicker>
+            <ul className="space-y-3 leading-relaxed text-muted">
+              <li>
+                Use Stagehand when your TypeScript app needs runtime AI browser
+                primitives such as act(), observe(), extract(), or agent(),
+                especially if you are already leaning on Browserbase for hosted
+                browser sessions.
+              </li>
+              <li>
+                Use Libretto when a workflow is known and repeated enough that
+                you want code generation, direct API-call shortcuts,
+                deterministic runs, and no model call on every execution.
+              </li>
+              <li>
+                The honest distinction: Stagehand helps you decide when to use
+                AI inside the automation. Libretto helps you stop using AI at
+                runtime once the workflow is understood.
+              </li>
+            </ul>
+          </Panel>
+
+          <ArticleSection
+            kicker="// HOW IT WORKS --"
+            title="Stagehand mixes code with AI browser primitives"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Stagehand, from Browserbase, describes itself as an AI browser
+                automation framework. Its core idea is practical: write
+                deterministic browser code when you know what should happen, and
+                use natural-language AI primitives when you want the system to
+                interpret the page.
+              </p>
+              <p>
+                The important primitives are act(), observe(), extract(), and
+                agent(). observe() can return candidate actions, act() can
+                execute a natural-language instruction or a previously observed
+                action, extract() can pull structured data with a schema, and
+                agent() can handle multi-step tasks. That makes Stagehand much
+                more developer-controlled than a fully autonomous browser agent.
+              </p>
+              <p>
+                Stagehand also has a credible caching story. Repeatable actions
+                can be cached and replayed to save time and tokens, while
+                self-healing can bring AI back in when the site changes. That is
+                useful, but it is still a runtime framework: fresh
+                natural-language actions, extraction, and agent execution
+                involve model inference while the automation runs.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// HOW LIBRETTO WORKS --"
+            title="Libretto records the workflow, then compiles it to owned code"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto starts from a different assumption. A coding agent uses
+                the CLI with a live browser to inspect pages, record actions,
+                capture relevant network calls, and compile a known workflow
+                into a deterministic script. The result is not a prompt plus
+                runtime AI primitive; it is code.
+              </p>
+              <p>
+                That script can combine Playwright with direct in-session API
+                calls, which matters when a portal performs a slow UI sequence
+                that maps to a cleaner underlying request. Once generated, the
+                workflow is readable and reviewable by engineers. You debug the
+                script, not a model's evolving interpretation of the page.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// CODE SHAPE --"
+            title="What the difference looks like in code"
+          >
+            <div className="mb-7 space-y-6 leading-[1.85] text-muted">
+              <p>
+                The comparison is easier to see in code. In Stagehand, the
+                durable program can still contain runtime natural-language
+                instructions. In Libretto, the goal is for the coding agent to
+                replace the discovered workflow with explicit TypeScript before
+                production runs.
+              </p>
+            </div>
+            <CodeComparison />
+          </ArticleSection>
+
+          <ArticleSection kicker="// HEAD TO HEAD --" title="Comparison table">
+            <ComparisonTable />
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// USE STAGEHAND WHEN --"
+            title="When to use Stagehand instead"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Stagehand is a good fit when you want runtime AI to stay in the
+                loop. If your product needs to interpret pages dynamically,
+                extract structured data from changing layouts, or execute
+                natural-language instructions inside a TypeScript application,
+                Stagehand gives you useful primitives without forcing you into a
+                fully autonomous agent model.
+              </p>
+              <p>
+                It is also compelling if Browserbase is already your preferred
+                browser infrastructure. Stagehand's local mode exists, but its
+                hosted-browser story is naturally aligned with Browserbase
+                sessions, debug URLs, regions, proxies, and related cloud
+                features.
+              </p>
+              <p>
+                The fairest version of the comparison is this: Stagehand is not
+                just another unpredictable agent. Its observe-to-act and caching
+                workflow gives developers more control than a pure runtime
+                agent. If you still want runtime AI adaptation, that is a real
+                advantage.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection
+            kicker="// USE LIBRETTO WHEN --"
+            title="When Libretto is the better choice"
+          >
+            <div className="space-y-6 leading-[1.85] text-muted">
+              <p>
+                Libretto is the better choice when the workflow is known,
+                repeated, and production-facing. At that point, runtime
+                flexibility is often less valuable than a script that behaves
+                the same way on the thousandth run as it did on the tenth.
+              </p>
+              <p>
+                That is especially true for messy portals. Libretto has been
+                battle-tested on complex healthcare and legacy sites where small
+                UI details, hidden API calls, and fragile state make runtime
+                interpretation expensive to debug. The goal is to turn the
+                portal workflow into maintainable automation code, not keep
+                asking a model what to do next.
+              </p>
+              <p>
+                If your team cares about auditability, code review,
+                reproducibility, and keeping model calls out of the hot path,
+                Libretto's compile-to-script model is the sharper fit.
+              </p>
+            </div>
+          </ArticleSection>
+
+          <ArticleSection kicker="// FAQ --" title="Short FAQ">
+            <FAQList />
+          </ArticleSection>
+
+          <section className="border-t border-rule py-14">
+            <Kicker className="mb-3 text-sm text-accent">
+              // NEXT STEP --
+            </Kicker>
+            <Text
+              as="h2"
+              size="3xl"
+              style="serif"
+              className="mb-5 font-[300] leading-tight text-ink"
+            >
+              Turn one known browser flow into owned code.
+            </Text>
+            <Text
+              as="p"
+              size="md"
+              className="mb-7 max-w-[640px] leading-relaxed text-muted"
+            >
+              If you already know the workflow, record it with Libretto and
+              inspect the generated script before putting it in a production
+              path.
+            </Text>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button
+                href="/docs/get-started/quickstart"
+                data-fathom-event="Stagehand comparison docs click"
+              >
+                Go to docs
+              </Button>
+              <AppLink
+                href="https://libretto.sh"
+                className="text-sm text-muted underline decoration-muted underline-offset-4 transition-colors hover:text-accent-bright"
+                data-fathom-event="Stagehand comparison homepage click"
+              >
+                libretto.sh
+              </AppLink>
+            </div>
+          </section>
+        </article>
+        <Footer />
+      </main>
+    </div>
+  );
+}

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -46,7 +46,7 @@
       "destination": "/blog/:slug.html"
     },
     {
-      "source": "/vs/browser-use",
+      "source": "/vs/:slug",
       "destination": "/index.html"
     },
     {

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -46,6 +46,10 @@
       "destination": "/blog/:slug.html"
     },
     {
+      "source": "/vs/browser-use",
+      "destination": "/index.html"
+    },
+    {
       "source": "/docs",
       "destination": "https://saffron-health-libretto-73.mintlify.dev/docs"
     },


### PR DESCRIPTION
## Summary
- add developer-focused `/vs/browser-use`, `/vs/stagehand`, and `/vs/playwright-codegen` comparison pages
- simplify website routing with Wouter routes and a nested `/vs` route switch
- add a reusable Vercel rewrite for `/vs/:slug`

## Verification
- `pnpm -s --filter @libretto/website type-check`
- `pnpm -s --filter @libretto/website lint`
- manually checked comparison pages on the dev server
