### PR TITLE
Simplify homepage comparison links

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -24,67 +24,6 @@ import { CloudProviders } from "./components/CloudProviders";
 import { FAQ } from "./components/FAQ";
 import { CTA } from "./components/CTA";
 import { SectionDivider } from "./components/SectionDivider.js";
-import { SiteSection } from "./components/SiteSection.js";
-import { SectionIntro } from "./components/SectionIntro.js";
-import { Panel } from "./components/Panel.js";
-import { Button } from "./components/Button.js";
-
-const comparisonPages = [
-  {
-    href: "/vs/browser-use",
-    title: "Libretto vs Browser Use",
-    description:
-      "Compare deterministic scripts with a runtime browser agent for production browser automation.",
-  },
-  {
-    href: "/vs/stagehand",
-    title: "Libretto vs Stagehand",
-    description:
-      "Compare generated workflows with act(), observe(), caching, and runtime inference trade-offs.",
-  },
-  {
-    href: "/vs/playwright-codegen",
-    title: "Libretto vs Playwright codegen",
-    description:
-      "Compare simple action recording with agent-built workflows, validation loops, and network shortcuts.",
-  },
-];
-
-function Comparisons() {
-  return (
-    <SiteSection id="comparisons">
-      <SectionIntro
-        kicker="// Comparisons --"
-        title="Compare browser automation tools"
-      >
-        See when Libretto is a better fit than runtime agents, AI action APIs,
-        or browser recorders.
-      </SectionIntro>
-      <div className="mt-12 grid gap-4 md:grid-cols-3">
-        {comparisonPages.map((page) => (
-          <Panel key={page.href} className="flex h-full flex-col gap-5" padding="lg">
-            <div className="flex flex-1 flex-col gap-3">
-              <Text as="h3" size="lg" className="font-medium text-ink">
-                {page.title}
-              </Text>
-              <Text as="p" size="sm" className="leading-relaxed text-muted">
-                {page.description}
-              </Text>
-            </div>
-            <Button
-              href={page.href}
-              variant="secondary"
-              size="sm"
-              data-fathom-event={`${page.title} homepage comparison click`}
-            >
-              Read comparison
-            </Button>
-          </Panel>
-        ))}
-      </div>
-    </SiteSection>
-  );
-}
 
 function Hero({
   paneUnlocked,
@@ -195,8 +134,6 @@ export function HomePage() {
         <MaintainingFeatures />
         <SectionDivider />
         <CloudProviders />
-        <SectionDivider />
-        <Comparisons />
         <SectionDivider />
         <FAQ />
         <SectionDivider />

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -11,6 +11,7 @@ interface FAQItem {
   id: string;
   question: string;
   answer: ReactNode;
+  defaultExpanded?: boolean;
 }
 
 const faqs: FAQItem[] = [
@@ -39,16 +40,30 @@ const faqs: FAQItem[] = [
   {
     id: "diff",
     question:
-      "How is it different from existing tools like Stagehand or Browser-Use?",
-    answer:
-      "Tools like Stagehand and Browser-Use use AI at runtime to handle edge cases without human involvement. They also rely entirely on UI interactions, which makes them slow, expensive, and nondeterministic.\n\nLibretto generates deterministic scripts that can use both UI automation and direct network requests. When a script breaks, you use Libretto to diagnose and fix it. You can still add AI runtime logic since it's all just TypeScript, but it's not the default.",
-  },
-  {
-    id: "diff-playwright",
-    question:
-      "How is it different from tools like playwright-cli, agent-browser, and dev-browser?",
-    answer:
-      "Libretto is both a runtime and a CLI, built specifically for writing reusable automation scripts.\n\nIt comes out of the box with a script validation loop that checks scripts run end-to-end when you generate them or make edits, pause statements agents can drop into your code for step-through debugging, and a workflow recorder that captures actions in a real browser and turns them into scripts.\n\nWhen you're happy with a script, you deploy it to the cloud and run it as a type-safe API with one command.",
+      "How is Libretto different from Browser Use, Stagehand, and Playwright codegen?",
+    answer: (
+      <>
+        Libretto generates deterministic TypeScript workflows that can use UI
+        automation and direct network requests. Browser Use is a runtime agent,
+        Stagehand adds AI actions on top of Playwright, and Playwright codegen is
+        a recorder for simple browser tests.
+        {"\n\n"}
+        Read the detailed comparisons: {" "}
+        <a href="/vs/browser-use" className={linkClass} data-fathom-event="FAQ Browser Use comparison click">
+          Libretto vs Browser Use
+        </a>
+        , {" "}
+        <a href="/vs/stagehand" className={linkClass} data-fathom-event="FAQ Stagehand comparison click">
+          Libretto vs Stagehand
+        </a>
+        , and {" "}
+        <a href="/vs/playwright-codegen" className={linkClass} data-fathom-event="FAQ Playwright codegen comparison click">
+          Libretto vs Playwright codegen
+        </a>
+        .
+      </>
+    ),
+    defaultExpanded: true,
   },
   {
     id: "providers",
@@ -137,7 +152,7 @@ function MinusIcon() {
 }
 
 function FAQAccordionItem({ item }: { item: FAQItem }) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(item.defaultExpanded ?? false);
   return (
     <div className="border-b border-ink/10">
       <button
@@ -168,7 +183,7 @@ function FAQAccordionItem({ item }: { item: FAQItem }) {
 
 export function FAQ() {
   return (
-    <SiteSection innerClassName="flex flex-col gap-12 md:flex-row md:gap-16">
+    <SiteSection id="comparisons" innerClassName="flex flex-col gap-12 md:flex-row md:gap-16">
       <div className="md:w-1/2 md:shrink-0 md:pt-5">
         <SectionIntro
           align="left"

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -1,7 +1,6 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode } from "react";
 import { SectionIntro } from "./SectionIntro.js";
 import { Text } from "./Text.js";
-import { CrossfadeIcon } from "./CrossfadeIcon.js";
 import { SiteSection } from "./SiteSection.js";
 import { REPO_URL, DISCORD_URL } from "../site";
 
@@ -11,7 +10,6 @@ interface FAQItem {
   id: string;
   question: string;
   answer: ReactNode;
-  defaultExpanded?: boolean;
 }
 
 const faqs: FAQItem[] = [
@@ -63,7 +61,6 @@ const faqs: FAQItem[] = [
         .
       </>
     ),
-    defaultExpanded: true,
   },
   {
     id: "providers",
@@ -152,32 +149,30 @@ function MinusIcon() {
 }
 
 function FAQAccordionItem({ item }: { item: FAQItem }) {
-  const [isExpanded, setIsExpanded] = useState(item.defaultExpanded ?? false);
   return (
-    <div className="border-b border-ink/10">
-      <button
-        className="flex w-full cursor-pointer items-center justify-between py-5 text-left outline-none focus-visible:ring-2 focus-visible:ring-accent/30 rounded-sm"
-        onClick={() => setIsExpanded(!isExpanded)}
-        aria-expanded={isExpanded}
+    <details className="group border-b border-ink/10 [&_summary::-webkit-details-marker]:hidden">
+      <summary
+        className="flex w-full cursor-pointer list-none items-center justify-between py-5 text-left outline-none rounded-sm focus-visible:ring-2 focus-visible:ring-accent/30"
         data-fathom-event={`FAQ ${item.id} toggle click`}
       >
         <Text size="md" className="font-medium text-ink">
           {item.question}
         </Text>
         <span className="ml-4 shrink-0 text-muted">
-          <CrossfadeIcon activeKey={isExpanded ? "minus" : "plus"}>
-            {isExpanded ? <MinusIcon /> : <PlusIcon />}
-          </CrossfadeIcon>
+          <span className="group-open:hidden">
+            <PlusIcon />
+          </span>
+          <span className="hidden group-open:block">
+            <MinusIcon />
+          </span>
         </span>
-      </button>
-      {isExpanded && (
-        <div className="overflow-hidden">
-          <Text as="p" size="sm" className="pb-5 leading-relaxed text-muted whitespace-pre-line">
-            {item.answer}
-          </Text>
-        </div>
-      )}
-    </div>
+      </summary>
+      <div className="overflow-hidden">
+        <Text as="p" size="sm" className="pb-5 leading-relaxed text-muted whitespace-pre-line">
+          {item.answer}
+        </Text>
+      </div>
+    </details>
   );
 }
 

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -162,7 +162,7 @@ function FAQAccordionItem({ item }: { item: FAQItem }) {
           <span className="group-open:hidden">
             <PlusIcon />
           </span>
-          <span className="hidden group-open:block">
+          <span className="hidden text-accent group-open:block">
             <MinusIcon />
           </span>
         </span>


### PR DESCRIPTION
## Summary
- remove the standalone homepage comparison cards section
- fold the comparison page links into the existing FAQ comparison answer
- keep the `#comparisons` nav/footer anchor pointing at the FAQ section

## Verification
- `pnpm -s --filter @libretto/website type-check`
- `pnpm -s --filter @libretto/website lint`
