### PR TITLE
Document residential proxy locations

### DIFF
--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -21,8 +21,11 @@ Request fields:
 - `callback_url`: optional callback URL
 - `callback_secret`: optional callback secret
 - `skip_callbacks`: optional boolean
+- `residential_proxy`: optional residential proxy location object
 
 If you set `callback_url`, you must also set `callback_secret`.
+
+Use `residential_proxy` for location-sensitive runs that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
 
 Callback delivery order:
 

--- a/docs/libretto-cloud-api/schedules.mdx
+++ b/docs/libretto-cloud-api/schedules.mdx
@@ -26,9 +26,12 @@ Request fields:
 - `callback_url`: optional
 - `callback_secret`: optional
 - `skip_callbacks`: optional, default `false`
+- `residential_proxy`: optional residential proxy location object
 - `enabled`: optional, default `true`
 
 If you set `callback_url`, you must also set `callback_secret`.
+
+Use `residential_proxy` for recurring workflows that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
 
 Response fields:
 
@@ -75,9 +78,11 @@ Request fields:
 - `callback_url`: optional string or `null`
 - `callback_secret`: optional string or `null`
 - `skip_callbacks`: optional
+- `residential_proxy`: optional object or `null`
 - `enabled`: optional
 
 To clear the callback, set both `callback_url` and `callback_secret` to `null`.
+To clear the configured residential proxy location, set `residential_proxy` to `null`.
 
 Response fields:
 
@@ -106,6 +111,7 @@ The `schedule` object returned by the schedules endpoints includes:
 - `cron_expr`
 - `timezone`
 - `timeout_seconds`
+- `residential_proxy`
 - `callback_url`
 - `skip_callbacks`
 - `enabled`

--- a/docs/libretto-cloud-api/sessions.mdx
+++ b/docs/libretto-cloud-api/sessions.mdx
@@ -13,6 +13,9 @@ Start a hosted browser session.
 Request fields:
 
 - `timeout_seconds`: optional session timeout, default `3600`, max `7200`
+- `residential_proxy`: optional residential proxy location object
+
+Use `residential_proxy` for location-sensitive sessions that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
 
 Response fields:
 

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -11,7 +11,7 @@ Libretto Cloud is the easiest way to host and run workflows. Sign up, run one de
 
 Use Libretto Cloud when you want to ship and run workflows without owning the runtime infrastructure yourself.
 
-- Libretto Cloud runs the browser layer for you, so you do not have to manage proxies, browser sessions, or CAPTCHA handling yourself.
+- Libretto Cloud runs the browser layer for you, so you do not have to manage proxies, browser sessions, or CAPTCHA handling yourself. For location-sensitive workflows, you can still choose the hosted browser's residential proxy location.
 - By default, when a run fails, Libretto Cloud automatically analyzes the failure and emails you a summary, along with the recordings, screenshots, logs, and other debug context you need to understand what broke.
 - Deployments can also enable auto-repair, which routes failed jobs to the autofix agent instead of only sending debug context.
 - You can build, debug, and deploy workflow packages from the same CLI instead of stitching together separate tools for local development, browsers, and hosting.

--- a/docs/libretto-cloud-hosting/stealth.mdx
+++ b/docs/libretto-cloud-hosting/stealth.mdx
@@ -9,6 +9,41 @@ Every Libretto Cloud browser runs in stealth mode. Hosted runs use residential p
 
 Stealth also includes automatic CAPTCHA handling. Libretto Cloud cannot guarantee every challenge will clear, but common CAPTCHA and bot-check pages can resolve without a manual handoff.
 
+## Residential proxy locations
+
+By default, Libretto Cloud uses a managed US residential proxy for each hosted browser. If the target site is location-sensitive, pass `residential_proxy` when you create a job, browser session, or schedule.
+
+`country` is required and must be a two-letter ISO country code. You can refine US locations with `state` or `zip`, target a city with `city`, or target an ISP/network with `asn`.
+
+```bash theme={null}
+curl -X POST "https://api.libretto.sh/v1/jobs/create" \
+  -H "x-api-key: $LIBRETTO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "json": {
+      "workflow": "check-eligibility",
+      "params": {
+        "memberId": "12345"
+      },
+      "residential_proxy": {
+        "country": "US",
+        "state": "CA",
+        "city": "san-francisco"
+      }
+    }
+  }'
+```
+
+Supported fields:
+
+- `country`: two-letter country code, such as `US`.
+- `state`: two-letter US state code. Only supported with `country: "US"`.
+- `city`: city slug without spaces.
+- `zip`: five-digit US ZIP code. Only supported with `country: "US"`; cannot be combined with `city` or `state`.
+- `asn`: network identifier such as `AS7922`; cannot be combined with `city` or `state`.
+
+For recurring workflows, pass the same object to `residential_proxy` on `/v1/schedules/create` or `/v1/schedules/update`. To clear a schedule's configured proxy location, set `residential_proxy` to `null` on `/v1/schedules/update`.
+
 ## Workflow behavior
 
 On Libretto Cloud, if a workflow reaches a CAPTCHA, Cloudflare check, or similar interstitial, wait up to 2 minutes before treating it as blocked. That gives the hosted browser time to finish the provider-side solve and continue to the page your workflow expects.


### PR DESCRIPTION
## Summary
- document `residential_proxy` location configuration in the Cloud stealth hosting page
- add `residential_proxy` to jobs, sessions, and schedules API reference fields
- note schedule response and clearing behavior for proxy location config

## Verification
- pnpm -s type-check
