### PR TITLE
fix: use import.meta.resolve instead of createRequire for tsx/cli resolution

### DIFF
--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { openSync, closeSync } from "node:fs";
-import { createRequire } from "node:module";
 import { homedir, userInfo } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createIpcPeer, type IpcPeer } from "../../../shared/ipc/ipc.js";
@@ -246,8 +245,7 @@ export class DaemonClient {
     const daemonEntryPath = fileURLToPath(
       new URL("./daemon.js", import.meta.url),
     );
-    const require = createRequire(import.meta.url);
-    const tsxCliPath = require.resolve("tsx/cli");
+    const tsxCliPath = fileURLToPath(import.meta.resolve("tsx/cli"));
 
     const childStderrFd = openSync(logPath, "a");
     const child = spawn(


### PR DESCRIPTION
Fixes #409

**Problem:** When a project is created with `pnpm create libretto@latest`, the daemon fails because `createRequire(import.meta.url).resolve("tsx/cli")` uses CJS resolution which does not traverse pnpm's virtual store symlinks.

**Fix:** Replace `createRequire` + `.resolve()` with `import.meta.resolve()` which uses ESM resolution and correctly follows pnpm's symlink layout.

This is the minimal Option A proposed in the issue — no bundling changes needed.