### PR TITLE
Add website security headers

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -2,6 +2,31 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://cdn.usefathom.com https://api.usefathom.com; form-action 'self'; upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/llms.txt",
       "headers": [
         {


### PR DESCRIPTION
## Summary
- Add global security headers for the Vercel-hosted website
- Configure CSP for current analytics, Google Fonts, and GitHub API usage
- Keep existing markdown content-type headers for llms.txt and start.md

## Testing
- node -e "JSON.parse(require('fs').readFileSync('packages/libretto/apps/website/vercel.json','utf8')); console.log('vercel.json valid JSON')"
- pnpm -C packages/libretto/apps/website -s type-check