### PR TITLE
Add cloud job and schedule CLI commands

### DIFF
--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -119,7 +119,15 @@ export default workflow(
 );
 ```
 
-then hit the endpoint with `workflow: "check-eligibility"`. The `params` object must match the workflow input schema:
+then create the hosted job with `workflow: "check-eligibility"`. The `params` object must match the workflow input schema:
+
+```bash theme={null}
+npx libretto cloud jobs create check-eligibility \
+  --params '{"memberId":"12345"}' \
+  --timeout-seconds 300
+```
+
+That command returns a `job_id` immediately. The equivalent API request is:
 
 ```bash theme={null}
 curl -X POST "https://api.libretto.sh/v1/jobs/create" \
@@ -136,7 +144,7 @@ curl -X POST "https://api.libretto.sh/v1/jobs/create" \
   }'
 ```
 
-That request returns a `job_id` immediately. Use that id to fetch status or the final result:
+Use the returned id to fetch status or the final result:
 
 ```bash theme={null}
 curl -X POST "https://api.libretto.sh/v1/jobs/get" \
@@ -150,6 +158,19 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
 ```
 
 The `workflow` value must match the workflow name declared in code and discovered during deploy, not the deployment id, filename, or export alias.
+
+### Schedule a deployed workflow
+
+Use `cloud schedules create` for recurring runs. The cron expression is standard 5-field cron, and the timezone defaults to `UTC`:
+
+```bash theme={null}
+npx libretto cloud schedules create check-eligibility \
+  --cron "0 14 * * 1-5" \
+  --timezone America/Los_Angeles \
+  --params '{"memberId":"12345"}'
+```
+
+The command prints the schedule id and next fire time. Use `--params-file` instead of `--params` when the workflow input is too large to keep inline.
 
 ### Hosting options
 

--- a/packages/libretto/src/cli/commands/cloud-credentials.ts
+++ b/packages/libretto/src/cli/commands/cloud-credentials.ts
@@ -1,5 +1,6 @@
 import { SimpleCLI } from "affordance";
-import { orpcCall, resolveApiUrl } from "../core/auth-fetch.js";
+import { orpcCall } from "../core/auth-fetch.js";
+import { withCloudApiKey } from "./shared.js";
 
 const CLOUD_CREDENTIAL_ENV_PREFIX = "LIBRETTO_CLOUD_";
 
@@ -9,19 +10,6 @@ type UpsertCredentialResponse = {
   overwritten: boolean;
   message: string;
 };
-
-function requireApiKeyCredential() {
-  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "LIBRETTO_API_KEY is required to manage Libretto Cloud credentials. Issue one with `libretto cloud auth api-key issue --label <label>`.",
-    );
-  }
-  return {
-    apiUrl: resolveApiUrl(null),
-    credential: { source: "env-api-key" as const, apiKey },
-  };
-}
 
 function parseEnvCredentials(prefix: string): Array<{ name: string; value: string }> {
   const credentials: Record<string, string> = {};
@@ -44,22 +32,22 @@ export const pushCredentialCommand = SimpleCLI.command({
     positionals: [],
     named: {},
   }))
-  .handle(async () => {
+  .use(withCloudApiKey("manage Libretto Cloud credentials"))
+  .handle(async ({ ctx }) => {
     const credentials = parseEnvCredentials(CLOUD_CREDENTIAL_ENV_PREFIX);
     if (credentials.length === 0) {
       throw new Error(
         `No non-empty env vars found with prefix ${CLOUD_CREDENTIAL_ENV_PREFIX}.`,
       );
     }
-    const { apiUrl, credential } = requireApiKeyCredential();
     let created = 0;
     let updated = 0;
     for (const item of credentials) {
       const response = await orpcCall<UpsertCredentialResponse>({
-        apiUrl,
+        apiUrl: ctx.apiUrl,
         path: "/v1/credentials/upsert",
         input: item,
-        credential,
+        credential: ctx.credential,
       });
       if (response.overwritten) {
         updated += 1;

--- a/packages/libretto/src/cli/commands/cloud-jobs.ts
+++ b/packages/libretto/src/cli/commands/cloud-jobs.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { SimpleCLI } from "affordance";
+import { orpcCall } from "../core/auth-fetch.js";
+import { withCloudApiKey } from "./shared.js";
+
+type JobStatus = "queued" | "starting_browser" | "running";
+
+type CreateJobResponse = {
+  success: true;
+  job_id: string;
+  status: JobStatus;
+  message: string;
+};
+
+const createJobUsage =
+  "Usage: libretto cloud jobs create <workflow> [--params <json> | --params-file <path>]";
+
+function parseJsonObject(label: string, raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function readJsonObjectFile(
+  label: string,
+  filePath: string,
+): Record<string, unknown> {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    throw new Error(
+      `Could not read ${label} "${filePath}". Ensure the file exists and is readable.`,
+    );
+  }
+  return parseJsonObject(label, content);
+}
+
+export const createCloudJobInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("workflow", z.string().optional(), {
+      help: "Deployed workflow name to run",
+    }),
+  ],
+  named: {
+    params: SimpleCLI.option(z.string().optional(), {
+      help: "Inline JSON params object",
+    }),
+    paramsFile: SimpleCLI.option(z.string().optional(), {
+      name: "params-file",
+      help: "Path to a JSON params file",
+    }),
+    credentialId: SimpleCLI.option(z.string().optional(), {
+      name: "credential-id",
+      help: "Stored cloud credential id to pass to the workflow",
+    }),
+    timeoutSeconds: SimpleCLI.option(z.coerce.number().int().min(1).optional(), {
+      name: "timeout-seconds",
+      help: "Job timeout in seconds",
+    }),
+    callbackUrl: SimpleCLI.option(z.string().optional(), {
+      name: "callback-url",
+      help: "Per-job callback URL",
+    }),
+    callbackSecret: SimpleCLI.option(z.string().optional(), {
+      name: "callback-secret",
+      help: "Secret used to sign the per-job callback",
+    }),
+    skipCallbacks: SimpleCLI.flag({
+      name: "skip-callbacks",
+      help: "Skip stored webhook callbacks for this job",
+    }),
+    residentialProxy: SimpleCLI.option(z.string().optional(), {
+      name: "residential-proxy",
+      help: "Residential proxy config as a JSON object",
+    }),
+  },
+})
+  .refine((input) => Boolean(input.workflow), createJobUsage)
+  .refine(
+    (input) => !(input.params && input.paramsFile),
+    "Pass either --params or --params-file, not both.",
+  )
+  .refine(
+    (input) =>
+      (!input.callbackUrl && !input.callbackSecret) ||
+      Boolean(input.callbackUrl && input.callbackSecret),
+    "Pass both --callback-url and --callback-secret, or omit both.",
+  );
+
+export const createCloudJobCommand = SimpleCLI.command({
+  description: "Create a Libretto Cloud job for a deployed workflow",
+})
+  .input(createCloudJobInput)
+  .use(withCloudApiKey("create Libretto Cloud jobs"))
+  .handle(async ({ input, ctx }) => {
+    const params = input.paramsFile
+      ? readJsonObjectFile("--params-file", input.paramsFile)
+      : input.params
+        ? parseJsonObject("--params", input.params)
+        : {};
+    const residentialProxy = input.residentialProxy
+      ? parseJsonObject("--residential-proxy", input.residentialProxy)
+      : undefined;
+
+    const payload: Record<string, unknown> = {
+      workflow: input.workflow!,
+      params,
+    };
+    if (input.credentialId) payload.credential_id = input.credentialId;
+    if (input.timeoutSeconds !== undefined) {
+      payload.timeout_seconds = input.timeoutSeconds;
+    }
+    if (input.callbackUrl) payload.callback_url = input.callbackUrl;
+    if (input.callbackSecret) payload.callback_secret = input.callbackSecret;
+    if (input.skipCallbacks) payload.skip_callbacks = true;
+    if (residentialProxy !== undefined) {
+      payload.residential_proxy = residentialProxy;
+    }
+
+    const response = await orpcCall<CreateJobResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/jobs/create",
+      input: payload,
+      credential: ctx.credential,
+    });
+
+    console.log(`Job created: ${response.job_id}`);
+    console.log(`Status: ${response.status}`);
+    console.log(response.message);
+    return response.job_id;
+  });
+
+export const cloudJobCommands = SimpleCLI.group({
+  description: "Create and manage hosted jobs",
+  routes: {
+    create: createCloudJobCommand,
+  },
+});

--- a/packages/libretto/src/cli/commands/cloud-schedules.ts
+++ b/packages/libretto/src/cli/commands/cloud-schedules.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { SimpleCLI } from "affordance";
+import { orpcCall } from "../core/auth-fetch.js";
+import { withCloudApiKey } from "./shared.js";
+
+type ScheduleResponse = {
+  id: string;
+  workflow: string;
+  cron_expr: string;
+  timezone: string;
+  enabled: boolean;
+  next_fire_at: string;
+};
+
+type CreateScheduleResponse = {
+  success: true;
+  schedule: ScheduleResponse;
+};
+
+const createScheduleUsage =
+  "Usage: libretto cloud schedules create <workflow> --cron <expr> [--params <json> | --params-file <path>]";
+
+function parseJsonObject(label: string, raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function readJsonObjectFile(
+  label: string,
+  filePath: string,
+): Record<string, unknown> {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    throw new Error(
+      `Could not read ${label} "${filePath}". Ensure the file exists and is readable.`,
+    );
+  }
+  return parseJsonObject(label, content);
+}
+
+export const createCloudScheduleInput = SimpleCLI.input({
+  positionals: [
+    SimpleCLI.positional("workflow", z.string().optional(), {
+      help: "Deployed workflow name to schedule",
+    }),
+  ],
+  named: {
+    cron: SimpleCLI.option(z.string().optional(), {
+      help: "Standard 5-field cron expression",
+    }),
+    timezone: SimpleCLI.option(z.string().optional(), {
+      help: "IANA timezone name (default: UTC)",
+    }),
+    params: SimpleCLI.option(z.string().optional(), {
+      help: "Inline JSON params object",
+    }),
+    paramsFile: SimpleCLI.option(z.string().optional(), {
+      name: "params-file",
+      help: "Path to a JSON params file",
+    }),
+    timeoutSeconds: SimpleCLI.option(z.coerce.number().int().min(1).optional(), {
+      name: "timeout-seconds",
+      help: "Job timeout in seconds for each schedule fire",
+    }),
+    callbackUrl: SimpleCLI.option(z.string().optional(), {
+      name: "callback-url",
+      help: "Per-schedule callback URL",
+    }),
+    callbackSecret: SimpleCLI.option(z.string().optional(), {
+      name: "callback-secret",
+      help: "Secret used to sign per-schedule callbacks",
+    }),
+    skipCallbacks: SimpleCLI.flag({
+      name: "skip-callbacks",
+      help: "Skip stored webhook callbacks for jobs created by this schedule",
+    }),
+    residentialProxy: SimpleCLI.option(z.string().optional(), {
+      name: "residential-proxy",
+      help: "Residential proxy config as a JSON object",
+    }),
+    disabled: SimpleCLI.flag({
+      help: "Create the schedule disabled",
+    }),
+  },
+})
+  .refine((input) => Boolean(input.workflow && input.cron), createScheduleUsage)
+  .refine(
+    (input) => !(input.params && input.paramsFile),
+    "Pass either --params or --params-file, not both.",
+  )
+  .refine(
+    (input) =>
+      (!input.callbackUrl && !input.callbackSecret) ||
+      Boolean(input.callbackUrl && input.callbackSecret),
+    "Pass both --callback-url and --callback-secret, or omit both.",
+  );
+
+export const createCloudScheduleCommand = SimpleCLI.command({
+  description: "Create a recurring schedule for a deployed workflow",
+})
+  .input(createCloudScheduleInput)
+  .use(withCloudApiKey("create Libretto Cloud schedules"))
+  .handle(async ({ input, ctx }) => {
+    const params = input.paramsFile
+      ? readJsonObjectFile("--params-file", input.paramsFile)
+      : input.params
+        ? parseJsonObject("--params", input.params)
+        : {};
+    const residentialProxy = input.residentialProxy
+      ? parseJsonObject("--residential-proxy", input.residentialProxy)
+      : undefined;
+
+    const payload: Record<string, unknown> = {
+      workflow: input.workflow!,
+      cron_expr: input.cron!,
+      timezone: input.timezone ?? "UTC",
+      params,
+      enabled: !input.disabled,
+    };
+    if (input.timeoutSeconds !== undefined) {
+      payload.timeout_seconds = input.timeoutSeconds;
+    }
+    if (input.callbackUrl) payload.callback_url = input.callbackUrl;
+    if (input.callbackSecret) payload.callback_secret = input.callbackSecret;
+    if (input.skipCallbacks) payload.skip_callbacks = true;
+    if (residentialProxy !== undefined) {
+      payload.residential_proxy = residentialProxy;
+    }
+
+    const response = await orpcCall<CreateScheduleResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/schedules/create",
+      input: payload,
+      credential: ctx.credential,
+    });
+
+    const { schedule } = response;
+    console.log(`Schedule created: ${schedule.id}`);
+    console.log(`Workflow: ${schedule.workflow}`);
+    console.log(`Cron: ${schedule.cron_expr} (${schedule.timezone})`);
+    console.log(`Next fire: ${schedule.next_fire_at}`);
+    console.log(`Enabled: ${schedule.enabled ? "yes" : "no"}`);
+    return schedule.id;
+  });
+
+export const cloudScheduleCommands = SimpleCLI.group({
+  description: "Create and manage hosted schedules",
+  routes: {
+    create: createCloudScheduleCommand,
+  },
+});

--- a/packages/libretto/src/cli/commands/cloud-sharing.ts
+++ b/packages/libretto/src/cli/commands/cloud-sharing.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { SimpleCLI } from "affordance";
-import { orpcCall, resolveApiUrl } from "../core/auth-fetch.js";
+import { orpcCall } from "../core/auth-fetch.js";
+import { withCloudApiKey, type CloudApiKeyContext } from "./shared.js";
 
 type CodeSharingStatusResponse = {
   enabled: boolean;
@@ -13,19 +14,6 @@ type ShareWorkflowResponse = {
   marketplace_url: string;
   code_url: string;
 };
-
-function requireCloudApiKey() {
-  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "LIBRETTO_API_KEY is required to share Libretto Cloud workflow code. Issue one with `libretto cloud auth api-key issue --label <label>`.",
-    );
-  }
-  return {
-    apiUrl: resolveApiUrl(null),
-    credential: { source: "env-api-key" as const, apiKey },
-  };
-}
 
 export const shareWorkflowCommand = SimpleCLI.command({
   description: "Share one hosted workflow's code publicly",
@@ -42,13 +30,13 @@ export const shareWorkflowCommand = SimpleCLI.command({
       }),
     },
   }))
-  .handle(async ({ input }) => {
-    const { apiUrl, credential } = requireCloudApiKey();
+  .use(withCloudApiKey("share Libretto Cloud workflow code"))
+  .handle(async ({ input, ctx }) => {
     const response = await orpcCall<ShareWorkflowResponse>({
-      apiUrl,
+      apiUrl: ctx.apiUrl,
       path: "/v1/workflows/share",
       input: { workflow: input.workflow, refresh: input.refresh },
-      credential,
+      credential: ctx.credential,
     });
 
     if (response.status === "existing") {
@@ -68,25 +56,27 @@ export const codeSharingStatusCommand = SimpleCLI.command({
   description: "Show whether tenant code sharing is enabled",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
-  .handle(async () => {
-    const { apiUrl, credential } = requireCloudApiKey();
+  .use(withCloudApiKey("manage tenant workflow code sharing"))
+  .handle(async ({ ctx }) => {
     const response = await orpcCall<CodeSharingStatusResponse>({
-      apiUrl,
+      apiUrl: ctx.apiUrl,
       path: "/v1/tenant/codeSharing",
       input: {},
-      credential,
+      credential: ctx.credential,
     });
     console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
     return response.enabled;
   });
 
-async function updateCodeSharing(enabled: boolean): Promise<boolean> {
-  const { apiUrl, credential } = requireCloudApiKey();
+async function updateCodeSharing(
+  enabled: boolean,
+  ctx: CloudApiKeyContext,
+): Promise<boolean> {
   const response = await orpcCall<CodeSharingStatusResponse>({
-    apiUrl,
+    apiUrl: ctx.apiUrl,
     path: "/v1/tenant/updateCodeSharing",
     input: { enabled },
-    credential,
+    credential: ctx.credential,
   });
   console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
   return response.enabled;
@@ -96,13 +86,15 @@ export const enableCodeSharingCommand = SimpleCLI.command({
   description: "Enable public workflow code sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
-  .handle(async () => updateCodeSharing(true));
+  .use(withCloudApiKey("manage tenant workflow code sharing"))
+  .handle(async ({ ctx }) => updateCodeSharing(true, ctx));
 
 export const disableCodeSharingCommand = SimpleCLI.command({
   description: "Disable public workflow code sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
-  .handle(async () => updateCodeSharing(false));
+  .use(withCloudApiKey("manage tenant workflow code sharing"))
+  .handle(async ({ ctx }) => updateCodeSharing(false, ctx));
 
 export const codeSharingCommands = SimpleCLI.group({
   description: "Manage tenant workflow code sharing",

--- a/packages/libretto/src/cli/commands/deploy.ts
+++ b/packages/libretto/src/cli/commands/deploy.ts
@@ -1,15 +1,13 @@
 import { randomBytes } from "node:crypto";
 import { z } from "zod";
-import {
-  orpcCall,
-  resolveApiUrl,
-} from "../core/auth-fetch.js";
+import { orpcCall } from "../core/auth-fetch.js";
 import {
   buildHostedDeployTarball,
   type WorkflowDeployMetadata,
 } from "../core/deploy-artifact.js";
 import { readAuthState } from "../core/auth-storage.js";
 import { SimpleCLI } from "affordance";
+import { withCloudApiKey } from "./shared.js";
 
 type DeploymentStatus = "building" | "ready" | "failed";
 
@@ -51,19 +49,6 @@ function deployApiKeyRequiredMessage(hasStoredSession: boolean): string {
     "  • Generate a key: run `libretto cloud auth api-key issue --label <label>`.",
     "  • Add it to your project .env file: `LIBRETTO_API_KEY=<issued-key>`.",
   ].join("\n");
-}
-
-async function requireDeployApiKey() {
-  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
-
-  if (!apiKey) {
-    throw new Error(deployApiKeyRequiredMessage(await hasStoredCloudSession()));
-  }
-
-  return {
-    apiUrl: resolveApiUrl(null),
-    credential: { source: "env-api-key" as const, apiKey },
-  };
 }
 
 async function hasStoredCloudSession(): Promise<boolean> {
@@ -188,8 +173,12 @@ export const deployCommand = SimpleCLI.command({
   description: "Deploy workflows to the hosted platform",
 })
   .input(deployInput)
-  .handle(async ({ input }) => {
-    const { apiUrl, credential } = await requireDeployApiKey();
+  .use(withCloudApiKey(
+    "deploy to Libretto Cloud",
+    async () => deployApiKeyRequiredMessage(await hasStoredCloudSession()),
+  ))
+  .handle(async ({ input, ctx }) => {
+    const { apiUrl, credential } = ctx;
     const deploymentName = generateDeploymentName();
 
     // Hosted deploy uploads a generated artifact with a deploy entrypoint and

--- a/packages/libretto/src/cli/commands/profiles.ts
+++ b/packages/libretto/src/cli/commands/profiles.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { SimpleCLI } from "affordance";
-import { orpcCall, resolveApiUrl } from "../core/auth-fetch.js";
+import { orpcCall } from "../core/auth-fetch.js";
 import { normalizeProfileName } from "../core/profiles.js";
+import { withCloudApiKey } from "./shared.js";
 
 type ListProfilesResponse = {
   profiles: Array<{
@@ -17,30 +18,17 @@ type DeleteProfileResponse = {
   deleted_count: number;
 };
 
-function requireApiKeyCredential() {
-  const apiKey = process.env.LIBRETTO_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "LIBRETTO_API_KEY is required to manage Libretto Cloud profiles. Issue one with `libretto cloud auth api-key issue --label <label>`.",
-    );
-  }
-  return {
-    apiUrl: resolveApiUrl(null),
-    credential: { source: "env-api-key" as const, apiKey },
-  };
-}
-
 export const listProfilesCommand = SimpleCLI.command({
   description: "List Libretto Cloud auth profiles",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
-  .handle(async () => {
-    const { apiUrl, credential } = requireApiKeyCredential();
+  .use(withCloudApiKey("manage Libretto Cloud profiles"))
+  .handle(async ({ ctx }) => {
     const response = await orpcCall<ListProfilesResponse>({
-      apiUrl,
+      apiUrl: ctx.apiUrl,
       path: "/v1/browserProfiles/list",
       input: {},
-      credential,
+      credential: ctx.credential,
     });
     if (response.profiles.length === 0) {
       console.log("No cloud profiles found.");
@@ -65,14 +53,14 @@ export const deleteProfileCommand = SimpleCLI.command({
     ],
     named: {},
   }))
-  .handle(async ({ input }) => {
+  .use(withCloudApiKey("manage Libretto Cloud profiles"))
+  .handle(async ({ input, ctx }) => {
     const profileName = normalizeProfileName(input.profileName);
-    const { apiUrl, credential } = requireApiKeyCredential();
     const response = await orpcCall<DeleteProfileResponse>({
-      apiUrl,
+      apiUrl: ctx.apiUrl,
       path: "/v1/browserProfiles/delete",
       input: { name: profileName },
-      credential,
+      credential: ctx.credential,
     });
     if (!response.success || response.deleted_count === 0) {
       console.log(`No cloud profile found for ${profileName}.`);

--- a/packages/libretto/src/cli/commands/shared.ts
+++ b/packages/libretto/src/cli/commands/shared.ts
@@ -9,6 +9,7 @@ import {
   type SessionState,
   validateSessionName,
 } from "../core/session.js";
+import { resolveApiUrl } from "../core/auth-fetch.js";
 import {
   SimpleCLI,
   type SimpleCLIContext,
@@ -40,6 +41,11 @@ export type ExperimentsContext = {
   experiments: Experiments;
 };
 
+export type CloudApiKeyContext = {
+  apiUrl: string;
+  credential: { source: "env-api-key"; apiKey: string };
+};
+
 export function withExperiments<
   TContext extends SimpleCLIContext,
 >(): SimpleCLIMiddleware<unknown, TContext, TContext & ExperimentsContext> {
@@ -47,6 +53,29 @@ export function withExperiments<
     ...ctx,
     experiments: resolveExperiments(),
   });
+}
+
+export function withCloudApiKey<
+  TContext extends SimpleCLIContext,
+>(
+  action: string,
+  formatMissingMessage?: () => string | Promise<string>,
+): SimpleCLIMiddleware<unknown, TContext, TContext & CloudApiKeyContext> {
+  return async ({ ctx }) => {
+    const apiKey = process.env.LIBRETTO_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error(
+        formatMissingMessage
+          ? await formatMissingMessage()
+          : `LIBRETTO_API_KEY is required to ${action}. Issue one with \`libretto cloud auth api-key issue --label <label>\`.`,
+      );
+    }
+    return {
+      ...ctx,
+      apiUrl: resolveApiUrl(null),
+      credential: { source: "env-api-key", apiKey },
+    };
+  };
 }
 
 export function withRequiredSession(): SimpleCLIMiddleware<

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -2,6 +2,8 @@ import { authCommands } from "./commands/auth.js";
 import { billingCommands } from "./commands/billing.js";
 import { browserCommands } from "./commands/browser.js";
 import { cloudCredentialCommands } from "./commands/cloud-credentials.js";
+import { cloudJobCommands } from "./commands/cloud-jobs.js";
+import { cloudScheduleCommands } from "./commands/cloud-schedules.js";
 import { codeSharingCommands, shareWorkflowCommand } from "./commands/cloud-sharing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
@@ -25,7 +27,9 @@ export const cliRoutes = {
       auth: authCommands,
       billing: billingCommands,
       credentials: cloudCredentialCommands,
+      jobs: cloudJobCommands,
       profiles: profileCommands,
+      schedules: cloudScheduleCommands,
       share: shareWorkflowCommand,
       sharing: codeSharingCommands,
     },

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -361,9 +361,60 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("deploy");
     expect(result.stdout).toContain("auth");
     expect(result.stdout).toContain("billing");
+    expect(result.stdout).toContain("jobs");
+    expect(result.stdout).toContain("schedules");
     expect(result.stdout).toContain("share");
     expect(result.stdout).toContain("sharing");
     expect(result.stderr).toBe("");
+  });
+
+  test("prints cloud jobs create help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud jobs create");
+    expect(result.stdout).toContain(
+      "Create a Libretto Cloud job for a deployed workflow",
+    );
+    expect(result.stdout).toContain("libretto cloud jobs create [workflow]");
+    expect(result.stdout).toContain("--params-file");
+    expect(result.stdout).toContain("--timeout-seconds");
+    expect(result.stderr).toBe("");
+  });
+
+  test("cloud jobs create requires an API key", async ({ librettoCli }) => {
+    const result = await librettoCli("cloud jobs create testWorkflow", {
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to create Libretto Cloud jobs.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
+  });
+
+  test("prints cloud schedules create help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud schedules create");
+    expect(result.stdout).toContain(
+      "Create a recurring schedule for a deployed workflow",
+    );
+    expect(result.stdout).toContain(
+      "libretto cloud schedules create [workflow]",
+    );
+    expect(result.stdout).toContain("--cron");
+    expect(result.stdout).toContain("--timezone");
+    expect(result.stderr).toBe("");
+  });
+
+  test("cloud schedules create requires an API key", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli(
+      'cloud schedules create testWorkflow --cron "0 * * * *"',
+      { LIBRETTO_API_KEY: undefined },
+    );
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to create Libretto Cloud schedules.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
   });
 
   test("prints cloud share help", async ({ librettoCli }) => {
@@ -602,7 +653,9 @@ export default workflow("main", async (ctx) => {
         auth <subcommand>  Hosted-platform auth commands
         billing <subcommand>  Hosted-platform subscription + usage commands
         credentials <subcommand>  Manage hosted credentials
+        jobs <subcommand>  Create and manage hosted jobs
         profiles <subcommand>  Manage hosted browser auth profiles
+        schedules <subcommand>  Create and manage hosted schedules
         share  Share one hosted workflow's code publicly
         sharing <subcommand>  Manage tenant workflow code sharing
     `}\n`);


### PR DESCRIPTION
## Summary
- add `libretto cloud jobs create` for creating hosted jobs from deployed workflows
- add `libretto cloud schedules create` for creating recurring hosted workflow schedules
- centralize API-key-only cloud command auth in `withCloudApiKey`
- document job creation and schedule creation in the cloud deployments guide

## Verification
- `cd packages/libretto/packages/libretto && pnpm -s type-check`
- `cd packages/libretto/packages/libretto && pnpm -s lint`
- `cd packages/libretto/packages/libretto && pnpm -s test:vitest test/basic.spec.ts`
