### PR TITLE
Fix docs CSP header scope

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
-      "source": "/(.*)",
+      "source": "/((?!docs(?:/|$)).*)",
       "headers": [
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
## Summary
- Exclude `/docs` and `/docs/*` from the marketing site's global Vercel security headers.
- Let Mintlify docs routes use docs-compatible headers so its client bundle is not blocked by the website CSP.

## Verification
- `jq empty apps/website/vercel.json`
- Reproduced live CSP errors before the fix with browser console capture.
