### PR TITLE
Clean up create-libretto template

### DIFF
--- a/packages/create-libretto/template/_gitignore
+++ b/packages/create-libretto/template/_gitignore
@@ -2,3 +2,4 @@ node_modules
 .libretto/sessions/
 .libretto/profiles/
 dist/
+.env

--- a/packages/create-libretto/template/package.json.template
+++ b/packages/create-libretto/template/package.json.template
@@ -8,9 +8,11 @@
     "build": "tsc"
   },
   "dependencies": {
-    "libretto": "{{librettoVersion}}"
+    "libretto": "{{librettoVersion}}",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.8.0"
   }
 }

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import outdent from "outdent";
@@ -983,8 +984,16 @@ export default workflow("main", async (ctx) => {
   test("validates workflow params before starting a browser session", async ({
     librettoCli,
     librettoRuntimePath,
+    workspacePath,
     writeWorkflowScript,
   }) => {
+    // Link zod into the temp workspace so the script can resolve it
+    const require_ = createRequire(import.meta.url);
+    const zodDir = join(require_.resolve("zod"), "..");
+    const nodeModules = workspacePath("node_modules");
+    await mkdir(nodeModules, { recursive: true });
+    await symlink(zodDir, join(nodeModules, "zod"), "dir");
+
     await writeWorkflowScript(
       "integration.ts",
       outdent`


### PR DESCRIPTION
## Summary

Cleans up the `create-libretto` project template:

- Add `zod` (`^4.0.0`) as a dependency — needed for workflow input/output schemas
- Add `@types/node` (`^22.0.0`) as a devDependency — needed for Node.js type definitions
- Add `.env` to the template `.gitignore`

Also fixes a flaky test (`validates workflow params before starting a browser session`) that was failing because `zod` couldn't be resolved in the isolated temp workspace.
