### PR TITLE
Add cloud user id to CLI telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, build channel (`node_modules`, `source`, or `unknown`), and, when signed into Libretto Cloud, the configured cloud user id. Libretto does not send command arguments, URLs, project paths, session cookies, API keys, error messages or details, or emails.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`packages/libretto/src/cli/core/telemetry.ts`](packages/libretto/src/cli/core/telemetry.ts).
 

--- a/packages/libretto/README.md
+++ b/packages/libretto/README.md
@@ -95,7 +95,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, build channel (`node_modules`, `source`, or `unknown`), and, when signed into Libretto Cloud, the configured cloud user id. Libretto does not send command arguments, URLs, project paths, session cookies, API keys, error messages or details, or emails.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`src/cli/core/telemetry.ts`](src/cli/core/telemetry.ts).
 

--- a/packages/libretto/README.template.md
+++ b/packages/libretto/README.template.md
@@ -93,7 +93,7 @@ All Libretto state lives in a `.libretto/` directory at your project root. See t
 
 ## Telemetry
 
-Libretto records anonymous CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, and build channel (`node_modules`, `source`, or `unknown`). Libretto does not send command arguments, URLs, project paths, auth state, API keys, error messages or details, or user identity.
+Libretto records CLI telemetry to help understand CLI usage and help us prioritize improvements. Each resolved command can send only an install id, timestamp, command event name such as `libretto run`, error boolean, package version, build channel (`node_modules`, `source`, or `unknown`), and, when signed into Libretto Cloud, the configured cloud user id. Libretto does not send command arguments, URLs, project paths, session cookies, API keys, error messages or details, or emails.
 
 The install id is stored in the telemetry file at `~/.libretto/telemetry.json`. The implementation lives in [`{{LIBRETTO_PATH_PREFIX}}src/cli/core/telemetry.ts`]({{LIBRETTO_PATH_PREFIX}}src/cli/core/telemetry.ts).
 

--- a/packages/libretto/src/cli/core/telemetry.ts
+++ b/packages/libretto/src/cli/core/telemetry.ts
@@ -6,6 +6,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SimpleCLICommandMeta, SimpleCLIMiddleware } from "affordance";
 import { resolveHostedApiUrl } from "./auth-fetch.js";
+import { readAuthState } from "./auth-storage.js";
 
 const TELEMETRY_FILE_NAME = "telemetry.json";
 const TELEMETRY_ENDPOINT_PATH = "/v1/telemetry/recordCliEvent";
@@ -25,6 +26,7 @@ type CliTelemetryPayload = {
   error: boolean;
   packageVersion: string;
   buildChannel: BuildChannel;
+  cloudUserId?: string;
 };
 
 type PackageJson = {
@@ -109,7 +111,7 @@ function writeTelemetryNotice(): void {
   if (!process.stderr.isTTY) return;
   process.stderr.write(
     [
-      "Libretto collects anonymous CLI telemetry: install id, timestamp, command event, error status, package version, and build channel only.",
+      "Libretto collects CLI telemetry: install id, timestamp, command event, error status, package version, build channel, and signed-in cloud user id only.",
       "Set LIBRETTO_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1 to disable it, or set enabled:false in ~/.libretto/telemetry.json.",
     ].join(" ") + "\n",
   );
@@ -130,6 +132,7 @@ async function recordCliTelemetryEvent(
   if (isTelemetryDisabled()) return;
   const installId = await readOrCreateInstallId();
   if (!installId) return;
+  const cloudUserId = await readConfiguredCloudUserId();
 
   await sendWithTimeout({
     installId,
@@ -138,7 +141,18 @@ async function recordCliTelemetryEvent(
     error,
     packageVersion,
     buildChannel,
+    ...(cloudUserId ? { cloudUserId } : {}),
   });
+}
+
+async function readConfiguredCloudUserId(): Promise<string | null> {
+  try {
+    const state = await readAuthState();
+    const cloudUserId = state?.session?.userId;
+    return cloudUserId && cloudUserId.length > 0 ? cloudUserId : null;
+  } catch {
+    return null;
+  }
 }
 
 async function sendWithTimeout(payload: CliTelemetryPayload): Promise<void> {

--- a/packages/libretto/test/telemetry.spec.ts
+++ b/packages/libretto/test/telemetry.spec.ts
@@ -70,6 +70,49 @@ describe("CLI telemetry", () => {
     });
   });
 
+  test("includes configured cloud user id when signed in", async ({
+    librettoCli,
+    telemetryServer,
+    workspacePath,
+  }) => {
+    const home = workspacePath("home-cloud-account");
+    await mkdir(join(home, ".libretto"), { recursive: true });
+    await writeFile(
+      join(home, ".libretto", "auth.json"),
+      JSON.stringify(
+        {
+          apiUrl: telemetryServer.url,
+          session: {
+            cookie: "better-auth.session_token=test-session",
+            userId: "cloud-account-123",
+            email: "person@example.test",
+            expiresAt: null,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await librettoCli("status", {
+      HOME: home,
+      LIBRETTO_API_URL: telemetryServer.url,
+      LIBRETTO_TELEMETRY_DISABLED: undefined,
+      DO_NOT_TRACK: undefined,
+      CI: undefined,
+    });
+
+    expect(result.stdout).toContain("No open sessions.");
+    expect(telemetryServer.requests).toHaveLength(1);
+    expect(telemetryServer.requests[0]).toMatchObject({
+      body: {
+        json: {
+          cloudUserId: "cloud-account-123",
+        },
+      },
+    });
+  });
+
   test("records failing resolved command events without changing the error", async ({
     librettoCli,
     telemetryServer,


### PR DESCRIPTION
## Summary
- include the signed-in Libretto Cloud user id as optional `cloudUserId` in CLI telemetry payloads
- keep telemetry best-effort and tolerant of missing/broken auth state
- update telemetry disclosure text and add coverage for signed-in telemetry

## Tests
- `pnpm exec vitest run test/telemetry.spec.ts`
- `pnpm --dir packages/libretto/packages/libretto type-check`