### PR TITLE
Pass headless mode to Libretto Cloud provider

### DIFF
--- a/packages/libretto/src/cli/commands/browser.ts
+++ b/packages/libretto/src/cli/commands/browser.ts
@@ -132,6 +132,7 @@ export const openCommand = SimpleCLI.command({
       await runOpenWithProvider(
         input.url,
         providerName,
+        input.headless,
         ctx.session,
         ctx.logger,
         resolveRequestedSessionMode(input.readOnly, input.writeAccess),

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -92,6 +92,7 @@ export function createRunBrowserConfig(args: {
     return {
       kind: "provider",
       providerName: args.providerName,
+      headless: args.headless,
     };
   }
 

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -529,6 +529,7 @@ export async function runOpen(
 export async function runOpenWithProvider(
   rawUrl: string,
   providerName: string,
+  headless: boolean,
   session: string,
   logger: LoggerApi,
   accessMode: SessionAccessMode,
@@ -557,6 +558,7 @@ export async function runOpenWithProvider(
       browser: {
         kind: "provider",
         providerName,
+        headless,
         initialUrl: url,
       },
     },

--- a/packages/libretto/src/cli/core/daemon/config.ts
+++ b/packages/libretto/src/cli/core/daemon/config.ts
@@ -39,6 +39,7 @@ export type DaemonBrowserConnectConfig = {
 export type DaemonBrowserProviderConfig = {
   kind: "provider";
   providerName: string;
+  headless?: boolean;
   initialUrl?: string;
   authProfileName?: string;
   authProfilePersist?: boolean;

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -479,6 +479,7 @@ class BrowserDaemon {
       providerSession = await provider.createSession({
         authProfileName: config.authProfileName,
         authProfilePersist: config.authProfilePersist,
+        headless: config.headless,
       });
       const browser = await chromium.connectOverCDP(
         providerSession.cdpEndpoint,

--- a/packages/libretto/src/cli/core/providers/kernel.ts
+++ b/packages/libretto/src/cli/core/providers/kernel.ts
@@ -99,7 +99,8 @@ export function createKernelProvider(
   >();
 
   return {
-    async createSession() {
+    async createSession(sessionOptions) {
+      const sessionHeadless = sessionOptions?.headless ?? headless;
       const json = await kernelFetchJson<KernelBrowserResponse>(
         endpoint,
         apiKey,
@@ -107,7 +108,7 @@ export function createKernelProvider(
         {
           method: "POST",
           body: JSON.stringify({
-            headless,
+            headless: sessionHeadless,
             stealth,
             timeout_seconds: timeoutSeconds,
           }),

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -39,6 +39,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
             timeout_seconds: browserSessionTimeoutSeconds,
             profile_name: options?.authProfileName,
             profile_persist: options?.authProfilePersist,
+            headless: options?.headless,
           },
         }),
       });

--- a/packages/libretto/src/cli/core/providers/types.ts
+++ b/packages/libretto/src/cli/core/providers/types.ts
@@ -21,6 +21,7 @@ export type ProviderApi = {
   createSession(options?: {
     authProfileName?: string;
     authProfilePersist?: boolean;
+    headless?: boolean;
   }): Promise<ProviderSession>;
   closeSession(sessionId: string): Promise<ProviderCloseResult>;
 };

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -337,6 +337,34 @@ describe("Kernel provider", () => {
     });
   });
 
+  it("uses per-session headless mode before provider defaults", async () => {
+    vi.stubEnv("KERNEL_API_KEY", "env-key");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/browsers") {
+          return jsonResponse({
+            session_id: "kernel-session",
+            cdp_ws_url: "wss://kernel.example.test/cdp",
+            browser_live_view_url: null,
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createKernelProvider({
+      apiKey: "constructor-key",
+      headless: false,
+    }).createSession({ headless: true });
+
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toMatchObject({
+      headless: true,
+    });
+  });
+
   it("starts and stops replay recording when enabled", async () => {
     const fetchMock = vi.fn(
       async (url: string | URL | Request, init?: RequestInit) => {

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -429,6 +429,37 @@ describe("Libretto Cloud provider", () => {
     });
   });
 
+  it("passes requested headless mode to cloud browser sessions", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-headless",
+              status: "open",
+              cdp_url: "wss://cloud.example.test/devtools/session-headless",
+              live_view_url: null,
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const session = await createLibrettoCloudProvider().createSession({
+      headless: true,
+    });
+
+    expect(session.sessionId).toBe("session-headless");
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      json: { timeout_seconds: 3600, headless: true },
+    });
+  });
+
   it("waits for queued sessions to receive a CDP URL", async () => {
     vi.stubEnv("LIBRETTO_API_KEY", "test-key");
     vi.stubEnv("LIBRETTO_TIMEOUT_SECONDS", "123");

--- a/packages/libretto/test/run-window-position.spec.ts
+++ b/packages/libretto/test/run-window-position.spec.ts
@@ -40,6 +40,7 @@ describe("createRunBrowserConfig", () => {
     ).toEqual({
       kind: "provider",
       providerName: "kernel",
+      headless: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Thread provider headless mode through Libretto daemon provider config
- Include `headless` in Libretto Cloud `/v1/sessions/create` requests
- Cover provider request payload and workflow browser config in tests

## Validation
- `pnpm --dir packages/libretto -s test:vitest test/browser.spec.ts test/run-window-position.spec.ts`
- `pnpm --dir packages/libretto -s type-check`
- Built local CLI with `pnpm --dir packages/libretto build`
- Against local browser-automations API on port 8081, verified `libretto open --provider libretto-cloud --headless` created a Kernel session with `headless=true` and `recording=null`
- Against local browser-automations API on port 8081, verified `libretto run --provider libretto-cloud --headless` created and closed a Kernel session with `headless=true` and `recording=null`

No merge performed.