### PR TITLE
Add headless flag to cloud job creation

### DIFF
--- a/packages/libretto/src/cli/commands/cloud-jobs.ts
+++ b/packages/libretto/src/cli/commands/cloud-jobs.ts
@@ -68,6 +68,8 @@ export const createCloudJobInput = SimpleCLI.input({
       name: "timeout-seconds",
       help: "Job timeout in seconds",
     }),
+    headed: SimpleCLI.flag({ help: "Run browser in headed mode" }),
+    headless: SimpleCLI.flag({ help: "Run browser in headless mode" }),
     callbackUrl: SimpleCLI.option(z.string().optional(), {
       name: "callback-url",
       help: "Per-job callback URL",
@@ -90,6 +92,10 @@ export const createCloudJobInput = SimpleCLI.input({
   .refine(
     (input) => !(input.params && input.paramsFile),
     "Pass either --params or --params-file, not both.",
+  )
+  .refine(
+    (input) => !(input.headed && input.headless),
+    "Cannot pass both --headed and --headless.",
   )
   .refine(
     (input) =>
@@ -121,6 +127,8 @@ export const createCloudJobCommand = SimpleCLI.command({
     if (input.timeoutSeconds !== undefined) {
       payload.timeout_seconds = input.timeoutSeconds;
     }
+    if (input.headed) payload.headless = false;
+    if (input.headless) payload.headless = true;
     if (input.callbackUrl) payload.callback_url = input.callbackUrl;
     if (input.callbackSecret) payload.callback_secret = input.callbackSecret;
     if (input.skipCallbacks) payload.skip_callbacks = true;

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -896,7 +896,7 @@ export const runCommand = SimpleCLI.command({
       console.log(`Connecting to ${providerName} browser...`);
     }
 
-    const headless = daemonProviderName ? true : (headlessMode ?? false);
+    const headless = headlessMode ?? false;
     const windowPosition = headless
       ? undefined
       : resolveWindowPosition(ctx.logger);

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -378,6 +378,7 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("libretto cloud jobs create [workflow]");
     expect(result.stdout).toContain("--params-file");
     expect(result.stdout).toContain("--timeout-seconds");
+    expect(result.stdout).toContain("--headless");
     expect(result.stderr).toBe("");
   });
 

--- a/packages/libretto/test/run-window-position.spec.ts
+++ b/packages/libretto/test/run-window-position.spec.ts
@@ -43,4 +43,18 @@ describe("createRunBrowserConfig", () => {
       headless: true,
     });
   });
+
+  it("passes headed mode to provider workflow runs", () => {
+    expect(
+      createRunBrowserConfig({
+        providerName: "kernel",
+        headless: false,
+        windowPosition: { x: 536, y: 33 },
+      }),
+    ).toEqual({
+      kind: "provider",
+      providerName: "kernel",
+      headless: false,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `--headless` and `--headed` to `libretto cloud jobs create`
- Send `headless` to `/v1/jobs/create` when explicitly requested
- Make `libretto run --provider ...` default to headed mode locally, matching non-provider run behavior; `--headless` still requests headless

## Validation
- `pnpm --dir packages/libretto build`
- `pnpm --dir packages/libretto -s test:vitest test/basic.spec.ts -t "prints cloud jobs create help"`
- `pnpm --dir packages/libretto -s test:vitest test/run-window-position.spec.ts`
- `pnpm --dir packages/libretto -s type-check`

No merge performed.