### PR TITLE
Add workflow browser launch metadata

### DIFF
--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -22,6 +22,10 @@ import {
   LIBRETTO_WORKFLOW_BRAND,
 } from "../../shared/workflow/workflow.js";
 import { normalizeCredentialNames } from "../../shared/workflow/credentials.js";
+import {
+  ViewportConfigSchema,
+  type ViewportConfig,
+} from "./config.js";
 
 type PackageManifest = {
   name?: string;
@@ -59,10 +63,7 @@ export type WorkflowDeployMetadata = {
   authProfileRefresh?: boolean;
   startUrl?: string;
   gpu?: boolean;
-  viewport?: {
-    width: number;
-    height: number;
-  };
+  viewport?: ViewportConfig;
   sourceFile?: string;
   sourceFiles?: string[];
 };
@@ -887,12 +888,9 @@ function extractDiscoveryLaunchMetadata(
     typeof record.viewport === "object" &&
     !Array.isArray(record.viewport)
   ) {
-    const viewport = record.viewport as { width?: unknown; height?: unknown };
-    if (typeof viewport.width === "number" && typeof viewport.height === "number") {
-      metadata.viewport = {
-        width: viewport.width,
-        height: viewport.height,
-      };
+    const viewport = ViewportConfigSchema.safeParse(record.viewport);
+    if (viewport.success) {
+      metadata.viewport = viewport.data;
     }
   }
 

--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -57,6 +57,12 @@ export type WorkflowDeployMetadata = {
   credentialNames: string[];
   authProfileName?: string;
   authProfileRefresh?: boolean;
+  startUrl?: string;
+  gpu?: boolean;
+  viewport?: {
+    width: number;
+    height: number;
+  };
   sourceFile?: string;
   sourceFiles?: string[];
 };
@@ -825,6 +831,7 @@ function createDiscoveryLibrettoModule(
         name,
         ...extractDiscoveryCredentialMetadata(definitionOrHandler),
         ...extractDiscoveryAuthProfileMetadata(definitionOrHandler),
+        ...extractDiscoveryLaunchMetadata(definitionOrHandler),
       });
       return {
         [LIBRETTO_WORKFLOW_BRAND]: true,
@@ -847,6 +854,49 @@ function createDiscoveryLibrettoModule(
       return createExternalDiscoveryStub();
     },
   });
+}
+
+function extractDiscoveryLaunchMetadata(
+  definitionOrHandler: unknown,
+): Omit<
+  WorkflowDeployMetadata,
+  "name" | "credentialNames" | "authProfileName" | "authProfileRefresh"
+> {
+  if (!definitionOrHandler || typeof definitionOrHandler !== "object") {
+    return {};
+  }
+
+  const record = definitionOrHandler as {
+    startUrl?: unknown;
+    gpu?: unknown;
+    viewport?: unknown;
+  };
+  const metadata: Omit<
+    WorkflowDeployMetadata,
+    "name" | "credentialNames" | "authProfileName" | "authProfileRefresh"
+  > = {};
+
+  if (typeof record.startUrl === "string") {
+    metadata.startUrl = record.startUrl;
+  }
+  if (typeof record.gpu === "boolean") {
+    metadata.gpu = record.gpu;
+  }
+  if (
+    record.viewport &&
+    typeof record.viewport === "object" &&
+    !Array.isArray(record.viewport)
+  ) {
+    const viewport = record.viewport as { width?: unknown; height?: unknown };
+    if (typeof viewport.width === "number" && typeof viewport.height === "number") {
+      metadata.viewport = {
+        width: viewport.width,
+        height: viewport.height,
+      };
+    }
+  }
+
+  return metadata;
 }
 
 function extractDiscoveryCredentialMetadata(
@@ -982,6 +1032,9 @@ function createBootstrapSource(args: {
           credentialNames: workflow.credentialNames,
           authProfileName: workflow.authProfileName,
           authProfileRefresh: workflow.authProfileRefresh,
+          startUrl: workflow.startUrl,
+          gpu: workflow.gpu,
+          viewport: workflow.viewport,
         })});`,
     )
     .join("\n");
@@ -1069,23 +1122,21 @@ function createWorkflowProxy(workflowName, metadata) {
     return await target.run(ctx, input);
   };
 
-  if (!metadata?.authProfileName) {
-    return workflow(workflowName, {
-      credentials: Array.isArray(metadata?.credentialNames)
-        ? metadata.credentialNames
-        : [],
-      handler,
-    });
-  }
-
   return workflow(workflowName, {
-    credentials: Array.isArray(metadata.credentialNames)
+    credentials: Array.isArray(metadata?.credentialNames)
       ? metadata.credentialNames
       : [],
-    authProfile: {
-      name: metadata.authProfileName,
-      ...(typeof metadata.authProfileRefresh === "boolean" ? { refresh: metadata.authProfileRefresh } : {}),
-    },
+    ...(metadata?.authProfileName
+      ? {
+          authProfile: {
+            name: metadata.authProfileName,
+            ...(typeof metadata.authProfileRefresh === "boolean" ? { refresh: metadata.authProfileRefresh } : {}),
+          },
+        }
+      : {}),
+    ...(typeof metadata?.startUrl === "string" ? { startUrl: metadata.startUrl } : {}),
+    ...(typeof metadata?.gpu === "boolean" ? { gpu: metadata.gpu } : {}),
+    ...(metadata?.viewport ? { viewport: metadata.viewport } : {}),
     handler,
   });
 }

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -131,7 +131,6 @@ export {
   type LibrettoWorkflowDefinition,
   type LibrettoWorkflowHandler,
   type LibrettoWorkflowOptions,
-  type LibrettoWorkflowViewport,
   type WorkflowInputValidator,
 } from "./shared/workflow/workflow.js";
 export {

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -128,8 +128,10 @@ export {
   workflow,
   type ExportedLibrettoWorkflow,
   type LibrettoWorkflowContext,
+  type LibrettoWorkflowDefinition,
   type LibrettoWorkflowHandler,
   type LibrettoWorkflowOptions,
+  type LibrettoWorkflowViewport,
   type WorkflowInputValidator,
 } from "./shared/workflow/workflow.js";
 export {

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -30,8 +30,6 @@ export type LibrettoWorkflowAuthProfile =
       refresh?: boolean;
     };
 
-export type LibrettoWorkflowViewport = ViewportConfig;
-
 export type LibrettoWorkflowDefinition<
   InputSchema extends z.ZodType = z.ZodType<unknown>,
   OutputSchema extends z.ZodType = z.ZodType<unknown>,
@@ -42,7 +40,7 @@ export type LibrettoWorkflowDefinition<
   authProfile?: LibrettoWorkflowAuthProfile;
   startUrl?: string;
   gpu?: boolean;
-  viewport?: LibrettoWorkflowViewport;
+  viewport?: ViewportConfig;
   recoveryAction?: RecoveryAction;
 };
 
@@ -163,7 +161,7 @@ export class LibrettoWorkflow<
   public readonly authProfileRefresh?: boolean;
   public readonly startUrl?: string;
   public readonly gpu?: boolean;
-  public readonly viewport?: LibrettoWorkflowViewport;
+  public readonly viewport?: ViewportConfig;
   public readonly recoveryAction?: RecoveryAction;
   private readonly handler: LibrettoWorkflowHandler<
     z.infer<InputSchema>,
@@ -181,7 +179,7 @@ export class LibrettoWorkflow<
           authProfileRefresh?: boolean;
           startUrl?: string;
           gpu?: boolean;
-          viewport?: LibrettoWorkflowViewport;
+          viewport?: ViewportConfig;
           recoveryAction?: RecoveryAction;
         }
       | undefined,
@@ -235,7 +233,7 @@ export type ExportedLibrettoWorkflow = {
   readonly authProfileRefresh?: boolean;
   readonly startUrl?: string;
   readonly gpu?: boolean;
-  readonly viewport?: LibrettoWorkflowViewport;
+  readonly viewport?: ViewportConfig;
   readonly recoveryAction?: RecoveryAction;
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
@@ -342,7 +340,7 @@ function getWorkflowConstructorOptions<
   authProfileRefresh?: boolean;
   startUrl?: string;
   gpu?: boolean;
-  viewport?: LibrettoWorkflowViewport;
+  viewport?: ViewportConfig;
   recoveryAction?: RecoveryAction;
 } {
   const authProfile = normalizeWorkflowAuthProfile(options.authProfile);

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -4,6 +4,7 @@ import {
   createRecoveryPage,
   type RecoveryAction,
 } from "../../runtime/recovery/page-fallbacks.js";
+import type { ViewportConfig } from "../../cli/core/config.js";
 import { normalizeProfileName } from "./auth-profile-name.js";
 import {
   mergeCredentialsIntoInput,
@@ -29,10 +30,7 @@ export type LibrettoWorkflowAuthProfile =
       refresh?: boolean;
     };
 
-export type LibrettoWorkflowViewport = {
-  width: number;
-  height: number;
-};
+export type LibrettoWorkflowViewport = ViewportConfig;
 
 export type LibrettoWorkflowDefinition<
   InputSchema extends z.ZodType = z.ZodType<unknown>,

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -29,6 +29,11 @@ export type LibrettoWorkflowAuthProfile =
       refresh?: boolean;
     };
 
+export type LibrettoWorkflowViewport = {
+  width: number;
+  height: number;
+};
+
 export type LibrettoWorkflowDefinition<
   InputSchema extends z.ZodType = z.ZodType<unknown>,
   OutputSchema extends z.ZodType = z.ZodType<unknown>,
@@ -37,6 +42,9 @@ export type LibrettoWorkflowDefinition<
   output?: OutputSchema;
   credentials?: readonly string[];
   authProfile?: LibrettoWorkflowAuthProfile;
+  startUrl?: string;
+  gpu?: boolean;
+  viewport?: LibrettoWorkflowViewport;
   recoveryAction?: RecoveryAction;
 };
 
@@ -155,6 +163,9 @@ export class LibrettoWorkflow<
   public readonly credentialNames: readonly string[];
   public readonly authProfileName?: string;
   public readonly authProfileRefresh?: boolean;
+  public readonly startUrl?: string;
+  public readonly gpu?: boolean;
+  public readonly viewport?: LibrettoWorkflowViewport;
   public readonly recoveryAction?: RecoveryAction;
   private readonly handler: LibrettoWorkflowHandler<
     z.infer<InputSchema>,
@@ -170,6 +181,9 @@ export class LibrettoWorkflow<
           credentialNames?: readonly string[];
           authProfileName?: string;
           authProfileRefresh?: boolean;
+          startUrl?: string;
+          gpu?: boolean;
+          viewport?: LibrettoWorkflowViewport;
           recoveryAction?: RecoveryAction;
         }
       | undefined,
@@ -184,6 +198,9 @@ export class LibrettoWorkflow<
     this.credentialNames = options?.credentialNames ?? [];
     this.authProfileName = options?.authProfileName;
     this.authProfileRefresh = options?.authProfileRefresh;
+    this.startUrl = options?.startUrl;
+    this.gpu = options?.gpu;
+    this.viewport = options?.viewport;
     this.recoveryAction = options?.recoveryAction;
     this.handler = handler;
   }
@@ -218,6 +235,9 @@ export type ExportedLibrettoWorkflow = {
   readonly credentialNames: readonly string[];
   readonly authProfileName?: string;
   readonly authProfileRefresh?: boolean;
+  readonly startUrl?: string;
+  readonly gpu?: boolean;
+  readonly viewport?: LibrettoWorkflowViewport;
   readonly recoveryAction?: RecoveryAction;
   run: (ctx: LibrettoWorkflowContext, input: unknown) => Promise<unknown>;
 };
@@ -322,6 +342,9 @@ function getWorkflowConstructorOptions<
   credentialNames: readonly string[];
   authProfileName?: string;
   authProfileRefresh?: boolean;
+  startUrl?: string;
+  gpu?: boolean;
+  viewport?: LibrettoWorkflowViewport;
   recoveryAction?: RecoveryAction;
 } {
   const authProfile = normalizeWorkflowAuthProfile(options.authProfile);
@@ -331,6 +354,9 @@ function getWorkflowConstructorOptions<
     credentialNames: normalizeCredentialNames(options.credentials),
     authProfileName: authProfile?.name,
     authProfileRefresh: authProfile?.refresh,
+    startUrl: options.startUrl,
+    gpu: options.gpu,
+    viewport: options.viewport,
     recoveryAction: options.recoveryAction,
   };
 }

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -478,7 +478,7 @@ describe("createHostedDeployPackage", () => {
     expect(implementation).toContain("lodash");
   });
 
-  it("preserves workflow auth profile name and refresh metadata without site metadata", async () => {
+  it("preserves workflow auth profile and browser launch metadata without site metadata", async () => {
     const workspaceRoot = createWorkspaceRoot();
     const sourceDir = join(workspaceRoot, "apps", "worker");
     const entryPoint = join(sourceDir, "src", "workflow.ts");
@@ -501,7 +501,13 @@ describe("createHostedDeployPackage", () => {
         "",
         "export const testWorkflow = workflow(",
         '  "testWorkflow",',
-        '  { credentials: ["openai_api_key"], authProfile: { name: "twitter", refresh: true } },',
+        "  {",
+        '    credentials: ["openai_api_key"],',
+        '    authProfile: { name: "twitter", refresh: true },',
+        '    startUrl: "https://example.com/start",',
+        "    gpu: true,",
+        "    viewport: { width: 1440, height: 900 },",
+        "  },",
         "  async () => ({ ok: true }),",
         ");",
         "",
@@ -521,9 +527,12 @@ describe("createHostedDeployPackage", () => {
         authProfileName: "twitter",
         authProfileRefresh: true,
         credentialNames: ["openai_api_key"],
+        gpu: true,
         name: "testWorkflow",
         sourceFile: "src/workflow.ts",
         sourceFiles: ["src/workflow.ts"],
+        startUrl: "https://example.com/start",
+        viewport: { width: 1440, height: 900 },
       },
     ]);
 
@@ -532,7 +541,7 @@ describe("createHostedDeployPackage", () => {
       "utf8",
     );
     expect(bundle).toContain(
-      'createWorkflowProxy("testWorkflow", {"credentialNames":["openai_api_key"],"authProfileName":"twitter","authProfileRefresh":true})',
+      'createWorkflowProxy("testWorkflow", {"credentialNames":["openai_api_key"],"authProfileName":"twitter","authProfileRefresh":true,"startUrl":"https://example.com/start","gpu":true,"viewport":{"width":1440,"height":900}})',
     );
     expect(bundle).not.toContain("authProfileSites");
     expect(bundle).not.toContain("sites:");

--- a/packages/libretto/test/workflow-zod-schema.spec.ts
+++ b/packages/libretto/test/workflow-zod-schema.spec.ts
@@ -56,6 +56,27 @@ describe("workflow() with Zod schemas", () => {
     expect("authProfileSites" in wf).toBe(false);
   });
 
+  it("exposes browser launch metadata for hosted workflow discovery", () => {
+    const wf = workflow(
+      "launch-configured",
+      {
+        input: inputSchema,
+        output: outputSchema,
+        startUrl: "https://example.com/start",
+        gpu: true,
+        viewport: { width: 1440, height: 900 },
+      },
+      async (_ctx, input) => ({
+        pageTitle: "x",
+        finalUrl: input.url,
+      }),
+    );
+
+    expect(wf.startUrl).toBe("https://example.com/start");
+    expect(wf.gpu).toBe(true);
+    expect(wf.viewport).toEqual({ width: 1440, height: 900 });
+  });
+
   it("rejects invalid workflow auth profile names", () => {
     expect(() =>
       workflow(


### PR DESCRIPTION
## Summary

- add `startUrl`, `gpu`, and `viewport` to workflow declaration metadata
- expose the launch metadata on `LibrettoWorkflow` / `ExportedLibrettoWorkflow` and package exports
- preserve launch metadata through hosted deploy discovery and generated workflow proxies

## Tests

- `pnpm --dir packages/libretto type-check`
- `pnpm --dir packages/libretto lint`
- `pnpm --dir packages/libretto exec vitest run test/workflow-zod-schema.spec.ts test/deploy-artifact.spec.ts -t "browser launch metadata|auth profile and browser launch metadata"`

## Notes

- This is the Libretto-side release prerequisite for `saffron-health/libretto-cloud#175`.
- No package version bump here; Tanishq will make the proper release.
