### PR TITLE
browser-tools: add live agent evals

### DIFF
--- a/packages/browser-tools/evals/hn-top-story.eval.ts
+++ b/packages/browser-tools/evals/hn-top-story.eval.ts
@@ -1,0 +1,43 @@
+import { openai } from "@ai-sdk/openai";
+import { stepCountIs, ToolLoopAgent } from "ai";
+import { expect, test } from "vitest";
+import { createAiSdkBrowserTools } from "../src/adapters/ai-sdk/index.js";
+import { LocalBrowserProvider } from "../src/providers/local.js";
+import { requireOpenAiApiKey } from "./setup.js";
+
+test("reads the first Hacker News story title", async () => {
+	requireOpenAiApiKey();
+
+	const { tools, dispose } = createAiSdkBrowserTools(
+		new LocalBrowserProvider({ headless: true }),
+	);
+
+	try {
+		const agent = new ToolLoopAgent({
+			model: openai("gpt-5.5"),
+			tools,
+			stopWhen: stepCountIs(8),
+			providerOptions: {
+				openai: {
+					// Required for Zero Data Retention orgs.
+					store: false,
+				},
+			},
+		});
+
+		const result = await agent.generate({
+			prompt:
+				"Open https://news.ycombinator.com, read the page, and reply with only " +
+				"the title of the first story link on the page (no commentary).",
+		});
+
+		const toolCalls = result.steps.flatMap((step) => step.toolCalls);
+
+		expect(result.text.trim().length).toBeGreaterThan(0);
+		expect(toolCalls.some((call) => call.toolName === "browser_open")).toBe(
+			true,
+		);
+	} finally {
+		await dispose();
+	}
+});

--- a/packages/browser-tools/evals/setup.ts
+++ b/packages/browser-tools/evals/setup.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "../../..");
+const envPath = join(repoRoot, ".env");
+
+if (existsSync(envPath)) {
+	for (const line of readFileSync(envPath, "utf8").split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = trimmed.indexOf("=");
+		if (eq <= 0) continue;
+		const key = trimmed.slice(0, eq);
+		const value = trimmed.slice(eq + 1);
+		if (process.env[key] === undefined) process.env[key] = value;
+	}
+}
+
+export function requireOpenAiApiKey(): string {
+	const apiKey = process.env.OPENAI_API_KEY?.trim();
+	if (!apiKey) {
+		throw new Error(
+			"OPENAI_API_KEY is not loaded. Add it to repo-root .env before running evals.",
+		);
+	}
+	return apiKey;
+}
+
+requireOpenAiApiKey();

--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -36,6 +36,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:vitest": "vitest run",
+    "evals": "vitest run --config vitest.evals.config.ts",
     "prepack": "pnpm run build"
   },
   "dependencies": {

--- a/packages/browser-tools/vitest.evals.config.ts
+++ b/packages/browser-tools/vitest.evals.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		name: "browser-tools-evals",
+		environment: "node",
+		setupFiles: ["evals/setup.ts"],
+		include: ["evals/**/*.eval.ts"],
+		testTimeout: 120_000,
+		pool: "forks",
+		isolate: true,
+		fileParallelism: false,
+		maxWorkers: 1,
+		reporters: ["minimal"],
+	},
+});


### PR DESCRIPTION
## Summary
- Add package-local Vitest eval runner (`pnpm --filter @libretto/browser-tools evals`) with a separate config from unit tests
- Load `OPENAI_API_KEY` from repo-root `.env`; evals fail fast if missing
- First live case: HN top-story title via `ToolLoopAgent` + `createAiSdkBrowserTools` + `LocalBrowserProvider`

## Test plan
- [x] `pnpm --filter @libretto/browser-tools test` (36 unit tests, no API key)
- [x] `pnpm --filter @libretto/browser-tools evals` with repo-root `.env` set


Made with [Cursor](https://cursor.com)