### PR TITLE
browser-tools: full session control (status, close, connect)

### DIFF
--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -10,8 +10,8 @@ import { LocalBrowserProvider } from "@libretto/browser-tools";
 
 // Cloud providers (Libretto Cloud, Browserbase, Kernel, ...) are on the way.
 const { tools, dispose } = createAiSdkBrowserTools(new LocalBrowserProvider());
-// The agent can now call browser_open and browser_exec.
-// Coming next: browser_snapshot, browser_status, browser_close, browser_connect.
+// The agent can now call browser_open, browser_connect, browser_exec,
+// browser_snapshot, browser_status, and browser_close.
 
 const result = await generateText({
   model: anthropic("claude-sonnet-4-5"),

--- a/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
@@ -37,13 +37,16 @@ const test = base.extend<{ toolkit: Toolkit }>({
 	},
 });
 
-test("createAiSdkBrowserTools exposes browser_open, browser_exec, and browser_snapshot", ({
+test("createAiSdkBrowserTools exposes all six browser tools", ({
 	toolkit,
 }) => {
 	expect(Object.keys(toolkit.tools).sort()).toEqual([
+		"browser_close",
+		"browser_connect",
 		"browser_exec",
 		"browser_open",
 		"browser_snapshot",
+		"browser_status",
 	]);
 });
 

--- a/packages/browser-tools/src/adapters/ai-sdk/index.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.ts
@@ -13,7 +13,14 @@ export function createAiSdkBrowserTools(provider: BrowserProvider): {
 	dispose(): Promise<void>;
 } {
 	const base = createBrowserTools(provider);
-	const { browser_open, browser_exec, browser_snapshot } = base.tools;
+	const {
+		browser_open,
+		browser_exec,
+		browser_snapshot,
+		browser_status,
+		browser_close,
+		browser_connect,
+	} = base.tools;
 	return {
 		tools: {
 			browser_open: tool({
@@ -31,6 +38,21 @@ export function createAiSdkBrowserTools(provider: BrowserProvider): {
 				inputSchema: browser_snapshot.inputSchema,
 				execute: (input) => browser_snapshot.execute(input),
 				toModelOutput: snapshotToModelOutput,
+			}),
+			browser_status: tool({
+				description: browser_status.description,
+				inputSchema: browser_status.inputSchema,
+				execute: (input) => browser_status.execute(input),
+			}),
+			browser_close: tool({
+				description: browser_close.description,
+				inputSchema: browser_close.inputSchema,
+				execute: (input) => browser_close.execute(input),
+			}),
+			browser_connect: tool({
+				description: browser_connect.description,
+				inputSchema: browser_connect.inputSchema,
+				execute: (input) => browser_connect.execute(input),
 			}),
 		},
 		dispose: base.dispose,

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -1,17 +1,26 @@
 import type { BrowserProvider } from "./provider.js";
 import { SessionRegistry } from "./session-registry.js";
+import type { CloseTool } from "./tools/close.js";
+import { createCloseTool } from "./tools/close.js";
+import type { ConnectTool } from "./tools/connect.js";
+import { createConnectTool } from "./tools/connect.js";
 import type { ExecTool } from "./tools/exec.js";
 import { createExecTool } from "./tools/exec.js";
 import type { OpenTool } from "./tools/open.js";
 import { createOpenTool } from "./tools/open.js";
 import type { SnapshotTool } from "./tools/snapshot.js";
 import { createSnapshotTool } from "./tools/snapshot.js";
+import type { StatusTool } from "./tools/status.js";
+import { createStatusTool } from "./tools/status.js";
 
 export interface BrowserToolkit {
 	tools: {
 		browser_open: OpenTool;
 		browser_exec: ExecTool;
 		browser_snapshot: SnapshotTool;
+		browser_status: StatusTool;
+		browser_close: CloseTool;
+		browser_connect: ConnectTool;
 	};
 	/** Closes every session opened through this toolkit. */
 	dispose(): Promise<void>;
@@ -28,6 +37,9 @@ export function createBrowserTools(provider: BrowserProvider): BrowserToolkit {
 			browser_open: createOpenTool(registry),
 			browser_exec: createExecTool(registry),
 			browser_snapshot: createSnapshotTool(registry),
+			browser_status: createStatusTool(registry),
+			browser_close: createCloseTool(registry),
+			browser_connect: createConnectTool(registry),
 		},
 		dispose: () => registry.dispose(),
 	};

--- a/packages/browser-tools/src/session-registry.spec.ts
+++ b/packages/browser-tools/src/session-registry.spec.ts
@@ -51,9 +51,9 @@ test("getCurrentPage tracks the newest page in the session", async ({
 	expect(registry.getCurrentPage(sessionId)).toBe(newest);
 	expect(await registry.getCurrentPage(sessionId).title()).toBe("newest");
 
-	const pages = registry.listSessionPages(sessionId);
-	expect(pages).toHaveLength(2);
-	expect(pages.filter((page) => page.active)).toEqual([
+	const [session] = registry.listSessions();
+	expect(session.pages).toHaveLength(2);
+	expect(session.pages.filter((page) => page.active)).toEqual([
 		expect.objectContaining({ url: expect.stringContaining("newest") }),
 	]);
 });

--- a/packages/browser-tools/src/session-registry.spec.ts
+++ b/packages/browser-tools/src/session-registry.spec.ts
@@ -50,6 +50,12 @@ test("getCurrentPage tracks the newest page in the session", async ({
 
 	expect(registry.getCurrentPage(sessionId)).toBe(newest);
 	expect(await registry.getCurrentPage(sessionId).title()).toBe("newest");
+
+	const pages = registry.listSessionPages(sessionId);
+	expect(pages).toHaveLength(2);
+	expect(pages.filter((page) => page.active)).toEqual([
+		expect.objectContaining({ url: expect.stringContaining("newest") }),
+	]);
 });
 
 test("unknown session ID throws with the ID in the message", ({ registry }) => {

--- a/packages/browser-tools/src/session-registry.spec.ts
+++ b/packages/browser-tools/src/session-registry.spec.ts
@@ -96,7 +96,7 @@ test("beforeExit disposes leftover sessions as a backstop", async ({
 	await vi.waitFor(() => expect(registry.listSessions()).toHaveLength(0));
 });
 
-test("dispose removes the exit hooks it installed", async ({ registry }) => {
+test("dispose removes the beforeExit hook it installed", async ({ registry }) => {
 	const before = process.listenerCount("beforeExit");
 	await registry.openSession();
 	expect(process.listenerCount("beforeExit")).toBeGreaterThan(before);

--- a/packages/browser-tools/src/session-registry.spec.ts
+++ b/packages/browser-tools/src/session-registry.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test as base } from "vitest";
+import { expect, test as base, vi } from "vitest";
 import { LocalBrowserProvider } from "./providers/local.js";
 import { SessionRegistry } from "./session-registry.js";
 
@@ -83,4 +83,24 @@ test("dispose closes all sessions and is idempotent", async ({ registry }) => {
 	);
 
 	await registry.dispose();
+});
+
+test("beforeExit disposes leftover sessions as a backstop", async ({
+	registry,
+}) => {
+	await registry.openSession();
+	expect(registry.listSessions()).toHaveLength(1);
+
+	process.emit("beforeExit", 0);
+
+	await vi.waitFor(() => expect(registry.listSessions()).toHaveLength(0));
+});
+
+test("dispose removes the exit hooks it installed", async ({ registry }) => {
+	const before = process.listenerCount("beforeExit");
+	await registry.openSession();
+	expect(process.listenerCount("beforeExit")).toBeGreaterThan(before);
+
+	await registry.dispose();
+	expect(process.listenerCount("beforeExit")).toBe(before);
 });

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -90,11 +90,7 @@ export class SessionRegistry {
 		return { sessionId };
 	}
 
-	getCurrentPage(sessionId: string): Page {
-		return this.resolvePage(sessionId);
-	}
-
-	resolvePage(sessionId: string, pageId?: string): Page {
+	getCurrentPage(sessionId: string, pageId?: string): Page {
 		const entry = this.requireSession(sessionId);
 		if (pageId) {
 			const page = entry.pageById.get(pageId);
@@ -121,24 +117,16 @@ export class SessionRegistry {
 	}
 
 	listSessions(): SessionSummary[] {
-		const summaries: SessionSummary[] = [];
-		for (const [sessionId, entry] of this.sessions) {
-			summaries.push({
-				sessionId,
-				provider: entry.providerName,
-				pages: this.listPagesForEntry(entry),
-			});
-		}
-		return summaries;
-	}
-
-	listSessionPages(sessionId: string): SessionPageSummary[] {
-		return this.listPagesForEntry(this.requireSession(sessionId));
+		return [...this.sessions].map(([sessionId, entry]) => ({
+			sessionId,
+			provider: entry.providerName,
+			pages: this.listPagesForEntry(entry),
+		}));
 	}
 
 	async getPageStatus(sessionId: string, pageId: string): Promise<PageStatus> {
-		const page = this.resolvePage(sessionId, pageId);
-		const activePage = this.resolvePage(sessionId);
+		const page = this.getCurrentPage(sessionId, pageId);
+		const activePage = this.getCurrentPage(sessionId);
 		return {
 			pageId,
 			url: page.url(),
@@ -165,7 +153,7 @@ export class SessionRegistry {
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
 		if (!pageId && entry.latestSnapshot) return entry.latestSnapshot;
-		return captureSnapshot(this.resolvePage(sessionId, pageId));
+		return captureSnapshot(this.getCurrentPage(sessionId, pageId));
 	}
 
 	/** Capture after exec and cache for the next call's baseline. */
@@ -174,7 +162,7 @@ export class SessionRegistry {
 		pageId?: string,
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		const after = await captureSnapshot(this.resolvePage(sessionId, pageId));
+		const after = await captureSnapshot(this.getCurrentPage(sessionId, pageId));
 		if (!pageId) entry.latestSnapshot = after;
 		return after;
 	}

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -14,8 +14,8 @@ interface SessionEntry {
 	context: BrowserContext;
 	currentPage: Page | undefined;
 	pageById: Map<string, Page>;
-	/** Post-exec snapshot baseline per page ID for snapshot diffs. */
-	latestSnapshotByPageId: Map<string, Snapshot>;
+	/** Post-exec snapshot baseline per page for snapshot diffs. */
+	latestSnapshotByPage: Map<Page, Snapshot>;
 }
 
 export interface SessionPageSummary {
@@ -159,10 +159,10 @@ export class SessionRegistry {
 		pageId?: string,
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		const cacheKey = this.snapshotPageId(entry, sessionId, pageId);
-		const cached = entry.latestSnapshotByPageId.get(cacheKey);
+		const page = this.getCurrentPage(sessionId, pageId);
+		const cached = entry.latestSnapshotByPage.get(page);
 		if (cached) return cached;
-		return captureSnapshot(this.getCurrentPage(sessionId, pageId));
+		return captureSnapshot(page);
 	}
 
 	/** Capture after exec and cache for the next call's baseline. */
@@ -171,15 +171,15 @@ export class SessionRegistry {
 		pageId?: string,
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		const cacheKey = this.snapshotPageId(entry, sessionId, pageId);
-		const after = await captureSnapshot(this.getCurrentPage(sessionId, pageId));
-		entry.latestSnapshotByPageId.set(cacheKey, after);
+		const page = this.getCurrentPage(sessionId, pageId);
+		const after = await captureSnapshot(page);
+		entry.latestSnapshotByPage.set(page, after);
 		return after;
 	}
 
 	clearSnapshotCache(sessionId: string): void {
 		const entry = this.sessions.get(sessionId);
-		if (entry) entry.latestSnapshotByPageId.clear();
+		if (entry) entry.latestSnapshotByPage.clear();
 	}
 
 	async dispose(): Promise<void> {
@@ -245,7 +245,7 @@ export class SessionRegistry {
 			context: args.context,
 			currentPage: undefined,
 			pageById: new Map(),
-			latestSnapshotByPageId: new Map(),
+			latestSnapshotByPage: new Map(),
 		};
 		// Newest page wins, so popups and tabs become current automatically.
 		args.context.on("page", (page) => {
@@ -265,7 +265,7 @@ export class SessionRegistry {
 		entry.pageById.set(pageId, page);
 		page.on("close", () => {
 			entry.pageById.delete(pageId);
-			entry.latestSnapshotByPageId.delete(pageId);
+			entry.latestSnapshotByPage.delete(page);
 			if (entry.currentPage === page) {
 				entry.currentPage = undefined;
 			}
@@ -279,32 +279,6 @@ export class SessionRegistry {
 			if (trackedPage === page) return pageId;
 		}
 		return undefined;
-	}
-
-	private snapshotPageId(
-		entry: SessionEntry,
-		sessionId: string,
-		pageId?: string,
-	): string {
-		if (pageId) {
-			const page = entry.pageById.get(pageId);
-			if (!page || page.isClosed()) {
-				throw new Error(
-					`Unknown page ID "${pageId}" in session "${sessionId}". ` +
-						"Call browser_status to list open pages.",
-				);
-			}
-			return pageId;
-		}
-
-		const page = this.getCurrentPage(sessionId);
-		const resolvedPageId = this.findPageId(entry, page);
-		if (!resolvedPageId) {
-			throw new Error(
-				`Session "${sessionId}" has no tracked page for the current tab.`,
-			);
-		}
-		return resolvedPageId;
 	}
 
 	private listPagesForEntry(entry: SessionEntry): SessionPageSummary[] {

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -14,7 +14,8 @@ interface SessionEntry {
 	context: BrowserContext;
 	currentPage: Page | undefined;
 	pageById: Map<string, Page>;
-	latestSnapshot?: Snapshot;
+	/** Post-exec snapshot baseline per page ID for snapshot diffs. */
+	latestSnapshotByPageId: Map<string, Snapshot>;
 }
 
 export interface SessionPageSummary {
@@ -158,7 +159,9 @@ export class SessionRegistry {
 		pageId?: string,
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		if (!pageId && entry.latestSnapshot) return entry.latestSnapshot;
+		const cacheKey = this.snapshotPageId(entry, sessionId, pageId);
+		const cached = entry.latestSnapshotByPageId.get(cacheKey);
+		if (cached) return cached;
 		return captureSnapshot(this.getCurrentPage(sessionId, pageId));
 	}
 
@@ -168,14 +171,15 @@ export class SessionRegistry {
 		pageId?: string,
 	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
+		const cacheKey = this.snapshotPageId(entry, sessionId, pageId);
 		const after = await captureSnapshot(this.getCurrentPage(sessionId, pageId));
-		if (!pageId) entry.latestSnapshot = after;
+		entry.latestSnapshotByPageId.set(cacheKey, after);
 		return after;
 	}
 
 	clearSnapshotCache(sessionId: string): void {
 		const entry = this.sessions.get(sessionId);
-		if (entry) delete entry.latestSnapshot;
+		if (entry) entry.latestSnapshotByPageId.clear();
 	}
 
 	async dispose(): Promise<void> {
@@ -241,6 +245,7 @@ export class SessionRegistry {
 			context: args.context,
 			currentPage: undefined,
 			pageById: new Map(),
+			latestSnapshotByPageId: new Map(),
 		};
 		// Newest page wins, so popups and tabs become current automatically.
 		args.context.on("page", (page) => {
@@ -260,6 +265,7 @@ export class SessionRegistry {
 		entry.pageById.set(pageId, page);
 		page.on("close", () => {
 			entry.pageById.delete(pageId);
+			entry.latestSnapshotByPageId.delete(pageId);
 			if (entry.currentPage === page) {
 				entry.currentPage = undefined;
 			}
@@ -273,6 +279,32 @@ export class SessionRegistry {
 			if (trackedPage === page) return pageId;
 		}
 		return undefined;
+	}
+
+	private snapshotPageId(
+		entry: SessionEntry,
+		sessionId: string,
+		pageId?: string,
+	): string {
+		if (pageId) {
+			const page = entry.pageById.get(pageId);
+			if (!page || page.isClosed()) {
+				throw new Error(
+					`Unknown page ID "${pageId}" in session "${sessionId}". ` +
+						"Call browser_status to list open pages.",
+				);
+			}
+			return pageId;
+		}
+
+		const page = this.getCurrentPage(sessionId);
+		const resolvedPageId = this.findPageId(entry, page);
+		if (!resolvedPageId) {
+			throw new Error(
+				`Session "${sessionId}" has no tracked page for the current tab.`,
+			);
+		}
+		return resolvedPageId;
 	}
 
 	private listPagesForEntry(entry: SessionEntry): SessionPageSummary[] {

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -6,11 +6,36 @@ import { snapshot as captureSnapshot } from "./snapshot/capture-snapshot.js";
 import type { BrowserProvider } from "./provider.js";
 
 interface SessionEntry {
-	providerSessionId: string;
+	providerSessionId: string | undefined;
+	providerName: string;
+	/** True for browser_connect sessions — close detaches without killing the browser. */
+	attached: boolean;
 	browser: Browser;
 	context: BrowserContext;
 	currentPage: Page | undefined;
+	pageById: Map<string, Page>;
 	latestSnapshot?: Snapshot;
+}
+
+export interface SessionPageSummary {
+	pageId: string;
+	url: string;
+	active: boolean;
+}
+
+export interface SessionSummary {
+	sessionId: string;
+	provider: string;
+	pages: SessionPageSummary[];
+}
+
+export interface PageStatus {
+	pageId: string;
+	url: string;
+	title: string;
+	viewport: { width: number; height: number } | null;
+	active: boolean;
+	readyState: string;
 }
 
 /**
@@ -26,21 +51,38 @@ export class SessionRegistry {
 	async openSession(): Promise<{ sessionId: string }> {
 		const providerSession = await this.provider.createSession();
 		const browser = await chromium.connectOverCDP(providerSession.cdpEndpoint);
-
 		const context = browser.contexts()[0] ?? (await browser.newContext());
-		const existingPages = context.pages();
-		const entry: SessionEntry = {
+		const entry = this.createSessionEntry({
 			providerSessionId: providerSession.sessionId,
+			providerName: this.provider.name,
+			attached: false,
 			browser,
 			context,
-			currentPage: existingPages[existingPages.length - 1],
-		};
-		// Newest page wins, so popups and tabs become current automatically.
-		context.on("page", (page) => {
-			entry.currentPage = page;
 		});
 		if (context.pages().length === 0) {
 			await context.newPage();
+		}
+		for (const page of context.pages()) {
+			this.trackPage(entry, page);
+		}
+
+		const sessionId = this.generateSessionId();
+		this.sessions.set(sessionId, entry);
+		return { sessionId };
+	}
+
+	async connectSession(cdpEndpoint: string): Promise<{ sessionId: string }> {
+		const browser = await chromium.connectOverCDP(cdpEndpoint);
+		const context = browser.contexts()[0] ?? (await browser.newContext());
+		const entry = this.createSessionEntry({
+			providerSessionId: undefined,
+			providerName: "attached",
+			attached: true,
+			browser,
+			context,
+		});
+		for (const page of context.pages()) {
+			this.trackPage(entry, page);
 		}
 
 		const sessionId = this.generateSessionId();
@@ -49,37 +91,91 @@ export class SessionRegistry {
 	}
 
 	getCurrentPage(sessionId: string): Page {
+		return this.resolvePage(sessionId);
+	}
+
+	resolvePage(sessionId: string, pageId?: string): Page {
 		const entry = this.requireSession(sessionId);
+		if (pageId) {
+			const page = entry.pageById.get(pageId);
+			if (!page || page.isClosed()) {
+				throw new Error(
+					`Unknown page ID "${pageId}" in session "${sessionId}". ` +
+						"Call browser_status to list open pages.",
+				);
+			}
+			return page;
+		}
+
 		if (entry.currentPage && !entry.currentPage.isClosed()) {
 			return entry.currentPage;
 		}
-		const pages = entry.context.pages();
-		const page = pages[pages.length - 1];
+
+		const openPages = [...entry.pageById.values()].filter((page) => !page.isClosed());
+		const page = openPages.at(-1);
 		if (!page) {
 			throw new Error(`Session "${sessionId}" has no open pages`);
 		}
+		entry.currentPage = page;
 		return page;
+	}
+
+	listSessions(): SessionSummary[] {
+		const summaries: SessionSummary[] = [];
+		for (const [sessionId, entry] of this.sessions) {
+			summaries.push({
+				sessionId,
+				provider: entry.providerName,
+				pages: this.listPagesForEntry(entry),
+			});
+		}
+		return summaries;
+	}
+
+	listSessionPages(sessionId: string): SessionPageSummary[] {
+		return this.listPagesForEntry(this.requireSession(sessionId));
+	}
+
+	async getPageStatus(sessionId: string, pageId: string): Promise<PageStatus> {
+		const page = this.resolvePage(sessionId, pageId);
+		const activePage = this.resolvePage(sessionId);
+		return {
+			pageId,
+			url: page.url(),
+			title: await page.title(),
+			viewport: page.viewportSize(),
+			active: page === activePage,
+			readyState: await page.evaluate(() => document.readyState),
+		};
 	}
 
 	async closeSession(sessionId: string): Promise<void> {
 		const entry = this.requireSession(sessionId);
 		this.sessions.delete(sessionId);
 		await entry.browser.close();
-		await this.provider.closeSession(entry.providerSessionId);
+		if (!entry.attached && entry.providerSessionId) {
+			await this.provider.closeSession(entry.providerSessionId);
+		}
 	}
 
 	/** Baseline for the next exec diff — cached post-exec snapshot or a fresh capture. */
-	async readSnapshotBaseline(sessionId: string): Promise<Snapshot> {
+	async readSnapshotBaseline(
+		sessionId: string,
+		pageId?: string,
+	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		if (entry.latestSnapshot) return entry.latestSnapshot;
-		return captureSnapshot(this.getCurrentPage(sessionId));
+		if (!pageId && entry.latestSnapshot) return entry.latestSnapshot;
+		return captureSnapshot(this.resolvePage(sessionId, pageId));
 	}
 
 	/** Capture after exec and cache for the next call's baseline. */
-	async captureSnapshotAfterExec(sessionId: string): Promise<Snapshot> {
+	async captureSnapshotAfterExec(
+		sessionId: string,
+		pageId?: string,
+	): Promise<Snapshot> {
 		const entry = this.requireSession(sessionId);
-		const after = await captureSnapshot(this.getCurrentPage(sessionId));
-		entry.latestSnapshot = after;
+		const after = await captureSnapshot(this.resolvePage(sessionId, pageId));
+		if (!pageId) entry.latestSnapshot = after;
 		return after;
 	}
 
@@ -93,6 +189,82 @@ export class SessionRegistry {
 		for (const sessionId of sessionIds) {
 			await this.closeSession(sessionId);
 		}
+	}
+
+	private createSessionEntry(args: {
+		providerSessionId: string | undefined;
+		providerName: string;
+		attached: boolean;
+		browser: Browser;
+		context: BrowserContext;
+	}): SessionEntry {
+		const entry: SessionEntry = {
+			providerSessionId: args.providerSessionId,
+			providerName: args.providerName,
+			attached: args.attached,
+			browser: args.browser,
+			context: args.context,
+			currentPage: undefined,
+			pageById: new Map(),
+		};
+		// Newest page wins, so popups and tabs become current automatically.
+		args.context.on("page", (page) => {
+			this.trackPage(entry, page);
+		});
+		return entry;
+	}
+
+	private trackPage(entry: SessionEntry, page: Page): string {
+		const existingPageId = this.findPageId(entry, page);
+		if (existingPageId) {
+			entry.currentPage = page;
+			return existingPageId;
+		}
+
+		const pageId = this.generatePageId(entry.pageById);
+		entry.pageById.set(pageId, page);
+		page.on("close", () => {
+			entry.pageById.delete(pageId);
+			if (entry.currentPage === page) {
+				entry.currentPage = undefined;
+			}
+		});
+		entry.currentPage = page;
+		return pageId;
+	}
+
+	private findPageId(entry: SessionEntry, page: Page): string | undefined {
+		for (const [pageId, trackedPage] of entry.pageById) {
+			if (trackedPage === page) return pageId;
+		}
+		return undefined;
+	}
+
+	private listPagesForEntry(entry: SessionEntry): SessionPageSummary[] {
+		const effectiveActive = this.getEffectiveActivePage(entry);
+		const pages: SessionPageSummary[] = [];
+		for (const [pageId, page] of entry.pageById) {
+			if (page.isClosed()) continue;
+			const url = page.url();
+			if (url.startsWith("devtools://") || url.startsWith("chrome-error://")) {
+				continue;
+			}
+			pages.push({
+				pageId,
+				url,
+				active: page === effectiveActive,
+			});
+		}
+		return pages;
+	}
+
+	private getEffectiveActivePage(entry: SessionEntry): Page | undefined {
+		if (entry.currentPage && !entry.currentPage.isClosed()) {
+			for (const page of entry.pageById.values()) {
+				if (page === entry.currentPage) return entry.currentPage;
+			}
+		}
+		return [...entry.pageById.values()].filter((page) => !page.isClosed()).at(-1);
 	}
 
 	private requireSession(sessionId: string): SessionEntry {
@@ -109,5 +281,13 @@ export class SessionRegistry {
 			sessionId = `ses-${randomBytes(2).toString("hex")}`;
 		} while (this.sessions.has(sessionId));
 		return sessionId;
+	}
+
+	private generatePageId(pageById: Map<string, Page>): string {
+		let pageId: string;
+		do {
+			pageId = `page-${randomBytes(2).toString("hex")}`;
+		} while (pageById.has(pageId));
+		return pageId;
 	}
 }

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -44,12 +44,9 @@ export interface PageStatus {
  * Playwright connections. Owned by a factory instance — no module-level
  * state. Sessions die with the process; `dispose()` closes everything.
  */
-/** Signals we attempt best-effort cleanup on, when no host handler owns them. */
-const EXIT_SIGNALS: readonly NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
-
 export class SessionRegistry {
 	private readonly sessions = new Map<string, SessionEntry>();
-	private exitHooksInstalled = false;
+	private beforeExitHookInstalled = false;
 
 	constructor(public readonly provider: BrowserProvider) {}
 
@@ -73,7 +70,7 @@ export class SessionRegistry {
 
 		const sessionId = this.generateSessionId();
 		this.sessions.set(sessionId, entry);
-		this.installExitHooks();
+		this.installBeforeExitHook();
 		return { sessionId };
 	}
 
@@ -93,7 +90,7 @@ export class SessionRegistry {
 
 		const sessionId = this.generateSessionId();
 		this.sessions.set(sessionId, entry);
-		this.installExitHooks();
+		this.installBeforeExitHook();
 		return { sessionId };
 	}
 
@@ -183,7 +180,7 @@ export class SessionRegistry {
 	}
 
 	async dispose(): Promise<void> {
-		this.removeExitHooks();
+		this.removeBeforeExitHook();
 		const sessionIds = [...this.sessions.keys()];
 		for (const sessionId of sessionIds) {
 			await this.closeSession(sessionId);
@@ -192,42 +189,23 @@ export class SessionRegistry {
 
 	/**
 	 * Best-effort backstop so provider-owned (cloud) sessions get released even
-	 * when a consumer forgets to call {@link dispose}. `beforeExit` covers a
-	 * script that finishes naturally; signals are only claimed when no host
-	 * handler already owns them, so we stay out of a host's own shutdown.
+	 * when a consumer forgets to call {@link dispose} and the process exits
+	 * naturally. Hosts remain responsible for cleanup during signal handling.
 	 */
-	private installExitHooks(): void {
-		if (this.exitHooksInstalled) return;
-		this.exitHooksInstalled = true;
+	private installBeforeExitHook(): void {
+		if (this.beforeExitHookInstalled) return;
+		this.beforeExitHookInstalled = true;
 		process.once("beforeExit", this.handleBeforeExit);
-		for (const signal of EXIT_SIGNALS) {
-			if (process.listenerCount(signal) === 0) {
-				process.on(signal, this.handleSignal);
-			}
-		}
 	}
 
-	private removeExitHooks(): void {
-		if (!this.exitHooksInstalled) return;
-		this.exitHooksInstalled = false;
+	private removeBeforeExitHook(): void {
+		if (!this.beforeExitHookInstalled) return;
+		this.beforeExitHookInstalled = false;
 		process.removeListener("beforeExit", this.handleBeforeExit);
-		for (const signal of EXIT_SIGNALS) {
-			process.removeListener(signal, this.handleSignal);
-		}
 	}
 
 	private readonly handleBeforeExit = (): void => {
 		void this.dispose();
-	};
-
-	private readonly handleSignal = (signal: NodeJS.Signals): void => {
-		// Adding a signal listener suppresses Node's default termination, so the
-		// process stays alive while dispose() runs; re-raise afterward to restore
-		// the default disposition (or defer to a handler the host added since).
-		void this.dispose().finally(() => {
-			process.removeListener(signal, this.handleSignal);
-			process.kill(process.pid, signal);
-		});
 	};
 
 	private createSessionEntry(args: {

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -43,8 +43,12 @@ export interface PageStatus {
  * Playwright connections. Owned by a factory instance — no module-level
  * state. Sessions die with the process; `dispose()` closes everything.
  */
+/** Signals we attempt best-effort cleanup on, when no host handler owns them. */
+const EXIT_SIGNALS: readonly NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+
 export class SessionRegistry {
 	private readonly sessions = new Map<string, SessionEntry>();
+	private exitHooksInstalled = false;
 
 	constructor(public readonly provider: BrowserProvider) {}
 
@@ -68,6 +72,7 @@ export class SessionRegistry {
 
 		const sessionId = this.generateSessionId();
 		this.sessions.set(sessionId, entry);
+		this.installExitHooks();
 		return { sessionId };
 	}
 
@@ -87,6 +92,7 @@ export class SessionRegistry {
 
 		const sessionId = this.generateSessionId();
 		this.sessions.set(sessionId, entry);
+		this.installExitHooks();
 		return { sessionId };
 	}
 
@@ -173,11 +179,52 @@ export class SessionRegistry {
 	}
 
 	async dispose(): Promise<void> {
+		this.removeExitHooks();
 		const sessionIds = [...this.sessions.keys()];
 		for (const sessionId of sessionIds) {
 			await this.closeSession(sessionId);
 		}
 	}
+
+	/**
+	 * Best-effort backstop so provider-owned (cloud) sessions get released even
+	 * when a consumer forgets to call {@link dispose}. `beforeExit` covers a
+	 * script that finishes naturally; signals are only claimed when no host
+	 * handler already owns them, so we stay out of a host's own shutdown.
+	 */
+	private installExitHooks(): void {
+		if (this.exitHooksInstalled) return;
+		this.exitHooksInstalled = true;
+		process.once("beforeExit", this.handleBeforeExit);
+		for (const signal of EXIT_SIGNALS) {
+			if (process.listenerCount(signal) === 0) {
+				process.on(signal, this.handleSignal);
+			}
+		}
+	}
+
+	private removeExitHooks(): void {
+		if (!this.exitHooksInstalled) return;
+		this.exitHooksInstalled = false;
+		process.removeListener("beforeExit", this.handleBeforeExit);
+		for (const signal of EXIT_SIGNALS) {
+			process.removeListener(signal, this.handleSignal);
+		}
+	}
+
+	private readonly handleBeforeExit = (): void => {
+		void this.dispose();
+	};
+
+	private readonly handleSignal = (signal: NodeJS.Signals): void => {
+		// Adding a signal listener suppresses Node's default termination, so the
+		// process stays alive while dispose() runs; re-raise afterward to restore
+		// the default disposition (or defer to a handler the host added since).
+		void this.dispose().finally(() => {
+			process.removeListener(signal, this.handleSignal);
+			process.kill(process.pid, signal);
+		});
+	};
 
 	private createSessionEntry(args: {
 		providerSessionId: string | undefined;

--- a/packages/browser-tools/src/tools/close.ts
+++ b/packages/browser-tools/src/tools/close.ts
@@ -11,10 +11,7 @@ const closeInputSchema = z.object({
 
 export type CloseToolInput = z.infer<typeof closeInputSchema>;
 
-export interface CloseToolOutput {
-	/** Empty success payload — session is closed. */
-	closed?: true;
-}
+export type CloseToolOutput = {};
 
 export interface CloseTool extends BrowserTool<CloseToolInput, CloseToolOutput> {
 	inputSchema: typeof closeInputSchema;

--- a/packages/browser-tools/src/tools/close.ts
+++ b/packages/browser-tools/src/tools/close.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { errorMessage } from "../errors.js";
+import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserTool, ToolResult } from "../tool.js";
+
+const closeInputSchema = z.object({
+	sessionId: z
+		.string()
+		.describe('Session ID returned by browser_open or browser_connect, e.g. "ses-4f2a".'),
+});
+
+export type CloseToolInput = z.infer<typeof closeInputSchema>;
+
+export interface CloseToolOutput {
+	/** Empty success payload — session is closed. */
+	closed?: true;
+}
+
+export interface CloseTool extends BrowserTool<CloseToolInput, CloseToolOutput> {
+	inputSchema: typeof closeInputSchema;
+}
+
+export function createCloseTool(registry: SessionRegistry): CloseTool {
+	return {
+		name: "browser_close",
+		description:
+			"Close a browser session by session ID. For provider-owned sessions this " +
+			"releases the remote browser; for browser_connect sessions it detaches " +
+			"without killing the externally managed browser.",
+		inputSchema: closeInputSchema,
+		async execute({ sessionId }): Promise<ToolResult<CloseToolOutput>> {
+			try {
+				await registry.closeSession(sessionId);
+				return { ok: true };
+			} catch (err) {
+				return {
+					ok: false,
+					error:
+						`${errorMessage(err)}. Call browser_status with no args to list ` +
+						"open sessions, or browser_open to start a new one.",
+				};
+			}
+		},
+	};
+}

--- a/packages/browser-tools/src/tools/connect.ts
+++ b/packages/browser-tools/src/tools/connect.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { errorMessage } from "../errors.js";
+import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserTool, ToolResult } from "../tool.js";
+
+const connectInputSchema = z.object({
+	cdpUrl: z
+		.string()
+		.describe(
+			"CDP websocket URL for an already-running browser, e.g. " +
+				'"ws://127.0.0.1:9222/devtools/browser/...".',
+		),
+});
+
+export type ConnectToolInput = z.infer<typeof connectInputSchema>;
+
+export interface ConnectToolOutput {
+	sessionId: string;
+}
+
+export interface ConnectTool
+	extends BrowserTool<ConnectToolInput, ConnectToolOutput> {
+	inputSchema: typeof connectInputSchema;
+}
+
+export function createConnectTool(registry: SessionRegistry): ConnectTool {
+	return {
+		name: "browser_connect",
+		description:
+			"Attach to an already-running browser via its CDP URL. Returns a session ID " +
+			"like browser_open, but closing the session detaches without killing the " +
+			"externally managed browser.",
+		inputSchema: connectInputSchema,
+		async execute({ cdpUrl }): Promise<ToolResult<ConnectToolOutput>> {
+			try {
+				const { sessionId } = await registry.connectSession(cdpUrl);
+				return { ok: true, sessionId };
+			} catch (err) {
+				return {
+					ok: false,
+					error:
+						`Could not connect to ${cdpUrl} (${errorMessage(err)}). ` +
+						"Verify the CDP endpoint is reachable and try again.",
+				};
+			}
+		},
+	};
+}

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -65,7 +65,7 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 		async execute({ sessionId, code, pageId }): Promise<ToolResult<ExecToolOutput>> {
 			let scope: ExecScope;
 			try {
-				const page = registry.resolvePage(sessionId, pageId);
+				const page = registry.getCurrentPage(sessionId, pageId);
 				const context = page.context();
 				const browser = context.browser();
 				if (!browser) {

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -20,6 +20,12 @@ const execInputSchema = z.object({
 			"Playwright code to run against the session. Runs as the body of an " +
 				"async function — use `return` to produce a result.",
 		),
+	pageId: z
+		.string()
+		.optional()
+		.describe(
+			'Optional page ID from browser_status. Defaults to the most recently opened tab.',
+		),
 });
 
 export type ExecToolInput = z.infer<typeof execInputSchema>;
@@ -56,10 +62,10 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			"unchanged). Failures come back as `{ ok: false, error }` — read the error, " +
 			"fix the code, and try again.",
 		inputSchema: execInputSchema,
-		async execute({ sessionId, code }): Promise<ToolResult<ExecToolOutput>> {
+		async execute({ sessionId, code, pageId }): Promise<ToolResult<ExecToolOutput>> {
 			let scope: ExecScope;
 			try {
-				const page = registry.getCurrentPage(sessionId);
+				const page = registry.resolvePage(sessionId, pageId);
 				const context = page.context();
 				const browser = context.browser();
 				if (!browser) {
@@ -81,14 +87,14 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 				};
 			}
 
-			const before = await registry.readSnapshotBaseline(sessionId);
+			const before = await registry.readSnapshotBaseline(sessionId, pageId);
 			const execResult = await runExecCode(code, scope);
 			if (!execResult.ok) return execResult;
 
 			let snapshotDiff = "";
 			try {
 				await waitForPageStable(scope.page);
-				const after = await registry.captureSnapshotAfterExec(sessionId);
+				const after = await registry.captureSnapshotAfterExec(sessionId, pageId);
 				snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
 			} catch {
 				registry.clearSnapshotCache(sessionId);

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -14,6 +14,12 @@ const snapshotInputSchema = z.object({
 		.boolean()
 		.optional()
 		.describe("When true, also return a PNG screenshot as base64 bytes."),
+	pageId: z
+		.string()
+		.optional()
+		.describe(
+			'Optional page ID from browser_status. Defaults to the most recently opened tab.',
+		),
 });
 
 export type SnapshotToolInput = z.infer<typeof snapshotInputSchema>;
@@ -45,10 +51,11 @@ export function createSnapshotTool(registry: SessionRegistry): SnapshotTool {
 		async execute({
 			sessionId,
 			screenshot,
+			pageId,
 		}): Promise<ToolResult<SnapshotToolOutput>> {
 			let page;
 			try {
-				page = registry.getCurrentPage(sessionId);
+				page = registry.resolvePage(sessionId, pageId);
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -55,7 +55,7 @@ export function createSnapshotTool(registry: SessionRegistry): SnapshotTool {
 		}): Promise<ToolResult<SnapshotToolOutput>> {
 			let page;
 			try {
-				page = registry.resolvePage(sessionId, pageId);
+				page = registry.getCurrentPage(sessionId, pageId);
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/browser-tools/src/tools/status.ts
+++ b/packages/browser-tools/src/tools/status.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { errorMessage } from "../errors.js";
+import type { PageStatus, SessionPageSummary, SessionSummary } from "../session-registry.js";
+import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserTool, ToolResult } from "../tool.js";
+
+const statusInputSchema = z.object({
+	sessionId: z
+		.string()
+		.optional()
+		.describe('Session ID from browser_open or browser_connect, e.g. "ses-4f2a".'),
+	pageId: z
+		.string()
+		.optional()
+		.describe('Page ID from browser_status, e.g. "page-a1b2".'),
+});
+
+export type StatusToolInput = z.infer<typeof statusInputSchema>;
+
+export interface StatusAllOutput {
+	sessions: SessionSummary[];
+}
+
+export interface StatusSessionOutput {
+	pages: SessionPageSummary[];
+}
+
+export type StatusToolOutput =
+	| StatusAllOutput
+	| StatusSessionOutput
+	| PageStatus;
+
+export interface StatusTool extends BrowserTool<StatusToolInput, StatusToolOutput> {
+	inputSchema: typeof statusInputSchema;
+}
+
+export function createStatusTool(registry: SessionRegistry): StatusTool {
+	return {
+		name: "browser_status",
+		description:
+			"Inspect open browser sessions and pages. Call with no args to list all " +
+			"sessions and their pages; with `sessionId` to list pages in one session; " +
+			"with `sessionId` and `pageId` for url, title, viewport, and loading state. " +
+			"When confused about which tab to target, start here.",
+		inputSchema: statusInputSchema,
+		async execute({
+			sessionId,
+			pageId,
+		}): Promise<ToolResult<StatusToolOutput>> {
+			if (pageId !== undefined && sessionId === undefined) {
+				return {
+					ok: false,
+					error:
+						"pageId requires sessionId. Call browser_status with sessionId only " +
+						"to list pages for that session.",
+				};
+			}
+
+			if (sessionId === undefined) {
+				return { ok: true, sessions: registry.listSessions() };
+			}
+
+			if (pageId === undefined) {
+				try {
+					return {
+						ok: true,
+						pages: registry.listSessionPages(sessionId),
+					};
+				} catch (err) {
+					return {
+						ok: false,
+						error:
+							`${errorMessage(err)}. Call browser_open to get a session ID, ` +
+							"or browser_status with no args to list open sessions.",
+					};
+				}
+			}
+
+			try {
+				return {
+					ok: true,
+					...(await registry.getPageStatus(sessionId, pageId)),
+				};
+			} catch (err) {
+				return {
+					ok: false,
+					error:
+						`${errorMessage(err)}. Call browser_status with sessionId only ` +
+						"to list open pages for that session.",
+				};
+			}
+		},
+	};
+}

--- a/packages/browser-tools/src/tools/status.ts
+++ b/packages/browser-tools/src/tools/status.ts
@@ -61,19 +61,18 @@ export function createStatusTool(registry: SessionRegistry): StatusTool {
 			}
 
 			if (pageId === undefined) {
-				try {
-					return {
-						ok: true,
-						pages: registry.listSessionPages(sessionId),
-					};
-				} catch (err) {
+				const session = registry
+					.listSessions()
+					.find((entry) => entry.sessionId === sessionId);
+				if (!session) {
 					return {
 						ok: false,
 						error:
-							`${errorMessage(err)}. Call browser_open to get a session ID, ` +
-							"or browser_status with no args to list open sessions.",
+							`Unknown session ID: ${sessionId}. Call browser_open to get a ` +
+							"session ID, or browser_status with no args to list open sessions.",
 					};
 				}
+				return { ok: true, pages: session.pages };
 			}
 
 			try {

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -275,6 +275,48 @@ test("browser_connect attaches to an external browser and close detaches without
 	expect(all).toMatchObject({ ok: true, sessions: [] });
 });
 
+test("browser_exec snapshot diff uses per-page cache across mixed pageId calls", async ({
+	openTool,
+	execTool,
+	statusTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<h1 id='t'>start</h1>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const status = await statusTool.execute({ sessionId: opened.sessionId });
+	if (!status.ok || !("pages" in status)) throw new Error("expected pages");
+	const pageId = status.pages[0].pageId;
+
+	const first = await execTool.execute({
+		sessionId: opened.sessionId,
+		code:
+			"await page.locator('#t').evaluate((el: HTMLElement) => { el.textContent = 'first'; });",
+	});
+	expect(first).toMatchObject({ ok: true });
+	expect(first.ok && first.snapshotDiff.length).toBeGreaterThan(0);
+
+	const second = await execTool.execute({
+		sessionId: opened.sessionId,
+		pageId,
+		code:
+			"await page.locator('#t').evaluate((el: HTMLElement) => { el.textContent = 'second'; });",
+	});
+	expect(second).toMatchObject({ ok: true });
+	expect(second.ok && second.snapshotDiff.length).toBeGreaterThan(0);
+
+	const third = await execTool.execute({
+		sessionId: opened.sessionId,
+		code: "return await page.locator('#t').textContent()",
+	});
+	expect(third).toMatchObject({
+		ok: true,
+		result: "second",
+		snapshotDiff: "",
+	});
+});
+
 test("browser_exec returns ok false for a stale page ID", async ({
 	openTool,
 	execTool,

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -136,21 +136,22 @@ test("browser_status lists sessions and pages at three zoom levels", async ({
 			},
 		],
 	});
+	if (!all.ok || !("sessions" in all)) throw new Error("expected sessions");
+	const pageId = all.sessions[0].pages[0].pageId;
 
 	const sessionOnly = await statusTool.execute({ sessionId: opened.sessionId });
-	expect(sessionOnly).toMatchObject({
-		ok: true,
-		pages: [{ pageId: expect.any(String), url: expect.any(String), active: true }],
-	});
 	if (!sessionOnly.ok || !("pages" in sessionOnly)) throw new Error("expected pages");
+	expect(sessionOnly.pages).toEqual([
+		{ pageId, url: expect.any(String), active: true },
+	]);
 
 	const pageOnly = await statusTool.execute({
 		sessionId: opened.sessionId,
-		pageId: sessionOnly.pages[0].pageId,
+		pageId,
 	});
 	expect(pageOnly).toMatchObject({
 		ok: true,
-		pageId: sessionOnly.pages[0].pageId,
+		pageId,
 		title: "status-page",
 		active: true,
 		readyState: expect.any(String),

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -1,17 +1,59 @@
+import { createServer } from "node:net";
+import type { Browser } from "playwright";
+import { chromium } from "playwright";
 import { expect, test as base } from "vitest";
 import { LocalBrowserProvider } from "../providers/local.js";
 import { SessionRegistry } from "../session-registry.js";
 import { createCloseTool } from "./close.js";
+import { createConnectTool } from "./connect.js";
 import { createExecTool } from "./exec.js";
 import { createOpenTool } from "./open.js";
+import { createSnapshotTool } from "./snapshot.js";
 import { createStatusTool } from "./status.js";
+
+async function pickFreePort(): Promise<number> {
+	return await new Promise((resolve, reject) => {
+		const server = createServer();
+		server.unref();
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address();
+			if (addr && typeof addr === "object") {
+				server.close(() => resolve(addr.port));
+				return;
+			}
+			server.close(() => reject(new Error("Failed to resolve debug port")));
+		});
+	});
+}
+
+async function fetchWebSocketDebuggerUrl(port: number): Promise<string> {
+	const versionUrl = `http://127.0.0.1:${port}/json/version`;
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(versionUrl);
+			const info = (await response.json()) as {
+				webSocketDebuggerUrl?: string;
+			};
+			if (info.webSocketDebuggerUrl) return info.webSocketDebuggerUrl;
+		} catch {
+			// Not listening yet; retry below.
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error(`Could not read webSocketDebuggerUrl from ${versionUrl}`);
+}
 
 const test = base.extend<{
 	registry: SessionRegistry;
 	openTool: ReturnType<typeof createOpenTool>;
 	execTool: ReturnType<typeof createExecTool>;
+	snapshotTool: ReturnType<typeof createSnapshotTool>;
 	statusTool: ReturnType<typeof createStatusTool>;
 	closeTool: ReturnType<typeof createCloseTool>;
+	connectTool: ReturnType<typeof createConnectTool>;
+	externalBrowser: { browser: Browser; cdpUrl: string };
 }>({
 	registry: async ({}, use) => {
 		const registry = new SessionRegistry(
@@ -31,6 +73,22 @@ const test = base.extend<{
 	},
 	closeTool: async ({ registry }, use) => {
 		await use(createCloseTool(registry));
+	},
+	connectTool: async ({ registry }, use) => {
+		await use(createConnectTool(registry));
+	},
+	snapshotTool: async ({ registry }, use) => {
+		await use(createSnapshotTool(registry));
+	},
+	externalBrowser: async ({}, use) => {
+		const port = await pickFreePort();
+		const browser = await chromium.launch({
+			headless: true,
+			args: [`--remote-debugging-port=${port}`],
+		});
+		const cdpUrl = await fetchWebSocketDebuggerUrl(port);
+		await use({ browser, cdpUrl });
+		await browser.close();
 	},
 });
 
@@ -173,4 +231,85 @@ test("browser_close removes a session from browser_status", async ({
 
 	const all = await statusTool.execute({});
 	expect(all).toMatchObject({ ok: true, sessions: [] });
+});
+
+test("browser_connect attaches to an external browser and close detaches without killing it", async ({
+	connectTool,
+	closeTool,
+	execTool,
+	statusTool,
+	externalBrowser,
+}) => {
+	const context =
+		externalBrowser.browser.contexts()[0] ??
+		(await externalBrowser.browser.newContext());
+	const page = context.pages()[0] ?? (await context.newPage());
+	await page.goto("data:text/html,<title>connected</title>");
+
+	const connected = await connectTool.execute({ cdpUrl: externalBrowser.cdpUrl });
+	if (!connected.ok) throw new Error(connected.error);
+
+	const status = await statusTool.execute({});
+	expect(status).toMatchObject({
+		ok: true,
+		sessions: [
+			{
+				sessionId: connected.sessionId,
+				provider: "attached",
+				pages: [{ pageId: expect.any(String), url: expect.any(String), active: true }],
+			},
+		],
+	});
+
+	const execResult = await execTool.execute({
+		sessionId: connected.sessionId,
+		code: "return page.url()",
+	});
+	expect(execResult).toMatchObject({ ok: true, result: expect.any(String) });
+
+	const closed = await closeTool.execute({ sessionId: connected.sessionId });
+	expect(closed).toEqual({ ok: true });
+	expect(externalBrowser.browser.isConnected()).toBe(true);
+
+	const all = await statusTool.execute({});
+	expect(all).toMatchObject({ ok: true, sessions: [] });
+});
+
+test("browser_exec returns ok false for a stale page ID", async ({
+	openTool,
+	execTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>stale-page</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await execTool.execute({
+		sessionId: opened.sessionId,
+		pageId: "page-nope",
+		code: "return page.title()",
+	});
+	expect(result.ok).toBe(false);
+	if (result.ok) return;
+	expect(result.error).toMatch(/page-nope/);
+	expect(result.error).toMatch(/browser_status/);
+});
+
+test("browser_snapshot returns ok false for a stale page ID", async ({
+	openTool,
+	snapshotTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>stale-page</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await snapshotTool.execute({
+		sessionId: opened.sessionId,
+		pageId: "page-nope",
+	});
+	expect(result.ok).toBe(false);
+	if (result.ok) return;
+	expect(result.error).toMatch(/page-nope/);
+	expect(result.error).toMatch(/browser_status/);
 });

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -1,13 +1,17 @@
 import { expect, test as base } from "vitest";
 import { LocalBrowserProvider } from "../providers/local.js";
 import { SessionRegistry } from "../session-registry.js";
+import { createCloseTool } from "./close.js";
 import { createExecTool } from "./exec.js";
 import { createOpenTool } from "./open.js";
+import { createStatusTool } from "./status.js";
 
 const test = base.extend<{
 	registry: SessionRegistry;
 	openTool: ReturnType<typeof createOpenTool>;
 	execTool: ReturnType<typeof createExecTool>;
+	statusTool: ReturnType<typeof createStatusTool>;
+	closeTool: ReturnType<typeof createCloseTool>;
 }>({
 	registry: async ({}, use) => {
 		const registry = new SessionRegistry(
@@ -21,6 +25,12 @@ const test = base.extend<{
 	},
 	execTool: async ({ registry }, use) => {
 		await use(createExecTool(registry));
+	},
+	statusTool: async ({ registry }, use) => {
+		await use(createStatusTool(registry));
+	},
+	closeTool: async ({ registry }, use) => {
+		await use(createCloseTool(registry));
 	},
 });
 
@@ -104,4 +114,62 @@ test("browser_exec returns ok false for an unknown session ID", async ({
 	if (result.ok) return;
 	expect(result.error).toMatch(/ses-nope/);
 	expect(result.error).toMatch(/browser_open/);
+});
+
+test("browser_status lists sessions and pages at three zoom levels", async ({
+	openTool,
+	statusTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>status-page</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const all = await statusTool.execute({});
+	expect(all).toMatchObject({
+		ok: true,
+		sessions: [
+			{
+				sessionId: opened.sessionId,
+				provider: "local",
+				pages: [{ pageId: expect.any(String), url: expect.any(String), active: true }],
+			},
+		],
+	});
+
+	const sessionOnly = await statusTool.execute({ sessionId: opened.sessionId });
+	expect(sessionOnly).toMatchObject({
+		ok: true,
+		pages: [{ pageId: expect.any(String), url: expect.any(String), active: true }],
+	});
+	if (!sessionOnly.ok || !("pages" in sessionOnly)) throw new Error("expected pages");
+
+	const pageOnly = await statusTool.execute({
+		sessionId: opened.sessionId,
+		pageId: sessionOnly.pages[0].pageId,
+	});
+	expect(pageOnly).toMatchObject({
+		ok: true,
+		pageId: sessionOnly.pages[0].pageId,
+		title: "status-page",
+		active: true,
+		readyState: expect.any(String),
+	});
+});
+
+test("browser_close removes a session from browser_status", async ({
+	openTool,
+	statusTool,
+	closeTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>close-me</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const closed = await closeTool.execute({ sessionId: opened.sessionId });
+	expect(closed).toEqual({ ok: true });
+
+	const all = await statusTool.execute({});
+	expect(all).toMatchObject({ ok: true, sessions: [] });
 });


### PR DESCRIPTION
## Summary
- Add `browser_status`, `browser_close`, and `browser_connect` — completes the six-tool surface
- Track generated page IDs in the session registry; `pageId` optional on `exec` and `snapshot`
- Add a `beforeExit` cleanup backstop when `dispose()` is forgotten; host applications retain signal-handler ownership
- Integration tests for connect attach/detach, stale page IDs, stable page IDs, and per-page snapshot diff caching

## Test plan
- [x] `pnpm --filter @libretto/browser-tools test` (44 unit/integration tests)
- [x] `browser_connect` attaches to an external Chromium and `browser_close` detaches without killing it
- [x] Stale `pageId` on `browser_exec` / `browser_snapshot` returns `{ ok: false }` with `browser_status` hint
- [x] Mixed default and `pageId` exec calls preserve the correct per-page snapshot diff baseline


Made with [Cursor](https://cursor.com)