### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,3 +89,11 @@ In `packages/browser-tools`, format caught errors with `errorMessage()` from `sr
 - Edit `packages/libretto/README.template.md` directly for README changes, then run `pnpm sync:mirrors`.
 - Edit `packages/libretto/skills/libretto/SKILL.md` directly.
 - `packages/libretto/skills/libretto` is the source of truth for Libretto skill files.
+
+## Cursor Cloud specific instructions
+
+The primary deliverable is the `libretto` CLI/library in `packages/libretto`; there is no long-running backend to stand up. Standard commands live in `## Important Commands` above (`pnpm -s type-check | test | lint | cli`); the startup update script already runs `pnpm install` and installs Playwright Chromium. Notes below are the non-obvious gotchas.
+
+- **`pnpm -s lint` needs Go 1.26** because `lintcn` compiles a custom `tsgolint` binary. The system Go is 1.22 and `GOTOOLCHAIN=auto` fails to resolve the bare `go 1.26` directive (`toolchain not available`). Fix is a persistent config write: `go env -w GOTOOLCHAIN=go1.26.0` (already set during setup). Turbo strips `GOTOOLCHAIN` passed as a shell env var, so it must be in Go's env file, not `export`ed. If lint suddenly fails to download `go1.26`, re-run that `go env -w` command. First lint run compiles the Go binary (~1-2 min); later runs reuse the cache in `~/.cache/lintcn/`.
+- **Browser runs are headless here** (no display). Pass `--headless` to `libretto open`/`run`, or they default to headed and hang. Exercise the CLI end to end with: `pnpm -s cli open <url> --headless --session <name>` → `snapshot` → `exec "<expression>"` (REPL expression, not a `return` statement) → `close --session <name>`.
+- **Optional marketing site**: `pnpm website:dev` serves Vite on `http://localhost:5173`. `pnpm docs:dev` (Mintlify) and `pnpm evals` / `pnpm benchmarks` need external LLM/Google Cloud credentials and are not required for core CLI development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this pnpm monorepo (Node 22, pnpm 11.1.1) and documents non-obvious startup caveats for future cloud agents.

- Configured the startup update script: `pnpm install` + `pnpm exec playwright install chromium`.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the durable gotchas below.

## Key findings

- **Lint requires Go 1.26.** `pnpm -s lint` uses `lintcn`, which compiles a custom `tsgolint` Go binary. The system Go is 1.22 and `GOTOOLCHAIN=auto` cannot resolve the bare `go 1.26` directive. Fix: `go env -w GOTOOLCHAIN=go1.26.0` (persistent config; `turbo` strips a shell-exported `GOTOOLCHAIN`).
- **Browsers run headless** (no display) — pass `--headless` to `libretto open`/`run`.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Type-check | `pnpm -s type-check` | pass (10 tasks) |
| Lint | `pnpm -s lint` | pass (after Go 1.26 fix) |
| Mirrors | `pnpm -s check:mirrors` | pass |
| Tests | `pnpm -s test` | pass (8 packages) |
| CLI (core) | `pnpm -s cli open … --headless` → `snapshot` → `exec` → `close` | drove a live browser end to end |
| Website (optional) | `pnpm website:dev` | HTTP 200 on `:5173` |

### CLI driving a live browser (clicked through example.com → IANA)
[IANA page after libretto click](https://cursor.com/agents/bc-49f46b6c-703f-4974-b65a-8a20db41e589/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flibretto_iana_after_click.png)

### Optional marketing site running under `pnpm website:dev`
[Libretto website dev server](https://cursor.com/agents/bc-49f46b6c-703f-4974-b65a-8a20db41e589/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_dev_localhost5173.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49f46b6c-703f-4974-b65a-8a20db41e589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f46b6c-703f-4974-b65a-8a20db41e589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

