### PR TITLE
browser-tools: add remaining cloud providers

### DIFF
--- a/packages/browser-tools/evals/hn-top-story.eval.ts
+++ b/packages/browser-tools/evals/hn-top-story.eval.ts
@@ -2,42 +2,54 @@ import { openai } from "@ai-sdk/openai";
 import { stepCountIs, ToolLoopAgent } from "ai";
 import { expect, test } from "vitest";
 import { createAiSdkBrowserTools } from "../src/adapters/ai-sdk/index.js";
-import { LocalBrowserProvider } from "../src/providers/local.js";
+import type { BrowserProvider } from "../src/provider.js";
+import { BrowserbaseBrowserProvider } from "../src/providers/browserbase.js";
+import { KernelBrowserProvider } from "../src/providers/kernel.js";
+import { LibrettoCloudBrowserProvider } from "../src/providers/libretto-cloud.js";
+import { SteelBrowserProvider } from "../src/providers/steel.js";
 import { requireOpenAiApiKey } from "./setup.js";
 
-test("reads the first Hacker News story title", async () => {
-	requireOpenAiApiKey();
+const providers: Array<[name: string, create: () => BrowserProvider]> = [
+	["Kernel", () => new KernelBrowserProvider()],
+	["Browserbase", () => new BrowserbaseBrowserProvider()],
+	["Steel", () => new SteelBrowserProvider()],
+	["Libretto Cloud", () => new LibrettoCloudBrowserProvider()],
+];
 
-	const { tools, dispose } = createAiSdkBrowserTools(
-		new LocalBrowserProvider({ headless: true }),
-	);
+test.each(providers)(
+	"reads the first Hacker News story title with %s",
+	async (_name, createProvider) => {
+		requireOpenAiApiKey();
 
-	try {
-		const agent = new ToolLoopAgent({
-			model: openai("gpt-5.5"),
-			tools,
-			stopWhen: stepCountIs(8),
-			providerOptions: {
-				openai: {
-					// Required for Zero Data Retention orgs.
-					store: false,
+		const { tools, dispose } = createAiSdkBrowserTools(createProvider());
+
+		try {
+			const agent = new ToolLoopAgent({
+				model: openai("gpt-5.5"),
+				tools,
+				stopWhen: stepCountIs(8),
+				providerOptions: {
+					openai: {
+						// Required for Zero Data Retention orgs.
+						store: false,
+					},
 				},
-			},
-		});
+			});
 
-		const result = await agent.generate({
-			prompt:
-				"Open https://news.ycombinator.com, read the page, and reply with only " +
-				"the title of the first story link on the page (no commentary).",
-		});
+			const result = await agent.generate({
+				prompt:
+					"Open https://news.ycombinator.com, read the page, and reply with only " +
+					"the title of the first story link on the page (no commentary).",
+			});
 
-		const toolCalls = result.steps.flatMap((step) => step.toolCalls);
+			const toolCalls = result.steps.flatMap((step) => step.toolCalls);
 
-		expect(result.text.trim().length).toBeGreaterThan(0);
-		expect(toolCalls.some((call) => call.toolName === "browser_open")).toBe(
-			true,
-		);
-	} finally {
-		await dispose();
-	}
-});
+			expect(result.text.trim().length).toBeGreaterThan(0);
+			expect(toolCalls.some((call) => call.toolName === "browser_open")).toBe(
+				true,
+			);
+		} finally {
+			await dispose();
+		}
+	},
+);

--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -33,13 +33,27 @@
       "types": "./dist/providers/kernel.d.ts",
       "import": "./dist/providers/kernel.js",
       "default": "./dist/providers/kernel.js"
+    },
+    "./browserbase": {
+      "types": "./dist/providers/browserbase.d.ts",
+      "import": "./dist/providers/browserbase.js",
+      "default": "./dist/providers/browserbase.js"
+    },
+    "./steel": {
+      "types": "./dist/providers/steel.d.ts",
+      "import": "./dist/providers/steel.js",
+      "default": "./dist/providers/steel.js"
+    },
+    "./libretto-cloud": {
+      "types": "./dist/providers/libretto-cloud.d.ts",
+      "import": "./dist/providers/libretto-cloud.js",
+      "default": "./dist/providers/libretto-cloud.js"
     }
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:kernel": "KERNEL_API_KEY=\"$(gcloud secrets versions access latest --secret=browser-tools-kernel-api-key --project=769071280674)\" && export KERNEL_API_KEY && test -n \"$KERNEL_API_KEY\" && vitest run src/providers/kernel.spec.ts",
     "test:vitest": "vitest run",
     "evals": "vitest run --config vitest.evals.config.ts",
     "prepack": "pnpm run build"

--- a/packages/browser-tools/src/providers/browserbase.spec.ts
+++ b/packages/browser-tools/src/providers/browserbase.spec.ts
@@ -1,11 +1,14 @@
 import { chromium } from "playwright";
 import { expect, test } from "vitest";
-import { KernelBrowserProvider } from "./kernel.js";
+import { BrowserbaseBrowserProvider } from "./browserbase.js";
 
-test.skipIf(!process.env.KERNEL_API_KEY?.trim())(
-	"creates, connects to, and closes a Kernel browser",
+test.skipIf(
+	!process.env.BROWSERBASE_API_KEY?.trim() ||
+		!process.env.BROWSERBASE_PROJECT_ID?.trim(),
+)(
+	"creates, connects to, and closes a Browserbase browser",
 	async () => {
-		const provider = new KernelBrowserProvider();
+		const provider = new BrowserbaseBrowserProvider();
 		const session = await provider.createSession();
 		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 

--- a/packages/browser-tools/src/providers/browserbase.ts
+++ b/packages/browser-tools/src/providers/browserbase.ts
@@ -1,0 +1,94 @@
+import type {
+	BrowserProvider,
+	ProviderSession,
+	ProviderSessionClosed,
+} from "../provider.js";
+
+export interface BrowserbaseBrowserProviderOptions {
+	apiKey?: string;
+	projectId?: string;
+	endpoint?: string;
+}
+
+interface BrowserbaseSessionResponse {
+	id: string;
+	connectUrl: string;
+}
+
+export class BrowserbaseBrowserProvider implements BrowserProvider {
+	readonly name = "browserbase";
+	private readonly apiKey: string;
+	private readonly projectId: string;
+	private readonly endpoint: string;
+
+	constructor(options: BrowserbaseBrowserProviderOptions = {}) {
+		const apiKey = (
+			options.apiKey ?? process.env.BROWSERBASE_API_KEY
+		)?.trim();
+		if (!apiKey) {
+			throw new Error(
+				"BrowserbaseBrowserProvider: missing API key. " +
+					"Pass new BrowserbaseBrowserProvider({ apiKey }) or set BROWSERBASE_API_KEY.",
+			);
+		}
+
+		const projectId = (
+			options.projectId ?? process.env.BROWSERBASE_PROJECT_ID
+		)?.trim();
+		if (!projectId) {
+			throw new Error(
+				"BrowserbaseBrowserProvider: missing project ID. " +
+					"Pass new BrowserbaseBrowserProvider({ projectId }) or set BROWSERBASE_PROJECT_ID.",
+			);
+		}
+
+		this.apiKey = apiKey;
+		this.projectId = projectId;
+		this.endpoint = (
+			options.endpoint ??
+			process.env.BROWSERBASE_ENDPOINT?.trim() ??
+			"https://api.browserbase.com"
+		).replace(/\/$/, "");
+	}
+
+	async createSession(): Promise<ProviderSession> {
+		const response = await fetch(`${this.endpoint}/v1/sessions`, {
+			method: "POST",
+			headers: {
+				"X-BB-API-Key": this.apiKey,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ projectId: this.projectId }),
+		});
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(`Browserbase API error (${response.status}): ${body}`);
+		}
+		const session = (await response.json()) as BrowserbaseSessionResponse;
+		return {
+			sessionId: session.id,
+			cdpEndpoint: session.connectUrl,
+		};
+	}
+
+	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const response = await fetch(
+			`${this.endpoint}/v1/sessions/${sessionId}`,
+			{
+				method: "POST",
+				headers: {
+					"X-BB-API-Key": this.apiKey,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ status: "REQUEST_RELEASE" }),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Browserbase API error closing session ${sessionId} (${response.status}): ${body}`,
+			);
+		}
+		return {};
+	}
+}

--- a/packages/browser-tools/src/providers/libretto-cloud.spec.ts
+++ b/packages/browser-tools/src/providers/libretto-cloud.spec.ts
@@ -1,11 +1,11 @@
 import { chromium } from "playwright";
 import { expect, test } from "vitest";
-import { KernelBrowserProvider } from "./kernel.js";
+import { LibrettoCloudBrowserProvider } from "./libretto-cloud.js";
 
-test.skipIf(!process.env.KERNEL_API_KEY?.trim())(
-	"creates, connects to, and closes a Kernel browser",
+test.skipIf(!process.env.LIBRETTO_API_KEY?.trim())(
+	"creates, connects to, and closes a Libretto Cloud browser",
 	async () => {
-		const provider = new KernelBrowserProvider();
+		const provider = new LibrettoCloudBrowserProvider();
 		const session = await provider.createSession();
 		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 

--- a/packages/browser-tools/src/providers/libretto-cloud.ts
+++ b/packages/browser-tools/src/providers/libretto-cloud.ts
@@ -1,0 +1,187 @@
+import type {
+	BrowserProvider,
+	ProviderSession,
+	ProviderSessionClosed,
+} from "../provider.js";
+
+const DEFAULT_HOSTED_API_URL = "https://api.libretto.sh";
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS = 3_600;
+const QUEUE_WAIT_TIMEOUT_MS = 10 * 60_000;
+
+export interface LibrettoCloudBrowserProviderOptions {
+	apiKey?: string;
+	apiUrl?: string;
+	/** Browser session TTL requested at create time. */
+	timeoutSeconds?: number;
+	headless?: boolean;
+}
+
+interface CloudSessionResponse {
+	session_id: string;
+	status: string;
+	cdp_url: string | null;
+	live_view_url: string | null;
+}
+
+async function cloudFetchJson<T>(
+	endpoint: string,
+	apiKey: string,
+	path: string,
+	body: unknown,
+): Promise<T> {
+	const response = await fetch(`${endpoint}${path}`, {
+		method: "POST",
+		headers: {
+			"x-api-key": apiKey,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ json: body }),
+	});
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`Libretto Cloud API error (${response.status}): ${text}`);
+	}
+	const payload = (await response.json()) as { json: T };
+	return payload.json;
+}
+
+async function cloudFetchOk(
+	endpoint: string,
+	apiKey: string,
+	path: string,
+	body: unknown,
+): Promise<void> {
+	const response = await fetch(`${endpoint}${path}`, {
+		method: "POST",
+		headers: {
+			"x-api-key": apiKey,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ json: body }),
+	});
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`Libretto Cloud API error (${response.status}): ${text}`);
+	}
+}
+
+async function waitForCloudSessionReady(args: {
+	endpoint: string;
+	apiKey: string;
+	session: CloudSessionResponse;
+}): Promise<CloudSessionResponse & { cdp_url: string }> {
+	let session = args.session;
+	if (session.cdp_url) {
+		return { ...session, cdp_url: session.cdp_url };
+	}
+
+	const deadline = Date.now() + QUEUE_WAIT_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, DEFAULT_POLL_INTERVAL_MS));
+		session = await cloudFetchJson<CloudSessionResponse>(
+			args.endpoint,
+			args.apiKey,
+			"/v1/sessions/get",
+			{ session_id: session.session_id },
+		);
+		if (session.cdp_url) {
+			return { ...session, cdp_url: session.cdp_url };
+		}
+		if (!["queued", "starting"].includes(session.status)) {
+			throw new Error(
+				`Libretto Cloud session ${session.session_id} entered status "${session.status}" before a CDP URL was available.`,
+			);
+		}
+	}
+
+	throw new Error(
+		`Timed out waiting for Libretto Cloud browser capacity after ${QUEUE_WAIT_TIMEOUT_MS / 1_000}s (session: ${session.session_id}).`,
+	);
+}
+
+/**
+ * Libretto Cloud browser sessions. The hosted API is an oRPC RPCHandler, so
+ * request bodies are wrapped as `{ json: ... }` and responses unwrap the same.
+ */
+export class LibrettoCloudBrowserProvider implements BrowserProvider {
+	readonly name = "libretto-cloud";
+	private readonly apiKey: string;
+	private readonly endpoint: string;
+	private readonly timeoutSeconds: number;
+	private readonly headless: boolean;
+
+	constructor(options: LibrettoCloudBrowserProviderOptions = {}) {
+		const apiKey = (options.apiKey ?? process.env.LIBRETTO_API_KEY)?.trim();
+		if (!apiKey) {
+			throw new Error(
+				"LibrettoCloudBrowserProvider: missing API key. " +
+					"Pass new LibrettoCloudBrowserProvider({ apiKey }) or set LIBRETTO_API_KEY.",
+			);
+		}
+
+		this.apiKey = apiKey;
+		this.endpoint = (
+			options.apiUrl ??
+			process.env.LIBRETTO_API_URL?.trim() ??
+			DEFAULT_HOSTED_API_URL
+		).replace(/\/$/, "");
+		this.timeoutSeconds =
+			options.timeoutSeconds ??
+			(Number(process.env.LIBRETTO_TIMEOUT_SECONDS) ||
+				DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS);
+		this.headless = options.headless ?? true;
+	}
+
+	async createSession(): Promise<ProviderSession> {
+		const created = await cloudFetchJson<CloudSessionResponse>(
+			this.endpoint,
+			this.apiKey,
+			"/v1/sessions/create",
+			{
+				timeout_seconds: this.timeoutSeconds,
+				headless: this.headless,
+			},
+		);
+
+		let ready: CloudSessionResponse & { cdp_url: string };
+		try {
+			ready = await waitForCloudSessionReady({
+				endpoint: this.endpoint,
+				apiKey: this.apiKey,
+				session: created,
+			});
+		} catch (error) {
+			await cloudFetchOk(this.endpoint, this.apiKey, "/v1/sessions/close", {
+				session_id: created.session_id,
+			}).catch(() => {});
+			throw error;
+		}
+
+		return {
+			sessionId: ready.session_id,
+			cdpEndpoint: ready.cdp_url,
+			liveViewUrl: ready.live_view_url ?? undefined,
+		};
+	}
+
+	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		await cloudFetchOk(this.endpoint, this.apiKey, "/v1/sessions/close", {
+			session_id: sessionId,
+		});
+
+		let replayUrl: string | undefined;
+		try {
+			const recording = await cloudFetchJson<{
+				recording_url: string | null;
+			}>(this.endpoint, this.apiKey, "/v1/recordings/get", {
+				session_id: sessionId,
+			});
+			replayUrl = recording.recording_url ?? undefined;
+		} catch {
+			// Recording may not exist yet; closing the session still succeeded.
+		}
+
+		return { replayUrl };
+	}
+}

--- a/packages/browser-tools/src/providers/steel.spec.ts
+++ b/packages/browser-tools/src/providers/steel.spec.ts
@@ -1,11 +1,11 @@
 import { chromium } from "playwright";
 import { expect, test } from "vitest";
-import { KernelBrowserProvider } from "./kernel.js";
+import { SteelBrowserProvider } from "./steel.js";
 
-test.skipIf(!process.env.KERNEL_API_KEY?.trim())(
-	"creates, connects to, and closes a Kernel browser",
+test.skipIf(!process.env.STEEL_API_KEY?.trim())(
+	"creates, connects to, and closes a Steel browser",
 	async () => {
-		const provider = new KernelBrowserProvider();
+		const provider = new SteelBrowserProvider();
 		const session = await provider.createSession();
 		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 

--- a/packages/browser-tools/src/providers/steel.ts
+++ b/packages/browser-tools/src/providers/steel.ts
@@ -1,0 +1,104 @@
+import type {
+	BrowserProvider,
+	ProviderSession,
+	ProviderSessionClosed,
+} from "../provider.js";
+
+const DEFAULT_STEEL_API_ENDPOINT = "https://api.steel.dev";
+const DEFAULT_STEEL_CONNECT_ENDPOINT = "wss://connect.steel.dev";
+
+export interface SteelBrowserProviderOptions {
+	apiKey?: string;
+	endpoint?: string;
+	connectEndpoint?: string;
+}
+
+interface SteelSessionResponse {
+	id: string;
+	sessionViewerUrl?: string;
+}
+
+function buildSteelCdpEndpoint(
+	connectEndpoint: string,
+	apiKey: string,
+	sessionId: string,
+): string {
+	const endpoint = new URL(connectEndpoint);
+	endpoint.searchParams.set("apiKey", apiKey);
+	endpoint.searchParams.set("sessionId", sessionId);
+	return endpoint.toString();
+}
+
+export class SteelBrowserProvider implements BrowserProvider {
+	readonly name = "steel";
+	private readonly apiKey: string;
+	private readonly endpoint: string;
+	private readonly connectEndpoint: string;
+
+	constructor(options: SteelBrowserProviderOptions = {}) {
+		const apiKey = (options.apiKey ?? process.env.STEEL_API_KEY)?.trim();
+		if (!apiKey) {
+			throw new Error(
+				"SteelBrowserProvider: missing API key. " +
+					"Pass new SteelBrowserProvider({ apiKey }) or set STEEL_API_KEY.",
+			);
+		}
+
+		this.apiKey = apiKey;
+		this.endpoint = (
+			options.endpoint ??
+			process.env.STEEL_BASE_URL?.trim() ??
+			DEFAULT_STEEL_API_ENDPOINT
+		).replace(/\/$/, "");
+		this.connectEndpoint =
+			options.connectEndpoint ??
+			process.env.STEEL_CONNECT_URL?.trim() ??
+			DEFAULT_STEEL_CONNECT_ENDPOINT;
+	}
+
+	async createSession(): Promise<ProviderSession> {
+		const response = await fetch(`${this.endpoint}/v1/sessions`, {
+			method: "POST",
+			headers: {
+				"steel-api-key": this.apiKey,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({}),
+		});
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(`Steel API error (${response.status}): ${body}`);
+		}
+		const session = (await response.json()) as SteelSessionResponse;
+		return {
+			sessionId: session.id,
+			cdpEndpoint: buildSteelCdpEndpoint(
+				this.connectEndpoint,
+				this.apiKey,
+				session.id,
+			),
+			liveViewUrl: session.sessionViewerUrl,
+		};
+	}
+
+	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const response = await fetch(
+			`${this.endpoint}/v1/sessions/${sessionId}/release`,
+			{
+				method: "POST",
+				headers: {
+					"steel-api-key": this.apiKey,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({}),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Steel API error closing session ${sessionId} (${response.status}): ${body}`,
+			);
+		}
+		return {};
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Browserbase, Steel, and Libretto Cloud provider subpath exports
- add live create/connect/close smoke tests for all four cloud providers
- run the Hacker News agent eval across Kernel, Browserbase, Steel, and Libretto Cloud

## Test plan
- [x] `pnpm -s type-check`
- [x] `pnpm -s test` with GCP-backed provider credentials (62 tests)
- [x] `pnpm -s exec vitest run --config vitest.evals.config.ts evals/hn-top-story.eval.ts` with GCP-backed provider and OpenAI credentials (4 evals)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbd23c74-d5aa-4967-b7f1-89d8397392d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbd23c74-d5aa-4967-b7f1-89d8397392d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

