### PR TITLE
Enforce type aliases in browser tools

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,6 +20,14 @@
     "libretto/no-await-import": "error",
     "libretto/require-disable-description": "error"
   },
+  "overrides": [
+    {
+      "files": ["packages/browser-tools/**/*.ts"],
+      "rules": {
+        "typescript/consistent-type-definitions": ["error", "type"]
+      }
+    }
+  ],
   "ignorePatterns": [
     "**/dist/**",
     "docs/**",

--- a/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
@@ -4,7 +4,7 @@ import { DomainPolicyRestricted } from "../../domain-policy.js";
 import { LocalBrowserProvider } from "../../providers/local.js";
 import { createAiSdkBrowserTools } from "./index.js";
 
-interface Toolkit {
+type Toolkit = {
 	tools: ToolSet;
 	dispose(): Promise<void>;
 }

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -14,7 +14,7 @@ import { createSnapshotTool } from "./tools/snapshot.js";
 import type { StatusTool } from "./tools/status.js";
 import { createStatusTool } from "./tools/status.js";
 
-export interface BrowserToolkit {
+export type BrowserToolkit = {
 	tools: {
 		browser_open: OpenTool;
 		browser_exec: ExecTool;

--- a/packages/browser-tools/src/domain-policy.ts
+++ b/packages/browser-tools/src/domain-policy.ts
@@ -2,7 +2,7 @@
  * Controls requests in the browser context managed by the toolkit.
  * This is not a sandbox for `browser_exec` or caller-created contexts.
  */
-export interface DomainPolicyOptions {
+export type DomainPolicyOptions = {
 	allowedDomains?: readonly string[];
 	blockedDomains?: readonly string[];
 }

--- a/packages/browser-tools/src/exec/exec-engine.ts
+++ b/packages/browser-tools/src/exec/exec-engine.ts
@@ -3,7 +3,7 @@ import type { Browser, BrowserContext, Page } from "playwright";
 import { errorMessage } from "../errors.js";
 import type { ToolResult } from "../tool.js";
 
-export interface ExecScope {
+export type ExecScope = {
 	page: Page;
 	context: BrowserContext;
 	browser: Browser;

--- a/packages/browser-tools/src/provider.ts
+++ b/packages/browser-tools/src/provider.ts
@@ -3,14 +3,14 @@
  * connects Playwright to it. Provider-specific settings (API keys, regions)
  * live in each provider's constructor, with env-var fallback.
  */
-export interface BrowserProvider {
+export type BrowserProvider = {
 	/** Shown in `status` output, e.g. "local", "kernel". */
 	readonly name: string;
 	createSession(): Promise<ProviderSession>;
 	closeSession(sessionId: string): Promise<ProviderSessionClosed>;
 }
 
-export interface ProviderSession {
+export type ProviderSession = {
 	/** Provider-scoped session identifier. */
 	sessionId: string;
 	/** CDP websocket endpoint the registry connects Playwright to. */
@@ -19,6 +19,6 @@ export interface ProviderSession {
 	recordingUrl?: string;
 }
 
-export interface ProviderSessionClosed {
+export type ProviderSessionClosed = {
 	replayUrl?: string;
 }

--- a/packages/browser-tools/src/providers/browserbase.ts
+++ b/packages/browser-tools/src/providers/browserbase.ts
@@ -4,13 +4,13 @@ import type {
 	ProviderSessionClosed,
 } from "../provider.js";
 
-export interface BrowserbaseBrowserProviderOptions {
+export type BrowserbaseBrowserProviderOptions = {
 	apiKey?: string;
 	projectId?: string;
 	endpoint?: string;
 }
 
-interface BrowserbaseSessionResponse {
+type BrowserbaseSessionResponse = {
 	id: string;
 	connectUrl: string;
 }

--- a/packages/browser-tools/src/providers/kernel.ts
+++ b/packages/browser-tools/src/providers/kernel.ts
@@ -4,7 +4,7 @@ import type {
 	ProviderSessionClosed,
 } from "../provider.js";
 
-export interface KernelBrowserProviderOptions {
+export type KernelBrowserProviderOptions = {
 	apiKey?: string;
 	headless?: boolean;
 	stealth?: boolean;
@@ -12,13 +12,13 @@ export interface KernelBrowserProviderOptions {
 	enableRecording?: boolean;
 }
 
-interface KernelBrowserResponse {
+type KernelBrowserResponse = {
 	session_id: string;
 	cdp_ws_url: string;
 	browser_live_view_url?: string | null;
 }
 
-interface KernelReplayResponse {
+type KernelReplayResponse = {
 	replay_view_url?: string | null;
 }
 

--- a/packages/browser-tools/src/providers/libretto-cloud.ts
+++ b/packages/browser-tools/src/providers/libretto-cloud.ts
@@ -9,7 +9,7 @@ const DEFAULT_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_BROWSER_SESSION_TIMEOUT_SECONDS = 3_600;
 const QUEUE_WAIT_TIMEOUT_MS = 10 * 60_000;
 
-export interface LibrettoCloudBrowserProviderOptions {
+export type LibrettoCloudBrowserProviderOptions = {
 	apiKey?: string;
 	apiUrl?: string;
 	/** Browser session TTL requested at create time. */
@@ -17,7 +17,7 @@ export interface LibrettoCloudBrowserProviderOptions {
 	headless?: boolean;
 }
 
-interface CloudSessionResponse {
+type CloudSessionResponse = {
 	session_id: string;
 	status: string;
 	cdp_url: string | null;

--- a/packages/browser-tools/src/providers/local.ts
+++ b/packages/browser-tools/src/providers/local.ts
@@ -7,7 +7,7 @@ import type {
 	ProviderSessionClosed,
 } from "../provider.js";
 
-export interface LocalBrowserProviderOptions {
+export type LocalBrowserProviderOptions = {
 	headless?: boolean;
 }
 

--- a/packages/browser-tools/src/providers/steel.ts
+++ b/packages/browser-tools/src/providers/steel.ts
@@ -7,13 +7,13 @@ import type {
 const DEFAULT_STEEL_API_ENDPOINT = "https://api.steel.dev";
 const DEFAULT_STEEL_CONNECT_ENDPOINT = "wss://connect.steel.dev";
 
-export interface SteelBrowserProviderOptions {
+export type SteelBrowserProviderOptions = {
 	apiKey?: string;
 	endpoint?: string;
 	connectEndpoint?: string;
 }
 
-interface SteelSessionResponse {
+type SteelSessionResponse = {
 	id: string;
 	sessionViewerUrl?: string;
 }

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -10,7 +10,7 @@ import type { Snapshot } from "./snapshot/capture-snapshot.js";
 import { snapshot as captureSnapshot } from "./snapshot/capture-snapshot.js";
 import type { BrowserProvider } from "./provider.js";
 
-interface SessionEntry {
+type SessionEntry = {
 	providerSessionId: string | undefined;
 	providerName: string;
 	/** True for browser_connect sessions — close detaches without killing the browser. */
@@ -23,19 +23,19 @@ interface SessionEntry {
 	latestSnapshotByPage: Map<Page, Snapshot>;
 }
 
-export interface SessionPageSummary {
+export type SessionPageSummary = {
 	pageId: string;
 	url: string;
 	active: boolean;
 }
 
-export interface SessionSummary {
+export type SessionSummary = {
 	sessionId: string;
 	provider: string;
 	pages: SessionPageSummary[];
 }
 
-export interface PageStatus {
+export type PageStatus = {
 	pageId: string;
 	url: string;
 	title: string;

--- a/packages/browser-tools/src/tool.ts
+++ b/packages/browser-tools/src/tool.ts
@@ -6,7 +6,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
  * Standard Schema so the public contract names no validator; schemas are
  * authored in zod internally.
  */
-export interface BrowserTool<Input = unknown, Output = unknown> {
+export type BrowserTool<Input = unknown, Output = unknown> = {
 	/** Prefixed name as exposed to the agent, e.g. `browser_open`. */
 	name: string;
 	description: string;
@@ -21,7 +21,7 @@ export interface BrowserTool<Input = unknown, Output = unknown> {
  * throw {@link DomainPolicyRestricted} so clients can inspect and render the
  * configured policy and attempted URL.
  */
-export interface ToolErrorResult {
+export type ToolErrorResult = {
 	ok: false;
 	error: string;
 	stdout?: string;

--- a/packages/browser-tools/src/tools/close.ts
+++ b/packages/browser-tools/src/tools/close.ts
@@ -13,9 +13,9 @@ export type CloseToolInput = z.infer<typeof closeInputSchema>;
 
 export type CloseToolOutput = {};
 
-export interface CloseTool extends BrowserTool<CloseToolInput, CloseToolOutput> {
+export type CloseTool = {
 	inputSchema: typeof closeInputSchema;
-}
+} & BrowserTool<CloseToolInput, CloseToolOutput>
 
 export function createCloseTool(registry: SessionRegistry): CloseTool {
 	return {

--- a/packages/browser-tools/src/tools/connect.ts
+++ b/packages/browser-tools/src/tools/connect.ts
@@ -15,14 +15,13 @@ const connectInputSchema = z.object({
 
 export type ConnectToolInput = z.infer<typeof connectInputSchema>;
 
-export interface ConnectToolOutput {
+export type ConnectToolOutput = {
 	sessionId: string;
 }
 
-export interface ConnectTool
-	extends BrowserTool<ConnectToolInput, ConnectToolOutput> {
+export type ConnectTool = {
 	inputSchema: typeof connectInputSchema;
-}
+} & BrowserTool<ConnectToolInput, ConnectToolOutput>
 
 export function createConnectTool(registry: SessionRegistry): ConnectTool {
 	return {

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -30,7 +30,7 @@ const execInputSchema = z.object({
 
 export type ExecToolInput = z.infer<typeof execInputSchema>;
 
-export interface ExecToolOutput {
+export type ExecToolOutput = {
 	result: unknown;
 	stdout: string;
 	stderr: string;
@@ -43,9 +43,9 @@ export interface ExecToolOutput {
  * StandardSchemaV1) so framework adapters like ai-sdk can pass it straight
  * through as their own schema input.
  */
-export interface ExecTool extends BrowserTool<ExecToolInput, ExecToolOutput> {
+export type ExecTool = {
 	inputSchema: typeof execInputSchema;
-}
+} & BrowserTool<ExecToolInput, ExecToolOutput>
 
 export function createExecTool(registry: SessionRegistry): ExecTool {
 	return {

--- a/packages/browser-tools/src/tools/open.ts
+++ b/packages/browser-tools/src/tools/open.ts
@@ -12,7 +12,7 @@ const openInputSchema = z.object({
 
 export type OpenToolInput = z.infer<typeof openInputSchema>;
 
-export interface OpenToolOutput {
+export type OpenToolOutput = {
 	sessionId: string;
 }
 
@@ -21,9 +21,9 @@ export interface OpenToolOutput {
  * StandardSchemaV1) so framework adapters like ai-sdk can pass it straight
  * through as their own schema input.
  */
-export interface OpenTool extends BrowserTool<OpenToolInput, OpenToolOutput> {
+export type OpenTool = {
 	inputSchema: typeof openInputSchema;
-}
+} & BrowserTool<OpenToolInput, OpenToolOutput>
 
 export function createOpenTool(registry: SessionRegistry): OpenTool {
 	return {

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -24,20 +24,19 @@ const snapshotInputSchema = z.object({
 
 export type SnapshotToolInput = z.infer<typeof snapshotInputSchema>;
 
-export interface SnapshotScreenshot {
+export type SnapshotScreenshot = {
 	base64: string;
 	mimeType: "image/png";
 }
 
-export interface SnapshotToolOutput {
+export type SnapshotToolOutput = {
 	tree: string;
 	screenshot?: SnapshotScreenshot;
 }
 
-export interface SnapshotTool
-	extends BrowserTool<SnapshotToolInput, SnapshotToolOutput> {
+export type SnapshotTool = {
 	inputSchema: typeof snapshotInputSchema;
-}
+} & BrowserTool<SnapshotToolInput, SnapshotToolOutput>
 
 export function createSnapshotTool(registry: SessionRegistry): SnapshotTool {
 	return {

--- a/packages/browser-tools/src/tools/status.ts
+++ b/packages/browser-tools/src/tools/status.ts
@@ -17,11 +17,11 @@ const statusInputSchema = z.object({
 
 export type StatusToolInput = z.infer<typeof statusInputSchema>;
 
-export interface StatusAllOutput {
+export type StatusAllOutput = {
 	sessions: SessionSummary[];
 }
 
-export interface StatusSessionOutput {
+export type StatusSessionOutput = {
 	pages: SessionPageSummary[];
 }
 
@@ -30,9 +30,9 @@ export type StatusToolOutput =
 	| StatusSessionOutput
 	| PageStatus;
 
-export interface StatusTool extends BrowserTool<StatusToolInput, StatusToolOutput> {
+export type StatusTool = {
 	inputSchema: typeof statusInputSchema;
-}
+} & BrowserTool<StatusToolInput, StatusToolOutput>
 
 export function createStatusTool(registry: SessionRegistry): StatusTool {
 	return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scope Oxlint's `typescript/consistent-type-definitions` rule to `packages/browser-tools/**/*.ts`
- migrate all 36 existing browser-tools interfaces to type aliases

## Testing
- `pnpm exec oxlint --type-aware packages/browser-tools`
- `pnpm --filter @libretto/browser-tools type-check`
- `pnpm --filter @libretto/browser-tools test` (58 passed, 4 skipped)
- `pnpm -s lint`
- `pnpm -s type-check` (10 tasks passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61165ffe-f0fe-4292-a1bb-d5cf0eb66c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61165ffe-f0fe-4292-a1bb-d5cf0eb66c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

