### PR TITLE
release: affordance v0.2.2

### DIFF
--- a/packages/affordance/package.json
+++ b/packages/affordance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affordance",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A TypeScript framework for building agent-friendly CLIs",
   "license": "MIT",
   "homepage": "https://libretto.sh",


### PR DESCRIPTION
## Summary

- publish affordance v0.2.2 before the coupled Libretto v0.6.34 release
- unblock release evals that install the packed Libretto package against npm

## Verification

- `pnpm --filter affordance type-check`
- `pnpm --filter affordance test`
