### PR TITLE
Publish standalone debugger packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,18 @@ jobs:
           version="$(node -p "require('./packages/libretto/package.json').version")"
           affordance_version="$(node -p "require('./packages/affordance/package.json').version")"
           create_libretto_package_name="$(node -p "require('./packages/create-libretto/package.json').name")"
+          browser_tools_package_name="$(node -p "require('./packages/browser-tools/package.json').name")"
+          browser_tools_version="$(node -p "require('./packages/browser-tools/package.json').version")"
+          playwright_debug_package_name="$(node -p "require('./packages/playwright-debug/package.json').name")"
+          playwright_debug_version="$(node -p "require('./packages/playwright-debug/package.json').version")"
           echo "package_name=${package_name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "affordance_version=${affordance_version}" >> "$GITHUB_OUTPUT"
           echo "create_libretto_package_name=${create_libretto_package_name}" >> "$GITHUB_OUTPUT"
+          echo "browser_tools_package_name=${browser_tools_package_name}" >> "$GITHUB_OUTPUT"
+          echo "browser_tools_version=${browser_tools_version}" >> "$GITHUB_OUTPUT"
+          echo "playwright_debug_package_name=${playwright_debug_package_name}" >> "$GITHUB_OUTPUT"
+          echo "playwright_debug_version=${playwright_debug_version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
       - name: Check release state
@@ -52,6 +60,8 @@ jobs:
           npm_exists=false
           affordance_npm_exists=false
           create_libretto_npm_exists=false
+          browser_tools_npm_exists=false
+          playwright_debug_npm_exists=false
           publish_needed=false
 
           if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
@@ -70,7 +80,15 @@ jobs:
             create_libretto_npm_exists=true
           fi
 
-          if [ "$release_exists" != true ] || [ "$npm_exists" != true ] || [ "$affordance_npm_exists" != true ] || [ "$create_libretto_npm_exists" != true ]; then
+          if npm view "${{ steps.version.outputs.browser_tools_package_name }}@${{ steps.version.outputs.browser_tools_version }}" version >/dev/null 2>&1; then
+            browser_tools_npm_exists=true
+          fi
+
+          if npm view "${{ steps.version.outputs.playwright_debug_package_name }}@${{ steps.version.outputs.playwright_debug_version }}" version >/dev/null 2>&1; then
+            playwright_debug_npm_exists=true
+          fi
+
+          if [ "$release_exists" != true ] || [ "$npm_exists" != true ] || [ "$affordance_npm_exists" != true ] || [ "$create_libretto_npm_exists" != true ] || [ "$browser_tools_npm_exists" != true ] || [ "$playwright_debug_npm_exists" != true ]; then
             publish_needed=true
           fi
 
@@ -78,12 +96,14 @@ jobs:
           echo "npm_exists=${npm_exists}" >> "$GITHUB_OUTPUT"
           echo "affordance_npm_exists=${affordance_npm_exists}" >> "$GITHUB_OUTPUT"
           echo "create_libretto_npm_exists=${create_libretto_npm_exists}" >> "$GITHUB_OUTPUT"
+          echo "browser_tools_npm_exists=${browser_tools_npm_exists}" >> "$GITHUB_OUTPUT"
+          echo "playwright_debug_npm_exists=${playwright_debug_npm_exists}" >> "$GITHUB_OUTPUT"
           echo "publish_needed=${publish_needed}" >> "$GITHUB_OUTPUT"
 
       - name: Skip already published version
         if: steps.state.outputs.publish_needed != 'true'
         run: |
-          echo "Version ${{ steps.version.outputs.version }} and affordance@${{ steps.version.outputs.affordance_version }} are already published to npm and GitHub."
+          echo "All release packages are already published to npm and GitHub."
 
       - name: Configure gcloud secret access for evaluator
         if: steps.state.outputs.publish_needed == 'true'
@@ -147,16 +167,26 @@ jobs:
         if: steps.state.outputs.publish_needed == 'true'
         run: |
           pnpm check:mirrors
-          pnpm --filter libretto... build
+          pnpm --filter libretto... --filter libretto-playwright-debug... build
           pnpm --filter libretto type-check
           pnpm --filter libretto test
+          pnpm --filter libretto-browser-tools type-check
+          pnpm --filter libretto-browser-tools test
+          pnpm --filter libretto-playwright-debug type-check
+          pnpm --filter libretto-playwright-debug test
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      browser_tools_package_name: ${{ steps.version.outputs.browser_tools_package_name }}
+      browser_tools_version: ${{ steps.version.outputs.browser_tools_version }}
+      playwright_debug_package_name: ${{ steps.version.outputs.playwright_debug_package_name }}
+      playwright_debug_version: ${{ steps.version.outputs.playwright_debug_version }}
       release_exists: ${{ steps.state.outputs.release_exists }}
       npm_exists: ${{ steps.state.outputs.npm_exists }}
       affordance_npm_exists: ${{ steps.state.outputs.affordance_npm_exists }}
       create_libretto_npm_exists: ${{ steps.state.outputs.create_libretto_npm_exists }}
+      browser_tools_npm_exists: ${{ steps.state.outputs.browser_tools_npm_exists }}
+      playwright_debug_npm_exists: ${{ steps.state.outputs.playwright_debug_npm_exists }}
       publish_needed: ${{ steps.state.outputs.publish_needed }}
 
   release:
@@ -185,7 +215,27 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build publish artifacts
-        run: pnpm --filter libretto... build
+        run: pnpm --filter libretto... --filter libretto-playwright-debug... build
+
+      - name: Publish browser tools to npm
+        if: needs.verify.outputs.browser_tools_npm_exists != 'true'
+        working-directory: packages/browser-tools
+        run: |
+          if ! npm view "${{ needs.verify.outputs.browser_tools_package_name }}@${{ needs.verify.outputs.browser_tools_version }}" version >/dev/null 2>&1; then
+            pnpm publish --access public --no-git-checks
+          else
+            echo "${{ needs.verify.outputs.browser_tools_package_name }}@${{ needs.verify.outputs.browser_tools_version }} already published, skipping."
+          fi
+
+      - name: Publish Playwright debugger to npm
+        if: needs.verify.outputs.playwright_debug_npm_exists != 'true'
+        working-directory: packages/playwright-debug
+        run: |
+          if ! npm view "${{ needs.verify.outputs.playwright_debug_package_name }}@${{ needs.verify.outputs.playwright_debug_version }}" version >/dev/null 2>&1; then
+            pnpm publish --access public --no-git-checks
+          else
+            echo "${{ needs.verify.outputs.playwright_debug_package_name }}@${{ needs.verify.outputs.playwright_debug_version }} already published, skipping."
+          fi
 
       - name: Publish affordance to npm
         if: needs.verify.outputs.affordance_npm_exists != 'true'

--- a/apps/website/src/SetupPage.tsx
+++ b/apps/website/src/SetupPage.tsx
@@ -20,7 +20,7 @@ const DEBUGGER_DOCS_URL = "/docs/reference/runtime/playwright-debug";
 const DEBUGGER_CONCEPT_URL = "/docs/understand-libretto/autofix-debugging";
 const DEBUGGER_PROMPT =
   "Add the Libretto Playwright debugging agent to my existing automation. " +
-  "Install @libretto/playwright-debug, then in my script's failure path call " +
+  "Install libretto-playwright-debug, then in my script's failure path call " +
   "debugPlaywrightFailure(error, page). Follow " +
   "https://libretto.sh/docs/reference/runtime/playwright-debug to configure " +
   "createLibrettoDebugger with my repo (owner, repo, baseBranch) and " +

--- a/docs/reference/runtime/playwright-debug.mdx
+++ b/docs/reference/runtime/playwright-debug.mdx
@@ -6,12 +6,12 @@ description: Investigate failures and automatically open pull requests to fix Pl
 The Playwright debugging agent investigates failed browser automations and
 automatically opens pull requests that fix broken scripts.
 
-`@libretto/playwright-debug` lets an existing Playwright script keep its current
+`libretto-playwright-debug` lets an existing Playwright script keep its current
 browser provider, retries, logging, and fallback logic while adding one agent
 call in the failure path.
 
 ```typescript
-import { createLibrettoDebugger } from "@libretto/playwright-debug";
+import { createLibrettoDebugger } from "libretto-playwright-debug";
 
 const librettoDebugger = createLibrettoDebugger({
   github: {
@@ -61,7 +61,7 @@ minified stacks, or a cross-file change).
 ## How It Investigates
 
 The debugger does not guess a fix from a static snapshot. It runs an agent loop
-built on the [`@libretto/browser-tools`](https://www.npmjs.com/package/@libretto/browser-tools)
+built on the [`libretto-browser-tools`](https://www.npmjs.com/package/libretto-browser-tools)
 SDK: the model is given the failure context and source files, then drives a real
 browser to confirm the root cause before proposing a change. It stays attached
 to the supplied failed `Page`, preserving its authentication, storage, routes,

--- a/docs/understand-libretto/autofix-debugging.mdx
+++ b/docs/understand-libretto/autofix-debugging.mdx
@@ -20,7 +20,7 @@ the real field is `name="login"`, because the page redirected, or because an
 element loads late — and the source code alone cannot tell you which.
 
 The debugging agent does not guess. It runs an agent loop on the
-[`@libretto/browser-tools`](../reference/runtime/playwright-debug) SDK and
+[`libretto-browser-tools`](../reference/runtime/playwright-debug) SDK and
 drives the supplied failed page in its existing browser context. Authentication,
 storage, open tabs, network routes, and in-memory state remain available while
 the agent confirms the cause. Fixes are grounded in what the agent actually

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -21,5 +21,3 @@ const result = await generateText({
 
 await dispose(); // close any sessions the agent left open
 ```
-
-Under active development — not yet published.

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -1,12 +1,12 @@
-# @libretto/browser-tools
+# libretto-browser-tools
 
 Browser tools for AI agents. Gives any agent framework a set of tools to open real browsers (local or cloud), inspect pages via accessibility snapshots, and drive them with Playwright code.
 
 ```typescript
 import { anthropic } from "@ai-sdk/anthropic";
 import { generateText } from "ai";
-import { createAiSdkBrowserTools } from "@libretto/browser-tools/ai-sdk";
-import { LocalBrowserProvider } from "@libretto/browser-tools";
+import { createAiSdkBrowserTools } from "libretto-browser-tools/ai-sdk";
+import { LocalBrowserProvider } from "libretto-browser-tools";
 
 // Cloud providers (Libretto Cloud, Browserbase, Kernel, ...) are on the way.
 const { tools, dispose } = createAiSdkBrowserTools(new LocalBrowserProvider());

--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@libretto/browser-tools",
+  "name": "libretto-browser-tools",
   "version": "0.1.0",
   "description": "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework",
   "license": "MIT",

--- a/packages/playwright-debug/README.md
+++ b/packages/playwright-debug/README.md
@@ -1,13 +1,13 @@
-# @libretto/playwright-debug
+# libretto-playwright-debug
 
-`@libretto/playwright-debug` adds a Playwright debugging agent that investigates
+`libretto-playwright-debug` adds a Playwright debugging agent that investigates
 failed runs on the supplied live page and automatically opens pull requests to
 fix broken scripts. It preserves the page's browser context and treats debugger
 infrastructure failures as best-effort results instead of replacing the original
 automation error.
 
 ```ts
-import { createLibrettoDebugger } from "@libretto/playwright-debug";
+import { createLibrettoDebugger } from "libretto-playwright-debug";
 
 const librettoDebugger = createLibrettoDebugger({
   github: {

--- a/packages/playwright-debug/package.json
+++ b/packages/playwright-debug/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@libretto/playwright-debug",
+  "name": "libretto-playwright-debug",
   "version": "0.1.0",
   "description": "Open GitHub autofix pull requests from failed Playwright runs",
   "license": "MIT",
@@ -39,7 +39,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.81",
     "@ai-sdk/openai": "3.0.66",
-    "@libretto/browser-tools": "workspace:*",
+    "libretto-browser-tools": "workspace:*",
     "ai": "6.0.140",
     "zod": "4.3.6"
   },

--- a/packages/playwright-debug/src/index.ts
+++ b/packages/playwright-debug/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "ai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
-import { createAiSdkBrowserToolsForPage } from "@libretto/browser-tools/ai-sdk";
+import { createAiSdkBrowserToolsForPage } from "libretto-browser-tools/ai-sdk";
 import type { Page } from "playwright";
 
 export type SupportedAgentProvider = "anthropic" | "openai";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,12 +351,12 @@ importers:
       '@ai-sdk/openai':
         specifier: 3.0.66
         version: 3.0.66(zod@4.3.6)
-      '@libretto/browser-tools':
-        specifier: workspace:*
-        version: link:../browser-tools
       ai:
         specifier: 6.0.140
         version: 6.0.140(zod@4.3.6)
+      libretto-browser-tools:
+        specifier: workspace:*
+        version: link:../browser-tools
       zod:
         specifier: 4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary
- publish browser tools as `libretto-browser-tools`
- publish the Playwright debugging agent as `libretto-playwright-debug`
- update source imports, package docs, website setup guidance, and reference docs
- include both packages in release-state checks, verification, builds, and trusted npm publishing

## Published bootstrap versions
- `libretto-browser-tools@0.1.0`
- `libretto-playwright-debug@0.1.0`

Both packages are configured to trust `release.yml` in the protected `release` environment for future versions.

## Validation
- browser tools: 64 tests passed, 4 skipped
- Playwright debugger: 9 tests passed
- package type-checks and builds
- website type-check
- docs validation
- repository lint
- mirror parity
- frozen install
