### PR TITLE
Add multi-product website pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
 - Docs: [libretto.sh/docs](https://libretto.sh/docs)
 - Repository: [github.com/saffron-health/libretto](https://github.com/saffron-health/libretto)
 - Discord: [discord.gg/NYrG56hVDt](https://discord.gg/NYrG56hVDt)
-- Youtube: [https://www.youtube.com/watch?v=0cDpIntmHAM]
 
 ## Installation
 

--- a/apps/website/public/sitemap.xml
+++ b/apps/website/public/sitemap.xml
@@ -9,6 +9,14 @@
     <lastmod>2026-07-14</lastmod>
   </url>
   <url>
+    <loc>https://libretto.sh/debug-agents</loc>
+    <lastmod>2026-07-15</lastmod>
+  </url>
+  <url>
+    <loc>https://libretto.sh/browser-tools</loc>
+    <lastmod>2026-07-15</lastmod>
+  </url>
+  <url>
     <loc>https://libretto.sh/blog</loc>
     <lastmod>2026-06-18</lastmod>
   </url>

--- a/apps/website/public/sitemap.xml
+++ b/apps/website/public/sitemap.xml
@@ -5,6 +5,10 @@
     <lastmod>2026-06-18</lastmod>
   </url>
   <url>
+    <loc>https://libretto.sh/cli</loc>
+    <lastmod>2026-07-14</lastmod>
+  </url>
+  <url>
     <loc>https://libretto.sh/blog</loc>
     <lastmod>2026-06-18</lastmod>
   </url>

--- a/apps/website/src/BrowserToolsPage.tsx
+++ b/apps/website/src/BrowserToolsPage.tsx
@@ -1,0 +1,71 @@
+import { motion } from "motion/react";
+import { Navbar } from "./components/Navbar";
+import { Footer } from "./components/Footer";
+import { Text } from "./components/Text";
+import { Kicker } from "./components/Kicker";
+
+export function BrowserToolsPage() {
+  return (
+    <div className="crt-page min-h-screen bg-bg text-ink">
+      <Navbar />
+      <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden px-8 py-24">
+        <div className="pointer-events-none absolute inset-0 bg-[repeating-linear-gradient(-12deg,transparent,transparent_18px,color-mix(in_oklch,var(--color-amber)_7%,transparent)_18px,color-mix(in_oklch,var(--color-amber)_7%,transparent)_36px)]" />
+        <div className="relative mx-auto flex max-w-[720px] flex-col items-center text-center">
+          <Kicker className="mb-6">// BROWSER TOOLS SDK --</Kicker>
+          <motion.div
+            initial={{ rotate: -8, y: 12, opacity: 0 }}
+            animate={{ rotate: -6, y: 0, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 120, damping: 14 }}
+            className="mb-10 border-[3px] border-amber bg-bg px-8 py-5 shadow-[8px_8px_0_color-mix(in_oklch,var(--color-amber)_40%,transparent)]"
+          >
+            <div className="font-mono text-xs tracking-[0.28em] text-amber">
+              CAUTION
+            </div>
+            <Text
+              as="p"
+              size="3xl"
+              style="serif"
+              className="mt-1 tracking-[-0.03em] text-ink"
+              htmlStyle={{ fontWeight: 400, fontSize: "clamp(28px, 5vw, 44px)" }}
+            >
+              Under construction
+            </Text>
+          </motion.div>
+          <Text
+            as="h1"
+            size="4xl"
+            style="serif"
+            className="crt-glow mb-4 tracking-[-0.03em] text-ink [text-wrap:balance]"
+            htmlStyle={{
+              fontWeight: 300,
+              fontSize: "clamp(32px, 4.5vw, 52px)",
+              lineHeight: 1.1,
+            }}
+          >
+            Browser Tools SDK
+          </Text>
+          <Text
+            as="p"
+            size="lg"
+            className="max-w-[480px] leading-relaxed text-muted [text-wrap:balance]"
+          >
+            Browser tools for AI agents — open, inspect, and drive real browsers
+            from any agent framework. This product page is coming soon.
+          </Text>
+          <a
+            href="https://github.com/saffron-health/libretto/tree/main/packages/browser-tools"
+            className="mt-8 text-sm text-accent-bright underline decoration-accent/40 underline-offset-4 transition-colors hover:decoration-accent"
+            data-fathom-event="Browser tools github click"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Peek at the package on GitHub →
+          </a>
+        </div>
+      </section>
+      <div className="section-rails relative mx-auto max-w-[1100px]">
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/BrowserToolsPage.tsx
+++ b/apps/website/src/BrowserToolsPage.tsx
@@ -35,7 +35,7 @@ export function BrowserToolsPage() {
             as="h1"
             size="4xl"
             style="serif"
-            className="crt-glow mb-4 tracking-[-0.03em] text-ink [text-wrap:balance]"
+            className="crt-glow mb-4 tracking-[-0.03em] text-ink [text-wrap:pretty]"
             htmlStyle={{
               fontWeight: 300,
               fontSize: "clamp(32px, 4.5vw, 52px)",
@@ -47,7 +47,7 @@ export function BrowserToolsPage() {
           <Text
             as="p"
             size="lg"
-            className="max-w-[480px] leading-relaxed text-muted [text-wrap:balance]"
+            className="max-w-[480px] leading-relaxed text-muted [text-wrap:pretty]"
           >
             Browser tools for AI agents — open, inspect, and drive real browsers
             from any agent framework. This product page is coming soon.

--- a/apps/website/src/BrowserToolsPage.tsx
+++ b/apps/website/src/BrowserToolsPage.tsx
@@ -49,8 +49,9 @@ export function BrowserToolsPage() {
             size="lg"
             className="max-w-[480px] leading-relaxed text-muted [text-wrap:pretty]"
           >
-            Browser tools for AI agents — open, inspect, and drive real browsers
-            from any agent framework. This product page is coming soon.
+            Browser tools for AI agents that open, inspect, and drive real
+            browsers from any agent framework. This product page is coming
+            soon.
           </Text>
           <a
             href="https://github.com/saffron-health/libretto/tree/main/packages/browser-tools"

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -26,7 +26,7 @@ function CliHero() {
             as="h1"
             size="5xl"
             style="serif"
-            className="crt-glow mx-auto mb-6 max-w-[720px] tracking-[-0.04em] text-ink [text-wrap:balance]"
+            className="crt-glow mx-auto mb-6 max-w-[720px] tracking-[-0.04em] text-ink [text-wrap:pretty]"
             htmlStyle={{
               fontWeight: 300,
               fontSize: "clamp(36px, 5vw, 64px)",
@@ -38,7 +38,7 @@ function CliHero() {
           <Text
             as="p"
             size="lg"
-            className="mx-auto mb-8 max-w-[640px] leading-relaxed text-muted [text-wrap:balance]"
+            className="mx-auto mb-8 max-w-[640px] leading-relaxed text-muted [text-wrap:pretty]"
           >
             An open-source CLI that records live browser workflows and compiles
             them into fast, reusable scripts in your codebase.

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -18,15 +18,15 @@ const DEMO_VIDEO_SOURCE =
 
 function CliHero() {
   return (
-    <section className="relative overflow-hidden px-8 pt-16 pb-8 md:pt-24">
-      <div className="mx-auto grid max-w-[1100px] items-center gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-14">
-        <div>
+    <section className="relative overflow-hidden px-8 pt-16 pb-16 md:pt-24">
+      <div className="relative mx-auto max-w-[1200px]">
+        <div className="text-center">
           <Kicker className="mb-4">// LIBRETTO CLI --</Kicker>
           <Text
             as="h1"
             size="5xl"
             style="serif"
-            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:balance]"
+            className="crt-glow mx-auto mb-6 max-w-[720px] tracking-[-0.04em] text-ink [text-wrap:balance]"
             htmlStyle={{
               fontWeight: 300,
               fontSize: "clamp(36px, 5vw, 64px)",
@@ -38,12 +38,12 @@ function CliHero() {
           <Text
             as="p"
             size="lg"
-            className="mb-8 max-w-[520px] leading-relaxed text-muted [text-wrap:balance]"
+            className="mx-auto mb-8 max-w-[640px] leading-relaxed text-muted [text-wrap:balance]"
           >
             An open-source CLI that records live browser workflows and compiles
             them into fast, reusable scripts in your codebase.
           </Text>
-          <div className="flex flex-col items-start gap-3">
+          <div className="mb-16 flex flex-col items-center justify-center gap-3">
             <InstallSnippet />
             <div className="text-xs text-muted">
               or{" "}
@@ -57,7 +57,7 @@ function CliHero() {
             </div>
           </div>
         </div>
-        <div className="overflow-hidden rounded-xl border border-rule bg-panel/50 shadow-lg shadow-black/30">
+        <div className="mx-auto max-w-[960px] overflow-hidden rounded-xl border border-rule bg-panel/50 shadow-lg shadow-black/30">
           <div className="flex items-center gap-2 border-b border-rule px-4 py-2.5">
             <span className="size-2.5 rounded-full bg-rule" />
             <span className="size-2.5 rounded-full bg-rule" />

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -4,17 +4,90 @@ import { FeatureRows } from "./components/FeatureRows";
 import { BattleTestedBanner } from "./components/BattleTestedBanner";
 import { Benchmarks } from "./components/Benchmarks";
 import { MaintainingFeatures } from "./components/MaintainingFeatures";
-import { AutofixPR } from "./components/AutofixPR";
 import { CloudProviders } from "./components/CloudProviders";
 import { FAQ } from "./components/FAQ";
 import { CTA } from "./components/CTA";
 import { SectionDivider } from "./components/SectionDivider.js";
+import { Text } from "./components/Text";
+import { InstallSnippet } from "./components/InstallSnippet";
+import { Kicker } from "./components/Kicker";
+
+const DEMO_VIDEO_SRC = "/demos/cli-demo.mp4";
+const DEMO_VIDEO_SOURCE =
+  "https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18";
+
+function CliHero() {
+  return (
+    <section className="relative overflow-hidden px-8 pt-16 pb-8 md:pt-24">
+      <div className="mx-auto grid max-w-[1100px] items-center gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-14">
+        <div>
+          <Kicker className="mb-4">// LIBRETTO CLI --</Kicker>
+          <Text
+            as="h1"
+            size="5xl"
+            style="serif"
+            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:balance]"
+            htmlStyle={{
+              fontWeight: 300,
+              fontSize: "clamp(36px, 5vw, 64px)",
+              lineHeight: 1.05,
+            }}
+          >
+            Turn website workflows into reliable APIs
+          </Text>
+          <Text
+            as="p"
+            size="lg"
+            className="mb-8 max-w-[520px] leading-relaxed text-muted [text-wrap:balance]"
+          >
+            An open-source CLI that records live browser workflows and compiles
+            them into fast, reusable scripts in your codebase.
+          </Text>
+          <div className="flex flex-col items-start gap-3">
+            <InstallSnippet />
+            <div className="text-xs text-muted">
+              or{" "}
+              <a
+                href="https://cal.com/team/libretto/demo"
+                className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
+                data-fathom-event="CLI hero demo click"
+              >
+                BOOK A DEMO
+              </a>
+            </div>
+          </div>
+        </div>
+        <div className="overflow-hidden rounded-xl border border-rule bg-panel/50 shadow-lg shadow-black/30">
+          <div className="flex items-center gap-2 border-b border-rule px-4 py-2.5">
+            <span className="size-2.5 rounded-full bg-rule" />
+            <span className="size-2.5 rounded-full bg-rule" />
+            <span className="size-2.5 rounded-full bg-rule" />
+            <span className="ml-2 font-mono text-[11px] text-muted">
+              libretto demo
+            </span>
+          </div>
+          <video
+            className="aspect-video w-full bg-bg object-cover"
+            controls
+            playsInline
+            preload="metadata"
+          >
+            <source src={DEMO_VIDEO_SRC} type="video/mp4" />
+            <a href={DEMO_VIDEO_SOURCE}>Watch the Libretto CLI demo</a>
+          </video>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 export function CliProductPage() {
   return (
     <div className="crt-page min-h-screen bg-bg text-ink">
       <Navbar />
+      <CliHero />
       <div className="section-rails relative mx-auto max-w-[1100px]">
+        <SectionDivider />
         <FeatureRows />
         <SectionDivider />
         <Benchmarks />
@@ -22,8 +95,6 @@ export function CliProductPage() {
         <BattleTestedBanner />
         <SectionDivider />
         <MaintainingFeatures />
-        <SectionDivider />
-        <AutofixPR />
         <SectionDivider />
         <CloudProviders />
         <SectionDivider />

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -1,0 +1,37 @@
+import { Navbar } from "./components/Navbar";
+import { Footer } from "./components/Footer";
+import { FeatureRows } from "./components/FeatureRows";
+import { BattleTestedBanner } from "./components/BattleTestedBanner";
+import { Benchmarks } from "./components/Benchmarks";
+import { MaintainingFeatures } from "./components/MaintainingFeatures";
+import { AutofixPR } from "./components/AutofixPR";
+import { CloudProviders } from "./components/CloudProviders";
+import { FAQ } from "./components/FAQ";
+import { CTA } from "./components/CTA";
+import { SectionDivider } from "./components/SectionDivider.js";
+
+export function CliProductPage() {
+  return (
+    <div className="crt-page min-h-screen bg-bg text-ink">
+      <Navbar />
+      <div className="section-rails relative mx-auto max-w-[1100px]">
+        <FeatureRows />
+        <SectionDivider />
+        <Benchmarks />
+        <SectionDivider />
+        <BattleTestedBanner />
+        <SectionDivider />
+        <MaintainingFeatures />
+        <SectionDivider />
+        <AutofixPR />
+        <SectionDivider />
+        <CloudProviders />
+        <SectionDivider />
+        <FAQ />
+        <SectionDivider />
+        <CTA />
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -52,7 +52,7 @@ function CliHero() {
                 className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
                 data-fathom-event="CLI hero demo click"
               >
-                BOOK A DEMO
+                TALK TO A DEV
               </a>
             </div>
           </div>

--- a/apps/website/src/DebugAgentsPage.tsx
+++ b/apps/website/src/DebugAgentsPage.tsx
@@ -38,7 +38,7 @@ function DebugAgentsHero() {
             as="h1"
             size="5xl"
             style="serif"
-            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:balance]"
+            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:pretty]"
             htmlStyle={{
               fontWeight: 300,
               fontSize: "clamp(36px, 5vw, 64px)",
@@ -50,7 +50,7 @@ function DebugAgentsHero() {
           <Text
             as="p"
             size="lg"
-            className="mb-8 max-w-[480px] leading-relaxed text-muted [text-wrap:balance]"
+            className="mb-8 max-w-[480px] leading-relaxed text-muted [text-wrap:pretty]"
           >
             Libretto&apos;s Playwright debugging agent investigates failures on
             the live site and opens a GitHub PR with the fix — turning a broken
@@ -84,7 +84,7 @@ function FeatureListing() {
       <SectionIntro
         align="left"
         className="mb-12 max-w-[640px]"
-        headingClassName="mb-4 [text-wrap:balance]"
+        headingClassName="mb-4 [text-wrap:pretty]"
         kicker="// FEATURES --"
         title="Failure to fix, without the guesswork"
       >

--- a/apps/website/src/DebugAgentsPage.tsx
+++ b/apps/website/src/DebugAgentsPage.tsx
@@ -3,97 +3,163 @@ import { Footer } from "./components/Footer";
 import { Text } from "./components/Text";
 import { Kicker } from "./components/Kicker";
 import { Button } from "./components/Button";
+import { FAQ, type FAQItem } from "./components/FAQ";
 import { GitHubPRMock } from "./components/GitHubPRMock";
 import { SectionIntro } from "./components/SectionIntro";
 import { SiteSection } from "./components/SiteSection";
 import { SectionDivider } from "./components/SectionDivider.js";
 
-const FEATURES = [
+const GET_STARTED_URL = "/signin?mode=signup&returnTo=%2Fsetup";
+const TALK_TO_A_DEV_URL = "https://cal.com/team/libretto/demo";
+
+const SECTION_POINTS = [
   {
-    title: "Diagnose against the live page",
-    body: "The agent attaches to the failed Playwright run, inspects the real DOM and network state, and confirms the root cause instead of guessing from stack traces.",
+    title: "Keep your existing Playwright scripts",
+    body: "Add Libretto at the failure boundary without changing your fixtures, retries, logging, or deployment.",
   },
   {
-    title: "Open a minimal pull request",
-    body: "It lands a focused diff on a new branch with evidence in the PR body — ready for your normal review flow.",
+    title: "Use any browser provider",
+    body: "Run locally, in your own infrastructure, or with a hosted browser provider. The agent uses the live page you already created.",
   },
   {
-    title: "Works in your existing CI",
-    body: "Route failing Playwright jobs to autofix. Free on your repositories while you keep ownership of the scripts.",
+    title: "Bring your own model keys",
+    body: "Choose your LLM provider and keep its API key in your own environment.",
   },
   {
-    title: "Built on browser tools",
-    body: "Debugging uses Libretto browser tools to snapshot, execute, and verify fixes against the page that actually broke.",
+    title: "Free to use",
+    body: "Libretto does not charge for the PR agent. Your model and browser providers may still charge for their usage.",
   },
 ];
 
+const PR_AGENT_FAQS: FAQItem[] = [
+  {
+    id: "finish-workflow",
+    question: "What happens to the workflow after a failure?",
+    answer:
+      "The PR agent focuses on diagnosing the failure and proposing a code fix for future runs. Your existing catch, retry, fallback, and error handling remain responsible for the current run, while the agent opens a pull request when it finds a fix.",
+  },
+  {
+    id: "runtime",
+    question: "Do I need to use the Libretto runtime?",
+    answer:
+      "No. Add libretto-playwright-debug to an existing Playwright project, initialize the debugger once, and call debugFailure() from the failure path. Your current runtime, browser provider, deployment, and workflow structure stay in place.",
+  },
+  {
+    id: "frameworks",
+    question: "Does it work with Selenium or Puppeteer?",
+    answer:
+      "Not yet. The current package accepts a Playwright Page, so the failed automation must run through Playwright. Selenium and Puppeteer would require separate adapters.",
+  },
+  {
+    id: "browser-provider",
+    question: "Does it work with any browser or cloud browser provider?",
+    answer:
+      "Yes. The PR agent works with local, self-hosted, and hosted browsers as long as your automation has a live Playwright Page and keeps it open while debugFailure() runs. You do not need to use Libretto Cloud for the browser session.",
+  },
+  {
+    id: "free",
+    question: "Is the PR agent free?",
+    answer:
+      "Libretto does not charge for the PR agent. You bring your own model provider API key and browser infrastructure, so your model or browser provider may still charge for their usage.",
+  },
+  {
+    id: "open-source",
+    question: "Is it open source?",
+    answer: (
+      <>
+        Yes. The Playwright debugger package is open source under the MIT
+        license in the{" "}
+        <a
+          href="https://github.com/saffron-health/libretto/tree/main/packages/playwright-debug"
+          className="underline text-accent transition-colors hover:text-accent-bright"
+          data-fathom-event="Debug agents FAQ GitHub click"
+        >
+          Libretto repository
+        </a>
+        .
+      </>
+    ),
+  },
+];
+
+function TalkToADevLink({ fathomEvent }: { fathomEvent: string }) {
+  return (
+    <div className="text-xs text-muted">
+      or{" "}
+      <a
+        href={TALK_TO_A_DEV_URL}
+        className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
+        data-fathom-event={fathomEvent}
+      >
+        TALK TO A DEV
+      </a>
+    </div>
+  );
+}
+
 function DebugAgentsHero() {
   return (
-    <section className="relative overflow-hidden px-8 pt-16 pb-12 md:pt-24 md:pb-20">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_80%_20%,color-mix(in_oklch,var(--color-accent)_12%,transparent),transparent_55%)]" />
-      <div className="relative mx-auto grid max-w-[1100px] items-center gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-16">
-        <div>
-          <Kicker className="mb-4">// DEBUG AGENTS --</Kicker>
-          <Text
-            as="h1"
-            size="5xl"
-            style="serif"
-            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:pretty]"
-            htmlStyle={{
-              fontWeight: 300,
-              fontSize: "clamp(36px, 5vw, 64px)",
-              lineHeight: 1.05,
-            }}
+    <section className="relative overflow-hidden px-8 pt-16 pb-16 md:pt-24">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_50%_20%,color-mix(in_oklch,var(--color-accent)_12%,transparent),transparent_55%)]" />
+      <div className="relative mx-auto max-w-[1200px] text-center">
+        <Kicker className="mb-4">// PLAYWRIGHT PR AGENTS --</Kicker>
+        <Text
+          as="h1"
+          size="5xl"
+          style="serif"
+          className="crt-glow mx-auto mb-6 max-w-[780px] tracking-[-0.04em] text-ink [text-wrap:pretty]"
+          htmlStyle={{
+            fontWeight: 300,
+            fontSize: "clamp(36px, 5vw, 64px)",
+            lineHeight: 1.05,
+          }}
+        >
+          Automatically fix failing Playwright scripts
+        </Text>
+        <Text
+          as="p"
+          size="lg"
+          className="mx-auto mb-8 max-w-[680px] leading-relaxed text-muted [text-wrap:pretty]"
+        >
+          Keep the browser automations you already run. When one fails,
+          Libretto investigates the live page and opens a GitHub pull request
+          with a proposed code fix.
+        </Text>
+        <div className="mb-16 flex flex-col items-center justify-center gap-3">
+          <Button
+            href={GET_STARTED_URL}
+            className="h-12 min-w-[240px] px-8 text-sm"
+            data-fathom-event="Debug agents hero get started click"
           >
-            When automations break, AI opens pull requests
-          </Text>
-          <Text
-            as="p"
-            size="lg"
-            className="mb-8 max-w-[480px] leading-relaxed text-muted [text-wrap:pretty]"
-          >
-            Libretto&apos;s Playwright debugging agent investigates failures on
-            the live site and opens a GitHub PR with the fix — turning a broken
-            run into a quick code review.
-          </Text>
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              href="/docs/understand-libretto/autofix-debugging"
-              data-fathom-event="Debug agents docs click"
-            >
-              Read the docs
-            </Button>
-            <Button
-              href="/signin?mode=signup"
-              variant="secondary"
-              data-fathom-event="Debug agents sign up click"
-            >
-              Set up PR agents
-            </Button>
-          </div>
+            Get started
+          </Button>
+          <TalkToADevLink fathomEvent="Debug agents hero talk to dev click" />
         </div>
-        <GitHubPRMock className="lg:translate-y-2" />
+        <GitHubPRMock className="mx-auto max-w-[900px] text-left" />
       </div>
     </section>
   );
 }
 
-function FeatureListing() {
+function IntegrationSection() {
   return (
     <SiteSection>
       <SectionIntro
-        align="left"
-        className="mb-12 max-w-[640px]"
+        className="mx-auto mb-14 max-w-[680px]"
         headingClassName="mb-4 [text-wrap:pretty]"
-        kicker="// FEATURES --"
-        title="Failure to fix, without the guesswork"
+        kicker="// ONE FAILURE CALL --"
+        title="Keep your scripts. Add the repair loop."
       >
-        Debug agents close the loop between a flaky selector and a reviewable
-        change — in the same repos you already ship.
+        Your existing Playwright script runs normally. The PR agent starts only
+        after a failure, when it can investigate what changed and propose a fix.
       </SectionIntro>
-      <div className="grid gap-10 sm:grid-cols-2">
-        {FEATURES.map((feature) => (
-          <div key={feature.title} className="max-w-[420px]">
+
+      <div className="grid gap-px overflow-hidden rounded-xl border border-rule bg-rule sm:grid-cols-2">
+        {SECTION_POINTS.map((point, index) => (
+          <div key={point.title} className="bg-bg p-7 md:p-9">
+            <span className="mb-5 block font-mono text-xs text-accent-bright">
+              {String(index + 1).padStart(2, "0")}
+            </span>
             <Text
               as="h3"
               size="xl"
@@ -101,10 +167,10 @@ function FeatureListing() {
               className="mb-3 tracking-[-0.02em] text-ink"
               htmlStyle={{ fontWeight: 400 }}
             >
-              {feature.title}
+              {point.title}
             </Text>
-            <Text as="p" size="sm" className="leading-relaxed text-muted">
-              {feature.body}
+            <Text as="p" size="sm" className="leading-6 text-muted">
+              {point.body}
             </Text>
           </div>
         ))}
@@ -120,7 +186,13 @@ export function DebugAgentsPage() {
       <DebugAgentsHero />
       <div className="section-rails relative mx-auto max-w-[1100px]">
         <SectionDivider />
-        <FeatureListing />
+        <IntegrationSection />
+        <SectionDivider />
+        <FAQ
+          id="pr-agent-faq"
+          items={PR_AGENT_FAQS}
+          title="Frequently asked questions"
+        />
         <Footer />
       </div>
     </div>

--- a/apps/website/src/DebugAgentsPage.tsx
+++ b/apps/website/src/DebugAgentsPage.tsx
@@ -1,0 +1,128 @@
+import { Navbar } from "./components/Navbar";
+import { Footer } from "./components/Footer";
+import { Text } from "./components/Text";
+import { Kicker } from "./components/Kicker";
+import { Button } from "./components/Button";
+import { GitHubPRMock } from "./components/GitHubPRMock";
+import { SectionIntro } from "./components/SectionIntro";
+import { SiteSection } from "./components/SiteSection";
+import { SectionDivider } from "./components/SectionDivider.js";
+
+const FEATURES = [
+  {
+    title: "Diagnose against the live page",
+    body: "The agent attaches to the failed Playwright run, inspects the real DOM and network state, and confirms the root cause instead of guessing from stack traces.",
+  },
+  {
+    title: "Open a minimal pull request",
+    body: "It lands a focused diff on a new branch with evidence in the PR body — ready for your normal review flow.",
+  },
+  {
+    title: "Works in your existing CI",
+    body: "Route failing Playwright jobs to autofix. Free on your repositories while you keep ownership of the scripts.",
+  },
+  {
+    title: "Built on browser tools",
+    body: "Debugging uses Libretto browser tools to snapshot, execute, and verify fixes against the page that actually broke.",
+  },
+];
+
+function DebugAgentsHero() {
+  return (
+    <section className="relative overflow-hidden px-8 pt-16 pb-12 md:pt-24 md:pb-20">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_80%_20%,color-mix(in_oklch,var(--color-accent)_12%,transparent),transparent_55%)]" />
+      <div className="relative mx-auto grid max-w-[1100px] items-center gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:gap-16">
+        <div>
+          <Kicker className="mb-4">// DEBUG AGENTS --</Kicker>
+          <Text
+            as="h1"
+            size="5xl"
+            style="serif"
+            className="crt-glow mb-6 max-w-[560px] tracking-[-0.04em] text-ink [text-wrap:balance]"
+            htmlStyle={{
+              fontWeight: 300,
+              fontSize: "clamp(36px, 5vw, 64px)",
+              lineHeight: 1.05,
+            }}
+          >
+            When automations break, AI opens pull requests
+          </Text>
+          <Text
+            as="p"
+            size="lg"
+            className="mb-8 max-w-[480px] leading-relaxed text-muted [text-wrap:balance]"
+          >
+            Libretto&apos;s Playwright debugging agent investigates failures on
+            the live site and opens a GitHub PR with the fix — turning a broken
+            run into a quick code review.
+          </Text>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              href="/docs/understand-libretto/autofix-debugging"
+              data-fathom-event="Debug agents docs click"
+            >
+              Read the docs
+            </Button>
+            <Button
+              href="/signin?mode=signup"
+              variant="secondary"
+              data-fathom-event="Debug agents sign up click"
+            >
+              Set up PR agents
+            </Button>
+          </div>
+        </div>
+        <GitHubPRMock className="lg:translate-y-2" />
+      </div>
+    </section>
+  );
+}
+
+function FeatureListing() {
+  return (
+    <SiteSection>
+      <SectionIntro
+        align="left"
+        className="mb-12 max-w-[640px]"
+        headingClassName="mb-4 [text-wrap:balance]"
+        kicker="// FEATURES --"
+        title="Failure to fix, without the guesswork"
+      >
+        Debug agents close the loop between a flaky selector and a reviewable
+        change — in the same repos you already ship.
+      </SectionIntro>
+      <div className="grid gap-10 sm:grid-cols-2">
+        {FEATURES.map((feature) => (
+          <div key={feature.title} className="max-w-[420px]">
+            <Text
+              as="h3"
+              size="xl"
+              style="serif"
+              className="mb-3 tracking-[-0.02em] text-ink"
+              htmlStyle={{ fontWeight: 400 }}
+            >
+              {feature.title}
+            </Text>
+            <Text as="p" size="sm" className="leading-relaxed text-muted">
+              {feature.body}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </SiteSection>
+  );
+}
+
+export function DebugAgentsPage() {
+  return (
+    <div className="crt-page min-h-screen bg-bg text-ink">
+      <Navbar />
+      <DebugAgentsHero />
+      <div className="section-rails relative mx-auto max-w-[1100px]">
+        <SectionDivider />
+        <FeatureListing />
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -61,7 +61,7 @@ function Hero({
           as="h1"
           size="5xl"
           style="serif"
-          className="crt-glow mx-auto mb-8 max-w-[720px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
+          className="crt-glow mx-auto mb-8 max-w-[960px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
         >
           <AnimatedTitle
             className=""

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -35,7 +35,7 @@ function Hero({
       <div
         data-animate={AnimationTarget.Icosahedron}
         style={{ opacity: 0 }}
-        className="pointer-events-none absolute inset-0 flex -translate-y-24 max-md:-translate-y-48 items-center justify-center select-none"
+        className="pointer-events-none absolute inset-0 flex translate-y-8 max-md:translate-y-0 items-center justify-center select-none"
       >
         <CanvasAsciihedron
           className="h-[1600px] w-[1600px] min-h-[1200px] min-w-[1200px] shrink-0 max-h-[180vw] max-w-[180vw] text-ink"
@@ -61,7 +61,7 @@ function Hero({
           as="h1"
           size="5xl"
           style="serif"
-          className="crt-glow mx-auto mb-8 max-w-[720px] text-center tracking-[-0.04em] text-ink [text-wrap:balance]"
+          className="crt-glow mx-auto mb-8 max-w-[720px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
         >
           <AnimatedTitle
             className=""
@@ -79,7 +79,7 @@ function Hero({
           size="lg"
           data-animate={AnimationTarget.Content}
           htmlStyle={{ opacity: 0 }}
-          className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:balance]"
+          className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:pretty]"
         >
           Open-source CLI, debug agents, and browser tools for building and
           maintaining reliable web integrations

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -5,7 +5,6 @@ import {
   KonamiOverlay,
 } from "./components/CanvasAsciihedron";
 import { Text } from "./components/Text";
-import { TerminalDemo } from "./components/TerminalDemo";
 import { InstallSnippet } from "./components/InstallSnippet";
 import {
   OrchestrationContainer,
@@ -16,6 +15,8 @@ import { AsciiLogo } from "./components/AsciiLogo";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
 import { VersionBadge } from "./components/VersionBadge";
+import { ProductListing } from "./components/ProductListing";
+import { SectionDivider } from "./components/SectionDivider.js";
 
 function Hero({
   paneUnlocked,
@@ -70,7 +71,7 @@ function Hero({
               lineHeight: 1.05,
             }}
           >
-            Turn website workflows into reliable APIs
+            Browser automation tooling for coding agents
           </AnimatedTitle>
         </Text>
         <Text
@@ -80,10 +81,14 @@ function Hero({
           htmlStyle={{ opacity: 0 }}
           className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:balance]"
         >
-          Libretto is an open-source CLI that turns website workflows into fast,
-          reusable scripts in your codebase
+          Open-source CLI, debug agents, and browser tools for building and
+          maintaining reliable web integrations
         </Text>
-        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }} className="mb-16 flex flex-col items-center justify-center gap-3">
+        <div
+          data-animate={AnimationTarget.Content}
+          style={{ opacity: 0 }}
+          className="flex flex-col items-center justify-center gap-3"
+        >
           <InstallSnippet />
           <div className="text-xs text-muted">
             or{" "}
@@ -95,9 +100,6 @@ function Hero({
               BOOK A DEMO
             </a>
           </div>
-        </div>
-        <div data-animate={AnimationTarget.Content} style={{ opacity: 0 }}>
-          <TerminalDemo />
         </div>
       </div>
     </section>
@@ -116,6 +118,8 @@ export function HomePage() {
       <Navbar animate />
       <Hero paneUnlocked={paneUnlocked} onClosePane={closePane} />
       <div className="section-rails relative mx-auto max-w-[1100px]">
+        <SectionDivider />
+        <ProductListing />
         <Footer />
       </div>
     </OrchestrationContainer>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -61,7 +61,7 @@ function Hero({
           as="h1"
           size="5xl"
           style="serif"
-          className="crt-glow mx-auto mb-8 max-w-[960px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
+          className="crt-glow mx-auto mb-8 max-w-[880px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
         >
           <AnimatedTitle
             className=""

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -30,7 +30,7 @@ function Hero({
   return (
     <section
       ref={sectionRef}
-      className="relative overflow-hidden px-8 pt-24 pb-16"
+      className="relative overflow-hidden px-8 pt-32 pb-24 md:pt-40 md:pb-32"
     >
       <div
         data-animate={AnimationTarget.Icosahedron}
@@ -97,7 +97,7 @@ function Hero({
               className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
               data-fathom-event="Hero demo click"
             >
-              BOOK A DEMO
+              TALK TO A DEV
             </a>
           </div>
         </div>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -16,15 +16,6 @@ import { AsciiLogo } from "./components/AsciiLogo";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
 import { VersionBadge } from "./components/VersionBadge";
-import { FeatureRows } from "./components/FeatureRows";
-import { BattleTestedBanner } from "./components/BattleTestedBanner";
-import { Benchmarks } from "./components/Benchmarks";
-import { MaintainingFeatures } from "./components/MaintainingFeatures";
-import { AutofixPR } from "./components/AutofixPR";
-import { CloudProviders } from "./components/CloudProviders";
-import { FAQ } from "./components/FAQ";
-import { CTA } from "./components/CTA";
-import { SectionDivider } from "./components/SectionDivider.js";
 
 function Hero({
   paneUnlocked,
@@ -125,22 +116,6 @@ export function HomePage() {
       <Navbar animate />
       <Hero paneUnlocked={paneUnlocked} onClosePane={closePane} />
       <div className="section-rails relative mx-auto max-w-[1100px]">
-        <SectionDivider />
-        <FeatureRows />
-        <SectionDivider />
-        <Benchmarks />
-        <SectionDivider />
-        <BattleTestedBanner />
-        <SectionDivider />
-        <MaintainingFeatures />
-        <SectionDivider />
-        <AutofixPR />
-        <SectionDivider />
-        <CloudProviders />
-        <SectionDivider />
-        <FAQ />
-        <SectionDivider />
-        <CTA />
         <Footer />
       </div>
     </OrchestrationContainer>

--- a/apps/website/src/SignInPage.tsx
+++ b/apps/website/src/SignInPage.tsx
@@ -304,14 +304,16 @@ export function SignInPage() {
         <section className="grid w-full gap-10 md:grid-cols-[1fr_440px] md:items-center">
           <div>
             <p className="mb-4 font-mono text-xs uppercase text-accent">
-              Libretto Cloud
+              Libretto
             </p>
             <h1 className="crt-glow max-w-[620px] font-serif text-[44px] font-[300] leading-[1.02] text-ink md:text-[64px]">
-              {mode === "signin" ? "Sign in to your hosted workflows." : "Create your hosted workflow account."}
+              {mode === "signin"
+                ? "Sign in to your Libretto account."
+                : "Create your Libretto account."}
             </h1>
             <p className="mt-6 max-w-[520px] text-sm leading-6 text-muted">
-              Review jobs, manage teammates, and update billing from the same
-              account used by the Libretto CLI.
+              Connect repositories for PR agents, run hosted workflows, and
+              manage your team from the same account used by the Libretto CLI.
             </p>
           </div>
 

--- a/apps/website/src/components/AutofixPR.tsx
+++ b/apps/website/src/components/AutofixPR.tsx
@@ -32,6 +32,7 @@ export function AutofixPR() {
     <SiteSection>
       <SectionIntro
         className="mb-12"
+        headingClassName="mb-4 [text-wrap:balance]"
         kicker="// AUTOFIX --"
         title="When automations break, AI opens pull requests"
       >

--- a/apps/website/src/components/AutofixPR.tsx
+++ b/apps/website/src/components/AutofixPR.tsx
@@ -33,7 +33,7 @@ export function AutofixPR() {
     <SiteSection>
       <SectionIntro
         className="mb-12"
-        headingClassName="mb-4 [text-wrap:balance]"
+        headingClassName="mb-4 [text-wrap:pretty]"
         kicker="// AUTOFIX --"
         title="When automations break, AI opens pull requests"
       >

--- a/apps/website/src/components/AutofixPR.tsx
+++ b/apps/website/src/components/AutofixPR.tsx
@@ -1,5 +1,6 @@
 import { SectionIntro } from "./SectionIntro.js";
 import { SiteSection } from "./SiteSection.js";
+import { GitHubPRMock } from "./GitHubPRMock.js";
 
 const AUTOFIX_DOCS_URL = "/docs/understand-libretto/autofix-debugging";
 
@@ -60,40 +61,7 @@ export function AutofixPR() {
           ))}
         </ol>
 
-        <div className="overflow-hidden rounded-xl border border-rule bg-panel/70 shadow-lg shadow-black/30">
-          <div className="flex items-center gap-2 border-b border-rule px-4 py-3">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-green-9/20 px-2.5 py-1 text-xs font-medium text-accent-bright">
-              <span className="size-1.5 rounded-full bg-accent-bright" />
-              Open
-            </span>
-            <span className="truncate text-sm font-semibold text-ink">
-              Libretto autofix for Playwright failure
-            </span>
-          </div>
-          <div className="px-4 py-3 text-xs text-muted">
-            <span className="font-mono text-accent-bright">libretto-agent</span>{" "}
-            wants to merge 1 commit into{" "}
-            <span className="font-mono text-ink">main</span>
-          </div>
-          <div className="border-t border-rule bg-bg/70 px-4 py-3">
-            <div className="mb-2 font-mono text-[11px] text-muted">
-              workflows/book-appointment.ts
-            </div>
-            <div className="overflow-hidden rounded-md border border-rule font-mono text-xs leading-5">
-              <div className="bg-red-500/10 px-3 py-1 text-red-300">
-                - await page.locator('input[name="username"]').fill(login);
-              </div>
-              <div className="bg-green-9/15 px-3 py-1 text-accent-bright">
-                + await page.locator('input[name="login"]').fill(login);
-              </div>
-            </div>
-            <p className="mt-3 text-xs leading-5 text-muted">
-              The sign-in field is{" "}
-              <span className="font-mono text-ink">name=&quot;login&quot;</span>,
-              confirmed by inspecting the live page.
-            </p>
-          </div>
-        </div>
+        <GitHubPRMock />
       </div>
 
       <div className="mt-12 flex justify-center">

--- a/apps/website/src/components/CTA.tsx
+++ b/apps/website/src/components/CTA.tsx
@@ -19,7 +19,7 @@ export function CTA() {
             variant="secondary"
             data-fathom-event="CTA demo click"
           >
-            book a demo
+            TALK TO A DEV
           </Button>
         </div>
       </div>

--- a/apps/website/src/components/FAQ.tsx
+++ b/apps/website/src/components/FAQ.tsx
@@ -6,7 +6,7 @@ import { REPO_URL, DISCORD_URL } from "../site";
 
 const linkClass = "underline text-accent hover:text-accent-bright transition-colors";
 
-interface FAQItem {
+export interface FAQItem {
   id: string;
   question: string;
   answer: ReactNode;
@@ -176,19 +176,29 @@ function FAQAccordionItem({ item }: { item: FAQItem }) {
   );
 }
 
-export function FAQ() {
+interface FAQProps {
+  id?: string;
+  items?: FAQItem[];
+  title?: ReactNode;
+}
+
+export function FAQ({
+  id = "comparisons",
+  items = faqs,
+  title = "Frequently asked questions",
+}: FAQProps = {}) {
   return (
-    <SiteSection id="comparisons" innerClassName="flex flex-col gap-12 md:flex-row md:gap-16">
+    <SiteSection id={id} innerClassName="flex flex-col gap-12 md:flex-row md:gap-16">
       <div className="md:w-1/2 md:shrink-0 md:pt-5">
         <SectionIntro
           align="left"
           headingClassName="mb-0"
           kicker="// FAQ --"
-          title="Frequently asked questions"
+          title={title}
         />
       </div>
       <div className="border-t border-ink/10 md:w-1/2">
-        {faqs.map((faq) => (
+        {items.map((faq) => (
           <FAQAccordionItem key={faq.id} item={faq} />
         ))}
       </div>

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -46,7 +46,17 @@ export function Footer() {
           <Text size="xs" className="text-muted/50">
             © {new Date().getFullYear()} Saffron Health
           </Text>
-          <div className="flex gap-6">
+          <div className="flex flex-wrap justify-end gap-x-6 gap-y-2">
+            <a href="/cli" className={linkClass} data-fathom-event="Footer cli click">
+              CLI
+            </a>
+            <a
+              href="/debug-agents"
+              className={linkClass}
+              data-fathom-event="Footer debug agents click"
+            >
+              Debug Agents
+            </a>
             <a href="/blog" className={linkClass} data-fathom-event="Footer blog click">
               Blog
             </a>

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -51,7 +51,7 @@ export function Footer() {
               Blog
             </a>
             <a
-              href="/#comparisons"
+              href="/cli#comparisons"
               className={linkClass}
               data-fathom-event="Footer comparisons click"
             >

--- a/apps/website/src/components/GitHubPRMock.tsx
+++ b/apps/website/src/components/GitHubPRMock.tsx
@@ -1,0 +1,40 @@
+export function GitHubPRMock({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`overflow-hidden rounded-xl border border-rule bg-panel/70 shadow-lg shadow-black/30 ${className}`.trim()}
+    >
+      <div className="flex items-center gap-2 border-b border-rule px-4 py-3">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-green-9/20 px-2.5 py-1 text-xs font-medium text-accent-bright">
+          <span className="size-1.5 rounded-full bg-accent-bright" />
+          Open
+        </span>
+        <span className="truncate text-sm font-semibold text-ink">
+          Libretto autofix for Playwright failure
+        </span>
+      </div>
+      <div className="px-4 py-3 text-xs text-muted">
+        <span className="font-mono text-accent-bright">libretto-agent</span>{" "}
+        wants to merge 1 commit into{" "}
+        <span className="font-mono text-ink">main</span>
+      </div>
+      <div className="border-t border-rule bg-bg/70 px-4 py-3">
+        <div className="mb-2 font-mono text-[11px] text-muted">
+          workflows/book-appointment.ts
+        </div>
+        <div className="overflow-hidden rounded-md border border-rule font-mono text-xs leading-5">
+          <div className="bg-red-500/10 px-3 py-1 text-red-300">
+            {`- await page.locator('input[name="username"]').fill(login);`}
+          </div>
+          <div className="bg-green-9/15 px-3 py-1 text-accent-bright">
+            {`+ await page.locator('input[name="login"]').fill(login);`}
+          </div>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-muted">
+          The sign-in field is{" "}
+          <span className="font-mono text-ink">name=&quot;login&quot;</span>,
+          confirmed by inspecting the live page.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -136,7 +136,7 @@ export function MobileMenu({
             <MenuItem
               href="/cli"
               className={itemClass}
-              data-fathom-event="Mobile nav products cli click"
+              data-fathom-event="Mobile nav open source cli click"
             >
               Libretto CLI
             </MenuItem>

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -141,6 +141,20 @@ export function MobileMenu({
               Libretto CLI
             </MenuItem>
             <MenuItem
+              href="/debug-agents"
+              className={itemClass}
+              data-fathom-event="Mobile nav open source debug agents click"
+            >
+              Debug Agents
+            </MenuItem>
+            <MenuItem
+              href="/browser-tools"
+              className={itemClass}
+              data-fathom-event="Mobile nav open source browser tools click"
+            >
+              Browser Tools SDK
+            </MenuItem>
+            <MenuItem
               href="/docs/get-started/quickstart"
               className={itemClass}
               data-fathom-event="Mobile nav docs click"

--- a/apps/website/src/components/MobileMenu.tsx
+++ b/apps/website/src/components/MobileMenu.tsx
@@ -134,6 +134,13 @@ export function MobileMenu({
               </MenuItem>
             )}
             <MenuItem
+              href="/cli"
+              className={itemClass}
+              data-fathom-event="Mobile nav products cli click"
+            >
+              Libretto CLI
+            </MenuItem>
+            <MenuItem
               href="/docs/get-started/quickstart"
               className={itemClass}
               data-fathom-event="Mobile nav docs click"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -323,6 +323,47 @@ function CliIcon() {
   );
 }
 
+function BugIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="size-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.7"
+    >
+      <circle cx="8" cy="9" r="3.2" />
+      <path d="M8 5.8V4.2" />
+      <path d="M4.4 7.2 3 6" />
+      <path d="M11.6 7.2 13 6" />
+      <path d="M4.4 10.8 3 12" />
+      <path d="M11.6 10.8 13 12" />
+    </svg>
+  );
+}
+
+function ToolsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="size-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.7"
+    >
+      <path d="M10.2 3.2a2.4 2.4 0 0 1 2.6 2.6L9.5 9.1 6.9 6.5z" />
+      <path d="M6.5 9.5 3.2 12.8" />
+      <path d="M4.2 8.2 3 9.4l3.6 3.6 1.2-1.2" />
+    </svg>
+  );
+}
+
 function OpenSourceNavMenu() {
   const { display, isScrambling, hovered, onEnter, onLeave } =
     useGlitchText("Open source");
@@ -363,13 +404,27 @@ function OpenSourceNavMenu() {
         </span>
       </AriaButton>
       <Popover placement="bottom start" offset={6} className="z-50 outline-none">
-        <Menu className="w-[300px] rounded-lg border border-rule bg-panel p-1 shadow-lg shadow-black/35 outline-none">
+        <Menu className="w-[320px] rounded-lg border border-rule bg-panel p-1 shadow-lg shadow-black/35 outline-none">
           <DashboardMenuItem
             href="/cli"
             icon={<CliIcon />}
             title="Libretto CLI"
             description="Turn website workflows into reliable APIs"
             fathomEvent="Nav open source cli click"
+          />
+          <DashboardMenuItem
+            href="/debug-agents"
+            icon={<BugIcon />}
+            title="Debug Agents"
+            description="Failing runs become pull requests"
+            fathomEvent="Nav open source debug agents click"
+          />
+          <DashboardMenuItem
+            href="/browser-tools"
+            icon={<ToolsIcon />}
+            title="Browser Tools SDK"
+            description="Coming soon"
+            fathomEvent="Nav open source browser tools click"
           />
         </Menu>
       </Popover>

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -305,6 +305,78 @@ function DashboardMenuItem({
   );
 }
 
+function CliIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="size-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.7"
+    >
+      <path d="M3 4.5 6.5 8 3 11.5" />
+      <path d="M8 11.5h5" />
+    </svg>
+  );
+}
+
+function ProductsNavMenu() {
+  const { display, isScrambling, hovered, onEnter, onLeave } =
+    useGlitchText("Products");
+
+  return (
+    <MenuTrigger>
+      <AriaButton
+        className="flex h-[1.9375rem] items-center gap-1 outline-none"
+        data-fathom-event="Nav products click"
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+      >
+        <span
+          className={`inline-flex items-center gap-1 transition-colors duration-75 ${
+            isScrambling ? "text-amber" : hovered ? "text-accent-bright" : "text-ink"
+          }`}
+        >
+          <Text
+            size="sm"
+            className={`font-medium leading-none ${
+              isScrambling ? "font-mono" : ""
+            }`}
+          >
+            {display}
+          </Text>
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 16 16"
+            className="size-3.5 text-muted"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+          >
+            <path d="m4 6 4 4 4-4" />
+          </svg>
+        </span>
+      </AriaButton>
+      <Popover placement="bottom start" offset={6} className="z-50 outline-none">
+        <Menu className="w-[300px] rounded-lg border border-rule bg-panel p-1 shadow-lg shadow-black/35 outline-none">
+          <DashboardMenuItem
+            href="/cli"
+            icon={<CliIcon />}
+            title="Libretto CLI"
+            description="Turn website workflows into reliable APIs"
+            fathomEvent="Nav products cli click"
+          />
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}
+
 function CloudAccountLink({ session }: { session: CloudSession | null }) {
   const [pageLabel, setPageLabel] = useState("Dashboard");
   const [signingOut, setSigningOut] = useState(false);
@@ -486,6 +558,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             <LibrettoLogoAndName />
           </a>
           <div className="hidden items-center gap-6 lg:flex">
+            <ProductsNavMenu />
             <GlitchNavLink
               href="/docs/get-started/quickstart"
               external={false}

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -323,15 +323,15 @@ function CliIcon() {
   );
 }
 
-function ProductsNavMenu() {
+function OpenSourceNavMenu() {
   const { display, isScrambling, hovered, onEnter, onLeave } =
-    useGlitchText("Products");
+    useGlitchText("Open source");
 
   return (
     <MenuTrigger>
       <AriaButton
         className="flex h-[1.9375rem] items-center gap-1 outline-none"
-        data-fathom-event="Nav products click"
+        data-fathom-event="Nav open source click"
         onMouseEnter={onEnter}
         onMouseLeave={onLeave}
       >
@@ -369,7 +369,7 @@ function ProductsNavMenu() {
             icon={<CliIcon />}
             title="Libretto CLI"
             description="Turn website workflows into reliable APIs"
-            fathomEvent="Nav products cli click"
+            fathomEvent="Nav open source cli click"
           />
         </Menu>
       </Popover>
@@ -558,7 +558,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
             <LibrettoLogoAndName />
           </a>
           <div className="hidden items-center gap-6 lg:flex">
-            <ProductsNavMenu />
+            <OpenSourceNavMenu />
             <GlitchNavLink
               href="/docs/get-started/quickstart"
               external={false}

--- a/apps/website/src/components/ProductListing.tsx
+++ b/apps/website/src/components/ProductListing.tsx
@@ -25,14 +25,32 @@ function ProductVisual({ index }: { index: number }) {
 
   if (index === 1) {
     return (
-      <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 p-5 shadow-lg shadow-black/25">
-        <div className="mb-3 flex items-center gap-2">
-          <span className="size-2 rounded-full bg-amber-bright" />
-          <span className="font-mono text-xs text-muted">playwright · failed</span>
+      <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 shadow-lg shadow-black/25">
+        <div className="flex items-center gap-2 border-b border-rule px-5 py-3.5">
+          <span className="size-2 rounded-full bg-red-300" />
+          <span className="font-mono text-xs text-ink/70">
+            playwright run · failed
+          </span>
         </div>
-        <div className="rounded-md border border-rule bg-bg/70 px-3 py-2 font-mono text-xs leading-5">
-          <div className="text-red-300">TimeoutError: locator.fill</div>
-          <div className="mt-2 text-accent-bright">+ opened PR #842</div>
+        <div className="p-5">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-muted">
+            Fix proposed
+          </div>
+          <div className="mb-3 text-sm text-ink">
+            Updated the renamed username field selector
+          </div>
+          <div className="overflow-hidden rounded-md border border-rule font-mono text-[11px] leading-5">
+            <div className="bg-red-500/10 px-3 py-1 text-red-300">
+              - input[name=&quot;username&quot;]
+            </div>
+            <div className="bg-green-9/15 px-3 py-1 text-accent-bright">
+              + input[name=&quot;login&quot;]
+            </div>
+          </div>
+          <div className="mt-4 flex items-center gap-2 border-t border-rule pt-3 font-mono text-xs text-accent-bright">
+            <span aria-hidden="true">✓</span>
+            <span>Pull request #842 opened</span>
+          </div>
         </div>
       </div>
     );

--- a/apps/website/src/components/ProductListing.tsx
+++ b/apps/website/src/components/ProductListing.tsx
@@ -1,0 +1,110 @@
+import { Text } from "./Text.js";
+import { Kicker } from "./Kicker.js";
+import { PRODUCTS } from "../products.js";
+import { SectionDivider } from "./SectionDivider.js";
+
+function ProductVisual({ index }: { index: number }) {
+  if (index === 0) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 p-5 font-mono text-xs leading-6 text-muted shadow-lg shadow-black/25">
+        <div className="mb-3 text-amber">$ npx libretto open</div>
+        <div>
+          <span className="text-accent-bright">→</span> session{" "}
+          <span className="text-ink">ses-4f2a</span>
+        </div>
+        <div>
+          <span className="text-accent-bright">→</span> record actions, capture
+          network, write scripts
+        </div>
+        <div className="mt-4 text-ink">
+          await page.getByRole(&quot;button&quot;, {"{"} name: &quot;Book&quot; {"}"}).click()
+        </div>
+      </div>
+    );
+  }
+
+  if (index === 1) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 p-5 shadow-lg shadow-black/25">
+        <div className="mb-3 flex items-center gap-2">
+          <span className="size-2 rounded-full bg-amber-bright" />
+          <span className="font-mono text-xs text-muted">playwright · failed</span>
+        </div>
+        <div className="rounded-md border border-rule bg-bg/70 px-3 py-2 font-mono text-xs leading-5">
+          <div className="text-red-300">TimeoutError: locator.fill</div>
+          <div className="mt-2 text-accent-bright">+ opened PR #842</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-dashed border-amber/50 bg-panel/40 p-5 shadow-lg shadow-black/25">
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="-rotate-6 border-2 border-amber bg-bg/90 px-4 py-2 font-mono text-sm font-medium tracking-wide text-amber shadow-[4px_4px_0_color-mix(in_oklch,var(--color-amber)_35%,transparent)]">
+          COMING SOON
+        </div>
+      </div>
+      <div className="font-mono text-xs leading-6 text-muted/50">
+        <div>createBrowserTools(page)</div>
+        <div>tools.snapshot()</div>
+        <div>tools.exec(...)</div>
+      </div>
+    </div>
+  );
+}
+
+export function ProductListing() {
+  return (
+    <section className="section-crt px-8 py-8 md:py-12">
+      <div className="mx-auto max-w-[1000px]">
+        {PRODUCTS.map((product, index) => {
+          const visualLeft = index % 2 === 1;
+          return (
+            <div key={product.href}>
+              {index > 0 ? <SectionDivider /> : null}
+              <a
+                href={product.href}
+                data-fathom-event={product.fathomEvent}
+                className="group grid items-center gap-10 py-16 no-underline md:grid-cols-2 md:gap-16 md:py-20"
+              >
+                <div className={visualLeft ? "md:order-2" : undefined}>
+                  <Kicker className="mb-3">{product.kicker}</Kicker>
+                  <Text
+                    as="h2"
+                    size="3xl"
+                    style="serif"
+                    className="crt-glow mb-4 tracking-[-0.02em] text-ink [text-wrap:balance] transition-colors group-hover:text-accent-bright"
+                    htmlStyle={{
+                      fontWeight: 300,
+                      fontSize: "clamp(32px, 4vw, 48px)",
+                      lineHeight: 1.15,
+                    }}
+                  >
+                    {product.name}
+                  </Text>
+                  <Text
+                    as="p"
+                    size="md"
+                    className="max-w-[420px] leading-relaxed text-muted [text-wrap:balance]"
+                  >
+                    {product.tagline}
+                  </Text>
+                  <div className="mt-6 inline-flex items-center gap-2 text-sm text-accent-bright">
+                    {product.status === "soon" ? "Coming soon" : "Explore"}
+                    <span aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+                      →
+                    </span>
+                  </div>
+                </div>
+                <div className={visualLeft ? "md:order-1" : undefined}>
+                  <ProductVisual index={index} />
+                </div>
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/ProductListing.tsx
+++ b/apps/website/src/components/ProductListing.tsx
@@ -3,8 +3,8 @@ import { Kicker } from "./Kicker.js";
 import { PRODUCTS } from "../products.js";
 import { SectionDivider } from "./SectionDivider.js";
 
-function ProductVisual({ index }: { index: number }) {
-  if (index === 0) {
+function ProductVisual({ href }: { href: string }) {
+  if (href === "/cli") {
     return (
       <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 p-5 font-mono text-xs leading-6 text-muted shadow-lg shadow-black/25">
         <div className="mb-3 text-amber">$ npx libretto open</div>
@@ -23,7 +23,7 @@ function ProductVisual({ index }: { index: number }) {
     );
   }
 
-  if (index === 1) {
+  if (href === "/debug-agents") {
     return (
       <div className="overflow-hidden rounded-xl border border-rule bg-panel/60 shadow-lg shadow-black/25">
         <div className="flex items-center gap-2 border-b border-rule px-5 py-3.5">
@@ -116,7 +116,7 @@ export function ProductListing() {
                   </div>
                 </div>
                 <div className={visualLeft ? "md:order-1" : undefined}>
-                  <ProductVisual index={index} />
+                  <ProductVisual href={product.href} />
                 </div>
               </a>
             </div>

--- a/apps/website/src/components/ProductListing.tsx
+++ b/apps/website/src/components/ProductListing.tsx
@@ -74,7 +74,7 @@ export function ProductListing() {
                     as="h2"
                     size="3xl"
                     style="serif"
-                    className="crt-glow mb-4 tracking-[-0.02em] text-ink [text-wrap:balance] transition-colors group-hover:text-accent-bright"
+                    className="crt-glow mb-4 tracking-[-0.02em] text-ink [text-wrap:pretty] transition-colors group-hover:text-accent-bright"
                     htmlStyle={{
                       fontWeight: 300,
                       fontSize: "clamp(32px, 4vw, 48px)",
@@ -86,7 +86,7 @@ export function ProductListing() {
                   <Text
                     as="p"
                     size="md"
-                    className="max-w-[420px] leading-relaxed text-muted [text-wrap:balance]"
+                    className="max-w-[420px] leading-relaxed text-muted [text-wrap:pretty]"
                   >
                     {product.tagline}
                   </Text>

--- a/apps/website/src/products.ts
+++ b/apps/website/src/products.ts
@@ -1,0 +1,38 @@
+export interface ProductLink {
+  href: string;
+  name: string;
+  tagline: string;
+  kicker: string;
+  status: "live" | "soon";
+  fathomEvent: string;
+}
+
+export const PRODUCTS: ProductLink[] = [
+  {
+    href: "/cli",
+    name: "Libretto CLI",
+    tagline:
+      "Open-source CLI that turns website workflows into fast, reusable scripts in your codebase.",
+    kicker: "// CLI --",
+    status: "live",
+    fathomEvent: "Product listing cli click",
+  },
+  {
+    href: "/debug-agents",
+    name: "Debug Agents",
+    tagline:
+      "When Playwright automations fail, an agent inspects the live page and opens a pull request with the fix.",
+    kicker: "// DEBUG --",
+    status: "live",
+    fathomEvent: "Product listing debug agents click",
+  },
+  {
+    href: "/browser-tools",
+    name: "Browser Tools SDK",
+    tagline:
+      "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework.",
+    kicker: "// SDK --",
+    status: "soon",
+    fathomEvent: "Product listing browser tools click",
+  },
+];

--- a/apps/website/src/products.ts
+++ b/apps/website/src/products.ts
@@ -30,7 +30,7 @@ export const PRODUCTS: ProductLink[] = [
     href: "/browser-tools",
     name: "Browser Tools SDK",
     tagline:
-      "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework.",
+      "Browser tools for AI agents that open, inspect, and drive real browsers from any agent framework.",
     kicker: "// SDK --",
     status: "soon",
     fathomEvent: "Product listing browser tools click",

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SetupRouteImport } from './routes/setup'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as InviteRouteImport } from './routes/invite'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as CliRouteImport } from './routes/cli'
 import { Route as BrandKitRouteImport } from './routes/brand-kit'
 import { Route as BlogRouteRouteImport } from './routes/blog/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -54,6 +55,11 @@ const InviteRoute = InviteRouteImport.update({
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CliRoute = CliRouteImport.update({
+  id: '/cli',
+  path: '/cli',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BrandKitRoute = BrandKitRouteImport.update({
@@ -111,6 +117,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRouteWithChildren
   '/brand-kit': typeof BrandKitRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
@@ -128,6 +135,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/brand-kit': typeof BrandKitRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
@@ -147,6 +155,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRouteWithChildren
   '/brand-kit': typeof BrandKitRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
@@ -167,6 +176,7 @@ export interface FileRouteTypes {
     | '/'
     | '/blog'
     | '/brand-kit'
+    | '/cli'
     | '/dashboard'
     | '/invite'
     | '/onboarding'
@@ -184,6 +194,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/brand-kit'
+    | '/cli'
     | '/dashboard'
     | '/invite'
     | '/onboarding'
@@ -202,6 +213,7 @@ export interface FileRouteTypes {
     | '/'
     | '/blog'
     | '/brand-kit'
+    | '/cli'
     | '/dashboard'
     | '/invite'
     | '/onboarding'
@@ -221,6 +233,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BlogRouteRoute: typeof BlogRouteRouteWithChildren
   BrandKitRoute: typeof BrandKitRoute
+  CliRoute: typeof CliRoute
   DashboardRoute: typeof DashboardRoute
   InviteRoute: typeof InviteRoute
   OnboardingRoute: typeof OnboardingRoute
@@ -276,6 +289,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cli': {
+      id: '/cli'
+      path: '/cli'
+      fullPath: '/cli'
+      preLoaderRoute: typeof CliRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/brand-kit': {
@@ -369,6 +389,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlogRouteRoute: BlogRouteRouteWithChildren,
   BrandKitRoute: BrandKitRoute,
+  CliRoute: CliRoute,
   DashboardRoute: DashboardRoute,
   InviteRoute: InviteRoute,
   OnboardingRoute: OnboardingRoute,

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -14,8 +14,10 @@ import { Route as SigninRouteImport } from './routes/signin'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as InviteRouteImport } from './routes/invite'
+import { Route as DebugAgentsRouteImport } from './routes/debug-agents'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as CliRouteImport } from './routes/cli'
+import { Route as BrowserToolsRouteImport } from './routes/browser-tools'
 import { Route as BrandKitRouteImport } from './routes/brand-kit'
 import { Route as BlogRouteRouteImport } from './routes/blog/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -52,6 +54,11 @@ const InviteRoute = InviteRouteImport.update({
   path: '/invite',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DebugAgentsRoute = DebugAgentsRouteImport.update({
+  id: '/debug-agents',
+  path: '/debug-agents',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -60,6 +67,11 @@ const DashboardRoute = DashboardRouteImport.update({
 const CliRoute = CliRouteImport.update({
   id: '/cli',
   path: '/cli',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BrowserToolsRoute = BrowserToolsRouteImport.update({
+  id: '/browser-tools',
+  path: '/browser-tools',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BrandKitRoute = BrandKitRouteImport.update({
@@ -117,8 +129,10 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRouteWithChildren
   '/brand-kit': typeof BrandKitRoute
+  '/browser-tools': typeof BrowserToolsRoute
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
+  '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
   '/setup': typeof SetupRoute
@@ -135,8 +149,10 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/brand-kit': typeof BrandKitRoute
+  '/browser-tools': typeof BrowserToolsRoute
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
+  '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
   '/setup': typeof SetupRoute
@@ -155,8 +171,10 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/blog': typeof BlogRouteRouteWithChildren
   '/brand-kit': typeof BrandKitRoute
+  '/browser-tools': typeof BrowserToolsRoute
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
+  '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
   '/setup': typeof SetupRoute
@@ -176,8 +194,10 @@ export interface FileRouteTypes {
     | '/'
     | '/blog'
     | '/brand-kit'
+    | '/browser-tools'
     | '/cli'
     | '/dashboard'
+    | '/debug-agents'
     | '/invite'
     | '/onboarding'
     | '/setup'
@@ -194,8 +214,10 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/brand-kit'
+    | '/browser-tools'
     | '/cli'
     | '/dashboard'
+    | '/debug-agents'
     | '/invite'
     | '/onboarding'
     | '/setup'
@@ -213,8 +235,10 @@ export interface FileRouteTypes {
     | '/'
     | '/blog'
     | '/brand-kit'
+    | '/browser-tools'
     | '/cli'
     | '/dashboard'
+    | '/debug-agents'
     | '/invite'
     | '/onboarding'
     | '/setup'
@@ -233,8 +257,10 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BlogRouteRoute: typeof BlogRouteRouteWithChildren
   BrandKitRoute: typeof BrandKitRoute
+  BrowserToolsRoute: typeof BrowserToolsRoute
   CliRoute: typeof CliRoute
   DashboardRoute: typeof DashboardRoute
+  DebugAgentsRoute: typeof DebugAgentsRoute
   InviteRoute: typeof InviteRoute
   OnboardingRoute: typeof OnboardingRoute
   SetupRoute: typeof SetupRoute
@@ -284,6 +310,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InviteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/debug-agents': {
+      id: '/debug-agents'
+      path: '/debug-agents'
+      fullPath: '/debug-agents'
+      preLoaderRoute: typeof DebugAgentsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard': {
       id: '/dashboard'
       path: '/dashboard'
@@ -296,6 +329,13 @@ declare module '@tanstack/react-router' {
       path: '/cli'
       fullPath: '/cli'
       preLoaderRoute: typeof CliRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/browser-tools': {
+      id: '/browser-tools'
+      path: '/browser-tools'
+      fullPath: '/browser-tools'
+      preLoaderRoute: typeof BrowserToolsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/brand-kit': {
@@ -389,8 +429,10 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlogRouteRoute: BlogRouteRouteWithChildren,
   BrandKitRoute: BrandKitRoute,
+  BrowserToolsRoute: BrowserToolsRoute,
   CliRoute: CliRoute,
   DashboardRoute: DashboardRoute,
+  DebugAgentsRoute: DebugAgentsRoute,
   InviteRoute: InviteRoute,
   OnboardingRoute: OnboardingRoute,
   SetupRoute: SetupRoute,

--- a/apps/website/src/routes/__root.tsx
+++ b/apps/website/src/routes/__root.tsx
@@ -2,9 +2,9 @@ import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-r
 import type { ReactNode } from "react";
 import "../index.css";
 
-const DEFAULT_TITLE = "Libretto | Turn website workflows into reliable APIs";
+const DEFAULT_TITLE = "Libretto | Browser automation tooling for coding agents";
 const DEFAULT_DESCRIPTION =
-  "Deterministic browser automation for AI agents and developers. Build fast, reliable scripts with agent-friendly debugging and seamless cloud deployment.";
+  "Open-source CLI, debug agents, and browser tools for building and maintaining reliable web integrations.";
 
 export const Route = createRootRoute({
   head: () => ({

--- a/apps/website/src/routes/browser-tools.tsx
+++ b/apps/website/src/routes/browser-tools.tsx
@@ -3,7 +3,7 @@ import { BrowserToolsPage } from "../BrowserToolsPage";
 
 const title = "Browser Tools SDK | Libretto";
 const description =
-  "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework. Coming soon.";
+  "Browser tools for AI agents that open, inspect, and drive real browsers from any agent framework. Coming soon.";
 const url = "https://libretto.sh/browser-tools";
 
 export const Route = createFileRoute("/browser-tools")({

--- a/apps/website/src/routes/browser-tools.tsx
+++ b/apps/website/src/routes/browser-tools.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BrowserToolsPage } from "../BrowserToolsPage";
+
+const title = "Browser Tools SDK | Libretto";
+const description =
+  "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework. Coming soon.";
+const url = "https://libretto.sh/browser-tools";
+
+export const Route = createFileRoute("/browser-tools")({
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:type", content: "website" },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: url },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+    links: [{ rel: "canonical", href: url }],
+  }),
+  component: BrowserToolsPage,
+});

--- a/apps/website/src/routes/cli.tsx
+++ b/apps/website/src/routes/cli.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CliProductPage } from "../CliProductPage";
+
+const title = "Libretto CLI | Turn website workflows into reliable APIs";
+const description =
+  "Libretto is an open-source CLI that turns website workflows into fast, reusable scripts in your codebase.";
+const url = "https://libretto.sh/cli";
+
+export const Route = createFileRoute("/cli")({
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:type", content: "website" },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: url },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+    links: [{ rel: "canonical", href: url }],
+  }),
+  component: CliProductPage,
+});

--- a/apps/website/src/routes/debug-agents.tsx
+++ b/apps/website/src/routes/debug-agents.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { DebugAgentsPage } from "../DebugAgentsPage";
+
+const title = "Debug Agents | Libretto";
+const description =
+  "When Playwright automations fail, Libretto's debugging agent inspects the live page and opens a GitHub pull request with the fix.";
+const url = "https://libretto.sh/debug-agents";
+
+export const Route = createFileRoute("/debug-agents")({
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:type", content: "website" },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: url },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+    links: [{ rel: "canonical", href: url }],
+  }),
+  component: DebugAgentsPage,
+});

--- a/apps/website/src/routes/debug-agents.tsx
+++ b/apps/website/src/routes/debug-agents.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { DebugAgentsPage } from "../DebugAgentsPage";
 
-const title = "Debug Agents | Libretto";
+const title = "Playwright PR Agents | Libretto";
 const description =
-  "When Playwright automations fail, Libretto's debugging agent inspects the live page and opens a GitHub pull request with the fix.";
+  "Automatically investigate failing Playwright scripts against the live page and open a GitHub pull request with a proposed fix.";
 const url = "https://libretto.sh/debug-agents";
 
 export const Route = createFileRoute("/debug-agents")({


### PR DESCRIPTION
## Summary
- add dedicated product pages for the Libretto CLI, Playwright PR agents, and the upcoming Browser Tools SDK
- redesign the homepage around the product family with clearer product previews and more breathing room in the hero
- give the PR agents page a centered setup flow, pull-request preview, concise compatibility grid, and focused FAQ
- expand navigation, mobile navigation, footer links, routes, metadata, and sitemap entries for the new pages
- generalize account copy for both hosted workflows and PR agents and replace “Book a demo” with “Talk to a dev” across the site

## Notes
- includes the compressed CLI demo video used by the CLI product page
- the Browser Tools SDK page remains marked as coming soon
