### PR TITLE
Rename and document the Playwright debugger setup

### DIFF
--- a/apps/website/src/SetupPage.tsx
+++ b/apps/website/src/SetupPage.tsx
@@ -20,11 +20,15 @@ const DEBUGGER_DOCS_URL = "/docs/reference/runtime/playwright-debug";
 const DEBUGGER_CONCEPT_URL = "/docs/understand-libretto/autofix-debugging";
 const DEBUGGER_PROMPT =
   "Add the Libretto Playwright debugging agent to my existing automation. " +
-  "Install libretto-playwright-debug, then in my script's failure path call " +
-  "debugPlaywrightFailure(error, page). Follow " +
+  "Install libretto-playwright-debug, then follow " +
   "https://libretto.sh/docs/reference/runtime/playwright-debug to configure " +
-  "createLibrettoDebugger with my repo (owner, repo, baseBranch) and " +
-  "authenticate GitHub with my LIBRETTO_API_KEY.";
+  "createPlaywrightDebugger with my repo (owner, repo, baseBranch), and " +
+  "authenticate GitHub with my LIBRETTO_API_KEY. Instantiate it once and add " +
+  "one awaited debugPlaywrightFailure(error, page) call directly to the " +
+  "existing failure path before Playwright teardown. Preserve my workflow, " +
+  "fallbacks, retries, logging, and rethrow behavior. Do not add wrapper " +
+  "abstractions such as withPlaywrightDebugger or debugWorkflow, and do not " +
+  "launch another browser or page.";
 const CLOUD_SETUP_PROMPT =
   "Fetch and follow https://libretto.sh/cloud.md to set up Libretto Cloud hosted browsers for this project.";
 const CLOUD_SETUP_COMPLETE_KEY = "libretto.setup.cloudSetupComplete";

--- a/apps/website/src/SetupPage.tsx
+++ b/apps/website/src/SetupPage.tsx
@@ -21,14 +21,14 @@ const DEBUGGER_CONCEPT_URL = "/docs/understand-libretto/autofix-debugging";
 const DEBUGGER_PROMPT =
   "Add the Libretto Playwright debugging agent to my existing automation. " +
   "Install libretto-playwright-debug, then follow " +
-  "https://libretto.sh/docs/reference/runtime/playwright-debug to configure " +
-  "createPlaywrightDebugger with my repo (owner, repo, baseBranch), and " +
-  "authenticate GitHub with my LIBRETTO_API_KEY. Instantiate it once and add " +
-  "one awaited debugPlaywrightFailure(error, page) call directly to the " +
-  "existing failure path before Playwright teardown. Preserve my workflow, " +
-  "fallbacks, retries, logging, and rethrow behavior. Do not add wrapper " +
-  "abstractions such as withPlaywrightDebugger or debugWorkflow, and do not " +
-  "launch another browser or page.";
+  "https://libretto.sh/docs/reference/runtime/playwright-debug. Create a " +
+  "module-scope playwrightDebugger with createPlaywrightDebugger, my repo " +
+  "(owner, repo, baseBranch), and model configuration, using LIBRETTO_API_KEY " +
+  "for GitHub authentication. At the existing failure point, before " +
+  "Playwright teardown, call await " +
+  "playwrightDebugger.debugFailure(error, page) with the live page that " +
+  "observed the failure. Keep my existing workflow, fallbacks, retries, " +
+  "logging, and rethrow behavior in place.";
 const CLOUD_SETUP_PROMPT =
   "Fetch and follow https://libretto.sh/cloud.md to set up Libretto Cloud hosted browsers for this project.";
 const CLOUD_SETUP_COMPLETE_KEY = "libretto.setup.cloudSetupComplete";
@@ -557,17 +557,18 @@ export function SetupPage() {
                     Add the debugger to your Playwright script
                   </h2>
                   <p className="mt-2 text-sm leading-6 text-muted">
-                    This is the one line that turns on autofix. Add{" "}
-                    <code className="rounded bg-ink/10 px-1 py-0.5 font-mono text-xs">
-                      debugPlaywrightFailure(error, page)
-                    </code>{" "}
-                    to your automation&apos;s failure path (its{" "}
+                    Initialize the Playwright debugger once. At your
+                    automation&apos;s existing failure point (its{" "}
                     <code className="rounded bg-ink/10 px-1 py-0.5 font-mono text-xs">
                       catch
                     </code>{" "}
-                    block). On the next failure, Libretto investigates the live
-                    page and opens a fix PR on your connected repo. Paste this
-                    prompt into your coding agent to wire it in:
+                    block), call{" "}
+                    <code className="rounded bg-ink/10 px-1 py-0.5 font-mono text-xs">
+                      playwrightDebugger.debugFailure(error, page)
+                    </code>{" "}
+                    before teardown. On the next failure, Libretto investigates
+                    the live page and opens a fix PR on your connected repo.
+                    Paste this prompt into your coding agent to wire it in:
                   </p>
                 </div>
                 <div className="flex flex-col items-start">

--- a/docs/reference/runtime/playwright-debug.mdx
+++ b/docs/reference/runtime/playwright-debug.mdx
@@ -35,36 +35,32 @@ The `agent.model` value uses Libretto's `provider/model-id` convention. For
 example, `openai/gpt-5.4` resolves to provider `openai` and model id `gpt-5.4`.
 The first version supports `openai/...` and `anthropic/...`.
 
+Initialize this debugger once at module scope. At the existing failure point,
+await `debugFailure()` with the error and the live `Page` before Playwright
+teardown runs:
+
 ```typescript
 try {
   await runAutomation(page);
 } catch (error) {
-  await playwrightDebugger.debugPlaywrightFailure(error, page);
-
-  await sendToExistingFallbackService(error);
+  await playwrightDebugger.debugFailure(error, page);
+  // Existing fallback and logging stay here.
   throw error;
 }
 ```
 
-Create one debugger instance at module scope and add this call directly to the
-existing failure boundary. Await it before any `finally` block or teardown
-closes the page, context, or browser. Preserve the automation's existing retry,
-fallback, logging, and rethrow behavior.
-
-Do not introduce a `withPlaywrightDebugger`, `debugWorkflow`, replacement
-workflow, or second agent abstraction. The object returned by
-`createPlaywrightDebugger()` is the integration boundary, and it must receive
-the live page that observed the failure.
+Keep the existing automation, retry, fallback, logging, and rethrow behavior in
+place around the new call.
 
 ## What It Captures
 
-`debugPlaywrightFailure()` captures the error message, stack trace, page URL,
-page title, screenshot, and DOM snapshot from the failed page. It uses the stack
-frames — plus any paths you pass in `includeFiles` — to read the relevant source
-files from GitHub at `baseBranch`.
+`debugFailure()` captures the error message, stack trace, page URL, page title,
+screenshot, and DOM snapshot from the failed page. It uses the stack frames —
+plus any paths you pass in `includeFiles` — to read the relevant source files
+from GitHub at `baseBranch`.
 
 ```typescript
-await playwrightDebugger.debugPlaywrightFailure(error, page, {
+await playwrightDebugger.debugFailure(error, page, {
   includeFiles: ["src/workflows/acme.ts"],
 });
 ```
@@ -125,19 +121,4 @@ export LIBRETTO_API_KEY=...
 
 With that setup, the debugger asks Libretto Cloud for a short-lived GitHub
 installation token scoped to the configured `owner/repo` and only the
-permissions needed to read/write contents and open pull requests.
-
-For local development, you can pass `github.token` or set
-`LIBRETTO_GITHUB_TOKEN` / `GITHUB_TOKEN`. The token needs permission to read
-contents, write contents, and open pull requests on the target repository.
-
-The GitHub App should request these repository permissions:
-
-- Contents: read and write
-- Pull requests: read and write
-- Metadata: read
-
-The hosted public Libretto app should be installable by any account. It does not
-need webhooks or device flow. It does need a callback URL and GitHub App user
-authorization so Libretto Cloud can verify and store the tenant/repository link
-before minting installation tokens.
+permissions needed to read and write contents and open pull requests.

--- a/docs/reference/runtime/playwright-debug.mdx
+++ b/docs/reference/runtime/playwright-debug.mdx
@@ -10,10 +10,16 @@ automatically opens pull requests that fix broken scripts.
 browser provider, retries, logging, and fallback logic while adding one agent
 call in the failure path.
 
-```typescript
-import { createLibrettoDebugger } from "libretto-playwright-debug";
+Install it in the project that runs the Playwright automation:
 
-const librettoDebugger = createLibrettoDebugger({
+```bash
+pnpm add libretto-playwright-debug
+```
+
+```typescript
+import { createPlaywrightDebugger } from "libretto-playwright-debug";
+
+const playwrightDebugger = createPlaywrightDebugger({
   github: {
     owner: "acme",
     repo: "automations",
@@ -33,12 +39,22 @@ The first version supports `openai/...` and `anthropic/...`.
 try {
   await runAutomation(page);
 } catch (error) {
-  await librettoDebugger.debugPlaywrightFailure(error, page);
+  await playwrightDebugger.debugPlaywrightFailure(error, page);
 
   await sendToExistingFallbackService(error);
   throw error;
 }
 ```
+
+Create one debugger instance at module scope and add this call directly to the
+existing failure boundary. Await it before any `finally` block or teardown
+closes the page, context, or browser. Preserve the automation's existing retry,
+fallback, logging, and rethrow behavior.
+
+Do not introduce a `withPlaywrightDebugger`, `debugWorkflow`, replacement
+workflow, or second agent abstraction. The object returned by
+`createPlaywrightDebugger()` is the integration boundary, and it must receive
+the live page that observed the failure.
 
 ## What It Captures
 
@@ -48,7 +64,7 @@ frames — plus any paths you pass in `includeFiles` — to read the relevant so
 files from GitHub at `baseBranch`.
 
 ```typescript
-await librettoDebugger.debugPlaywrightFailure(error, page, {
+await playwrightDebugger.debugPlaywrightFailure(error, page, {
   includeFiles: ["src/workflows/acme.ts"],
 });
 ```

--- a/docs/understand-libretto/autofix-debugging.mdx
+++ b/docs/understand-libretto/autofix-debugging.mdx
@@ -46,8 +46,9 @@ observed on the page.
   the repo so Libretto can open PRs on it.
 - **A `LIBRETTO_API_KEY`.** The agent exchanges it for a short-lived,
   repo-scoped GitHub token — you never manage a raw GitHub token in production.
-- **The debugger call in your script.** Add `debugPlaywrightFailure(error, page)`
-  in your automation's `catch` block.
+- **The debugger call in your script.** Add
+  `playwrightDebugger.debugFailure(error, page)` in your automation's `catch`
+  block before Playwright teardown.
 
 The [setup flow](https://libretto.sh/setup) walks through connecting GitHub,
 minting the API key, and adding the debugger to an existing script.

--- a/packages/playwright-debug/README.md
+++ b/packages/playwright-debug/README.md
@@ -25,17 +25,11 @@ The project must already depend on Playwright.
 3. Set the API key for the configured model provider: `OPENAI_API_KEY` for an
    `openai/...` model or `ANTHROPIC_API_KEY` for an `anthropic/...` model.
 
-Do not commit these keys to the repository.
-
-For local development, you can pass `github.token`, set
-`LIBRETTO_GITHUB_TOKEN`, or set `GITHUB_TOKEN` instead of using the hosted
-GitHub App. The token needs permission to read and write repository contents
-and open pull requests.
+Store both keys in the project's existing secret-management system.
 
 ## Add it to the existing failure path
 
-Create one debugger instance at module scope, then call it directly from the
-existing error boundary while the failed `Page` is still open:
+Initialize the debugger once at module scope:
 
 ```ts
 import { createPlaywrightDebugger } from "libretto-playwright-debug";
@@ -50,43 +44,29 @@ const playwrightDebugger = createPlaywrightDebugger({
     model: "openai/gpt-5.4",
   },
 });
+```
 
+At the existing failure point, await `debugFailure()` before teardown closes
+the failed `Page`:
+
+```ts
 try {
   await runAutomation(page);
 } catch (error) {
-  await playwrightDebugger.debugPlaywrightFailure(error, page);
-  // Keep any existing fallback or logging here.
+  await playwrightDebugger.debugFailure(error, page);
+  // Existing fallback and logging stay here.
   throw error;
 }
 ```
 
-Keep the call before any `finally` block or teardown that closes the page,
-context, or browser. Await the debugger so it can inspect the live failure
-state. Continue the existing fallback and rethrow behavior afterward.
+Use the `Page` that observed the failure. Keep the existing automation,
+fallback, retry, logging, and rethrow behavior in place around the new call.
 
-`debugPlaywrightFailure()` uses stack frames to find source files. When the
-stack does not identify every relevant file, pass repository-relative paths:
+`debugFailure()` uses stack frames to find source files. When the stack does not
+identify every relevant file, pass repository-relative paths:
 
 ```ts
-await playwrightDebugger.debugPlaywrightFailure(error, page, {
+await playwrightDebugger.debugFailure(error, page, {
   includeFiles: ["src/workflows/checkout.ts"],
 });
 ```
-
-## Instructions for coding agents
-
-When installing this package in an existing codebase:
-
-1. Find the current runner or error boundary where both the thrown error and the
-   failed Playwright `Page` are available.
-2. Add `createPlaywrightDebugger()` once at module scope.
-3. Add one awaited `debugPlaywrightFailure(error, page)` call to that existing
-   failure path, before Playwright teardown.
-4. Preserve the automation, fallback, retry, logging, and rethrow behavior
-   around the new call.
-5. Configure secrets in the project's existing secret-management system.
-
-Do not create `withPlaywrightDebugger`, `debugWorkflow`, a replacement workflow,
-or another debugger-agent abstraction. The object returned by
-`createPlaywrightDebugger()` is the integration boundary. Do not launch a new
-browser or page for the debugger; pass the live page that observed the failure.

--- a/packages/playwright-debug/README.md
+++ b/packages/playwright-debug/README.md
@@ -6,10 +6,41 @@ fix broken scripts. It preserves the page's browser context and treats debugger
 infrastructure failures as best-effort results instead of replacing the original
 automation error.
 
-```ts
-import { createLibrettoDebugger } from "libretto-playwright-debug";
+## Install
 
-const librettoDebugger = createLibrettoDebugger({
+Add the package to the project that runs the Playwright automation:
+
+```bash
+pnpm add libretto-playwright-debug
+```
+
+The project must already depend on Playwright.
+
+## Configure authentication
+
+1. Open the [Libretto setup flow](https://libretto.sh/setup), install the
+   Libretto GitHub App for the target repository, and create a Libretto Cloud
+   API key.
+2. Set `LIBRETTO_API_KEY` in the environment that runs the automation.
+3. Set the API key for the configured model provider: `OPENAI_API_KEY` for an
+   `openai/...` model or `ANTHROPIC_API_KEY` for an `anthropic/...` model.
+
+Do not commit these keys to the repository.
+
+For local development, you can pass `github.token`, set
+`LIBRETTO_GITHUB_TOKEN`, or set `GITHUB_TOKEN` instead of using the hosted
+GitHub App. The token needs permission to read and write repository contents
+and open pull requests.
+
+## Add it to the existing failure path
+
+Create one debugger instance at module scope, then call it directly from the
+existing error boundary while the failed `Page` is still open:
+
+```ts
+import { createPlaywrightDebugger } from "libretto-playwright-debug";
+
+const playwrightDebugger = createPlaywrightDebugger({
   github: {
     owner: "acme",
     repo: "automations",
@@ -23,23 +54,39 @@ const librettoDebugger = createLibrettoDebugger({
 try {
   await runAutomation(page);
 } catch (error) {
-  await librettoDebugger.debugPlaywrightFailure(error, page);
+  await playwrightDebugger.debugPlaywrightFailure(error, page);
+  // Keep any existing fallback or logging here.
   throw error;
 }
 ```
 
-## Authentication
+Keep the call before any `finally` block or teardown that closes the page,
+context, or browser. Await the debugger so it can inspect the live failure
+state. Continue the existing fallback and rethrow behavior afterward.
 
-For model calls, use the provider's normal API key environment variable:
+`debugPlaywrightFailure()` uses stack frames to find source files. When the
+stack does not identify every relevant file, pass repository-relative paths:
 
-- `OPENAI_API_KEY` for `openai/...`
-- `ANTHROPIC_API_KEY` for `anthropic/...`
+```ts
+await playwrightDebugger.debugPlaywrightFailure(error, page, {
+  includeFiles: ["src/workflows/checkout.ts"],
+});
+```
 
-For GitHub, use the [Libretto setup flow](https://libretto.sh/setup) to connect
-the repository, then configure the generated Libretto Cloud API key:
+## Instructions for coding agents
 
-- `LIBRETTO_API_KEY`
+When installing this package in an existing codebase:
 
-Libretto Cloud mints the short-lived GitHub installation token needed to read
-contents, write contents, and open pull requests. For local development, you can
-also pass `github.token`, set `LIBRETTO_GITHUB_TOKEN`, or set `GITHUB_TOKEN`.
+1. Find the current runner or error boundary where both the thrown error and the
+   failed Playwright `Page` are available.
+2. Add `createPlaywrightDebugger()` once at module scope.
+3. Add one awaited `debugPlaywrightFailure(error, page)` call to that existing
+   failure path, before Playwright teardown.
+4. Preserve the automation, fallback, retry, logging, and rethrow behavior
+   around the new call.
+5. Configure secrets in the project's existing secret-management system.
+
+Do not create `withPlaywrightDebugger`, `debugWorkflow`, a replacement workflow,
+or another debugger-agent abstraction. The object returned by
+`createPlaywrightDebugger()` is the integration boundary. Do not launch a new
+browser or page for the debugger; pass the live page that observed the failure.

--- a/packages/playwright-debug/src/index.ts
+++ b/packages/playwright-debug/src/index.ts
@@ -75,7 +75,7 @@ export type DebugAgentRunner = (
   context: DebugAgentContext,
 ) => Promise<AgentFix>;
 
-export type LibrettoDebuggerOptions = {
+export type PlaywrightDebuggerOptions = {
   github: GitHubDebuggerConfig;
   agent: AgentModelConfig;
   modelRunner?: DebugAgentRunner;
@@ -108,7 +108,7 @@ export type DebugPlaywrightFailureResult =
       sourceFiles: SourceFile[];
     };
 
-export type LibrettoDebugger = {
+export type PlaywrightDebugger = {
   debugPlaywrightFailure: (
     error: unknown,
     page: Page,
@@ -168,9 +168,9 @@ const agentFixSchema = z.object({
   ),
 });
 
-export function createLibrettoDebugger(
-  options: LibrettoDebuggerOptions,
-): LibrettoDebugger {
+export function createPlaywrightDebugger(
+  options: PlaywrightDebuggerOptions,
+): PlaywrightDebugger {
   const model = parseAgentModel(options.agent.model);
   const maxSourceFileBytes =
     options.agent.maxSourceFileBytes ?? DEFAULT_MAX_SOURCE_FILE_BYTES;

--- a/packages/playwright-debug/src/index.ts
+++ b/packages/playwright-debug/src/index.ts
@@ -83,11 +83,11 @@ export type PlaywrightDebuggerOptions = {
   now?: () => Date;
 };
 
-export type DebugPlaywrightFailureOptions = {
+export type DebugFailureOptions = {
   includeFiles?: string[];
 };
 
-export type DebugPlaywrightFailureResult =
+export type DebugFailureResult =
   | {
       status: "debugger_failed";
       error: string;
@@ -109,11 +109,11 @@ export type DebugPlaywrightFailureResult =
     };
 
 export type PlaywrightDebugger = {
-  debugPlaywrightFailure: (
+  debugFailure: (
     error: unknown,
     page: Page,
-    options?: DebugPlaywrightFailureOptions,
-  ) => Promise<DebugPlaywrightFailureResult>;
+    options?: DebugFailureOptions,
+  ) => Promise<DebugFailureResult>;
 };
 
 type GitRefResponse = {
@@ -176,11 +176,11 @@ export function createPlaywrightDebugger(
     options.agent.maxSourceFileBytes ?? DEFAULT_MAX_SOURCE_FILE_BYTES;
   const now = options.now ?? (() => new Date());
 
-  const runDebugPlaywrightFailure = async (
+  const runDebugFailure = async (
     error: unknown,
     page: Page,
-    failureOptions: DebugPlaywrightFailureOptions,
-  ): Promise<DebugPlaywrightFailureResult> => {
+    failureOptions: DebugFailureOptions,
+  ): Promise<DebugFailureResult> => {
       const failure = await captureFailureContext(error, page);
       const github = await GitHubClient.create({
         config: options.github,
@@ -258,9 +258,9 @@ export function createPlaywrightDebugger(
   };
 
   return {
-    async debugPlaywrightFailure(error, page, failureOptions = {}) {
+    async debugFailure(error, page, failureOptions = {}) {
       try {
-        return await runDebugPlaywrightFailure(error, page, failureOptions);
+        return await runDebugFailure(error, page, failureOptions);
       } catch (debuggerError) {
         return {
           status: "debugger_failed",
@@ -691,7 +691,7 @@ class GitHubClient {
       }));
     if (!token) {
       throw new Error(
-        "GitHub authentication is missing. Provide github.token, LIBRETTO_GITHUB_TOKEN, GITHUB_TOKEN, or LIBRETTO_API_KEY for a repository linked to Libretto Cloud.",
+        "GitHub authentication is missing. Set LIBRETTO_API_KEY for a repository linked through Libretto setup.",
       );
     }
     return new GitHubClient({

--- a/packages/playwright-debug/test/debugger.spec.ts
+++ b/packages/playwright-debug/test/debugger.spec.ts
@@ -114,7 +114,7 @@ describe("createPlaywrightDebugger", () => {
       modelRunner: runner,
     });
 
-    const result = await debuggerInstance.debugPlaywrightFailure(
+    const result = await debuggerInstance.debugFailure(
       createError(),
       createPage(),
     );
@@ -183,7 +183,7 @@ describe("createPlaywrightDebugger", () => {
       modelRunner: runner,
     });
 
-    await debuggerInstance.debugPlaywrightFailure(error, createPage());
+    await debuggerInstance.debugFailure(error, createPage());
 
     expect(runner).toHaveBeenCalledOnce();
   });
@@ -265,7 +265,7 @@ describe("createPlaywrightDebugger", () => {
       }),
     });
 
-    const result = await debuggerInstance.debugPlaywrightFailure(
+    const result = await debuggerInstance.debugFailure(
       createError(),
       createPage(),
     );
@@ -301,7 +301,7 @@ describe("createPlaywrightDebugger", () => {
       base: "main",
     });
 
-    const secondResult = await debuggerInstance.debugPlaywrightFailure(
+    const secondResult = await debuggerInstance.debugFailure(
       createError(),
       createPage(),
     );
@@ -374,7 +374,7 @@ describe("createPlaywrightDebugger", () => {
       }),
     });
 
-    await debuggerInstance.debugPlaywrightFailure(createError(), createPage());
+    await debuggerInstance.debugFailure(createError(), createPage());
 
     expect(calls[0]).toMatchObject({
       method: "POST",
@@ -410,7 +410,7 @@ describe("createPlaywrightDebugger", () => {
     });
 
     await expect(
-      debuggerInstance.debugPlaywrightFailure(createError(), createPage()),
+      debuggerInstance.debugFailure(createError(), createPage()),
     ).resolves.toMatchObject({
       status: "debugger_failed",
       error: expect.stringContaining("GitHub authentication is missing"),
@@ -442,7 +442,7 @@ describe("createPlaywrightDebugger", () => {
       try {
         throw originalError;
       } catch (error) {
-        const debugResult = await debuggerInstance.debugPlaywrightFailure(
+        const debugResult = await debuggerInstance.debugFailure(
           error,
           createPage(),
         );
@@ -496,7 +496,7 @@ describe("createPlaywrightDebugger", () => {
     });
 
     await expect(
-      debuggerInstance.debugPlaywrightFailure(createError(), createPage()),
+      debuggerInstance.debugFailure(createError(), createPage()),
     ).resolves.toMatchObject({
       status: "debugger_failed",
       error: expect.stringContaining("Unsafe repository path"),

--- a/packages/playwright-debug/test/debugger.spec.ts
+++ b/packages/playwright-debug/test/debugger.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "playwright";
 import { describe, expect, it, vi } from "vitest";
 import {
-  createLibrettoDebugger,
+  createPlaywrightDebugger,
   parseAgentModel,
   type DebugAgentRunner,
 } from "../src/index.js";
@@ -54,7 +54,7 @@ describe("parseAgentModel", () => {
   });
 });
 
-describe("createLibrettoDebugger", () => {
+describe("createPlaywrightDebugger", () => {
   it("captures failure context and returns no_changes when the agent has no fix", async () => {
     const requests: Array<{ method: string; url: string }> = [];
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
@@ -99,7 +99,7 @@ describe("createLibrettoDebugger", () => {
       };
     });
 
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -168,7 +168,7 @@ describe("createLibrettoDebugger", () => {
       "    at runAutomation (C:\\repo\\src\\workflow.ts:12:7)",
     ].join("\n");
 
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -239,7 +239,7 @@ describe("createLibrettoDebugger", () => {
       return jsonResponse({ message: "not found" }, { status: 404 });
     }) as unknown as typeof fetch;
 
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -353,7 +353,7 @@ describe("createLibrettoDebugger", () => {
       return jsonResponse({ message: "not found" }, { status: 404 });
     }) as unknown as typeof fetch;
 
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -391,7 +391,7 @@ describe("createLibrettoDebugger", () => {
   });
 
   it("requires GitHub token auth or a Libretto Cloud API key", async () => {
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -418,7 +418,7 @@ describe("createLibrettoDebugger", () => {
   });
 
   it("does not replace the original automation error or prevent fallback logic", async () => {
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",
@@ -475,7 +475,7 @@ describe("createLibrettoDebugger", () => {
       return jsonResponse({ message: "not found" }, { status: 404 });
     }) as unknown as typeof fetch;
 
-    const debuggerInstance = createLibrettoDebugger({
+    const debuggerInstance = createPlaywrightDebugger({
       github: {
         owner: "acme",
         repo: "automations",


### PR DESCRIPTION
## Summary
- rename the public API to `createPlaywrightDebugger()` and `playwrightDebugger.debugFailure()` and align its public types and tests
- expand the package README with installation, Libretto API key authentication, and exact module-scope/failure-point integration steps
- preserve the existing workflow, fallback, retry, logging, and rethrow behavior while passing the live failed `Page` before teardown
- align the runtime reference, conceptual autofix guide, website setup prompt, and setup UI with the canonical integration pattern

## Validation
- `pnpm --dir packages/playwright-debug test`
- `pnpm --dir packages/playwright-debug type-check`
- `pnpm --dir packages/playwright-debug build`
- `pnpm --dir apps/website check`
- `pnpm docs:validate`
- `pnpm docs:broken-links`
- `pnpm -s type-check`
- `pnpm -s lint`
- `pnpm -s test`
