### PR TITLE
Add YouTube link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/user-attachments/assets/9b9a0ab3-5133-4b20-b3be-459943349d18
 - Docs: [libretto.sh/docs](https://libretto.sh/docs)
 - Repository: [github.com/saffron-health/libretto](https://github.com/saffron-health/libretto)
 - Discord: [discord.gg/NYrG56hVDt](https://discord.gg/NYrG56hVDt)
+- Youtube: [https://www.youtube.com/watch?v=0cDpIntmHAM]
 
 ## Installation
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Adds a **YouTube** entry under **Quick Links** in `README.md`, pointing to `https://www.youtube.com/watch?v=0cDpIntmHAM`.
> 
> The new line follows the same bullet list as Website, Docs, Repository, and Discord; it uses a bare URL in the link text rather than the labeled markdown style used for the other quick links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90442df1f958f8d15e4244b39ed487d03df8ac1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->