### PR TITLE
Simplify homepage for a more minimal look

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -1,9 +1,3 @@
-import { useRef } from "react";
-import {
-  CanvasAsciihedron,
-  useKonamiPane,
-  KonamiOverlay,
-} from "./components/CanvasAsciihedron";
 import { Text } from "./components/Text";
 import { InstallSnippet } from "./components/InstallSnippet";
 import {
@@ -14,64 +8,33 @@ import { AnimatedTitle } from "./components/AnimatedTitle";
 import { AsciiLogo } from "./components/AsciiLogo";
 import { Navbar } from "./components/Navbar";
 import { Footer } from "./components/Footer";
-import { VersionBadge } from "./components/VersionBadge";
 import { ProductListing } from "./components/ProductListing";
 import { SectionDivider } from "./components/SectionDivider.js";
 
-function Hero({
-  paneUnlocked,
-  onClosePane,
-}: {
-  paneUnlocked: boolean;
-  onClosePane: () => void;
-}) {
-  const sectionRef = useRef<HTMLElement>(null);
-
+function Hero() {
   return (
-    <section
-      ref={sectionRef}
-      className="relative overflow-hidden px-8 pt-32 pb-24 md:pt-40 md:pb-32"
-    >
-      <div
-        data-animate={AnimationTarget.Icosahedron}
-        style={{ opacity: 0 }}
-        className="pointer-events-none absolute inset-0 flex translate-y-8 max-md:translate-y-0 items-center justify-center select-none"
-      >
-        <CanvasAsciihedron
-          className="h-[1600px] w-[1600px] min-h-[1200px] min-w-[1200px] shrink-0 max-h-[180vw] max-w-[180vw] text-ink"
-          showAnnotations={false}
-          objectScale={1.2}
-          baseOpacity={0.11}
-          paneUnlocked={paneUnlocked}
-          onClosePane={onClosePane}
-        />
-      </div>
-      <div className="relative mx-auto max-w-[1200px]">
-        <div data-animate={AnimationTarget.Navbar} style={{ opacity: 0 }}>
-          <VersionBadge />
-        </div>
+    <section className="relative px-8 pt-28 pb-20 md:pt-36 md:pb-28">
+      <div className="relative mx-auto max-w-[720px]">
         <div
           data-animate={AnimationTarget.AsciiLogo}
-          style={{ filter: "drop-shadow(0 0 12px color-mix(in oklch, var(--color-amber-bright) 50%, transparent)) drop-shadow(0 0 32px color-mix(in oklch, var(--color-amber-bright) 25%, transparent))" }}
-          className="mb-10 flex justify-center overflow-hidden"
+          className="mb-12 flex justify-center overflow-hidden"
         >
-          <AsciiLogo className="text-[5px] sm:text-[7px] md:text-[10px] lg:text-[13px]" />
+          <AsciiLogo className="text-[5px] sm:text-[7px] md:text-[9px] text-ink/80" />
         </div>
         <Text
           as="h1"
           size="5xl"
           style="serif"
-          className="crt-glow mx-auto mb-8 max-w-[880px] text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
+          className="mx-auto mb-6 text-center tracking-[-0.04em] text-ink [text-wrap:pretty]"
         >
           <AnimatedTitle
-            className=""
             style={{
               fontWeight: 300,
-              fontSize: "clamp(40px, 6vw, 80px)",
-              lineHeight: 1.05,
+              fontSize: "clamp(36px, 5vw, 64px)",
+              lineHeight: 1.1,
             }}
           >
-            Browser automation tooling for coding agents
+            Browser automation for coding agents
           </AnimatedTitle>
         </Text>
         <Text
@@ -79,10 +42,9 @@ function Hero({
           size="lg"
           data-animate={AnimationTarget.Content}
           htmlStyle={{ opacity: 0 }}
-          className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:pretty]"
+          className="mx-auto mb-10 max-w-[480px] text-center leading-relaxed text-muted md:text-base [text-wrap:pretty]"
         >
-          Open-source CLI, debug agents, and browser tools for building and
-          maintaining reliable web integrations
+          Open-source CLI and tools for building reliable web integrations
         </Text>
         <div
           data-animate={AnimationTarget.Content}
@@ -107,17 +69,11 @@ function Hero({
 }
 
 export function HomePage() {
-  const { konamiProgress, konamiCompleted, paneUnlocked, closePane } =
-    useKonamiPane();
-
   return (
-    <OrchestrationContainer className="crt-page min-h-screen bg-bg text-ink">
-      {!paneUnlocked && (
-        <KonamiOverlay progress={konamiProgress} completed={konamiCompleted} />
-      )}
+    <OrchestrationContainer className="min-h-screen bg-bg text-ink">
       <Navbar animate />
-      <Hero paneUnlocked={paneUnlocked} onClosePane={closePane} />
-      <div className="section-rails relative mx-auto max-w-[1100px]">
+      <Hero />
+      <div className="relative mx-auto max-w-[1100px]">
         <SectionDivider />
         <ProductListing />
         <Footer />

--- a/apps/website/src/components/AnimationOrchestration.tsx
+++ b/apps/website/src/components/AnimationOrchestration.tsx
@@ -6,9 +6,8 @@ import { useEffect, type PropsWithChildren } from "react";
  *
  * Sequence:
  *  1. Title words appear one-by-one (staggered fade+translate)
- *  2. Description, install snippet, docs button, terminal demo fade in
+ *  2. Description + install snippet fade in
  *  3. Navbar slides down from top
- *  4. Icosahedron fades in + scales down from 1.15→1
  */
 
 /** Animation target names — use as `data-animate={AnimationTarget.xxx}` */
@@ -38,25 +37,13 @@ export function OrchestrationContainer({
     async function run() {
       const selector = (name: string) => `[data-animate='${name}']`;
 
-      // ── 1. ASCII logo is already visible; glow slowly fades while rest animates ──
-      animate(
-        selector(AnimationTarget.AsciiLogo),
-        {
-          filter: [
-            "drop-shadow(0 0 12px color-mix(in oklch, var(--color-amber-bright) 50%, transparent)) drop-shadow(0 0 32px color-mix(in oklch, var(--color-amber-bright) 25%, transparent))",
-            "drop-shadow(0 0 0px color-mix(in oklch, var(--color-amber-bright) 0%, transparent)) drop-shadow(0 0 0px color-mix(in oklch, var(--color-amber-bright) 0%, transparent))",
-          ],
-        },
-        { duration: 3, ease: "easeOut" },
-      );
-
-      // ── 2. Title words fade in ──
+      // ── 1. Title words fade in ──
       await animate(
         selector(AnimationTarget.TitleWord),
         { opacity: [0, 1], y: [6, 0] },
         {
           duration: 0.3,
-          delay: stagger(0.055, { startDelay: 0.3 }),
+          delay: stagger(0.055, { startDelay: 0.2 }),
         },
       );
       if (cancelled) return;
@@ -64,10 +51,10 @@ export function OrchestrationContainer({
       // ── 2. Content elements fade in together ──
       animate(
         selector(AnimationTarget.Content),
-        { opacity: [0, 1], y: [18, 0] },
+        { opacity: [0, 1], y: [12, 0] },
         {
-          duration: 0.45,
-          delay: stagger(0.12, { startDelay: 0.05 }),
+          duration: 0.4,
+          delay: stagger(0.1, { startDelay: 0.05 }),
           ease: "easeOut",
         },
       );
@@ -75,21 +62,9 @@ export function OrchestrationContainer({
       // Navbar slides down
       animate(
         selector(AnimationTarget.Navbar),
-        { opacity: [0, 1], y: [-20, 0] },
-        { duration: 0.5, delay: 0.1, ease: "easeOut" },
+        { opacity: [0, 1], y: [-16, 0] },
+        { duration: 0.4, delay: 0.05, ease: "easeOut" },
       );
-
-      // Icosahedron fades in + scales down
-      await animate(
-        selector(AnimationTarget.Icosahedron),
-        {
-          opacity: [0, 1],
-          scale: [1.15, 1],
-          filter: ["blur(4px)", "blur(0px)"],
-        },
-        { duration: 1.2, delay: 0.15 },
-      );
-      if (cancelled) return;
     }
 
     void run();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Strip the home hero down: no icosahedron background, CRT page overlays, version badge, or amber logo glow
- Tighten copy and layout so the first viewport is quieter: brand logo, one headline, one line of supporting text, CTA
- Keep the existing product listing and footer; simplify the entrance animation so it no longer expects the icosahedron

## Test plan
- [ ] Open `/` and confirm the hero loads without the background polyhedron
- [ ] Confirm logo, headline, prompt CTA, product list, and footer still render
- [ ] Spot-check mobile and desktop widths

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f67e5-d892-781e-969c-5c954f371523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f67e5-d892-781e-969c-5c954f371523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

