### PR TITLE
Add Orwell writing rules to agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,19 @@ pnpm -s cli
 - Prefer small, focused functions over large ones.
 - Name things for what they do, not how they're implemented.
 
+## Writing Rules
+
+Writing rules, from Orwell, 1946. These govern prose: docs, PR text, messages. Never touch code or technical terms; swap in everyday words only where precision survives.
+
+1. Never use a metaphor, simile or other figure of speech which you are used to seeing in print.
+2. Never use a long word where a short one will do.
+3. If it is possible to cut a word out, always cut it out.
+4. Never use the passive where you can use the active.
+5. Never use a foreign phrase, a scientific word or a jargon word if you can think of an everyday English equivalent.
+6. Break any of these rules sooner than say anything outright barbarous.
+
+Review every prose output against these rules before delivering.
+
 ## Agent-facing error messages
 
 Errors returned to agents (tool `{ ok: false, error }` results, MCP `isError` content, CLI output an agent reads) must tell the agent what to do next — not just what went wrong.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add Orwell's six prose rules to `AGENTS.md`.
- Apply them to docs, PR text, and messages while preserving code and technical terms.
- Require a prose review before delivery.

## Checks

- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-446a2aa8-2323-469b-b1dc-31c7f3bb7046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-446a2aa8-2323-469b-b1dc-31c7f3bb7046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

