### PR TITLE
Simplify status output when no sessions are open

### DIFF
--- a/packages/libretto/src/cli/commands/status.ts
+++ b/packages/libretto/src/cli/commands/status.ts
@@ -4,13 +4,12 @@ import { SimpleCLI } from "affordance";
 // ── Session status printing ─────────────────────────────────────────────────
 
 function printOpenSessions(sessions: SessionState[]): void {
-  console.log("\nOpen sessions:");
-
   if (sessions.length === 0) {
-    console.log("  No open sessions.");
+    console.log("\nNo open sessions.");
     return;
   }
 
+  console.log("\nOpen sessions:");
   for (const session of sessions) {
     const statusLabel = session.status ? ` [${session.status}]` : "";
     const endpoint = session.provider

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -205,6 +205,7 @@ describe("state-driven CLI subprocess behavior", () => {
   }) => {
     const status = await librettoCli("status");
     expect(status.stdout).toContain("No open sessions.");
+    expect(status.stdout).not.toContain("Open sessions:");
   });
 
   test("open and connect sessions default to write-access and support --read-only", async ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- When `libretto status` finds no running sessions, print only `No open sessions.`
- Keep the `Open sessions:` header for non-empty session lists.

## Test plan
- [x] Run the status empty-session test in `stateful.spec.ts`
- [x] Spot-check `libretto status` with no sessions open

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f1a118d-bdcc-43bf-8d0a-d799399c282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f1a118d-bdcc-43bf-8d0a-d799399c282c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

