### PR TITLE
release: publish libretto-browser-tools 0.1.1

### DIFF
--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto-browser-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Browser tools for AI agents — open, inspect, and drive real browsers from any agent framework",
   "license": "MIT",
   "homepage": "https://libretto.sh",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump `libretto-browser-tools` from `0.1.0` to `0.1.1` so the release workflow can publish current package contents
- `0.1.0` is already on npm and missing newer exports (notably `./browser-use`)

## Testing
- `pnpm --filter libretto-browser-tools type-check`
- `pnpm --filter libretto-browser-tools test`

After merge, the `Release` workflow on `main` should publish `libretto-browser-tools@0.1.1` because that version is not on npm yet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66eeb3be-9ca1-4f76-bc9c-f83bc929f60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66eeb3be-9ca1-4f76-bc9c-f83bc929f60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

