### PR TITLE
Update browser-tools README for launch

### DIFF
--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -1,6 +1,33 @@
-# libretto-browser-tools
+<div align="center">
+  <a href="https://libretto.sh/browser-tools">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="../../apps/website/public/logos/logo-dark.svg" alt="Libretto">
+      <img src="../../apps/website/public/logos/logo-light.svg" alt="Libretto" height="72">
+    </picture>
+  </a>
+  <br/>
+  <br/>
+  <h3>Browser Tools SDK gives any AI agent a real browser.</h3>
+  <p>Six tools to open, inspect, and drive browsers from AI SDK, Pi, or your own agent loop.</p>
+  <p>
+    <a href="https://libretto.sh/docs/browser-tools/quickstart">Quickstart</a> •
+    <a href="https://libretto.sh/docs/browser-tools/quickstart">Documentation</a> •
+    <a href="https://libretto.sh/browser-tools">Product</a> •
+    <a href="https://www.npmjs.com/package/libretto-browser-tools">npm</a> •
+    <a href="https://discord.gg/NYrG56hVDt">Discord</a>
+  </p>
+</div>
 
-Browser tools for AI agents. Gives any agent framework a set of tools to open real browsers (local or cloud), inspect pages via accessibility snapshots, and drive them with Playwright code.
+## Install
+
+```bash
+npm i libretto-browser-tools
+npx playwright install chromium
+```
+
+For the AI SDK adapter, also install `ai` and a model provider package.
+
+## Example
 
 ```typescript
 import { anthropic } from "@ai-sdk/anthropic";
@@ -24,15 +51,6 @@ const result = await generateText({
 
 await dispose(); // close any sessions the agent left open
 ```
-
-## Install
-
-```bash
-npm i libretto-browser-tools
-npx playwright install chromium
-```
-
-For the AI SDK adapter, also install `ai` and a model provider package.
 
 ## Docs
 

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -7,8 +7,11 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { generateText } from "ai";
 import { createAiSdkBrowserTools } from "libretto-browser-tools/ai-sdk";
 import { LocalBrowserProvider } from "libretto-browser-tools";
+// Or a cloud provider:
+// import { LibrettoCloudBrowserProvider } from "libretto-browser-tools/libretto-cloud";
+// import { BrowserbaseBrowserProvider } from "libretto-browser-tools/browserbase";
+// import { KernelBrowserProvider } from "libretto-browser-tools/kernel";
 
-// Cloud providers (Libretto Cloud, Browserbase, Kernel, ...) are on the way.
 const { tools, dispose } = createAiSdkBrowserTools(new LocalBrowserProvider());
 // The agent can now call browser_open, browser_connect, browser_exec,
 // browser_snapshot, browser_status, and browser_close.
@@ -21,3 +24,23 @@ const result = await generateText({
 
 await dispose(); // close any sessions the agent left open
 ```
+
+## Install
+
+```bash
+npm i libretto-browser-tools
+npx playwright install chromium
+```
+
+For the AI SDK adapter, also install `ai` and a model provider package.
+
+## Docs
+
+- Product page: https://libretto.sh/browser-tools
+- Quickstart: https://libretto.sh/docs/browser-tools/quickstart
+- Adapters: [AI SDK](https://libretto.sh/docs/browser-tools/adapters/ai-sdk), [Pi](https://libretto.sh/docs/browser-tools/adapters/pi), [Custom](https://libretto.sh/docs/browser-tools/adapters/custom)
+- Providers: https://libretto.sh/docs/browser-tools/providers/overview
+
+## License
+
+MIT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- refresh `packages/browser-tools/README.md` for launch with a Rivet-style centered header (logo, tagline, quick links)
- document published cloud providers, install steps, and docs/product links
- remove the stale “cloud providers on the way” note

Also updated the Notion [Launch copy](https://www.notion.so/39cac9fb35f180b782efc14601e25af8) page (outside this PR): correct package name/API, AI SDK + Pi (not Flue), fixed code samples, docs + Discord links.

## Testing
- manual review of README header rendering intent and Notion page content
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66eeb3be-9ca1-4f76-bc9c-f83bc929f60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66eeb3be-9ca1-4f76-bc9c-f83bc929f60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

