### PR TITLE
Restore visible docs code block surfaces

### DIFF
--- a/docs/global.css
+++ b/docs/global.css
@@ -273,13 +273,13 @@
   padding: 12px;
   border: 0;
   border-radius: 6px;
-  background: var(--card);
+  background: var(--code-block-background);
   box-shadow: var(--docs-shadow-minimal);
 }
 
 .dark .slot-main figure[class~='group/code'] {
   border: 1px solid var(--docs-outline);
-  background: var(--card);
+  background: var(--code-block-background);
 }
 
 .slot-main figure[class~='group/code'] button[aria-label='Copy code'] {

--- a/docs/global.css
+++ b/docs/global.css
@@ -109,7 +109,6 @@
     0 0 0 1px rgba(18, 206, 65, 0.65),
     0 0 8px 1px rgba(18, 206, 65, 0.1);
   --code-block-background: var(--card);
-  --code-block-border: 1px solid var(--docs-outline);
 
   --prism-fg: #eeeeee;
   --prism-keyword: #7ee79a;
@@ -275,11 +274,6 @@
   border-radius: 6px;
   background: var(--code-block-background);
   box-shadow: var(--docs-shadow-minimal);
-}
-
-.dark .slot-main figure[class~='group/code'] {
-  border: 1px solid var(--docs-outline);
-  background: var(--code-block-background);
 }
 
 .slot-main figure[class~='group/code'] button[aria-label='Copy code'] {

--- a/docs/global.css
+++ b/docs/global.css
@@ -60,9 +60,14 @@
     0 0 0 1px rgba(0, 0, 0, 0.04),
     0 1px 1px -0.5px rgba(0, 0, 0, 0.08),
     0 3px 3px -1.5px rgba(0, 0, 0, 0.08);
+  --docs-shadow-foreground-rgb: 38, 36, 42;
+  --docs-shadow-blur-opacity: 0.06;
   --docs-shadow-minimal:
-    0 0 0 1px rgba(0, 0, 0, 0.06),
-    0 1px 1px -0.5px rgba(0, 0, 0, 0.08);
+    rgba(0, 0, 0, 0) 0 0 0 0,
+    rgba(0, 0, 0, 0) 0 0 0 0,
+    rgba(var(--docs-shadow-foreground-rgb), 0.06) 0 0 0 1px,
+    rgba(0, 0, 0, var(--docs-shadow-blur-opacity)) 0 1px 1px -0.5px,
+    rgba(0, 0, 0, var(--docs-shadow-blur-opacity)) 0 3px 3px -1.5px;
   --docs-focus:
     0 0 0 1px rgba(6, 122, 34, 0.65),
     0 0 8px 1px rgba(6, 122, 34, 0.1);
@@ -105,9 +110,8 @@
     0 0 0 1px rgba(255, 255, 255, 0.06),
     0 1px 1px -0.5px rgba(0, 0, 0, 0.12),
     0 3px 3px -1.5px rgba(0, 0, 0, 0.12);
-  --docs-shadow-minimal:
-    0 0 0 1px rgba(255, 255, 255, 0.08),
-    0 1px 1px -0.5px rgba(0, 0, 0, 0.12);
+  --docs-shadow-foreground-rgb: 227, 226, 229;
+  --docs-shadow-blur-opacity: 0.12;
   --docs-focus:
     0 0 0 1px rgba(18, 206, 65, 0.65),
     0 0 8px 1px rgba(18, 206, 65, 0.1);

--- a/docs/global.css
+++ b/docs/global.css
@@ -64,6 +64,11 @@
   --docs-focus:
     0 0 0 1px rgba(6, 122, 34, 0.65),
     0 0 8px 1px rgba(6, 122, 34, 0.1);
+  --code-block-background: #f7f7f7;
+  --code-block-border: 0;
+  --code-block-radius: 6px;
+  --code-block-padding-x: 12px;
+  --code-block-padding-y: 12px;
 }
 
 .dark {
@@ -103,6 +108,8 @@
   --docs-focus:
     0 0 0 1px rgba(18, 206, 65, 0.65),
     0 0 8px 1px rgba(18, 206, 65, 0.1);
+  --code-block-background: var(--card);
+  --code-block-border: 1px solid var(--docs-outline);
 
   --prism-fg: #eeeeee;
   --prism-keyword: #7ee79a;
@@ -267,7 +274,7 @@
   border: 0;
   border-radius: 6px;
   background: var(--card);
-  box-shadow: none;
+  box-shadow: var(--docs-shadow-minimal);
 }
 
 .dark .slot-main figure[class~='group/code'] {

--- a/docs/global.css
+++ b/docs/global.css
@@ -60,12 +60,13 @@
     0 0 0 1px rgba(0, 0, 0, 0.04),
     0 1px 1px -0.5px rgba(0, 0, 0, 0.08),
     0 3px 3px -1.5px rgba(0, 0, 0, 0.08);
-  --docs-shadow-minimal: 0 1px 1px -0.5px rgba(0, 0, 0, 0.08);
+  --docs-shadow-minimal:
+    0 0 0 1px rgba(0, 0, 0, 0.06),
+    0 1px 1px -0.5px rgba(0, 0, 0, 0.08);
   --docs-focus:
     0 0 0 1px rgba(6, 122, 34, 0.65),
     0 0 8px 1px rgba(6, 122, 34, 0.1);
   --code-block-background: #f7f7f7;
-  --code-block-border: 0;
   --code-block-radius: 6px;
   --code-block-padding-x: 12px;
   --code-block-padding-y: 12px;
@@ -104,7 +105,9 @@
     0 0 0 1px rgba(255, 255, 255, 0.06),
     0 1px 1px -0.5px rgba(0, 0, 0, 0.12),
     0 3px 3px -1.5px rgba(0, 0, 0, 0.12);
-  --docs-shadow-minimal: 0 1px 1px -0.5px rgba(0, 0, 0, 0.12);
+  --docs-shadow-minimal:
+    0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 1px 1px -0.5px rgba(0, 0, 0, 0.12);
   --docs-focus:
     0 0 0 1px rgba(18, 206, 65, 0.65),
     0 0 8px 1px rgba(18, 206, 65, 0.1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- define Holocron 0.25's code-block CSS variables so inline styles resolve correctly
- use a light `#f7f7f7` code surface in light mode and the existing dark card surface in dark mode
- remove the separate code-block border variable
- match Craft's minimal shadow token exactly: two transparent compatibility layers, a 6% foreground ring, and 1px/3px blur layers at 6% light and 12% dark

## Testing
- `pnpm -s docs:build`
- light and dark modes compute `border-width: 0px`
- verified all five computed shadow layers match Craft's `--shadow-minimal` values exactly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8032cc46-d008-41ba-9fca-9071c827d3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8032cc46-d008-41ba-9fca-9071c827d3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

