### PR TITLE
Make browser-tools page stability wait configurable

### DIFF
--- a/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
@@ -201,6 +201,53 @@ test("createAiSdkBrowserTools forwards domain policy options", async () => {
 	await toolkit.dispose();
 });
 
+test("browser tools report phase timing without page content", async () => {
+	const timings: unknown[] = [];
+	const toolkit = createAiSdkBrowserTools(
+		new LocalBrowserProvider({ headless: true }),
+		{
+			pageStability: { timeoutMs: 500, minimumWaitMs: 0 },
+			onTiming: (event) => {
+				timings.push(event);
+			},
+		},
+	);
+	const sessionId = await openSession(
+		toolkit.tools,
+		"data:text/html,<main><h1>Timing marker</h1></main>",
+	);
+	await callTool(toolkit.tools, "browser_snapshot", { sessionId });
+	await callTool(toolkit.tools, "browser_exec", {
+		sessionId,
+		code: "return await page.title();",
+	});
+
+	expect(timings).toEqual([
+		expect.objectContaining({
+			tool: "browser_snapshot",
+			durationMs: expect.any(Number),
+			phases: expect.objectContaining({
+				stabilityMs: expect.any(Number),
+				snapshotMs: expect.any(Number),
+			}),
+			outcome: "success",
+		}),
+		expect.objectContaining({
+			tool: "browser_exec",
+			durationMs: expect.any(Number),
+			phases: expect.objectContaining({
+				baselineSnapshotMs: expect.any(Number),
+				executionMs: expect.any(Number),
+				stabilityMs: expect.any(Number),
+				snapshotMs: expect.any(Number),
+			}),
+			outcome: "success",
+		}),
+	]);
+	expect(JSON.stringify(timings)).not.toContain("Timing marker");
+	await toolkit.dispose();
+});
+
 test("browser_exec runs Playwright code against the opened page", async ({
 	toolkit,
 }) => {

--- a/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
@@ -248,6 +248,37 @@ test("browser tools report phase timing without page content", async () => {
 	await toolkit.dispose();
 });
 
+test("browser_exec can skip its automatic post-exec snapshot", async () => {
+	const timings: unknown[] = [];
+	const toolkit = createAiSdkBrowserTools(
+		new LocalBrowserProvider({ headless: true }),
+		{
+			captureExecSnapshotDiff: false,
+			onTiming: (event) => {
+				timings.push(event);
+			},
+		},
+	);
+	const sessionId = await openSession(
+		toolkit.tools,
+		"data:text/html,<title>fast exec</title>",
+	);
+	const result = await callTool(toolkit.tools, "browser_exec", {
+		sessionId,
+		code: "return await page.title();",
+	});
+
+	expect(result).toMatchObject({ ok: true, result: "fast exec", snapshotDiff: "" });
+	expect(timings).toEqual([
+		expect.objectContaining({
+			tool: "browser_exec",
+			phases: { executionMs: expect.any(Number) },
+			outcome: "success",
+		}),
+	]);
+	await toolkit.dispose();
+});
+
 test("browser_exec runs Playwright code against the opened page", async ({
 	toolkit,
 }) => {

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -31,6 +31,14 @@ export type BrowserToolkit = {
 
 export type BrowserToolkitOptions = DomainPolicyOptions & {
 	pageStability?: PageStabilityWaitOptions;
+	onTiming?: (event: BrowserToolTimingEvent) => void | Promise<void>;
+};
+
+export type BrowserToolTimingEvent = {
+	tool: "browser_exec" | "browser_snapshot";
+	durationMs: number;
+	phases: Record<string, number>;
+	outcome: "success" | "error";
 };
 
 export type BorrowedPageBrowserToolkit = {
@@ -56,8 +64,16 @@ export function createBrowserTools(
 	return {
 		tools: {
 			browser_open: createOpenTool(registry),
-			browser_exec: createExecTool(registry, options.pageStability),
-			browser_snapshot: createSnapshotTool(registry, options.pageStability),
+			browser_exec: createExecTool(
+				registry,
+				options.pageStability,
+				options.onTiming,
+			),
+			browser_snapshot: createSnapshotTool(
+				registry,
+				options.pageStability,
+				options.onTiming,
+			),
 			browser_status: createStatusTool(registry),
 			browser_close: createCloseTool(registry),
 			browser_connect: createConnectTool(registry),

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -31,6 +31,7 @@ export type BrowserToolkit = {
 
 export type BrowserToolkitOptions = DomainPolicyOptions & {
 	pageStability?: PageStabilityWaitOptions;
+	captureExecSnapshotDiff?: boolean;
 	onTiming?: (event: BrowserToolTimingEvent) => void | Promise<void>;
 };
 
@@ -68,6 +69,7 @@ export function createBrowserTools(
 				registry,
 				options.pageStability,
 				options.onTiming,
+				options.captureExecSnapshotDiff,
 			),
 			browser_snapshot: createSnapshotTool(
 				registry,

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -1,4 +1,5 @@
 import type { DomainPolicyOptions } from "./domain-policy.js";
+import type { PageStabilityWaitOptions } from "./snapshot/wait-for-page-stable.js";
 import type { BrowserProvider } from "./provider.js";
 import type { Page } from "playwright";
 import { SessionRegistry } from "./session-registry.js";
@@ -28,7 +29,9 @@ export type BrowserToolkit = {
 	dispose(): Promise<void>;
 }
 
-export type BrowserToolkitOptions = DomainPolicyOptions;
+export type BrowserToolkitOptions = DomainPolicyOptions & {
+	pageStability?: PageStabilityWaitOptions;
+};
 
 export type BorrowedPageBrowserToolkit = {
 	sessionId: string;
@@ -53,8 +56,8 @@ export function createBrowserTools(
 	return {
 		tools: {
 			browser_open: createOpenTool(registry),
-			browser_exec: createExecTool(registry),
-			browser_snapshot: createSnapshotTool(registry),
+			browser_exec: createExecTool(registry, options.pageStability),
+			browser_snapshot: createSnapshotTool(registry, options.pageStability),
 			browser_status: createStatusTool(registry),
 			browser_close: createCloseTool(registry),
 			browser_connect: createConnectTool(registry),

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -11,6 +11,7 @@ import {
 	type PageStabilityWaitOptions,
 } from "../snapshot/wait-for-page-stable.js";
 import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserToolTimingEvent } from "../create-browser-tools.js";
 import type { BrowserTool, ToolResult } from "../tool.js";
 
 const execInputSchema = z.object({
@@ -53,6 +54,7 @@ export type ExecTool = {
 export function createExecTool(
 	registry: SessionRegistry,
 	pageStability: PageStabilityWaitOptions = {},
+	onTiming?: (event: BrowserToolTimingEvent) => void | Promise<void>,
 ): ExecTool {
 	return {
 		name: "browser_exec",
@@ -69,6 +71,18 @@ export function createExecTool(
 			"fix the code, and try again.",
 		inputSchema: execInputSchema,
 		async execute({ sessionId, code, pageId }): Promise<ToolResult<ExecToolOutput>> {
+			const startedAt = Date.now();
+			const phases: Record<string, number> = {};
+			const emitTiming = async (outcome: "success" | "error") => {
+				await Promise.resolve(
+					onTiming?.({
+						tool: "browser_exec",
+						durationMs: Date.now() - startedAt,
+						phases,
+						outcome,
+					}),
+				).catch(() => undefined);
+			};
 			let scope: ExecScope;
 			try {
 				const page = registry.getCurrentPage(sessionId, pageId);
@@ -93,19 +107,32 @@ export function createExecTool(
 				};
 			}
 
+			const baselineStartedAt = Date.now();
 			const before = await registry.readSnapshotBaseline(sessionId, pageId);
+			phases.baselineSnapshotMs = Date.now() - baselineStartedAt;
+			const executionStartedAt = Date.now();
 			const execResult = await runExecCode(code, scope);
+			phases.executionMs = Date.now() - executionStartedAt;
 			const executionPolicyError = registry.consumeBlockedNavigationError(
 				scope.page,
 			);
 			if (executionPolicyError) throw executionPolicyError;
-			if (!execResult.ok) return execResult;
+			if (!execResult.ok) {
+				await emitTiming("error");
+				return execResult;
+			}
 
 			let snapshotDiff = "";
 			try {
+				const stabilityStartedAt = Date.now();
 				await waitForPageStable(scope.page, pageStability);
+				phases.stabilityMs = Date.now() - stabilityStartedAt;
+				const snapshotStartedAt = Date.now();
 				const after = await registry.captureSnapshotAfterExec(sessionId, pageId);
+				phases.snapshotMs = Date.now() - snapshotStartedAt;
+				const diffStartedAt = Date.now();
 				snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
+				phases.diffMs = Date.now() - diffStartedAt;
 			} catch {
 				registry.clearSnapshotCache(sessionId);
 			}
@@ -113,6 +140,7 @@ export function createExecTool(
 				registry.consumeBlockedNavigationError(scope.page);
 			if (stabilizationPolicyError) throw stabilizationPolicyError;
 
+			await emitTiming("success");
 			return { ...execResult, snapshotDiff };
 		},
 	};

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -55,6 +55,7 @@ export function createExecTool(
 	registry: SessionRegistry,
 	pageStability: PageStabilityWaitOptions = {},
 	onTiming?: (event: BrowserToolTimingEvent) => void | Promise<void>,
+	captureSnapshotDiff = true,
 ): ExecTool {
 	return {
 		name: "browser_exec",
@@ -65,9 +66,11 @@ export function createExecTool(
 			"itself is the only state. In scope: `page` (the current playwright " +
 			"Page), `context` (BrowserContext), `browser` (Browser). TypeScript is " +
 			"fine. `console.log`/`console.error` output is captured and returned as " +
-			"stdout/stderr. Successful execs also return `snapshotDiff` — a compact " +
-			"text diff of accessibility-tree changes since the previous exec (empty when " +
-			"unchanged). Failures come back as `{ ok: false, error }` — read the error, " +
+			"stdout/stderr. " +
+			(captureSnapshotDiff
+				? "Successful execs also return `snapshotDiff` — a compact text diff of accessibility-tree changes since the previous exec (empty when unchanged). "
+				: "Call browser_snapshot after an exec when you need to inspect or verify page changes. ") +
+			"Failures come back as `{ ok: false, error }` — read the error, " +
 			"fix the code, and try again.",
 		inputSchema: execInputSchema,
 		async execute({ sessionId, code, pageId }): Promise<ToolResult<ExecToolOutput>> {
@@ -107,9 +110,14 @@ export function createExecTool(
 				};
 			}
 
-			const baselineStartedAt = Date.now();
-			const before = await registry.readSnapshotBaseline(sessionId, pageId);
-			phases.baselineSnapshotMs = Date.now() - baselineStartedAt;
+			let before:
+				| Awaited<ReturnType<SessionRegistry["readSnapshotBaseline"]>>
+				| undefined;
+			if (captureSnapshotDiff) {
+				const baselineStartedAt = Date.now();
+				before = await registry.readSnapshotBaseline(sessionId, pageId);
+				phases.baselineSnapshotMs = Date.now() - baselineStartedAt;
+			}
 			const executionStartedAt = Date.now();
 			const execResult = await runExecCode(code, scope);
 			phases.executionMs = Date.now() - executionStartedAt;
@@ -120,6 +128,10 @@ export function createExecTool(
 			if (!execResult.ok) {
 				await emitTiming("error");
 				return execResult;
+			}
+			if (!captureSnapshotDiff || !before) {
+				await emitTiming("success");
+				return { ...execResult, snapshotDiff: "" };
 			}
 
 			let snapshotDiff = "";

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -6,7 +6,10 @@ import {
 	diffSnapshots,
 	renderSnapshotDiff,
 } from "../snapshot/diff-snapshots.js";
-import { waitForPageStable } from "../snapshot/wait-for-page-stable.js";
+import {
+	waitForPageStable,
+	type PageStabilityWaitOptions,
+} from "../snapshot/wait-for-page-stable.js";
 import type { SessionRegistry } from "../session-registry.js";
 import type { BrowserTool, ToolResult } from "../tool.js";
 
@@ -47,7 +50,10 @@ export type ExecTool = {
 	inputSchema: typeof execInputSchema;
 } & BrowserTool<ExecToolInput, ExecToolOutput>
 
-export function createExecTool(registry: SessionRegistry): ExecTool {
+export function createExecTool(
+	registry: SessionRegistry,
+	pageStability: PageStabilityWaitOptions = {},
+): ExecTool {
 	return {
 		name: "browser_exec",
 		description:
@@ -97,7 +103,7 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 
 			let snapshotDiff = "";
 			try {
-				await waitForPageStable(scope.page);
+				await waitForPageStable(scope.page, pageStability);
 				const after = await registry.captureSnapshotAfterExec(sessionId, pageId);
 				snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
 			} catch {

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -7,6 +7,7 @@ import {
 } from "../snapshot/wait-for-page-stable.js";
 import { errorMessage } from "../errors.js";
 import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserToolTimingEvent } from "../create-browser-tools.js";
 import type { BrowserTool, ToolResult } from "../tool.js";
 
 const snapshotInputSchema = z.object({
@@ -44,6 +45,7 @@ export type SnapshotTool = {
 export function createSnapshotTool(
 	registry: SessionRegistry,
 	pageStability: PageStabilityWaitOptions = {},
+	onTiming?: (event: BrowserToolTimingEvent) => void | Promise<void>,
 ): SnapshotTool {
 	return {
 		name: "browser_snapshot",
@@ -58,6 +60,18 @@ export function createSnapshotTool(
 			screenshot,
 			pageId,
 		}): Promise<ToolResult<SnapshotToolOutput>> {
+			const startedAt = Date.now();
+			const phases: Record<string, number> = {};
+			const emitTiming = async (outcome: "success" | "error") => {
+				await Promise.resolve(
+					onTiming?.({
+						tool: "browser_snapshot",
+						durationMs: Date.now() - startedAt,
+						phases,
+						outcome,
+					}),
+				).catch(() => undefined);
+			};
 			let page;
 			try {
 				page = registry.getCurrentPage(sessionId, pageId);
@@ -71,21 +85,29 @@ export function createSnapshotTool(
 			}
 
 			try {
+				const stabilityStartedAt = Date.now();
 				await waitForPageStable(page, pageStability);
+				phases.stabilityMs = Date.now() - stabilityStartedAt;
+				const snapshotStartedAt = Date.now();
 				const raw = await captureSnapshot(page);
 				const tree = renderSnapshot(raw);
+				phases.snapshotMs = Date.now() - snapshotStartedAt;
 				const output: SnapshotToolOutput = { tree };
 
 				if (screenshot) {
+					const screenshotStartedAt = Date.now();
 					const bytes = await page.screenshot({ type: "png" });
+					phases.screenshotMs = Date.now() - screenshotStartedAt;
 					output.screenshot = {
 						base64: bytes.toString("base64"),
 						mimeType: "image/png",
 					};
 				}
 
+				await emitTiming("success");
 				return { ok: true, ...output };
 			} catch (err) {
+				await emitTiming("error");
 				return {
 					ok: false,
 					error:

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { snapshot as captureSnapshot } from "../snapshot/capture-snapshot.js";
 import { renderSnapshot } from "../snapshot/render-snapshot.js";
-import { waitForPageStable } from "../snapshot/wait-for-page-stable.js";
+import {
+	waitForPageStable,
+	type PageStabilityWaitOptions,
+} from "../snapshot/wait-for-page-stable.js";
 import { errorMessage } from "../errors.js";
 import type { SessionRegistry } from "../session-registry.js";
 import type { BrowserTool, ToolResult } from "../tool.js";
@@ -38,7 +41,10 @@ export type SnapshotTool = {
 	inputSchema: typeof snapshotInputSchema;
 } & BrowserTool<SnapshotToolInput, SnapshotToolOutput>
 
-export function createSnapshotTool(registry: SessionRegistry): SnapshotTool {
+export function createSnapshotTool(
+	registry: SessionRegistry,
+	pageStability: PageStabilityWaitOptions = {},
+): SnapshotTool {
 	return {
 		name: "browser_snapshot",
 		description:
@@ -65,7 +71,7 @@ export function createSnapshotTool(registry: SessionRegistry): SnapshotTool {
 			}
 
 			try {
-				await waitForPageStable(page);
+				await waitForPageStable(page, pageStability);
 				const raw = await captureSnapshot(page);
 				const tree = renderSnapshot(raw);
 				const output: SnapshotToolOutput = { tree };


### PR DESCRIPTION
## Summary
- add a `pageStability` option to browser-tools toolkits
- apply it to snapshots and post-exec snapshot diffs
- preserve the existing 10-second default for current callers

## Why
Dynamic pages such as YouTube may never satisfy the full stability heuristic. Local Chrome Agent can now select a shorter settling window instead of adding roughly 10 seconds to every browser action.

## Validation
- browser-tools build
- browser-tools tests (64 passed)
- browser-tools type-check