### PR TITLE
Return provider-selected Playwright pages

### DIFF
--- a/packages/browser-tools/benchmarks/harness/browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/browser-tools.ts
@@ -1,4 +1,4 @@
-import { createPiBrowserTools } from "libretto-browser-tools/pi";
+import { createPiBrowserTools } from "../../src/adapters/pi/index.js";
 import { SessionRunError, type SessionRun } from "../agent.js";
 import {
 	createBenchmarkBrowserProvider,

--- a/packages/browser-tools/benchmarks/harness/cloud-browser.ts
+++ b/packages/browser-tools/benchmarks/harness/cloud-browser.ts
@@ -5,6 +5,7 @@ import { BrowserUseBrowserProvider } from "../../src/providers/browser-use.js";
 import { KernelBrowserProvider } from "../../src/providers/kernel.js";
 import { LocalBrowserProvider } from "../../src/providers/local.js";
 import { SteelBrowserProvider } from "../../src/providers/steel.js";
+import { getProviderSessionCdpEndpoint } from "../../src/provider.js";
 import { DEFAULT_TIMEOUT_MS } from "../agent.js";
 
 type BenchmarkBrowserProvider =
@@ -77,9 +78,16 @@ export async function createCloudBrowserConnection(
 ): Promise<CloudBrowserConnection> {
 	const provider = createBenchmarkBrowserProvider(providerName);
 	const session = await provider.createSession();
+	const cdpEndpoint = getProviderSessionCdpEndpoint(session);
+	if (!cdpEndpoint) {
+		await provider.closeSession(session.sessionId);
+		throw new Error(
+			`${providerName} did not expose its benchmark CDP endpoint. Use a provider that supports CDP attachment.`,
+		);
+	}
 	return {
 		provider: providerName,
-		cdpEndpoint: session.cdpEndpoint,
+		cdpEndpoint,
 		sessionId: session.sessionId,
 		sessionName: `benchmark-${session.sessionId}`,
 		async close() {

--- a/packages/browser-tools/src/provider.spec.ts
+++ b/packages/browser-tools/src/provider.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test, vi } from "vitest";
+import { LocalBrowserProvider } from "./providers/local.js";
+
+test("local closeSession closes its Playwright browser exactly once", async () => {
+	const provider = new LocalBrowserProvider({ headless: true });
+	const session = await provider.createSession();
+	const browser = session.page.context().browser();
+	if (!browser) throw new Error("expected provider page browser");
+	const close = vi.spyOn(browser, "close");
+
+	await provider.closeSession(session.sessionId);
+	await provider.closeSession(session.sessionId);
+
+	expect(browser.isConnected()).toBe(false);
+	expect(close).toHaveBeenCalledOnce();
+});

--- a/packages/browser-tools/src/provider.ts
+++ b/packages/browser-tools/src/provider.ts
@@ -1,8 +1,9 @@
+import type { Browser, Page } from "playwright";
+import { chromium } from "playwright";
+
 /**
- * Every provider reduces to "produce a CDP endpoint"; the session registry
- * connects Playwright to it. Provider-level settings (API keys, regions,
- * default headless/stealth) live in each provider's constructor, with env-var
- * fallback. Per-session launch options go on createSession.
+ * Providers own browser launch, Playwright attachment, page selection, and
+ * cleanup. Per-session launch options go on createSession.
  */
 export type ProviderSessionCreateOptions = {
 	startUrl?: string;
@@ -22,8 +23,8 @@ export type BrowserProvider = {
 export type ProviderSession = {
 	/** Provider-scoped session identifier. */
 	sessionId: string;
-	/** CDP websocket endpoint the registry connects Playwright to. */
-	cdpEndpoint: string;
+	/** The page selected by the provider for this logical session. */
+	page: Page;
 	liveViewUrl?: string;
 	recordingUrl?: string;
 	/**
@@ -35,4 +36,59 @@ export type ProviderSession = {
 
 export type ProviderSessionClosed = {
 	replayUrl?: string;
+}
+
+const cdpEndpointBySession = new WeakMap<ProviderSession, string>();
+
+/** @internal Used by the benchmark harness. */
+export function getProviderSessionCdpEndpoint(
+	session: ProviderSession,
+): string | undefined {
+	return cdpEndpointBySession.get(session);
+}
+
+/** @internal Used by providers that expose their endpoint to benchmarks. */
+export function setProviderSessionCdpEndpoint(
+	session: ProviderSession,
+	cdpEndpoint: string,
+): void {
+	cdpEndpointBySession.set(session, cdpEndpoint);
+}
+
+/** @internal Connects a provider endpoint and selects its initial page. */
+export async function connectProviderPage(
+	cdpEndpoint: string,
+): Promise<{ browser: Browser; page: Page }> {
+	let browser: Browser | undefined;
+	try {
+		browser = await chromium.connectOverCDP(cdpEndpoint);
+		const context = browser.contexts()[0] ?? (await browser.newContext());
+		const page = context.pages().at(-1) ?? (await context.newPage());
+		return { browser, page };
+	} catch (error) {
+		await browser?.close().catch(() => {});
+		throw error;
+	}
+}
+
+/** @internal Runs Playwright and provider cleanup even if either one fails. */
+export async function closeProviderBrowser(
+	browser: Browser,
+	closeProvider: () => Promise<void>,
+): Promise<void> {
+	const errors: unknown[] = [];
+	try {
+		await browser.close();
+	} catch (error) {
+		errors.push(error);
+	}
+	try {
+		await closeProvider();
+	} catch (error) {
+		errors.push(error);
+	}
+	if (errors.length === 1) throw errors[0];
+	if (errors.length > 1) {
+		throw new AggregateError(errors, "Failed to close browser provider session");
+	}
 }

--- a/packages/browser-tools/src/providers/browser-use.spec.ts
+++ b/packages/browser-tools/src/providers/browser-use.spec.ts
@@ -1,39 +1,41 @@
 import { afterEach, expect, test, vi } from "vitest";
-import { SteelBrowserProvider } from "./steel.js";
+import { BrowserUseBrowserProvider } from "./browser-use.js";
 
 afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
-test("releases a Steel session when its CDP URL is invalid", async () => {
+test("releases a Browser Use session when its CDP URL is invalid", async () => {
 	const fetchMock = vi
 		.fn<typeof fetch>()
 		.mockResolvedValueOnce(
-			new Response(JSON.stringify({ id: "steel-1" }), { status: 200 }),
+			new Response(
+				JSON.stringify({ id: "browser-use-1", cdpUrl: "not a URL" }),
+				{ status: 200 },
+			),
 		)
 		.mockResolvedValueOnce(new Response(null, { status: 200 }));
 	vi.stubGlobal("fetch", fetchMock);
-	const provider = new SteelBrowserProvider({
+	const provider = new BrowserUseBrowserProvider({
 		apiKey: "test-key",
-		endpoint: "https://steel.test",
-		connectEndpoint: "not a URL",
+		endpoint: "https://browser-use.test",
 	});
 
 	await expect(provider.createSession()).rejects.toBeInstanceOf(TypeError);
 
 	expect(fetchMock).toHaveBeenLastCalledWith(
-		"https://steel.test/v1/sessions/steel-1/release",
+		"https://browser-use.test/browsers/browser-use-1",
 		expect.objectContaining({
-			method: "POST",
-			body: JSON.stringify({}),
+			method: "PATCH",
+			body: JSON.stringify({ action: "stop" }),
 		}),
 	);
 });
 
-test.skipIf(!process.env.STEEL_API_KEY?.trim())(
-	"creates, connects to, and closes a Steel browser",
+test.skipIf(!process.env.BROWSER_USE_API_KEY?.trim())(
+	"creates, connects to, and closes a Browser Use browser",
 	async () => {
-		const provider = new SteelBrowserProvider();
+		const provider = new BrowserUseBrowserProvider();
 		const session = await provider.createSession();
 
 		expect(session.page.context().browser()?.isConnected()).toBe(true);

--- a/packages/browser-tools/src/providers/browser-use.ts
+++ b/packages/browser-tools/src/providers/browser-use.ts
@@ -1,8 +1,14 @@
+import type { Browser } from "playwright";
 import type {
 	BrowserProvider,
 	ProviderSession,
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
+} from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
 } from "../provider.js";
 
 const DEFAULT_BROWSER_USE_ENDPOINT = "https://api.browser-use.com/api/v3";
@@ -33,6 +39,7 @@ export class BrowserUseBrowserProvider implements BrowserProvider {
 	private readonly endpoint: string;
 	private readonly proxyCountryCode: string | null | undefined;
 	private readonly timeoutMinutes: number | undefined;
+	private readonly browsers = new Map<string, Browser>();
 
 	constructor(options: BrowserUseBrowserProviderOptions = {}) {
 		const apiKey = (
@@ -80,19 +87,38 @@ export class BrowserUseBrowserProvider implements BrowserProvider {
 
 		const session = (await response.json()) as BrowserUseSessionResponse;
 		if (!session.cdpUrl) {
+			await this.releaseSession(session.id).catch(() => {});
 			throw new Error(
 				`Browser Use session ${session.id} did not return a CDP URL. Stop the session in the Browser Use dashboard, then create a fresh session.`,
 			);
 		}
-		return {
-			sessionId: session.id,
-			cdpEndpoint: normalizeCdpEndpoint(session.cdpUrl),
-			...(session.liveUrl ? { liveViewUrl: session.liveUrl } : {}),
-			startUrlPreloaded: false,
-		};
+		try {
+			const cdpEndpoint = normalizeCdpEndpoint(session.cdpUrl);
+			const { browser, page } = await connectProviderPage(cdpEndpoint);
+			const providerSession: ProviderSession = {
+				sessionId: session.id,
+				page,
+				...(session.liveUrl ? { liveViewUrl: session.liveUrl } : {}),
+				startUrlPreloaded: false,
+			};
+			this.browsers.set(session.id, browser);
+			setProviderSessionCdpEndpoint(providerSession, cdpEndpoint);
+			return providerSession;
+		} catch (error) {
+			await this.releaseSession(session.id).catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const browser = this.browsers.get(sessionId);
+		if (!browser) return {};
+		this.browsers.delete(sessionId);
+		await closeProviderBrowser(browser, () => this.releaseSession(sessionId));
+		return {};
+	}
+
+	private async releaseSession(sessionId: string): Promise<void> {
 		const response = await fetch(`${this.endpoint}/browsers/${sessionId}`, {
 			method: "PATCH",
 			headers: {
@@ -107,6 +133,5 @@ export class BrowserUseBrowserProvider implements BrowserProvider {
 				`Browser Use API error closing session ${sessionId} (${response.status}): ${body}. Stop the session in the Browser Use dashboard.`,
 			);
 		}
-		return {};
 	}
 }

--- a/packages/browser-tools/src/providers/browserbase.spec.ts
+++ b/packages/browser-tools/src/providers/browserbase.spec.ts
@@ -1,4 +1,3 @@
-import { chromium } from "playwright";
 import { expect, test } from "vitest";
 import { BrowserbaseBrowserProvider } from "./browserbase.js";
 
@@ -7,9 +6,8 @@ test.skipIf(!process.env.BROWSERBASE_API_KEY?.trim())(
 	async () => {
 		const provider = new BrowserbaseBrowserProvider();
 		const session = await provider.createSession();
-		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 
-		expect(browser.isConnected()).toBe(true);
+		expect(session.page.context().browser()?.isConnected()).toBe(true);
 
 		await provider.closeSession(session.sessionId);
 	},

--- a/packages/browser-tools/src/providers/browserbase.ts
+++ b/packages/browser-tools/src/providers/browserbase.ts
@@ -1,8 +1,14 @@
+import type { Browser } from "playwright";
 import type {
 	BrowserProvider,
 	ProviderSession,
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
+} from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
 } from "../provider.js";
 
 export type BrowserbaseBrowserProviderOptions = {
@@ -37,6 +43,7 @@ export class BrowserbaseBrowserProvider implements BrowserProvider {
 	private readonly proxies: boolean | undefined;
 	private readonly solveCaptchas: boolean | undefined;
 	private readonly timeoutSeconds: number | undefined;
+	private readonly browsers = new Map<string, Browser>();
 
 	constructor(options: BrowserbaseBrowserProviderOptions = {}) {
 		const apiKey = (
@@ -103,14 +110,31 @@ export class BrowserbaseBrowserProvider implements BrowserProvider {
 			throw new Error(`Browserbase API error (${response.status}): ${body}`);
 		}
 		const session = (await response.json()) as BrowserbaseSessionResponse;
-		return {
-			sessionId: session.id,
-			cdpEndpoint: session.connectUrl,
-			startUrlPreloaded: false,
-		};
+		try {
+			const { browser, page } = await connectProviderPage(session.connectUrl);
+			const providerSession: ProviderSession = {
+				sessionId: session.id,
+				page,
+				startUrlPreloaded: false,
+			};
+			this.browsers.set(session.id, browser);
+			setProviderSessionCdpEndpoint(providerSession, session.connectUrl);
+			return providerSession;
+		} catch (error) {
+			await this.releaseSession(session.id).catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const browser = this.browsers.get(sessionId);
+		if (!browser) return {};
+		this.browsers.delete(sessionId);
+		await closeProviderBrowser(browser, () => this.releaseSession(sessionId));
+		return {};
+	}
+
+	private async releaseSession(sessionId: string): Promise<void> {
 		const response = await fetch(
 			`${this.endpoint}/v1/sessions/${sessionId}`,
 			{
@@ -128,6 +152,5 @@ export class BrowserbaseBrowserProvider implements BrowserProvider {
 				`Browserbase API error closing session ${sessionId} (${response.status}): ${body}`,
 			);
 		}
-		return {};
 	}
 }

--- a/packages/browser-tools/src/providers/kernel.spec.ts
+++ b/packages/browser-tools/src/providers/kernel.spec.ts
@@ -1,4 +1,3 @@
-import { chromium } from "playwright";
 import { expect, test } from "vitest";
 import { KernelBrowserProvider } from "./kernel.js";
 
@@ -7,9 +6,8 @@ test.skipIf(!process.env.KERNEL_API_KEY?.trim())(
 	async () => {
 		const provider = new KernelBrowserProvider();
 		const session = await provider.createSession();
-		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 
-		expect(browser.isConnected()).toBe(true);
+		expect(session.page.context().browser()?.isConnected()).toBe(true);
 
 		await provider.closeSession(session.sessionId);
 	},

--- a/packages/browser-tools/src/providers/kernel.ts
+++ b/packages/browser-tools/src/providers/kernel.ts
@@ -1,11 +1,17 @@
 import { randomBytes } from "node:crypto";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
+import type { Browser } from "playwright";
 import type {
 	BrowserProvider,
 	ProviderSession,
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
+} from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
 } from "../provider.js";
 
 export type KernelBrowserProviderOptions = {
@@ -160,6 +166,7 @@ export class KernelBrowserProvider implements BrowserProvider {
 	private readonly proxyId: string | undefined;
 	private readonly timeoutSeconds: number;
 	private readonly enableRecording: boolean;
+	private readonly browsers = new Map<string, Browser>();
 	private readonly replayUrlBySession = new Map<string, string>();
 
 	constructor(options: KernelBrowserProviderOptions = {}) {
@@ -241,12 +248,6 @@ export class KernelBrowserProvider implements BrowserProvider {
 					`/browsers/${browser.session_id}/replays`,
 					{ method: "POST", body: JSON.stringify({}) },
 				);
-				if (replay.replay_view_url) {
-					this.replayUrlBySession.set(
-						browser.session_id,
-						replay.replay_view_url,
-					);
-				}
 			} catch (error) {
 				await kernelFetchNoBody(
 					this.endpoint,
@@ -258,26 +259,46 @@ export class KernelBrowserProvider implements BrowserProvider {
 			}
 		}
 
-		return {
-			sessionId: browser.session_id,
-			cdpEndpoint: browser.cdp_ws_url,
-			liveViewUrl: browser.browser_live_view_url ?? undefined,
-			recordingUrl: replay?.replay_view_url ?? undefined,
-			startUrlPreloaded: Boolean(startUrl),
-		};
+		try {
+			const connected = await connectProviderPage(browser.cdp_ws_url);
+			const providerSession: ProviderSession = {
+				sessionId: browser.session_id,
+				page: connected.page,
+				liveViewUrl: browser.browser_live_view_url ?? undefined,
+				recordingUrl: replay?.replay_view_url ?? undefined,
+				startUrlPreloaded: Boolean(startUrl),
+			};
+			this.browsers.set(browser.session_id, connected.browser);
+			if (replay?.replay_view_url) {
+				this.replayUrlBySession.set(
+					browser.session_id,
+					replay.replay_view_url,
+				);
+			}
+			setProviderSessionCdpEndpoint(providerSession, browser.cdp_ws_url);
+			return providerSession;
+		} catch (error) {
+			await this.releaseSession(browser.session_id).catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const browser = this.browsers.get(sessionId);
+		if (!browser) return {};
 		const replayUrl = this.replayUrlBySession.get(sessionId);
+		this.browsers.delete(sessionId);
+		this.replayUrlBySession.delete(sessionId);
+		await closeProviderBrowser(browser, () => this.releaseSession(sessionId));
+		return { replayUrl };
+	}
 
+	private async releaseSession(sessionId: string): Promise<void> {
 		await kernelFetchNoBody(
 			this.endpoint,
 			this.apiKey,
 			`/browsers/${sessionId}`,
 			{ method: "DELETE" },
 		);
-		this.replayUrlBySession.delete(sessionId);
-
-		return { replayUrl };
 	}
 }

--- a/packages/browser-tools/src/providers/libretto-cloud.spec.ts
+++ b/packages/browser-tools/src/providers/libretto-cloud.spec.ts
@@ -1,4 +1,3 @@
-import { chromium } from "playwright";
 import { expect, test } from "vitest";
 import { LibrettoCloudBrowserProvider } from "./libretto-cloud.js";
 
@@ -7,9 +6,8 @@ test.skipIf(!process.env.LIBRETTO_API_KEY?.trim())(
 	async () => {
 		const provider = new LibrettoCloudBrowserProvider();
 		const session = await provider.createSession();
-		const browser = await chromium.connectOverCDP(session.cdpEndpoint);
 
-		expect(browser.isConnected()).toBe(true);
+		expect(session.page.context().browser()?.isConnected()).toBe(true);
 
 		await provider.closeSession(session.sessionId);
 	},

--- a/packages/browser-tools/src/providers/libretto-cloud.ts
+++ b/packages/browser-tools/src/providers/libretto-cloud.ts
@@ -1,8 +1,14 @@
+import type { Browser } from "playwright";
 import type {
 	BrowserProvider,
 	ProviderSession,
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
+} from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
 } from "../provider.js";
 
 const DEFAULT_HOSTED_API_URL = "https://api.libretto.sh";
@@ -111,6 +117,7 @@ export class LibrettoCloudBrowserProvider implements BrowserProvider {
 	private readonly endpoint: string;
 	private readonly timeoutSeconds: number;
 	private readonly headless: boolean;
+	private readonly browsers = new Map<string, Browser>();
 
 	constructor(options: LibrettoCloudBrowserProviderOptions = {}) {
 		const apiKey = (options.apiKey ?? process.env.LIBRETTO_API_KEY)?.trim();
@@ -174,18 +181,28 @@ export class LibrettoCloudBrowserProvider implements BrowserProvider {
 			throw error;
 		}
 
-		return {
-			sessionId: ready.session_id,
-			cdpEndpoint: ready.cdp_url,
-			liveViewUrl: ready.live_view_url ?? undefined,
-			startUrlPreloaded: Boolean(startUrl),
-		};
+		try {
+			const { browser, page } = await connectProviderPage(ready.cdp_url);
+			const providerSession: ProviderSession = {
+				sessionId: ready.session_id,
+				page,
+				liveViewUrl: ready.live_view_url ?? undefined,
+				startUrlPreloaded: Boolean(startUrl),
+			};
+			this.browsers.set(ready.session_id, browser);
+			setProviderSessionCdpEndpoint(providerSession, ready.cdp_url);
+			return providerSession;
+		} catch (error) {
+			await this.releaseSession(ready.session_id).catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
-		await cloudFetchOk(this.endpoint, this.apiKey, "/v1/sessions/close", {
-			session_id: sessionId,
-		});
+		const browser = this.browsers.get(sessionId);
+		if (!browser) return {};
+		this.browsers.delete(sessionId);
+		await closeProviderBrowser(browser, () => this.releaseSession(sessionId));
 
 		let replayUrl: string | undefined;
 		try {
@@ -200,5 +217,11 @@ export class LibrettoCloudBrowserProvider implements BrowserProvider {
 		}
 
 		return { replayUrl };
+	}
+
+	private async releaseSession(sessionId: string): Promise<void> {
+		await cloudFetchOk(this.endpoint, this.apiKey, "/v1/sessions/close", {
+			session_id: sessionId,
+		});
 	}
 }

--- a/packages/browser-tools/src/providers/local.ts
+++ b/packages/browser-tools/src/providers/local.ts
@@ -7,6 +7,11 @@ import type {
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
 } from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
+} from "../provider.js";
 
 export type LocalBrowserProviderOptions = {
 	channel?: string;
@@ -49,16 +54,17 @@ async function fetchWebSocketDebuggerUrl(port: number): Promise<string> {
 }
 
 /**
- * Launches a local Chromium with an ephemeral remote-debugging port and hands
- * back its CDP websocket endpoint. This is the only provider that needs the
- * Chromium binary installed (`npx playwright install chromium`); cloud
- * providers attach over CDP without a local browser download.
+ * Launches local Chromium and returns its initial CDP-attached page. This is
+ * the only provider that needs a local browser binary.
  */
 export class LocalBrowserProvider implements BrowserProvider {
 	readonly name = "local";
 	private readonly channel: string | undefined;
 	private readonly headless: boolean;
-	private readonly browsers = new Map<string, Browser>();
+	private readonly sessions = new Map<
+		string,
+		{ browser: Browser; launchedBrowser: Browser }
+	>();
 	private nextSessionNumber = 1;
 
 	constructor(options: LocalBrowserProviderOptions = {}) {
@@ -70,23 +76,36 @@ export class LocalBrowserProvider implements BrowserProvider {
 		_options: ProviderSessionCreateOptions = {},
 	): Promise<ProviderSession> {
 		const port = await pickFreePort();
-		const browser = await chromium.launch({
+		const launchedBrowser = await chromium.launch({
 			...(this.channel ? { channel: this.channel } : {}),
 			headless: this.headless,
 			args: [`--remote-debugging-port=${port}`],
 		});
-		const cdpEndpoint = await fetchWebSocketDebuggerUrl(port);
-		const sessionId = `local-${this.nextSessionNumber++}`;
-		this.browsers.set(sessionId, browser);
-		return { sessionId, cdpEndpoint, startUrlPreloaded: false };
+		try {
+			const cdpEndpoint = await fetchWebSocketDebuggerUrl(port);
+			const { browser, page } = await connectProviderPage(cdpEndpoint);
+			const sessionId = `local-${this.nextSessionNumber++}`;
+			const session: ProviderSession = {
+				sessionId,
+				page,
+				startUrlPreloaded: false,
+			};
+			this.sessions.set(sessionId, { browser, launchedBrowser });
+			setProviderSessionCdpEndpoint(session, cdpEndpoint);
+			return session;
+		} catch (error) {
+			await launchedBrowser.close().catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
-		const browser = this.browsers.get(sessionId);
-		if (browser) {
-			this.browsers.delete(sessionId);
-			await browser.close();
-		}
+		const session = this.sessions.get(sessionId);
+		if (!session) return {};
+		this.sessions.delete(sessionId);
+		await closeProviderBrowser(session.browser, () =>
+			session.launchedBrowser.close(),
+		);
 		return {};
 	}
 }

--- a/packages/browser-tools/src/providers/steel.ts
+++ b/packages/browser-tools/src/providers/steel.ts
@@ -1,8 +1,14 @@
+import type { Browser } from "playwright";
 import type {
 	BrowserProvider,
 	ProviderSession,
 	ProviderSessionClosed,
 	ProviderSessionCreateOptions,
+} from "../provider.js";
+import {
+	closeProviderBrowser,
+	connectProviderPage,
+	setProviderSessionCdpEndpoint,
 } from "../provider.js";
 
 const DEFAULT_STEEL_API_ENDPOINT = "https://api.steel.dev";
@@ -51,6 +57,7 @@ export class SteelBrowserProvider implements BrowserProvider {
 	private readonly solveCaptcha: boolean | undefined;
 	private readonly timeoutMs: number | undefined;
 	private readonly inactivityTimeoutMs: number | undefined;
+	private readonly browsers = new Map<string, Browser>();
 
 	constructor(options: SteelBrowserProviderOptions = {}) {
 		const apiKey = (options.apiKey ?? process.env.STEEL_API_KEY)?.trim();
@@ -114,19 +121,37 @@ export class SteelBrowserProvider implements BrowserProvider {
 			throw new Error(`Steel API error (${response.status}): ${body}`);
 		}
 		const session = (await response.json()) as SteelSessionResponse;
-		return {
-			sessionId: session.id,
-			cdpEndpoint: buildSteelCdpEndpoint(
+		try {
+			const cdpEndpoint = buildSteelCdpEndpoint(
 				this.connectEndpoint,
 				this.apiKey,
 				session.id,
-			),
-			liveViewUrl: session.sessionViewerUrl,
-			startUrlPreloaded: false,
-		};
+			);
+			const { browser, page } = await connectProviderPage(cdpEndpoint);
+			const providerSession: ProviderSession = {
+				sessionId: session.id,
+				page,
+				liveViewUrl: session.sessionViewerUrl,
+				startUrlPreloaded: false,
+			};
+			this.browsers.set(session.id, browser);
+			setProviderSessionCdpEndpoint(providerSession, cdpEndpoint);
+			return providerSession;
+		} catch (error) {
+			await this.releaseSession(session.id).catch(() => {});
+			throw error;
+		}
 	}
 
 	async closeSession(sessionId: string): Promise<ProviderSessionClosed> {
+		const browser = this.browsers.get(sessionId);
+		if (!browser) return {};
+		this.browsers.delete(sessionId);
+		await closeProviderBrowser(browser, () => this.releaseSession(sessionId));
+		return {};
+	}
+
+	private async releaseSession(sessionId: string): Promise<void> {
 		const response = await fetch(
 			`${this.endpoint}/v1/sessions/${sessionId}/release`,
 			{
@@ -144,6 +169,5 @@ export class SteelBrowserProvider implements BrowserProvider {
 				`Steel API error closing session ${sessionId} (${response.status}): ${body}`,
 			);
 		}
-		return {};
 	}
 }

--- a/packages/browser-tools/src/session-registry.spec.ts
+++ b/packages/browser-tools/src/session-registry.spec.ts
@@ -1,8 +1,16 @@
+import type { Browser, Page } from "playwright";
+import { chromium } from "playwright";
 import { expect, test as base, vi } from "vitest";
+import type { BrowserProvider } from "./provider.js";
 import { LocalBrowserProvider } from "./providers/local.js";
 import { SessionRegistry } from "./session-registry.js";
 
-const test = base.extend<{ registry: SessionRegistry }>({
+const test = base.extend<{ browser: Browser; registry: SessionRegistry }>({
+	browser: async ({}, use) => {
+		const browser = await chromium.launch({ headless: true });
+		await use(browser);
+		await browser.close();
+	},
 	registry: async ({}, use) => {
 		const registry = new SessionRegistry(
 			new LocalBrowserProvider({ headless: true }),
@@ -11,6 +19,19 @@ const test = base.extend<{ registry: SessionRegistry }>({
 		await registry.dispose();
 	},
 });
+
+function providerReturning(
+	page: Page,
+	closeSession: BrowserProvider["closeSession"],
+): BrowserProvider {
+	return {
+		name: "selected-page",
+		async createSession() {
+			return { sessionId: "host-window", page };
+		},
+		closeSession,
+	};
+}
 
 test("openSession returns a session ID and a usable current page", async ({
 	registry,
@@ -56,6 +77,57 @@ test("getCurrentPage tracks the newest page in the session", async ({
 	expect(session.pages.filter((page) => page.active)).toEqual([
 		expect.objectContaining({ url: expect.stringContaining("newest") }),
 	]);
+});
+
+test("openSession registers only the page selected by the provider", async ({
+	browser,
+}) => {
+	const context = await browser.newContext();
+	const selectedPage = await context.newPage();
+	await selectedPage.goto("data:text/html,<title>selected</title>");
+	const unrelatedPage = await context.newPage();
+	await unrelatedPage.goto("data:text/html,<title>unrelated</title>");
+	const closeSession = vi.fn(async () => ({}));
+	const registry = new SessionRegistry(
+		providerReturning(selectedPage, closeSession),
+	);
+
+	const { sessionId } = await registry.openSession();
+
+	expect(registry.getCurrentPage(sessionId)).toBe(selectedPage);
+	expect(registry.listSessions()[0].pages).toEqual([
+		expect.objectContaining({ url: expect.stringContaining("selected") }),
+	]);
+
+	await registry.closeSession(sessionId);
+	expect(closeSession).toHaveBeenCalledOnce();
+	expect(browser.isConnected()).toBe(true);
+	expect(selectedPage.isClosed()).toBe(false);
+	await registry.dispose();
+});
+
+test("failed page registration closes the provider session once", async ({
+	browser,
+}) => {
+	const context = await browser.newContext();
+	const page = await context.newPage();
+	await page.goto("https://example.com");
+	const closeSession = vi.fn(async () => ({}));
+	const registry = new SessionRegistry(
+		providerReturning(page, closeSession),
+		{ blockedDomains: ["example.com"] },
+	);
+
+	await expect(registry.openSession()).rejects.toMatchObject({
+		name: "DomainPolicyRestricted",
+		attemptedNavigationUrl: "https://example.com/",
+	});
+
+	expect(closeSession).toHaveBeenCalledOnce();
+	expect(browser.isConnected()).toBe(true);
+	await page.reload();
+	expect(page.url()).toBe("https://example.com/");
+	await registry.dispose();
 });
 
 test("unknown session ID throws with the ID in the message", ({ registry }) => {

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -13,12 +13,15 @@ import type {
 	ProviderSessionCreateOptions,
 } from "./provider.js";
 
+type RouteHandler = Parameters<BrowserContext["route"]>[1];
+
 type SessionEntry = {
 	providerSessionId: string | undefined;
 	providerName: string;
 	sessionSource: "existing-page" | "existing-cdp" | "new-session";
 	browser: Browser;
 	context: BrowserContext;
+	domainPolicyRouteHandler: RouteHandler | undefined;
 	currentPage: Page | undefined;
 	pageById: Map<string, Page>;
 	contextPageListener: (page: Page) => void;
@@ -83,25 +86,27 @@ export class SessionRegistry {
 			...options,
 			startUrl,
 		});
-		let browser: Browser | undefined;
+		const page = providerSession.page;
+		const context = page.context();
+		const browser = context.browser();
+		let domainPolicyRouteHandler: RouteHandler | undefined;
 		try {
-			browser = await chromium.connectOverCDP(providerSession.cdpEndpoint);
-			const context = browser.contexts()[0] ?? (await browser.newContext());
-			await this.applyDomainPolicy(context);
-			this.assertCurrentPagesAllowed(context);
+			if (!browser) {
+				throw new Error(
+					"The provider returned a page that is not connected to a Playwright browser.",
+				);
+			}
+			domainPolicyRouteHandler = await this.applyDomainPolicy(context);
+			this.assertPageAllowed(page);
 			const entry = this.createSessionEntry({
 				providerSessionId: providerSession.sessionId,
 				providerName: provider.name,
 				sessionSource: "new-session",
 				browser,
 				context,
+				domainPolicyRouteHandler,
 			});
-			if (context.pages().length === 0) {
-				await context.newPage();
-			}
-			for (const page of context.pages()) {
-				this.trackPage(entry, page);
-			}
+			this.trackPage(entry, page);
 
 			const sessionId = this.generateSessionId();
 			this.sessions.set(sessionId, entry);
@@ -111,7 +116,11 @@ export class SessionRegistry {
 				startUrlPreloaded: Boolean(providerSession.startUrlPreloaded),
 			};
 		} catch (error) {
-			await browser?.close().catch(() => {});
+			if (domainPolicyRouteHandler) {
+				await context
+					.unroute("**/*", domainPolicyRouteHandler)
+					.catch(() => {});
+			}
 			await provider.closeSession(providerSession.sessionId).catch(() => {});
 			throw error;
 		}
@@ -121,7 +130,7 @@ export class SessionRegistry {
 		const browser = await chromium.connectOverCDP(cdpEndpoint);
 		try {
 			const context = browser.contexts()[0] ?? (await browser.newContext());
-			await this.applyDomainPolicy(context);
+			const domainPolicyRouteHandler = await this.applyDomainPolicy(context);
 			this.assertCurrentPagesAllowed(context);
 			const entry = this.createSessionEntry({
 				providerSessionId: undefined,
@@ -129,6 +138,7 @@ export class SessionRegistry {
 				sessionSource: "existing-cdp",
 				browser,
 				context,
+				domainPolicyRouteHandler,
 			});
 			for (const page of context.pages()) {
 				this.trackPage(entry, page);
@@ -218,11 +228,14 @@ export class SessionRegistry {
 	async closeSession(sessionId: string): Promise<void> {
 		const entry = this.requireSession(sessionId);
 		this.sessions.delete(sessionId);
-		this.releaseSessionEntry(entry);
-		if (entry.sessionSource === "existing-page") return;
-		await entry.browser.close();
-		if (entry.sessionSource === "new-session" && entry.providerSessionId) {
-			await this.provider?.closeSession(entry.providerSessionId);
+		try {
+			await this.releaseSessionEntry(entry);
+		} finally {
+			if (entry.sessionSource === "new-session" && entry.providerSessionId) {
+				await this.provider?.closeSession(entry.providerSessionId);
+			} else if (entry.sessionSource === "existing-cdp") {
+				await entry.browser.close();
+			}
 		}
 	}
 
@@ -293,15 +306,17 @@ export class SessionRegistry {
 		void this.dispose();
 	};
 
-	private async applyDomainPolicy(context: BrowserContext): Promise<void> {
+	private async applyDomainPolicy(
+		context: BrowserContext,
+	): Promise<RouteHandler | undefined> {
 		if (
 			this.domainPolicy.allowedDomains === undefined &&
 			!this.domainPolicy.blockedDomains?.length
 		) {
-			return;
+			return undefined;
 		}
 
-		await context.route("**/*", async (route, request) => {
+		const handler: RouteHandler = async (route, request) => {
 			const url = request.url();
 			if (isUrlAllowed(url, this.domainPolicy)) {
 				await route.continue();
@@ -318,7 +333,9 @@ export class SessionRegistry {
 				}
 			}
 			await route.abort("blockedbyclient");
-		});
+		};
+		await context.route("**/*", handler);
+		return handler;
 	}
 
 	private assertCurrentPagesAllowed(context: BrowserContext): void {
@@ -330,12 +347,20 @@ export class SessionRegistry {
 		}
 	}
 
+	private assertPageAllowed(page: Page): void {
+		const url = page.url();
+		if (!isUrlAllowed(url, this.domainPolicy)) {
+			throw new DomainPolicyRestricted(this.domainPolicy, url);
+		}
+	}
+
 	private createSessionEntry(args: {
 		providerSessionId: string | undefined;
 		providerName: string;
 		sessionSource: SessionEntry["sessionSource"];
 		browser: Browser;
 		context: BrowserContext;
+		domainPolicyRouteHandler?: RouteHandler;
 	}): SessionEntry {
 		const entry: SessionEntry = {
 			providerSessionId: args.providerSessionId,
@@ -343,6 +368,7 @@ export class SessionRegistry {
 			sessionSource: args.sessionSource,
 			browser: args.browser,
 			context: args.context,
+			domainPolicyRouteHandler: args.domainPolicyRouteHandler,
 			currentPage: undefined,
 			pageById: new Map(),
 			contextPageListener: () => {},
@@ -380,7 +406,7 @@ export class SessionRegistry {
 		return pageId;
 	}
 
-	private releaseSessionEntry(entry: SessionEntry): void {
+	private async releaseSessionEntry(entry: SessionEntry): Promise<void> {
 		entry.context.off("page", entry.contextPageListener);
 		for (const [page, listener] of entry.pageCloseListenerByPage) {
 			page.off("close", listener);
@@ -389,6 +415,9 @@ export class SessionRegistry {
 		entry.pageById.clear();
 		entry.latestSnapshotByPage.clear();
 		entry.currentPage = undefined;
+		if (entry.domainPolicyRouteHandler) {
+			await entry.context.unroute("**/*", entry.domainPolicyRouteHandler);
+		}
 	}
 
 	private findPageId(entry: SessionEntry, page: Page): string | undefined {

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -126,11 +126,7 @@ test("browser_open does not create a provider session for a blocked start URL", 
 			name: "preload",
 			async createSession() {
 				created = true;
-				return {
-					sessionId: "provider-session",
-					cdpEndpoint: "ws://127.0.0.1:1",
-					startUrlPreloaded: true,
-				};
+				throw new Error("provider.createSession should not be called");
 			},
 			async closeSession() {
 				return {};
@@ -151,15 +147,12 @@ test("browser_open does not create a provider session for a blocked start URL", 
 	await registry.dispose();
 });
 
-test("browser_open closes provider sessions when browser setup fails", async () => {
+test("browser_open reports provider setup failures", async () => {
 	let closedSessionId: string | undefined;
 	const registry = new SessionRegistry({
 		name: "unreachable",
 		async createSession() {
-			return {
-				sessionId: "provider-session",
-				cdpEndpoint: "ws://127.0.0.1:1",
-			};
+			throw new Error("connection failed");
 		},
 		async closeSession(sessionId) {
 			closedSessionId = sessionId;
@@ -167,8 +160,10 @@ test("browser_open closes provider sessions when browser setup fails", async () 
 		},
 	});
 
-	await expect(createOpenTool(registry).execute({})).rejects.toThrow();
-	expect(closedSessionId).toBe("provider-session");
+	await expect(createOpenTool(registry).execute({})).rejects.toThrow(
+		"connection failed",
+	);
+	expect(closedSessionId).toBeUndefined();
 	await registry.dispose();
 });
 
@@ -193,7 +188,7 @@ test("browser_open rejects a provider browser already showing a blocked page", a
 			async createSession() {
 				return {
 					sessionId: "provider-session",
-					cdpEndpoint: externalBrowser.cdpUrl,
+					page,
 				};
 			},
 			async closeSession(sessionId) {

--- a/specs/browser-tools-provider-pages-spec.md
+++ b/specs/browser-tools-provider-pages-spec.md
@@ -71,32 +71,31 @@ async openSession(options: ProviderSessionCreateOptions = {}) {
 }
 ```
 
-- [ ] Replace `ProviderSession.cdpEndpoint` with required `ProviderSession.page`.
-- [ ] Add one small internal CDP helper that connects and returns `{ browser, page }`; close a partial connection if page selection fails.
-- [ ] Update all six built-in providers to connect internally and return `page`.
-- [ ] Keep each provider's Playwright browser handle by `sessionId` so `closeSession()` owns Playwright and remote cleanup.
-- [ ] Remove provider state before awaiting close so repeated `closeSession()` calls cannot clean up twice.
-- [ ] If CDP attachment fails after remote allocation, release the remote session before rejecting `createSession()`.
-- [ ] Preserve all existing provider options, live-view data, recording data, preload state, and close results.
-- [ ] Register only the supplied page initially.
-- [ ] Derive the context and browser from `page.context()` without calling `connectOverCDP()`.
-- [ ] Keep `context.on("page")` tracking for pages opened after registration.
-- [ ] On close or registration failure, remove registry listeners and call `provider.closeSession(sessionId)` without calling `browser.close()`.
-- [ ] Keep `browser_connect` and `createBrowserToolsForPage()` unchanged.
-- [ ] Add a test with two pages proving the registry selects the page returned by the provider.
-- [ ] Add a test proving close calls provider cleanup once while leaving the returned page and host browser open.
-- [ ] Add a blocked-page test proving partial registration calls provider cleanup once.
-- [ ] Update built-in provider tests to execute against `session.page` and close through `provider.closeSession(session.sessionId)`.
-- [ ] Add a local test proving two `closeSession()` calls close the browser once.
-- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
-- [ ] Verify `pnpm --filter libretto-browser-tools test` passes.
+- [x] Replace `ProviderSession.cdpEndpoint` with required `ProviderSession.page`.
+- [x] Add one small internal CDP helper that connects and returns `{ browser, page }`; close a partial connection if page selection fails.
+- [x] Update all six built-in providers to connect internally and return `page`.
+- [x] Keep each provider's Playwright browser handle by `sessionId` so `closeSession()` owns Playwright and remote cleanup.
+- [x] Remove provider state before awaiting close so repeated `closeSession()` calls cannot clean up twice.
+- [x] If CDP attachment fails after remote allocation, release the remote session before rejecting `createSession()`.
+- [x] Preserve all existing provider options, live-view data, recording data, preload state, and close results.
+- [x] Register only the supplied page initially.
+- [x] Derive the context and browser from `page.context()` without calling `connectOverCDP()`.
+- [x] Keep `context.on("page")` tracking for pages opened after registration.
+- [x] On close or registration failure, remove registry listeners and call `provider.closeSession(sessionId)` without calling `browser.close()`.
+- [x] Keep `browser_connect` and `createBrowserToolsForPage()` unchanged.
+- [x] Add a test with two pages proving the registry selects the page returned by the provider.
+- [x] Add a test proving close calls provider cleanup once while leaving the returned page and host browser open.
+- [x] Add a blocked-page test proving partial registration calls provider cleanup once.
+- [x] Update built-in provider tests to execute against `session.page` and close through `provider.closeSession(session.sessionId)`.
+- [x] Add a local test proving two `closeSession()` calls close the browser once.
+- [x] Retain provider CDP endpoints through an internal benchmark accessor and update the benchmark harness.
+- [x] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [x] Verify `pnpm --filter libretto-browser-tools test` passes.
 
 ### Phase 2: Update benchmarks and provider documentation
 
-Keep endpoint data private for the benchmark harness and document the one canonical provider-session representation.
+Document the one canonical provider-session representation.
 
-- [ ] Retain provider CDP endpoints only through an internal benchmark accessor.
-- [ ] Update the benchmark harness to close through `provider.closeSession()`.
 - [ ] Update custom-provider docs to return an exact page from `createSession()`.
 - [ ] Document that providers own launch, CDP attachment, page selection, and cleanup.
 - [ ] Confirm `browser_connect` documentation and behavior remain unchanged.

--- a/specs/browser-tools-provider-pages-spec.md
+++ b/specs/browser-tools-provider-pages-spec.md
@@ -1,0 +1,166 @@
+# Provider-selected browser pages
+
+## Problem overview
+
+`BrowserProvider.createSession()` returns a CDP endpoint, so `SessionRegistry` connects to the whole endpoint and chooses a context and page. A Craft Agent provider already knows which Electron `BrowserView` belongs to the session, but the registry can select another target and can close the host connection itself.
+
+## Solution overview
+
+Make every provider return its selected Playwright `Page` from `createSession()`. Providers retain `createSession()` and `closeSession()` and own browser connection and cleanup details. `SessionRegistry` registers the returned page without calling `connectOverCDP()` and calls `provider.closeSession()` when the logical session closes.
+
+Keep `browser_connect` unchanged as the explicit raw-CDP tool. It remains registry-owned and may use the current context and page selection behavior.
+
+## Goals
+
+- A Craft Agent provider returns the exact Playwright page for its Electron `BrowserView`.
+- `SessionRegistry` never derives a provider-created page from a CDP endpoint.
+- `browser_close` and toolkit disposal call `provider.closeSession(sessionId)` once for provider-created sessions.
+- A provider can release one Electron window without the registry closing the host browser.
+- Built-in local and cloud providers keep their current launch options, metadata, and cleanup behavior.
+- Pages opened after registration continue to appear in `browser_status`.
+
+## Non-goals
+
+- No changes to `browser_connect`, including target-ID selection or close behavior.
+- No changes to `createBrowserToolsForPage()`.
+- No shared-context isolation for `browser_exec`.
+- No filtering of future `context.on("page")` events from a shared Electron context.
+- No changes to the separate Libretto CLI provider API.
+- No backward compatibility for custom browser-tools providers that return only a CDP endpoint.
+- No migrations or backfills.
+
+## Important files/docs/websites for implementation
+
+- `packages/browser-tools/src/provider.ts` — Browser provider and provider-session contracts.
+- `packages/browser-tools/src/session-registry.ts` — Provider session registration and cleanup.
+- `packages/browser-tools/src/session-registry.spec.ts` — Selected-page and lifecycle coverage.
+- `packages/browser-tools/src/tools/tools.spec.ts` — End-to-end `browser_open` and `browser_close` behavior.
+- `packages/browser-tools/src/providers/local.ts` — Local Chromium launch, Playwright attachment, and cleanup.
+- `packages/browser-tools/src/providers/browserbase.ts` — Browserbase connection and release.
+- `packages/browser-tools/src/providers/browser-use.ts` — Browser Use connection and release.
+- `packages/browser-tools/src/providers/kernel.ts` — Kernel connection, recording metadata, and release.
+- `packages/browser-tools/src/providers/libretto-cloud.ts` — Libretto Cloud connection, recording metadata, and release.
+- `packages/browser-tools/src/providers/steel.ts` — Steel connection and release.
+- `packages/browser-tools/src/providers/*.spec.ts` — Built-in provider integration tests.
+- `packages/browser-tools/benchmarks/harness/cloud-browser.ts` — Benchmark-only access to provider CDP endpoints.
+- `docs/browser-tools/providers/custom.mdx` — Custom provider example.
+- `docs/browser-tools/providers/overview.mdx` — Provider ownership documentation.
+- [Playwright `BrowserType.connectOverCDP`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp) — How built-in providers obtain Playwright pages.
+- [Playwright `Browser.close`](https://playwright.dev/docs/api/class-browser#browser-close) — Cleanup behavior providers must own.
+
+## Implementation
+
+### Phase 1: Add provider-selected page registration
+
+Add the page path first so Craft can use it without changing built-in providers in the same commit. The temporary endpoint branch keeps the tree working while providers migrate; the final phase removes it.
+
+```ts
+// packages/browser-tools/src/provider.ts
+export type ProviderSession =
+  | { sessionId: string; page: Page; cdpEndpoint?: never; /* metadata */ }
+  | { sessionId: string; cdpEndpoint: string; page?: never; /* metadata */ };
+
+// packages/browser-tools/src/session-registry.ts
+async openSession(options: ProviderSessionCreateOptions = {}) {
+  const session = await this.provider.createSession(options);
+  return session.page
+    ? this.registerProviderPage(session)
+    : this.registerProviderEndpoint(session);
+}
+```
+
+- [ ] Add a typed provider-session variant containing `sessionId`, `page`, and existing metadata.
+- [ ] Register only the supplied page initially for the page variant.
+- [ ] Derive the context and browser from `page.context()` without calling `connectOverCDP()`.
+- [ ] Keep `context.on("page")` tracking for pages opened after registration.
+- [ ] On close or registration failure, remove registry listeners and call `provider.closeSession(sessionId)` without calling `browser.close()` for the page variant.
+- [ ] Keep the current endpoint path unchanged during provider migration.
+- [ ] Add a test with two pages proving the registry selects the page returned by the provider.
+- [ ] Add a test proving close calls provider cleanup once while leaving the returned page and host browser open.
+- [ ] Add a blocked-page test proving partial registration calls provider cleanup once.
+- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [ ] Verify `pnpm --filter libretto-browser-tools test -- src/session-registry.spec.ts src/tools/tools.spec.ts` passes.
+
+### Phase 2: Migrate local, Browserbase, and Browser Use providers
+
+Move CDP attachment into the first provider group. Each provider stores its Playwright browser handle by provider session ID so `closeSession()` can detach Playwright and then perform existing browser or API cleanup.
+
+```ts
+// packages/browser-tools/src/providers/browserbase.ts
+class BrowserbaseBrowserProvider implements BrowserProvider {
+  private readonly browsers = new Map<string, Browser>();
+  ...
+
+  async createSession(options = {}) {
+    const remote = await this.createRemoteSession(options);
+    const { browser, page } = await connectProviderPage(remote.connectUrl);
+    this.browsers.set(remote.id, browser);
+    return { sessionId: remote.id, page, startUrlPreloaded: false };
+  }
+}
+```
+
+- [ ] Add one small internal CDP helper that connects and returns `{ browser, page }`; it must close a partial connection if page selection fails.
+- [ ] Update `LocalBrowserProvider`, `BrowserbaseBrowserProvider`, and `BrowserUseBrowserProvider` to return `page`.
+- [ ] Store each Playwright browser by `sessionId` and remove it from the map before awaiting close.
+- [ ] Make `closeSession()` detach or close Playwright before running existing provider cleanup.
+- [ ] If internal CDP attachment fails after remote allocation, release the remote session before rejecting `createSession()`.
+- [ ] Preserve local channel and headless options, Browserbase settings, and Browser Use proxy and timeout options.
+- [ ] Update provider tests to execute against `session.page` and close through `provider.closeSession(session.sessionId)`.
+- [ ] Add a local test proving two `closeSession()` calls close the browser once.
+- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [ ] Verify the three provider test files pass.
+
+### Phase 3: Migrate Kernel, Steel, and Libretto Cloud providers
+
+Apply the same provider-owned attachment and cleanup path to the remaining providers. Preserve preload and recording behavior rather than changing their API requests.
+
+```ts
+// packages/browser-tools/src/providers/kernel.ts
+async createSession(options = {}) {
+  const remote = await this.createKernelBrowser(options);
+  const { browser, page } = await connectProviderPage(remote.cdp_ws_url);
+  this.browsers.set(remote.session_id, browser);
+  return {
+    sessionId: remote.session_id,
+    page,
+    liveViewUrl: remote.browser_live_view_url ?? undefined,
+    startUrlPreloaded: Boolean(options.startUrl),
+  };
+}
+```
+
+- [ ] Update Kernel, Steel, and Libretto Cloud providers to return their selected page.
+- [ ] Keep provider browser handles keyed by `sessionId` and make close idempotent.
+- [ ] Preserve Kernel CDP readiness retries, replay URLs, start URL, GPU, viewport, stealth, and proxy options.
+- [ ] Preserve Steel viewer URL, dimensions, proxy, captcha, and timeout options.
+- [ ] Preserve Libretto Cloud queue polling, live-view URL, recording lookup, start URL, GPU, viewport, headless, and timeout options.
+- [ ] Release each remote session if internal Playwright attachment fails.
+- [ ] Update the three provider integration tests to use the returned page and `closeSession()`.
+- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [ ] Verify the three provider test files pass.
+
+### Phase 4: Remove endpoint sessions from the provider contract
+
+Finish the contract after every built-in provider returns a page. Keep endpoint data private for benchmarks and update the two provider docs.
+
+```ts
+// packages/browser-tools/src/provider.ts
+export type ProviderSession = {
+  sessionId: string;
+  page: Page;
+  liveViewUrl?: string;
+  recordingUrl?: string;
+  startUrlPreloaded?: boolean;
+};
+```
+
+- [ ] Remove `cdpEndpoint` from the public `ProviderSession` contract and delete the temporary registry endpoint branch.
+- [ ] Retain provider CDP endpoints only through an internal benchmark accessor.
+- [ ] Update the benchmark harness to close through `provider.closeSession()`.
+- [ ] Update custom-provider docs to return an exact page from `createSession()`.
+- [ ] Document that providers own launch, CDP attachment, page selection, and cleanup.
+- [ ] Confirm `browser_connect` documentation and behavior remain unchanged.
+- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [ ] Verify `pnpm --filter libretto-browser-tools test` passes.
+- [ ] Verify `pnpm -s lint` passes.

--- a/specs/browser-tools-provider-pages-spec.md
+++ b/specs/browser-tools-provider-pages-spec.md
@@ -50,99 +50,9 @@ Keep `browser_connect` unchanged as the explicit raw-CDP tool. It remains regist
 
 ## Implementation
 
-### Phase 1: Add provider-selected page registration
+### Phase 1: Switch providers and the registry to pages
 
-Add the page path first so Craft can use it without changing built-in providers in the same commit. The temporary endpoint branch keeps the tree working while providers migrate; the final phase removes it.
-
-```ts
-// packages/browser-tools/src/provider.ts
-export type ProviderSession =
-  | { sessionId: string; page: Page; cdpEndpoint?: never; /* metadata */ }
-  | { sessionId: string; cdpEndpoint: string; page?: never; /* metadata */ };
-
-// packages/browser-tools/src/session-registry.ts
-async openSession(options: ProviderSessionCreateOptions = {}) {
-  const session = await this.provider.createSession(options);
-  return session.page
-    ? this.registerProviderPage(session)
-    : this.registerProviderEndpoint(session);
-}
-```
-
-- [ ] Add a typed provider-session variant containing `sessionId`, `page`, and existing metadata.
-- [ ] Register only the supplied page initially for the page variant.
-- [ ] Derive the context and browser from `page.context()` without calling `connectOverCDP()`.
-- [ ] Keep `context.on("page")` tracking for pages opened after registration.
-- [ ] On close or registration failure, remove registry listeners and call `provider.closeSession(sessionId)` without calling `browser.close()` for the page variant.
-- [ ] Keep the current endpoint path unchanged during provider migration.
-- [ ] Add a test with two pages proving the registry selects the page returned by the provider.
-- [ ] Add a test proving close calls provider cleanup once while leaving the returned page and host browser open.
-- [ ] Add a blocked-page test proving partial registration calls provider cleanup once.
-- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
-- [ ] Verify `pnpm --filter libretto-browser-tools test -- src/session-registry.spec.ts src/tools/tools.spec.ts` passes.
-
-### Phase 2: Migrate local, Browserbase, and Browser Use providers
-
-Move CDP attachment into the first provider group. Each provider stores its Playwright browser handle by provider session ID so `closeSession()` can detach Playwright and then perform existing browser or API cleanup.
-
-```ts
-// packages/browser-tools/src/providers/browserbase.ts
-class BrowserbaseBrowserProvider implements BrowserProvider {
-  private readonly browsers = new Map<string, Browser>();
-  ...
-
-  async createSession(options = {}) {
-    const remote = await this.createRemoteSession(options);
-    const { browser, page } = await connectProviderPage(remote.connectUrl);
-    this.browsers.set(remote.id, browser);
-    return { sessionId: remote.id, page, startUrlPreloaded: false };
-  }
-}
-```
-
-- [ ] Add one small internal CDP helper that connects and returns `{ browser, page }`; it must close a partial connection if page selection fails.
-- [ ] Update `LocalBrowserProvider`, `BrowserbaseBrowserProvider`, and `BrowserUseBrowserProvider` to return `page`.
-- [ ] Store each Playwright browser by `sessionId` and remove it from the map before awaiting close.
-- [ ] Make `closeSession()` detach or close Playwright before running existing provider cleanup.
-- [ ] If internal CDP attachment fails after remote allocation, release the remote session before rejecting `createSession()`.
-- [ ] Preserve local channel and headless options, Browserbase settings, and Browser Use proxy and timeout options.
-- [ ] Update provider tests to execute against `session.page` and close through `provider.closeSession(session.sessionId)`.
-- [ ] Add a local test proving two `closeSession()` calls close the browser once.
-- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
-- [ ] Verify the three provider test files pass.
-
-### Phase 3: Migrate Kernel, Steel, and Libretto Cloud providers
-
-Apply the same provider-owned attachment and cleanup path to the remaining providers. Preserve preload and recording behavior rather than changing their API requests.
-
-```ts
-// packages/browser-tools/src/providers/kernel.ts
-async createSession(options = {}) {
-  const remote = await this.createKernelBrowser(options);
-  const { browser, page } = await connectProviderPage(remote.cdp_ws_url);
-  this.browsers.set(remote.session_id, browser);
-  return {
-    sessionId: remote.session_id,
-    page,
-    liveViewUrl: remote.browser_live_view_url ?? undefined,
-    startUrlPreloaded: Boolean(options.startUrl),
-  };
-}
-```
-
-- [ ] Update Kernel, Steel, and Libretto Cloud providers to return their selected page.
-- [ ] Keep provider browser handles keyed by `sessionId` and make close idempotent.
-- [ ] Preserve Kernel CDP readiness retries, replay URLs, start URL, GPU, viewport, stealth, and proxy options.
-- [ ] Preserve Steel viewer URL, dimensions, proxy, captcha, and timeout options.
-- [ ] Preserve Libretto Cloud queue polling, live-view URL, recording lookup, start URL, GPU, viewport, headless, and timeout options.
-- [ ] Release each remote session if internal Playwright attachment fails.
-- [ ] Update the three provider integration tests to use the returned page and `closeSession()`.
-- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
-- [ ] Verify the three provider test files pass.
-
-### Phase 4: Remove endpoint sessions from the provider contract
-
-Finish the contract after every built-in provider returns a page. Keep endpoint data private for benchmarks and update the two provider docs.
+Change the contract atomically so `ProviderSession` has one representation. Built-in providers connect to CDP internally, while the registry accepts only the page they select.
 
 ```ts
 // packages/browser-tools/src/provider.ts
@@ -153,9 +63,38 @@ export type ProviderSession = {
   recordingUrl?: string;
   startUrlPreloaded?: boolean;
 };
+
+// packages/browser-tools/src/session-registry.ts
+async openSession(options: ProviderSessionCreateOptions = {}) {
+  const session = await this.provider.createSession(options);
+  return this.registerProviderPage(session);
+}
 ```
 
-- [ ] Remove `cdpEndpoint` from the public `ProviderSession` contract and delete the temporary registry endpoint branch.
+- [ ] Replace `ProviderSession.cdpEndpoint` with required `ProviderSession.page`.
+- [ ] Add one small internal CDP helper that connects and returns `{ browser, page }`; close a partial connection if page selection fails.
+- [ ] Update all six built-in providers to connect internally and return `page`.
+- [ ] Keep each provider's Playwright browser handle by `sessionId` so `closeSession()` owns Playwright and remote cleanup.
+- [ ] Remove provider state before awaiting close so repeated `closeSession()` calls cannot clean up twice.
+- [ ] If CDP attachment fails after remote allocation, release the remote session before rejecting `createSession()`.
+- [ ] Preserve all existing provider options, live-view data, recording data, preload state, and close results.
+- [ ] Register only the supplied page initially.
+- [ ] Derive the context and browser from `page.context()` without calling `connectOverCDP()`.
+- [ ] Keep `context.on("page")` tracking for pages opened after registration.
+- [ ] On close or registration failure, remove registry listeners and call `provider.closeSession(sessionId)` without calling `browser.close()`.
+- [ ] Keep `browser_connect` and `createBrowserToolsForPage()` unchanged.
+- [ ] Add a test with two pages proving the registry selects the page returned by the provider.
+- [ ] Add a test proving close calls provider cleanup once while leaving the returned page and host browser open.
+- [ ] Add a blocked-page test proving partial registration calls provider cleanup once.
+- [ ] Update built-in provider tests to execute against `session.page` and close through `provider.closeSession(session.sessionId)`.
+- [ ] Add a local test proving two `closeSession()` calls close the browser once.
+- [ ] Verify `pnpm --filter libretto-browser-tools type-check` passes.
+- [ ] Verify `pnpm --filter libretto-browser-tools test` passes.
+
+### Phase 2: Update benchmarks and provider documentation
+
+Keep endpoint data private for the benchmark harness and document the one canonical provider-session representation.
+
 - [ ] Retain provider CDP endpoints only through an internal benchmark accessor.
 - [ ] Update the benchmark harness to close through `provider.closeSession()`.
 - [ ] Update custom-provider docs to return an exact page from `createSession()`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make `ProviderSession` contain one provider-selected Playwright `Page`
- move CDP attachment and browser cleanup into all built-in providers
- register only the returned page for provider sessions while preserving new-page tracking
- keep `browser_connect` and borrowed-page behavior unchanged
- clean up remote sessions on partial attachment failures and make provider close idempotent
- complete Phase 1 in `specs/browser-tools-provider-pages-spec.md`

## Validation
- `pnpm --filter libretto-browser-tools type-check`
- `pnpm --filter libretto-browser-tools test` (74 passed, 5 skipped)
- `pnpm -s lint`
- root `pnpm -s type-check` and `pnpm -s test` are blocked by the existing docs build incompatibility: this VM's Node `node:module` does not export `registerHooks`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47a595b-bd83-44fd-a1a2-0eb430c96236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47a595b-bd83-44fd-a1a2-0eb430c96236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

