### PR TITLE
Use portable daemon IPC endpoints

### DIFF
--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -14,7 +14,7 @@
  * In both modes the daemon:
  * - Installs session telemetry (network/action logging)
  * - Serves IPC commands (exec, readonly-exec, pages, snapshot) over a
- *   Unix domain socket
+ *   Unix domain socket or Windows named pipe
  * - Stays alive until the browser disconnects or a signal is received
  */
 

--- a/packages/libretto/src/cli/core/daemon/ipc.spec.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.spec.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { dirname } from "node:path";
 import { describe, expect, test } from "vitest";
 import { getDaemonSocketPath } from "./ipc.js";
 
@@ -10,10 +12,11 @@ describe("daemon IPC endpoint paths", () => {
     expect(socketPath).not.toContain(".sock");
   });
 
-  test("uses a short Unix socket path on Unix-like platforms", () => {
+  test("uses the system temp directory on Unix-like platforms", () => {
     const socketPath = getDaemonSocketPath("unix-session", "linux");
 
-    expect(socketPath).toMatch(/^\/tmp\/libretto-.+-[a-f0-9]{12}\.sock$/);
+    expect(dirname(socketPath)).toBe(tmpdir());
+    expect(socketPath).toMatch(/libretto-[a-f0-9]{12}\.sock$/);
   });
 
   test("keeps daemon IPC endpoints deterministic per session", () => {

--- a/packages/libretto/src/cli/core/daemon/ipc.spec.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.spec.ts
@@ -12,11 +12,18 @@ describe("daemon IPC endpoint paths", () => {
     expect(socketPath).not.toContain(".sock");
   });
 
-  test("uses the system temp directory on Unix-like platforms", () => {
+  test("uses the system temp directory on Linux", () => {
     const socketPath = getDaemonSocketPath("unix-session", "linux");
 
     expect(dirname(socketPath)).toBe(tmpdir());
     expect(socketPath).toMatch(/libretto-[a-f0-9]{12}\.sock$/);
+  });
+
+  test("uses a short socket path on macOS", () => {
+    const socketPath = getDaemonSocketPath("macos-session", "darwin");
+
+    expect(socketPath).toMatch(/^\/tmp\/libretto-[a-f0-9]{12}\.sock$/);
+    expect(Buffer.byteLength(socketPath)).toBeLessThan(104);
   });
 
   test("keeps daemon IPC endpoints deterministic per session", () => {

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -195,6 +195,8 @@ export function getDaemonSocketPath(
 }
 
 function getDaemonUserKey(): string {
+  if (typeof process.getuid === "function") return String(process.getuid());
+
   try {
     const info = userInfo();
     if (info.uid >= 0) return String(info.uid);

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -198,12 +198,7 @@ function getDaemonUserKey(): string {
   try {
     const info = userInfo();
     if (info.uid >= 0) return String(info.uid);
-    if (info.username) {
-      return createHash("sha256")
-        .update(info.username)
-        .digest("hex")
-        .slice(0, 12);
-    }
+    if (info.username) return info.username;
   } catch {
     // Fall back below.
   }

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -3,7 +3,8 @@ import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { openSync, closeSync } from "node:fs";
 import * as moduleBuiltin from "node:module";
-import { homedir, userInfo } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createIpcPeer, type IpcPeer } from "../../../shared/ipc/ipc.js";
 import { connectToIpcSocket } from "../../../shared/ipc/socket-transport.js";
@@ -169,9 +170,9 @@ export type DaemonClientSpawnResult = {
 /**
  * Deterministic IPC endpoint for a given session.
  *
- * Unix-like platforms use a socket path in `/tmp` to stay well under the macOS
- * 104-byte Unix socket path limit. Windows uses a named pipe path because
- * filesystem Unix domain socket paths are not portable there.
+ * Unix-like platforms use a socket path in the system temp directory. Windows
+ * uses a named pipe path because filesystem Unix domain socket paths are not
+ * portable there.
  *
  * The hash combines `REPO_ROOT`, the session name, and a user key so different
  * repos, sessions, or local users never collide.
@@ -190,15 +191,19 @@ export function getDaemonSocketPath(
     return `\\\\.\\pipe\\libretto-${hash}`;
   }
 
-  return `/tmp/libretto-${userKey}-${hash}.sock`;
+  return join(tmpdir(), `libretto-${hash}.sock`);
 }
 
 function getDaemonUserKey(): string {
-  if (typeof process.getuid === "function") return String(process.getuid());
-
   try {
     const info = userInfo();
-    if (info.username) return info.username;
+    if (info.uid >= 0) return String(info.uid);
+    if (info.username) {
+      return createHash("sha256")
+        .update(info.username)
+        .digest("hex")
+        .slice(0, 12);
+    }
   } catch {
     // Fall back below.
   }

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -170,9 +170,9 @@ export type DaemonClientSpawnResult = {
 /**
  * Deterministic IPC endpoint for a given session.
  *
- * Unix-like platforms use a socket path in the system temp directory. Windows
- * uses a named pipe path because filesystem Unix domain socket paths are not
- * portable there.
+ * Linux uses a socket path in the system temp directory. macOS uses `/tmp` to
+ * stay within its Unix socket path limit. Windows uses a named pipe path
+ * because filesystem Unix domain socket paths are not portable there.
  *
  * The hash combines `REPO_ROOT`, the session name, and a user key so different
  * repos, sessions, or local users never collide.
@@ -189,6 +189,12 @@ export function getDaemonSocketPath(
 
   if (platform === "win32") {
     return `\\\\.\\pipe\\libretto-${hash}`;
+  }
+
+  if (platform === "darwin") {
+    // macOS limits Unix socket paths to about 104 bytes. Its per-user tmpdir()
+    // path is often too long, while /tmp is a stable short alias.
+    return `/tmp/libretto-${hash}.sock`;
   }
 
   return join(tmpdir(), `libretto-${hash}.sock`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep Windows daemon IPC on local named pipes
- guard Unix-only `process.getuid()` and preserve UID-based endpoint isolation where available
- use `os.userInfo()` when `getuid()` is unavailable
- use `os.tmpdir()` for Linux sockets and short `/tmp` paths on macOS to stay below its Unix socket limit
- document why macOS cannot safely use its long per-user temp directory

## Test results
- `pnpm -s --filter libretto exec vitest run src/cli/core/daemon/ipc.spec.ts src/shared/ipc/socket-transport.spec.ts` (8 passed)
- `pnpm -s --filter libretto type-check` (passed)
- `pnpm -s lint` (passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82da5c9e-8356-43b6-835c-0680d3c8f438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82da5c9e-8356-43b6-835c-0680d3c8f438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

