### PR TITLE
Make exec snapshot diffs opt-in

### DIFF
--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -121,8 +121,7 @@ npx libretto session-mode --session my-session
 
 - Use `snapshot` as the primary page observation tool.
 - Run `snapshot` without `--objective` or `--context`; the command prints a screenshot path and compact accessibility tree for the current page.
-- Run `snapshot <ref>` to inspect a subtree from the latest full snapshot. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
-- Run an unscoped snapshot before using refs. Subtree snapshots capture a fresh screenshot but reuse the latest cached tree.
+- Run `snapshot <ref>` to inspect a subtree. Each call captures a fresh screenshot and accessibility tree, then scopes output to that ref. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
 - Use it before guessing at selectors, after workflow failures, and whenever the visible page state is unclear.
 
 ```bash
@@ -142,7 +141,7 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
 - Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
-- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work.
 
 ```bash
 npx libretto exec "await page.url()"

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -141,11 +141,13 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
-- After successful mutations, `exec` prints page-change diffs from compact snapshots.
+- Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
 
 ```bash
 npx libretto exec "await page.url()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+npx libretto exec --diff-snapshot "await page.locator('button:has-text(\"Continue\")').click()"
 echo "async function textOf(selector) { return await page.locator(selector).textContent(); }" | npx libretto exec - --session debug-example
 npx libretto exec --session debug-example "await textOf('h1')"
 ```

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -121,8 +121,7 @@ npx libretto session-mode --session my-session
 
 - Use `snapshot` as the primary page observation tool.
 - Run `snapshot` without `--objective` or `--context`; the command prints a screenshot path and compact accessibility tree for the current page.
-- Run `snapshot <ref>` to inspect a subtree from the latest full snapshot. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
-- Run an unscoped snapshot before using refs. Subtree snapshots capture a fresh screenshot but reuse the latest cached tree.
+- Run `snapshot <ref>` to inspect a subtree. Each call captures a fresh screenshot and accessibility tree, then scopes output to that ref. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
 - Use it before guessing at selectors, after workflow failures, and whenever the visible page state is unclear.
 
 ```bash
@@ -142,7 +141,7 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
 - Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
-- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work.
 
 ```bash
 npx libretto exec "await page.url()"

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -141,11 +141,13 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
-- After successful mutations, `exec` prints page-change diffs from compact snapshots.
+- Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
 
 ```bash
 npx libretto exec "await page.url()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+npx libretto exec --diff-snapshot "await page.locator('button:has-text(\"Continue\")').click()"
 echo "async function textOf(selector) { return await page.locator(selector).textContent(); }" | npx libretto exec - --session debug-example
 npx libretto exec --session debug-example "await textOf('h1')"
 ```

--- a/apps/website/src/BrowserToolsPage.tsx
+++ b/apps/website/src/BrowserToolsPage.tsx
@@ -222,7 +222,7 @@ function ToolsSection() {
                   <>
                     <span className="text-ink">browser_exec</span>{" "}
                     <span className="text-amber">
-                      &quot;await page.locator(&apos;.titleline &gt; a&apos;).first().click()&quot;
+                      {"{ code: \"await page.locator('.titleline > a').first().click()\", diffSnapshot: true }"}
                     </span>
                   </>
                 }
@@ -245,8 +245,9 @@ function ToolsSection() {
               />
             }
           >
-            Runs Playwright code on the live page. Each call returns a compact
-            snapshot diff that shows what changed.
+            Runs Playwright code on the live page. Pass{" "}
+            <span className="font-mono text-ink">diffSnapshot</span> to get a
+            compact snapshot diff of what changed.
           </ToolCard>
         </div>
 

--- a/docs/browser-tools/tools.mdx
+++ b/docs/browser-tools/tools.mdx
@@ -53,10 +53,10 @@ Results are JSON-serialized when possible; values that cannot be serialized beco
 </ParamField>
 
 <ParamField path="diffSnapshot" type="boolean">
-  When `true`, wait for the page to settle after a successful exec and return
-  `snapshotDiff` — a compact accessibility-tree diff since the previous opted-in
-  exec (or a fresh baseline). Use for exploratory mutations when you do not know
-  what will change. Defaults to off.
+  When `true`, capture a compact accessibility-tree baseline before the exec,
+  wait for the page to settle after success, then return `snapshotDiff` against
+  a fresh after-tree. Use for exploratory mutations when you do not know what
+  will change. Defaults to off.
 </ParamField>
 
 Success:

--- a/docs/browser-tools/tools.mdx
+++ b/docs/browser-tools/tools.mdx
@@ -52,6 +52,13 @@ Results are JSON-serialized when possible; values that cannot be serialized beco
   Optional page ID from `browser_status`. Defaults to the most recently opened tab.
 </ParamField>
 
+<ParamField path="diffSnapshot" type="boolean">
+  When `true`, wait for the page to settle after a successful exec and return
+  `snapshotDiff` — a compact accessibility-tree diff since the previous opted-in
+  exec (or a fresh baseline). Use for exploratory mutations when you do not know
+  what will change. Defaults to off.
+</ParamField>
+
 Success:
 
 ```typescript theme={null}
@@ -60,7 +67,7 @@ Success:
   result: unknown,
   stdout: string,
   stderr: string,
-  snapshotDiff: string, // a11y-tree diff since the previous exec; empty when unchanged
+  snapshotDiff: string, // set when diffSnapshot is true; empty when off or unchanged
 }
 ```
 
@@ -69,7 +76,7 @@ Code-level failures return `{ ok: false, error, stdout?, stderr? }` — fix the 
 ### Snapshot vs snapshotDiff
 
 - Call `browser_snapshot` to orient on a full accessibility tree before interacting, or to verify state after a change.
-- Successful `browser_exec` calls already return `snapshotDiff` for what changed since the previous exec on that session. Prefer reading that before taking another full snapshot.
+- Pass `diffSnapshot: true` on `browser_exec` when you want a page-change diff after an exploratory mutation. Prefer that before taking another full snapshot when you do not know what changed.
 
 ## browser_snapshot
 

--- a/docs/reference/cli/exec.mdx
+++ b/docs/reference/cli/exec.mdx
@@ -108,6 +108,13 @@ The `page` and `frame` globals are refreshed for each call, including calls that
   and element highlights as Playwright interacts with the page.
 </ParamField>
 
+<ParamField path="--diff-snapshot" type="boolean">
+  After a successful `exec`, wait for the page to settle and print a compact
+  accessibility-tree diff of what changed. Use this for exploratory mutations
+  when you do not know what will change. Omit it when you already know what to
+  check — return that value from `exec`, or run `snapshot` afterward.
+</ParamField>
+
 ### Return values
 
 If the code evaluates to a value, `exec` prints it to stdout:

--- a/docs/reference/cli/snapshot.mdx
+++ b/docs/reference/cli/snapshot.mdx
@@ -17,8 +17,8 @@ npx libretto snapshot --session debug-example
 
 <ParamField path="ref" type="string">
   Optional element ref to scope output to that subtree, for example `l16` or
-  `e16`. Run an unscoped snapshot first; subtree snapshots capture a fresh
-  screenshot but reuse the latest cached tree for that page.
+  `e16`. Each call captures a fresh screenshot and accessibility tree, then
+  scopes the printed tree to that ref.
 </ParamField>
 
 ### Required flags

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -1,17 +1,18 @@
 # Browser harness benchmark results
 
-Results from three full Browser Use Cloud runs completed July 17–20, 2026.
+Results from three full Browser Use Cloud runs completed July 17–20, 2026, plus a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in.
 
 ## Methodology
 
 - 26 live-site tasks across search, commerce, travel, delivery, real estate, and documentation sites.
-- Four harnesses: `browser-tools`, `agent-browser`, `playwright-cli`, and `dev-browser`.
-- GPT-5.6 Sol ran through the Pi agent with a Browser Use Cloud session, US proxy, and concurrency 5.
-- Every full run scheduled 104 attempts: 26 tasks per harness.
+- Four harnesses in the July 17–20 suite: `browser-tools`, `agent-browser`, `playwright-cli`, and `dev-browser`.
+- GPT-5.6 Sol ran through the Pi agent with concurrency 5.
+- July 17–20 runs used Browser Use Cloud with a US proxy. Every full run scheduled 104 attempts: 26 tasks per harness.
+- The July 29 re-run used Kernel and only the `browser-tools` harness (26 attempts), with opt-in `diffSnapshot` on `browser_exec`.
 - A separate judge scored raw Pi events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
 - Cost, token, duration, and tool-call metrics below cover the task agent, not the judge.
 
-Run command:
+Browser Use Cloud suite command:
 
 ```bash
 pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
@@ -19,7 +20,34 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
-## Full runs
+Kernel `browser-tools` re-run command:
+
+```bash
+pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
+  --harnesses browser-tools \
+  --provider kernel \
+  --concurrency 5
+```
+
+## Latest `browser-tools` run (Kernel, opt-in diffs)
+
+July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: true`.
+
+| Metric | Value |
+|---|---:|
+| Passed | 23/26 |
+| Completed | 26/26 |
+| Avg duration | 88.6s |
+| Agent tokens | 1.59M |
+| Agent cost | $2.78 |
+| Tool calls | 239 |
+| Wall time | 9m 28s |
+
+Failures were all anti-bot: Reddit, Walmart, and Yelp. Agents set `diffSnapshot: true` on 15 of 137 `browser_exec` calls (7 of 26 cases).
+
+Compared with the best prior Browser Use `browser-tools` row (24/26, 1.45M tokens, $2.53, 85.9s avg), this run was one pass lower and about 10% higher on tokens and cost. Excluding the long Walmart bot-check failure (170k tokens, $0.23, 239s), the remaining tasks were 1.42M tokens, $2.54, and 82.6s avg — on par with that earlier best. Provider differs (Kernel vs Browser Use), so the comparison is not causal for the opt-in change.
+
+## Full runs (Browser Use Cloud, all harnesses)
 
 | Run | Passed | Completed | Pass rate | Agent tokens | Agent cost | Tool calls | Wall time |
 |---|---:|---:|---:|---:|---:|---:|---:|
@@ -36,7 +64,7 @@ Harness scores by run:
 | `playwright-cli` | 21/26 | 22/26 | 22/26 |
 | `dev-browser` | 21/26 | 24/26 | 19/26 |
 
-## Best result per harness
+## Best result per harness (Browser Use Cloud)
 
 The selection uses highest pass count, then completion count, then lower cost. These rows come from different runs and do not represent one simultaneous run.
 
@@ -51,8 +79,9 @@ The best-result composite is 93/104 passed at $20.56 and 10.73M agent tokens.
 
 ## Findings
 
-- `browser-tools` and `dev-browser` tied at 24/26. `browser-tools` used 59% fewer tokens and cost 59% less.
-- `agent-browser` was the most stable harness at 23/26 in all three runs.
+- `browser-tools` and `dev-browser` tied at 24/26 in the Browser Use suite. `browser-tools` used 59% fewer tokens and cost 59% less.
+- `agent-browser` was the most stable harness at 23/26 in all three Browser Use runs.
 - `playwright-cli` used the most tokens and had the highest cost per successful task.
-- Anti-bot behavior dominated the selected failures. Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one.
-- Results are exploratory, not causal harness rankings. Live content, proxy reputation, anti-bot state, and agent behavior varied between runs.
+- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp.
+- The Kernel opt-in-diff re-run (23/26) stayed in the prior `browser-tools` pass-rate band (20–24/26). The modest token and cost increase versus the Browser Use best row was driven mainly by one long Walmart challenge, not by frequent use of snapshot diffs.
+- Results are exploratory, not causal harness rankings. Live content, provider, proxy reputation, anti-bot state, and agent behavior varied between runs.

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -432,6 +432,14 @@ export class SessionRegistry {
 		if (entry) entry.latestSnapshotByPage.clear();
 	}
 
+	/** True when navigations may be aborted and reported after exec settles. */
+	hasDomainNavigationPolicy(): boolean {
+		return (
+			this.domainPolicy.allowedDomains !== undefined ||
+			Boolean(this.domainPolicy.blockedDomains?.length)
+		);
+	}
+
 	consumeBlockedNavigationError(
 		page: Page,
 	): DomainPolicyRestricted | undefined {

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -8,8 +8,6 @@ import {
 	isUrlAllowed,
 } from "./domain-policy.js";
 import { errorMessage } from "./errors.js";
-import type { Snapshot } from "./snapshot/capture-snapshot.js";
-import { snapshot as captureSnapshot } from "./snapshot/capture-snapshot.js";
 import {
 	AuthProfileError,
 	ProviderCloseError,
@@ -85,8 +83,6 @@ type SessionEntry = {
 	pageById: Map<string, Page>;
 	contextPageListener: (page: Page) => void;
 	pageCloseListenerByPage: Map<Page, () => void>;
-	/** Post-exec snapshot baseline per page for snapshot diffs. */
-	latestSnapshotByPage: Map<Page, Snapshot>;
 }
 
 export type SessionPageSummary = {
@@ -403,35 +399,6 @@ export class SessionRegistry {
 		);
 	}
 
-	/** Baseline for the next exec diff — cached post-exec snapshot or a fresh capture. */
-	async readSnapshotBaseline(
-		sessionId: string,
-		pageId?: string,
-	): Promise<Snapshot> {
-		const entry = this.requireSession(sessionId);
-		const page = this.getCurrentPage(sessionId, pageId);
-		const cached = entry.latestSnapshotByPage.get(page);
-		if (cached) return cached;
-		return captureSnapshot(page);
-	}
-
-	/** Capture after exec and cache for the next call's baseline. */
-	async captureSnapshotAfterExec(
-		sessionId: string,
-		pageId?: string,
-	): Promise<Snapshot> {
-		const entry = this.requireSession(sessionId);
-		const page = this.getCurrentPage(sessionId, pageId);
-		const after = await captureSnapshot(page);
-		entry.latestSnapshotByPage.set(page, after);
-		return after;
-	}
-
-	clearSnapshotCache(sessionId: string): void {
-		const entry = this.sessions.get(sessionId);
-		if (entry) entry.latestSnapshotByPage.clear();
-	}
-
 	/** True when allowedDomains or blockedDomains constrain navigations. */
 	hasNonemptyDomainPolicy(): boolean {
 		return (
@@ -550,7 +517,6 @@ export class SessionRegistry {
 			pageById: new Map(),
 			contextPageListener: () => {},
 			pageCloseListenerByPage: new Map(),
-			latestSnapshotByPage: new Map(),
 		};
 		// Newest page wins, so popups and tabs become current automatically.
 		entry.contextPageListener = (page) => {
@@ -572,7 +538,6 @@ export class SessionRegistry {
 		const closeListener = () => {
 			entry.pageById.delete(pageId);
 			entry.pageCloseListenerByPage.delete(page);
-			entry.latestSnapshotByPage.delete(page);
 			if (entry.currentPage === page) {
 				entry.currentPage = undefined;
 			}
@@ -590,7 +555,6 @@ export class SessionRegistry {
 		}
 		entry.pageCloseListenerByPage.clear();
 		entry.pageById.clear();
-		entry.latestSnapshotByPage.clear();
 		entry.currentPage = undefined;
 	}
 

--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -432,8 +432,8 @@ export class SessionRegistry {
 		if (entry) entry.latestSnapshotByPage.clear();
 	}
 
-	/** True when navigations may be aborted and reported after exec settles. */
-	hasDomainNavigationPolicy(): boolean {
+	/** True when allowedDomains or blockedDomains constrain navigations. */
+	hasNonemptyDomainPolicy(): boolean {
 		return (
 			this.domainPolicy.allowedDomains !== undefined ||
 			Boolean(this.domainPolicy.blockedDomains?.length)

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -112,17 +112,26 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			if (executionPolicyError) throw executionPolicyError;
 			if (!execResult.ok) return execResult;
 
+			// Settle after exec when the caller opted into a snapshot diff, or when
+			// a domain policy may still report an unawaited blocked navigation.
+			const settleAfterExec =
+				Boolean(diffSnapshot) || registry.hasDomainNavigationPolicy();
+
 			let snapshotDiff = "";
-			if (diffSnapshot && before) {
+			if (settleAfterExec) {
 				try {
 					await waitForPageStable(scope.page);
-					const after = await registry.captureSnapshotAfterExec(
-						sessionId,
-						pageId,
-					);
-					snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
+					if (diffSnapshot && before) {
+						const after = await registry.captureSnapshotAfterExec(
+							sessionId,
+							pageId,
+						);
+						snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
+					}
 				} catch {
-					registry.clearSnapshotCache(sessionId);
+					if (diffSnapshot) {
+						registry.clearSnapshotCache(sessionId);
+					}
 				}
 				const stabilizationPolicyError =
 					registry.consumeBlockedNavigationError(scope.page);

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -68,10 +68,10 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			"Page), `context` (BrowserContext), `browser` (Browser). TypeScript is " +
 			"fine. `console.log`/`console.error` output is captured and returned as " +
 			"stdout/stderr. Pass `diffSnapshot: true` to also return `snapshotDiff` — " +
-			"a compact text diff of accessibility-tree changes since the previous " +
-			"opted-in exec (empty when unchanged). Use that for exploratory mutations " +
-			"when you do not know what will change; omit it otherwise. Failures come " +
-			"back as `{ ok: false, error }` — read the error, fix the code, and try again.",
+			"a compact text diff of accessibility-tree changes from just before this " +
+			"exec (empty when unchanged). Use that for exploratory mutations when you " +
+			"do not know what will change; omit it otherwise. Failures come back as " +
+			"`{ ok: false, error }` — read the error, fix the code, and try again.",
 		inputSchema: execInputSchema,
 		async execute({
 			sessionId,
@@ -126,8 +126,14 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 						const after = await captureSnapshot(scope.page);
 						snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
 					}
-				} catch {
-					// Keep the successful exec result when after-snapshot capture fails.
+				} catch (err) {
+					// Keep the successful exec result when after-diff capture fails.
+					if (diffSnapshot) {
+						snapshotDiff =
+							`Failed to do post-diff snapshot: ${errorMessage(err)}. ` +
+							"The exec itself succeeded. Call browser_snapshot if you need " +
+							"the current page state, or omit diffSnapshot when the page may close.";
+					}
 				}
 				const stabilizationPolicyError =
 					registry.consumeBlockedNavigationError(scope.page);

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -115,7 +115,7 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			// Settle after exec when the caller opted into a snapshot diff, or when
 			// a domain policy may still report an unawaited blocked navigation.
 			const settleAfterExec =
-				Boolean(diffSnapshot) || registry.hasDomainNavigationPolicy();
+				Boolean(diffSnapshot) || registry.hasNonemptyDomainPolicy();
 
 			let snapshotDiff = "";
 			if (settleAfterExec) {

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { errorMessage } from "../errors.js";
 import type { ExecScope } from "../exec/exec-engine.js";
 import { runExecCode } from "../exec/exec-engine.js";
+import { snapshot as captureSnapshot } from "../snapshot/capture-snapshot.js";
 import {
 	diffSnapshots,
 	renderSnapshotDiff,
@@ -30,10 +31,10 @@ const execInputSchema = z.object({
 		.boolean()
 		.optional()
 		.describe(
-			"When true, wait for the page to settle after a successful exec and return " +
-				"`snapshotDiff` — a compact accessibility-tree diff since the previous " +
-				"opted-in exec (or a fresh baseline). Use for exploratory mutations when " +
-				"you do not know what will change. Omit or set false to skip the cost.",
+			"When true, capture a compact accessibility-tree baseline before the exec, " +
+				"wait for the page to settle after success, then return `snapshotDiff` " +
+				"against a fresh after-tree. Use for exploratory mutations when you do " +
+				"not know what will change. Omit or set false to skip the cost.",
 		),
 });
 
@@ -103,7 +104,7 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			}
 
 			const before = diffSnapshot
-				? await registry.readSnapshotBaseline(sessionId, pageId)
+				? await captureSnapshot(scope.page)
 				: undefined;
 			const execResult = await runExecCode(code, scope);
 			const executionPolicyError = registry.consumeBlockedNavigationError(
@@ -122,16 +123,11 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 				try {
 					await waitForPageStable(scope.page);
 					if (diffSnapshot && before) {
-						const after = await registry.captureSnapshotAfterExec(
-							sessionId,
-							pageId,
-						);
+						const after = await captureSnapshot(scope.page);
 						snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
 					}
 				} catch {
-					if (diffSnapshot) {
-						registry.clearSnapshotCache(sessionId);
-					}
+					// Keep the successful exec result when after-snapshot capture fails.
 				}
 				const stabilizationPolicyError =
 					registry.consumeBlockedNavigationError(scope.page);

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -26,6 +26,15 @@ const execInputSchema = z.object({
 		.describe(
 			'Optional page ID from browser_status. Defaults to the most recently opened tab.',
 		),
+	diffSnapshot: z
+		.boolean()
+		.optional()
+		.describe(
+			"When true, wait for the page to settle after a successful exec and return " +
+				"`snapshotDiff` — a compact accessibility-tree diff since the previous " +
+				"opted-in exec (or a fresh baseline). Use for exploratory mutations when " +
+				"you do not know what will change. Omit or set false to skip the cost.",
+		),
 });
 
 export type ExecToolInput = z.infer<typeof execInputSchema>;
@@ -34,7 +43,7 @@ export type ExecToolOutput = {
 	result: unknown;
 	stdout: string;
 	stderr: string;
-	/** Rendered a11y-tree diff since the previous exec on this session; empty when unchanged. */
+	/** Rendered a11y-tree diff when `diffSnapshot` was true; empty when off or unchanged. */
 	snapshotDiff: string;
 }
 
@@ -57,12 +66,18 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			"itself is the only state. In scope: `page` (the current playwright " +
 			"Page), `context` (BrowserContext), `browser` (Browser). TypeScript is " +
 			"fine. `console.log`/`console.error` output is captured and returned as " +
-			"stdout/stderr. Successful execs also return `snapshotDiff` — a compact " +
-			"text diff of accessibility-tree changes since the previous exec (empty when " +
-			"unchanged). Failures come back as `{ ok: false, error }` — read the error, " +
-			"fix the code, and try again.",
+			"stdout/stderr. Pass `diffSnapshot: true` to also return `snapshotDiff` — " +
+			"a compact text diff of accessibility-tree changes since the previous " +
+			"opted-in exec (empty when unchanged). Use that for exploratory mutations " +
+			"when you do not know what will change; omit it otherwise. Failures come " +
+			"back as `{ ok: false, error }` — read the error, fix the code, and try again.",
 		inputSchema: execInputSchema,
-		async execute({ sessionId, code, pageId }): Promise<ToolResult<ExecToolOutput>> {
+		async execute({
+			sessionId,
+			code,
+			pageId,
+			diffSnapshot,
+		}): Promise<ToolResult<ExecToolOutput>> {
 			let scope: ExecScope;
 			try {
 				const page = registry.getCurrentPage(sessionId, pageId);
@@ -87,7 +102,9 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 				};
 			}
 
-			const before = await registry.readSnapshotBaseline(sessionId, pageId);
+			const before = diffSnapshot
+				? await registry.readSnapshotBaseline(sessionId, pageId)
+				: undefined;
 			const execResult = await runExecCode(code, scope);
 			const executionPolicyError = registry.consumeBlockedNavigationError(
 				scope.page,
@@ -96,16 +113,21 @@ export function createExecTool(registry: SessionRegistry): ExecTool {
 			if (!execResult.ok) return execResult;
 
 			let snapshotDiff = "";
-			try {
-				await waitForPageStable(scope.page);
-				const after = await registry.captureSnapshotAfterExec(sessionId, pageId);
-				snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
-			} catch {
-				registry.clearSnapshotCache(sessionId);
+			if (diffSnapshot && before) {
+				try {
+					await waitForPageStable(scope.page);
+					const after = await registry.captureSnapshotAfterExec(
+						sessionId,
+						pageId,
+					);
+					snapshotDiff = renderSnapshotDiff(diffSnapshots(before, after));
+				} catch {
+					registry.clearSnapshotCache(sessionId);
+				}
+				const stabilizationPolicyError =
+					registry.consumeBlockedNavigationError(scope.page);
+				if (stabilizationPolicyError) throw stabilizationPolicyError;
 			}
-			const stabilizationPolicyError =
-				registry.consumeBlockedNavigationError(scope.page);
-			if (stabilizationPolicyError) throw stabilizationPolicyError;
 
 			return { ...execResult, snapshotDiff };
 		},

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -321,8 +321,8 @@ test("browser_exec carries browser state across calls and supports TypeScript", 
 		result: "updated",
 		stdout: "mutated to updated",
 		stderr: "",
+		snapshotDiff: "",
 	});
-	expect(mutate.ok && mutate.snapshotDiff.length).toBeGreaterThan(0);
 
 	const read = await execTool.execute({
 		sessionId: opened.sessionId,
@@ -333,6 +333,40 @@ test("browser_exec carries browser state across calls and supports TypeScript", 
 		result: "updated",
 		stdout: "",
 		stderr: "",
+		snapshotDiff: "",
+	});
+});
+
+test("browser_exec returns snapshotDiff only when diffSnapshot is true", async ({
+	openTool,
+	execTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<h1 id='t'>start</h1>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const mutate = await execTool.execute({
+		sessionId: opened.sessionId,
+		diffSnapshot: true,
+		code:
+			"await page.locator('#t').evaluate((el: HTMLElement) => { el.textContent = 'updated'; }); " +
+			"return await page.locator('#t').textContent()",
+	});
+	expect(mutate).toMatchObject({
+		ok: true,
+		result: "updated",
+	});
+	expect(mutate.ok && mutate.snapshotDiff.length).toBeGreaterThan(0);
+
+	const read = await execTool.execute({
+		sessionId: opened.sessionId,
+		diffSnapshot: true,
+		code: "return await page.locator('#t').textContent()",
+	});
+	expect(read).toMatchObject({
+		ok: true,
+		result: "updated",
 		snapshotDiff: "",
 	});
 });
@@ -598,6 +632,7 @@ test("browser_exec snapshot diff uses per-page cache across mixed pageId calls",
 
 	const first = await execTool.execute({
 		sessionId: opened.sessionId,
+		diffSnapshot: true,
 		code:
 			"await page.locator('#t').evaluate((el: HTMLElement) => { el.textContent = 'first'; });",
 	});
@@ -607,6 +642,7 @@ test("browser_exec snapshot diff uses per-page cache across mixed pageId calls",
 	const second = await execTool.execute({
 		sessionId: opened.sessionId,
 		pageId,
+		diffSnapshot: true,
 		code:
 			"await page.locator('#t').evaluate((el: HTMLElement) => { el.textContent = 'second'; });",
 	});
@@ -615,6 +651,7 @@ test("browser_exec snapshot diff uses per-page cache across mixed pageId calls",
 
 	const third = await execTool.execute({
 		sessionId: opened.sessionId,
+		diffSnapshot: true,
 		code: "return await page.locator('#t').textContent()",
 	});
 	expect(third).toMatchObject({

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -616,7 +616,7 @@ test("domain policy rejects a connected browser already showing a blocked page",
 	if (disposed instanceof Error) throw disposed;
 });
 
-test("browser_exec snapshot diff uses per-page cache across mixed pageId calls", async ({
+test("browser_exec snapshot diffs each call against a fresh before-tree", async ({
 	openTool,
 	execTool,
 	statusTool,

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -371,6 +371,29 @@ test("browser_exec returns snapshotDiff only when diffSnapshot is true", async (
 	});
 });
 
+test("browser_exec keeps success and reports post-diff failure when the page closes", async ({
+	openTool,
+	execTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>closing</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await execTool.execute({
+		sessionId: opened.sessionId,
+		diffSnapshot: true,
+		code: "await page.close(); return 'closed ok'",
+	});
+	expect(result).toMatchObject({
+		ok: true,
+		result: "closed ok",
+	});
+	expect(result.ok && result.snapshotDiff).toContain(
+		"Failed to do post-diff snapshot:",
+	);
+});
+
 test("browser_exec returns ok false for an unknown session ID", async ({
 	execTool,
 }) => {

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -121,8 +121,7 @@ npx libretto session-mode --session my-session
 
 - Use `snapshot` as the primary page observation tool.
 - Run `snapshot` without `--objective` or `--context`; the command prints a screenshot path and compact accessibility tree for the current page.
-- Run `snapshot <ref>` to inspect a subtree from the latest full snapshot. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
-- Run an unscoped snapshot before using refs. Subtree snapshots capture a fresh screenshot but reuse the latest cached tree.
+- Run `snapshot <ref>` to inspect a subtree. Each call captures a fresh screenshot and accessibility tree, then scopes output to that ref. Use ref forms printed in the tree, such as `l16`; numeric-suffix aliases such as `e16` also match `l16`.
 - Use it before guessing at selectors, after workflow failures, and whenever the visible page state is unclear.
 
 ```bash
@@ -142,7 +141,7 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
 - Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
-- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work.
 
 ```bash
 npx libretto exec "await page.url()"

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -141,11 +141,13 @@ npx libretto snapshot --session debug-example --page <page-id>
 - Let failures throw. Do not hide `exec` failures with `try/catch` or `.catch()`.
 - Do not run multiple `exec` commands in parallel.
 - Do not use `exec` in read-only diagnosis flows. Use `readonly-exec` from the `libretto-readonly` skill for those sessions.
-- After successful mutations, `exec` prints page-change diffs from compact snapshots.
+- Snapshot diffs are opt-in. Pass `--diff-snapshot` when you mutate the page and do not know what will change (for example clicking an unfamiliar control). Prefer returning a specific value or running `snapshot` when you already know what to check.
+- Without `--diff-snapshot`, `exec` skips the before/after compact snapshot work. After mutations, run a fresh `snapshot` before using refs if you need an up-to-date tree.
 
 ```bash
 npx libretto exec "await page.url()"
 npx libretto exec "await page.locator('button:has-text(\"Continue\")').click()"
+npx libretto exec --diff-snapshot "await page.locator('button:has-text(\"Continue\")').click()"
 echo "async function textOf(selector) { return await page.locator(selector).textContent(); }" | npx libretto exec - --session debug-example
 npx libretto exec --session debug-example "await textOf('h1')"
 ```

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -165,7 +165,7 @@ async function execViaDaemon(
     throw new Error(response.message);
   }
 
-  const { result, output, snapshotDiff } = response.data;
+  const { result, output, snapshotDiff, snapshotDiffError } = response.data;
   writeDaemonExecOutput(output);
 
   logger.info(`${mode}-success`, {
@@ -181,6 +181,9 @@ async function execViaDaemon(
     console.log("Executed successfully");
   }
   writeDaemonSnapshotDiff(snapshotDiff);
+  if (snapshotDiffError) {
+    console.error(snapshotDiffError);
+  }
 }
 
 async function runExec(

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -135,6 +135,7 @@ async function execViaDaemon(
     visualize?: boolean;
     pageId?: string;
     mode?: ExecMode;
+    diffSnapshot?: boolean;
   },
 ): Promise<void> {
   const mode = options.mode ?? "exec";
@@ -148,6 +149,7 @@ async function execViaDaemon(
     codePreview: cleanedCode.slice(0, 200),
     visualize: options.visualize,
     pageId: options.pageId,
+    diffSnapshot: options.diffSnapshot,
     via: "daemon",
   });
 
@@ -160,6 +162,7 @@ async function execViaDaemon(
             code: cleanedCode,
             pageId: options.pageId,
             visualize: options.visualize,
+            diffSnapshot: options.diffSnapshot,
           })
         : await client.readonlyExec({
             code: cleanedCode,
@@ -342,6 +345,7 @@ async function runExec(
     visualize?: boolean;
     pageId?: string;
     mode?: ExecMode;
+    diffSnapshot?: boolean;
   } = {},
 ): Promise<void> {
   const state = readSessionStateOrThrow(session);
@@ -710,11 +714,15 @@ export const execInput = SimpleCLI.input({
     visualize: SimpleCLI.flag({
       help: "Enable ghost cursor + highlight visualization",
     }),
+    diffSnapshot: SimpleCLI.flag({
+      name: "diff-snapshot",
+      help: "After a successful mutation, print compact snapshot page-change diffs",
+    }),
     page: pageOption(),
   },
 }).refine(
   (input) => input.code !== undefined,
-  `Usage: libretto exec <code|-> [--session <name>] [--visualize]\n       echo '<code>' | libretto exec - [--session <name>] [--visualize]`,
+  `Usage: libretto exec <code|-> [--session <name>] [--visualize] [--diff-snapshot]\n       echo '<code>' | libretto exec - [--session <name>] [--visualize] [--diff-snapshot]`,
 );
 
 export const execCommand = SimpleCLI.command({
@@ -739,6 +747,7 @@ export const execCommand = SimpleCLI.command({
         visualize: input.visualize,
         pageId: input.page,
         mode: "exec",
+        diffSnapshot: input.diffSnapshot,
       },
     );
   });

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -1,11 +1,8 @@
 import { readFileSync } from "node:fs";
 import * as moduleBuiltin from "node:module";
 import { z } from "zod";
-import { installInstrumentation } from "../../shared/instrumentation/index.js";
 import type { LoggerApi } from "../../shared/logger/index.js";
 import {
-  connect,
-  disconnectBrowser,
   runClose,
   resolveWindowPosition,
   resolveViewport,
@@ -35,10 +32,7 @@ import {
 import {
   getAbsoluteIntegrationPath,
 } from "../core/workflow-runtime.js";
-import {
-  compileExecFunction,
-  stripEmptyCatchHandlers,
-} from "../core/exec-compiler.js";
+import { stripEmptyCatchHandlers } from "../core/exec-compiler.js";
 import {
   DaemonClient,
   type DaemonExecSuccess,
@@ -46,12 +40,6 @@ import {
   type DaemonToCliApi,
 } from "../core/daemon/ipc.js";
 import type { DaemonConfig } from "../core/daemon/config.js";
-import { createReadonlyExecHelpers } from "../core/readonly-exec.js";
-import {
-  readActionLog,
-  readNetworkLog,
-  wrapPageForActionLogging,
-} from "../core/session-logs.js";
 import type { SessionAccessMode } from "../../shared/state/index.js";
 import type { Experiments } from "../core/experiments.js";
 import { SimpleCLI } from "affordance";
@@ -195,148 +183,6 @@ async function execViaDaemon(
   writeDaemonSnapshotDiff(snapshotDiff);
 }
 
-async function execViaCdpFallback(
-  code: string,
-  session: string,
-  logger: LoggerApi,
-  options: {
-    visualize?: boolean;
-    pageId?: string;
-    mode?: ExecMode;
-  },
-): Promise<void> {
-  const visualize = options.visualize ?? false;
-  const pageId = options.pageId;
-  const mode = options.mode ?? "exec";
-  const { cleaned: cleanedCode, strippedCount } = stripEmptyCatchHandlers(code);
-  if (strippedCount > 0) {
-    console.log("(Stripped `.catch(() => {})` — letting errors bubble up)");
-  }
-  logger.info(`${mode}-start`, {
-    session,
-    codeLength: cleanedCode.length,
-    codePreview: cleanedCode.slice(0, 200),
-    visualize,
-    pageId,
-    via: "cdp-fallback",
-  });
-
-  const {
-    browser,
-    context,
-    page,
-    pageId: resolvedPageId,
-  } = await connect(session, logger, 10000, {
-    pageId,
-  });
-
-  const STALL_THRESHOLD_MS = 60_000;
-  let lastActivityTs = Date.now();
-  const onActivity = () => {
-    lastActivityTs = Date.now();
-  };
-
-  const stallInterval = setInterval(() => {
-    const silenceMs = Date.now() - lastActivityTs;
-    if (silenceMs >= STALL_THRESHOLD_MS) {
-      logger.warn(`${mode}-stall-warning`, {
-        session,
-        silenceMs,
-        codePreview: cleanedCode.slice(0, 200),
-        via: "cdp-fallback",
-      });
-      console.warn(
-        `[stall-warning] No Playwright activity for ${Math.round(silenceMs / 1000)}s — ${mode} may be hung (code: ${cleanedCode.slice(0, 100)}...)`,
-      );
-    }
-  }, STALL_THRESHOLD_MS);
-
-  const execStartTs = Date.now();
-  const sigintHandler = () => {
-    logger.info(`${mode}-interrupted`, {
-      session,
-      duration: Date.now() - execStartTs,
-      codePreview: cleanedCode.slice(0, 200),
-      via: "cdp-fallback",
-    });
-  };
-  process.on("SIGINT", sigintHandler);
-
-  if (mode === "exec") {
-    wrapPageForActionLogging(page, session, resolvedPageId, onActivity);
-  }
-
-  if (visualize && mode === "exec") {
-    await installInstrumentation(page, { visualize: true, logger });
-  }
-
-  try {
-    const execState: Record<string, unknown> = {};
-    const helpers =
-      mode === "readonly-exec"
-        ? createReadonlyExecHelpers(page, { onActivity })
-        : {
-            page,
-            context,
-            state: execState,
-            browser,
-            networkLog: (
-              opts: {
-                last?: number;
-                filter?: string;
-                method?: string;
-                pageId?: string;
-              } = {},
-            ) => readNetworkLog(session, opts),
-            actionLog: (
-              opts: {
-                last?: number;
-                filter?: string;
-                action?: string;
-                source?: string;
-                pageId?: string;
-              } = {},
-            ) => readActionLog(session, opts),
-            console,
-            setTimeout,
-            setInterval,
-            clearTimeout,
-            clearInterval,
-            fetch,
-            URL,
-            Buffer,
-          };
-
-    const helperNames = Object.keys(helpers);
-    const fn = compileExecFunction(cleanedCode, helperNames);
-    const result = await fn(...Object.values(helpers));
-    logger.info(`${mode}-success`, {
-      session,
-      hasResult: result !== undefined,
-      via: "cdp-fallback",
-    });
-    if (result !== undefined) {
-      console.log(
-        typeof result === "string" ? result : JSON.stringify(result, null, 2),
-      );
-    } else {
-      console.log("Executed successfully");
-    }
-  } catch (err) {
-    logger.error(`${mode}-error`, {
-      error: err,
-      session,
-      codePreview: cleanedCode.slice(0, 200),
-      via: "cdp-fallback",
-    });
-    throw err;
-  } finally {
-    clearInterval(stallInterval);
-    process.removeListener("SIGINT", sigintHandler);
-    disconnectBrowser(browser, logger, session);
-  }
-}
-
 async function runExec(
   code: string,
   session: string,
@@ -350,15 +196,10 @@ async function runExec(
 ): Promise<void> {
   const state = readSessionStateOrThrow(session);
   if (!state.daemonSocketPath) {
-    // Compatibility fallback for older sessions that predate daemon-backed
-    // command handling. Keep `exec` inspection working when state has a live
-    // CDP endpoint/port but no daemon socket.
-    logger.warn(`${options.mode ?? "exec"}-daemon-socket-missing-cdp-fallback`, {
-      session,
-      hasCdpEndpoint: Boolean(state.cdpEndpoint),
-      port: state.port,
-    });
-    return execViaCdpFallback(code, session, logger, options);
+    throw new Error(
+      `Session "${session}" has no daemon socket. The browser daemon may have crashed. ` +
+        `Close and reopen the session: libretto close --session ${session}`,
+    );
   }
   return execViaDaemon(code, session, state.daemonSocketPath, logger, options);
 }

--- a/packages/libretto/src/cli/commands/snapshot.ts
+++ b/packages/libretto/src/cli/commands/snapshot.ts
@@ -132,7 +132,6 @@ async function runCompactSnapshot(
   try {
     result = await client.snapshot({
       pageId: args.pageId,
-      useCachedSnapshot: args.ref !== undefined,
     });
   } finally {
     client.destroy();

--- a/packages/libretto/src/cli/core/browser.ts
+++ b/packages/libretto/src/cli/core/browser.ts
@@ -1,10 +1,4 @@
-import {
-  chromium,
-  type Browser,
-  type BrowserContext,
-  type CDPSession,
-  type Page,
-} from "playwright";
+import { chromium, type Browser } from "playwright";
 import {
   existsSync,
   readFileSync,
@@ -126,38 +120,6 @@ export function normalizeDomain(url: URL): string {
   return url.hostname.replace(/^www\./, "");
 }
 
-async function tryConnectToCDP(
-  endpoint: string,
-  logger: LoggerApi,
-  timeoutMs: number = 5000,
-): Promise<Browser | null> {
-  logger.info("cdp-connect-attempt", { endpoint, timeoutMs });
-  try {
-    const connectPromise = chromium.connectOverCDP(endpoint);
-    const timeoutPromise = new Promise<null>((resolve) =>
-      setTimeout(() => resolve(null), timeoutMs),
-    );
-    const browser = await Promise.race([connectPromise, timeoutPromise]);
-    if (browser) {
-      logger.info("cdp-connect-success", {
-        endpoint,
-        contexts: browser.contexts().length,
-      });
-    } else {
-      logger.warn("cdp-connect-timeout", { endpoint, timeoutMs });
-    }
-    return browser;
-  } catch (err) {
-    logger.error("cdp-connect-error", { error: err, endpoint });
-    return null;
-  }
-}
-
-function isOperationalPage(page: Page): boolean {
-  const url = page.url();
-  return !url.startsWith("devtools://") && !url.startsWith("chrome-error://");
-}
-
 export function disconnectBrowser(
   browser: Browser,
   logger: LoggerApi,
@@ -171,163 +133,11 @@ export function disconnectBrowser(
   }
 }
 
-function resolveOperationalPages(browser: Browser): Page[] {
-  return browser
-    .contexts()
-    .flatMap((context) => context.pages())
-    .filter(isOperationalPage);
-}
-
-type PageReference = {
-  id: string;
-  page: Page;
-};
-
 export type OpenPageSummary = {
   id: string;
   url: string;
   active: boolean;
 };
-
-async function resolvePageId(page: Page): Promise<string> {
-  const cdpSession: CDPSession = await page.context().newCDPSession(page);
-  try {
-    const targetInfo = await cdpSession.send("Target.getTargetInfo");
-    const targetId = (targetInfo as { targetInfo?: { targetId?: unknown } })
-      ?.targetInfo?.targetId;
-    if (typeof targetId !== "string" || targetId.length === 0) {
-      throw new Error(
-        `Could not resolve target id for page at URL "${page.url()}".`,
-      );
-    }
-    return targetId;
-  } finally {
-    await cdpSession.detach();
-  }
-}
-
-async function resolvePageReferences(pages: Page[]): Promise<PageReference[]> {
-  const refs = await Promise.all(
-    pages.map(async (page) => {
-      const id = await resolvePageId(page);
-      return { id, page };
-    }),
-  );
-  return refs;
-}
-
-export async function connect(
-  session: string,
-  logger: LoggerApi,
-  timeoutMs: number = 10000,
-  options?: {
-    pageId?: string;
-    requireSinglePage?: boolean;
-  },
-): Promise<{
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
-  pageId: string;
-}> {
-  logger.info("connect", { session, timeoutMs });
-  const state = readSessionStateOrThrow(session);
-  const endpoint = state.cdpEndpoint ?? `http://localhost:${state.port}`;
-  const browser = await tryConnectToCDP(endpoint, logger, timeoutMs);
-  if (!browser) {
-    logger.error("connect-no-browser", {
-      session,
-      endpoint,
-      pid: state.pid,
-    });
-    // Provider sessions have no local PID to check liveness.
-    // Don't destroy the remote session on a transient failure —
-    // let the user retry or explicitly close.
-    if (state.provider) {
-      throw new Error(
-        `Could not connect to ${state.provider.name} session for "${session}" at ${endpoint}. ` +
-          `The remote session may still be active. Try again, or close with: libretto close --session ${session}`,
-      );
-    }
-
-    if (state.pid == null || !isPidRunning(state.pid)) {
-      clearSessionState(session, logger);
-      throw new Error(
-        `No browser running for session "${session}". Run 'libretto open <url> --session ${session}' first.`,
-      );
-    }
-
-    throw new Error(
-      `Could not connect to the browser for session "${session}" at ${endpoint}, but the session process (pid ${state.pid}) is still running. Try the command again, or close and reopen the session if it stays stuck.`,
-    );
-  }
-
-  const contexts = browser.contexts();
-  logger.info("connect-contexts", { session, contextCount: contexts.length });
-  if (contexts.length === 0) {
-    logger.error("connect-no-contexts", { session });
-    throw new Error("No browser context found.");
-  }
-
-  const allPages = contexts.flatMap((c) => c.pages());
-  const pages = resolveOperationalPages(browser);
-
-  logger.info("connect-pages", {
-    session,
-    totalPages: allPages.length,
-    filteredPages: pages.length,
-    urls: allPages.map((p) => p.url()),
-  });
-
-  if (pages.length === 0) {
-    logger.error("connect-no-pages", {
-      session,
-      allPageUrls: allPages.map((p) => p.url()),
-    });
-    throw new Error("No pages found.");
-  }
-
-  if (options?.requireSinglePage && !options.pageId && pages.length > 1) {
-    throw new Error(
-      `Multiple pages are open in session "${session}". Pass --page <id> to target a page (run "libretto pages --session ${session}" to list ids).`,
-    );
-  }
-
-  const pageRefs = await resolvePageReferences(pages);
-  const pageRef = options?.pageId
-    ? (pageRefs.find((ref) => ref.id === options.pageId) ?? null)
-    : pageRefs[pageRefs.length - 1]!;
-  if (!pageRef) {
-    throw new Error(
-      `Page "${options?.pageId}" was not found in session "${session}". Run "libretto pages --session ${session}" to list ids.`,
-    );
-  }
-  const page = pageRef.page;
-  const context = page.context();
-
-  page.on("close", () => {
-    logger.error("page-closed-during-command", {
-      session,
-      url: page.url(),
-      trace: new Error("page-closed-trace").stack,
-    });
-  });
-  page.on("crash", () => {
-    logger.error("page-crashed-during-command", {
-      session,
-      url: page.url(),
-    });
-  });
-  browser.on("disconnected", () => {
-    logger.error("browser-disconnected-during-command", {
-      session,
-      trace: new Error("browser-disconnected-trace").stack,
-    });
-  });
-
-  logger.info("connect-success", { session, pageUrl: page.url() });
-  return { browser, context, page, pageId: pageRef.id };
-}
 
 export async function runPages(
   session: string,

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -750,12 +750,19 @@ class BrowserDaemon {
           const snapshotDiff = diffSnapshots(before, after);
           return { ...result, snapshotDiff };
         } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
           this.logger.warn("compact-exec-diff-failed", {
             session: this.session,
             pageId: args.pageId,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
           });
-          return result;
+          return {
+            ...result,
+            snapshotDiffError:
+              `Failed to do post-diff snapshot: ${message}. ` +
+              "The exec itself succeeded. Run libretto snapshot if you need the " +
+              "current page state, or omit --diff-snapshot when the page may close.",
+          };
         }
       });
       return { ok: true, data };

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -66,7 +66,6 @@ import { handlePages } from "./pages.js";
 import { handleExec, handleReadonlyExec } from "./exec.js";
 import { DaemonExecRepl } from "./exec-repl.js";
 import { handleCompactSnapshot } from "./snapshot.js";
-import type { Snapshot } from "../../../shared/snapshot/types.js";
 import { snapshot } from "../../../shared/snapshot/capture-snapshot.js";
 import { diffSnapshots } from "../../../shared/snapshot/diff-snapshots.js";
 import {
@@ -153,8 +152,6 @@ class BrowserDaemon {
   private readonly connectedClis = new Set<IpcPeer<DaemonToCliApi>>();
   private workflowController: WorkflowController | undefined;
   private shutdownPromise: Promise<DaemonCloseResult> | undefined;
-  private readonly latestCompactSnapshotByPage = new WeakMap<Page, Snapshot>();
-
   private constructor(
     private readonly session: string,
     private readonly experiments: Experiments,
@@ -684,22 +681,11 @@ class BrowserDaemon {
     args: Parameters<CliToDaemonApi["snapshot"]>[0],
   ): Promise<ReturnType<CliToDaemonApi["snapshot"]>> {
     const targetPage = this.resolveTargetPage(args.pageId);
-    const result = await this.withRequestTimeout(() =>
-      handleCompactSnapshot(
-        targetPage,
-        this.session,
-        this.logger,
-        {
-          pageId: args.pageId,
-          cachedSnapshot: this.latestCompactSnapshotByPage.get(targetPage),
-          useCachedSnapshot: args.useCachedSnapshot,
-        },
-      ),
+    return this.withRequestTimeout(() =>
+      handleCompactSnapshot(targetPage, this.session, this.logger, {
+        pageId: args.pageId,
+      }),
     );
-    if (!args.useCachedSnapshot) {
-      this.latestCompactSnapshotByPage.set(targetPage, result.snapshot);
-    }
-    return result;
   }
 
   private async withRequestTimeout<T>(
@@ -738,10 +724,7 @@ class BrowserDaemon {
       targetPage = this.resolveTargetPage(args.pageId);
       const page = targetPage;
       const data = await this.withRequestTimeout(async () => {
-        const before = args.diffSnapshot
-          ? (this.latestCompactSnapshotByPage.get(page) ??
-            (await snapshot(page)))
-          : undefined;
+        const before = args.diffSnapshot ? await snapshot(page) : undefined;
         const result = await handleExec(
           page,
           args.code,
@@ -765,10 +748,8 @@ class BrowserDaemon {
 
           const after = await snapshot(page);
           const snapshotDiff = diffSnapshots(before, after);
-          this.latestCompactSnapshotByPage.set(page, after);
           return { ...result, snapshotDiff };
         } catch (error) {
-          this.latestCompactSnapshotByPage.delete(page);
           this.logger.warn("compact-exec-diff-failed", {
             session: this.session,
             pageId: args.pageId,
@@ -779,7 +760,6 @@ class BrowserDaemon {
       });
       return { ok: true, data };
     } catch (error) {
-      if (targetPage) this.latestCompactSnapshotByPage.delete(targetPage);
       return this.createExecErrorResult(error);
     }
   }

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -738,14 +738,20 @@ class BrowserDaemon {
       targetPage = this.resolveTargetPage(args.pageId);
       const page = targetPage;
       const data = await this.withRequestTimeout(async () => {
-        const before =
-          this.latestCompactSnapshotByPage.get(page) ?? (await snapshot(page));
+        const before = args.diffSnapshot
+          ? (this.latestCompactSnapshotByPage.get(page) ??
+            (await snapshot(page)))
+          : undefined;
         const result = await handleExec(
           page,
           args.code,
           this.execRepl,
           args.visualize,
         );
+
+        if (!args.diffSnapshot || !before) {
+          return result;
+        }
 
         try {
           const waitResult = await waitForPageStable(page);

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -31,7 +31,6 @@ export type DaemonReadonlyExecArgs = { code: string; pageId?: string };
 
 export type DaemonSnapshotArgs = {
   pageId?: string;
-  useCachedSnapshot?: boolean;
 };
 
 export type DaemonExecSuccess = {

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -37,6 +37,8 @@ export type DaemonExecSuccess = {
   result: unknown;
   output?: DaemonExecOutput;
   snapshotDiff?: SnapshotDiff;
+  /** Set when `--diff-snapshot` was requested but after-diff capture failed. */
+  snapshotDiffError?: string;
 };
 
 export type DaemonSnapshotResult = {

--- a/packages/libretto/src/cli/core/daemon/ipc.ts
+++ b/packages/libretto/src/cli/core/daemon/ipc.ts
@@ -23,6 +23,8 @@ export type DaemonExecArgs = {
   code: string;
   pageId?: string;
   visualize?: boolean;
+  /** When true, capture before/after compact snapshots and return a page-change diff. */
+  diffSnapshot?: boolean;
 };
 
 export type DaemonReadonlyExecArgs = { code: string; pageId?: string };

--- a/packages/libretto/src/cli/core/daemon/snapshot.ts
+++ b/packages/libretto/src/cli/core/daemon/snapshot.ts
@@ -30,33 +30,12 @@ export async function handleCompactSnapshot(
   logger: LoggerApi,
   options: {
     pageId?: string;
-    cachedSnapshot?: Snapshot | null;
-    useCachedSnapshot?: boolean;
   } = {},
 ): Promise<{
   mode: "compact";
   pngPath: string;
   snapshot: Snapshot;
 }> {
-  if (options.useCachedSnapshot) {
-    if (!options.cachedSnapshot) {
-      throw new Error(
-        `No compact snapshot is cached for session "${session}". Run libretto snapshot --session ${session} first.`,
-      );
-    }
-    const screenshot = await captureSnapshotScreenshot(
-      targetPage,
-      session,
-      logger,
-      options.pageId,
-    );
-    return {
-      mode: "compact",
-      pngPath: screenshot.pngPath,
-      snapshot: options.cachedSnapshot,
-    };
-  }
-
   const waitResult = await waitForPageStable(targetPage);
   if (!waitResult.ok) {
     logger.warn("compact-snapshot-stability-wait-incomplete", {

--- a/packages/libretto/src/cli/core/exec-compiler.ts
+++ b/packages/libretto/src/cli/core/exec-compiler.ts
@@ -1,9 +1,8 @@
 /**
  * Shared exec compilation utilities.
  *
- * Used by both the daemon (daemon/exec.ts) and the connect-based
- * session path (execution.ts) to compile user-provided code strings
- * into callable async functions.
+ * Used by the daemon exec path to compile user-provided code strings into
+ * callable async functions.
  */
 
 import * as moduleBuiltin from "node:module";

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -462,6 +462,27 @@ throw new Error('expected late exec failure');
     expect(result.stderr).toContain(`snapshot --session ${session}`);
   }, 45_000);
 
+  test("compact exec omits page changes unless --diff-snapshot is set", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "daemon-ipc-compact-exec-diff-opt-in";
+    const url = await writeFixturePage(
+      workspacePath,
+      "compact-exec-diff-opt-in",
+      "Compact Exec Diff Opt In Test",
+      `<main><h1>Before Heading</h1></main>`,
+    );
+
+    await librettoCli(`open "${url}" --headless --session ${session}`);
+
+    const withoutFlag = await librettoCli(
+      `exec "await page.locator('h1').evaluate((node) => { node.textContent = 'After Heading'; })" --session ${session}`,
+    );
+    expect(withoutFlag.stdout).toContain("Executed successfully");
+    expect(withoutFlag.stdout).not.toContain("Page changes:");
+  }, 45_000);
+
   test("compact exec diff uses the snapshot cache as its before state", async ({
     librettoCli,
     workspacePath,
@@ -480,7 +501,7 @@ throw new Error('expected late exec failure');
     expect(beforeSnapshot.stdout).toContain("Before Heading");
 
     const result = await librettoCli(
-      `exec "await page.locator('h1').evaluate((node) => { node.textContent = 'After Heading'; })" --session ${session}`,
+      `exec "await page.locator('h1').evaluate((node) => { node.textContent = 'After Heading'; })" --session ${session} --diff-snapshot`,
     );
     expect(result.stdout).toContain("Executed successfully");
     expect(result.stdout).toContain("Page changes:");
@@ -503,7 +524,7 @@ throw new Error('expected late exec failure');
     await librettoCli(`open "${url}" --headless --session ${session}`);
 
     const result = await librettoCli(
-      `exec "await page.locator('main').evaluate((node) => node.insertAdjacentHTML('beforeend', '<p>New Content</p>'))" --session ${session}`,
+      `exec "await page.locator('main').evaluate((node) => node.insertAdjacentHTML('beforeend', '<p>New Content</p>'))" --session ${session} --diff-snapshot`,
     );
     expect(result.stdout).toContain("Executed successfully");
     expect(result.stdout).toContain("Page changes:");
@@ -525,7 +546,7 @@ throw new Error('expected late exec failure');
     await librettoCli(`open "${url}" --headless --session ${session}`);
 
     const result = await librettoCli(
-      `exec "await page.close(), 'closed ok'" --session ${session}`,
+      `exec "await page.close(), 'closed ok'" --session ${session} --diff-snapshot`,
     );
     expect(result.stdout).toContain("closed ok");
     expect(result.stdout).not.toContain("Page changes:");

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -490,7 +490,7 @@ throw new Error('expected late exec failure');
     );
     expect(result.stdout).toContain("closed ok");
     expect(result.stdout).not.toContain("Page changes:");
-    expect(result.stderr).not.toContain("Target page, context or browser has been closed");
+    expect(result.stderr).toContain("Failed to do post-diff snapshot:");
   }, 45_000);
 
   test("readonly-exec does not print page changes", async ({

--- a/packages/libretto/test/daemon-ipc.spec.ts
+++ b/packages/libretto/test/daemon-ipc.spec.ts
@@ -370,7 +370,7 @@ throw new Error('expected late exec failure');
     expect(result.stderr).toBe("");
   }, 45_000);
 
-  test("compact snapshot ref uses cached full snapshot and scopes output", async ({
+  test("compact snapshot ref captures a fresh tree and scopes output", async ({
     librettoCli,
     workspacePath,
   }) => {
@@ -396,70 +396,35 @@ throw new Error('expected late exec failure');
     expect(scopedSnapshot.stdout).not.toContain("Sibling Details");
   }, 45_000);
 
-  test("compact snapshot refs only reuse cache for the same page", async ({
+  test("compact snapshot ref reflects DOM changes from a fresh tree", async ({
     librettoCli,
     workspacePath,
   }) => {
-    const session = "daemon-ipc-compact-snapshot-page-cache";
-    const firstUrl = await writeFixturePage(
-      workspacePath,
-      "compact-snapshot-page-cache-first",
-      "Compact Snapshot First Page",
-      `<main><button>First Page Button</button></main>`,
-    );
-    const secondUrl = await writeFixturePage(
-      workspacePath,
-      "compact-snapshot-page-cache-second",
-      "Compact Snapshot Second Page",
-      `<main><button>Second Page Button</button></main>`,
-    );
-
-    await librettoCli(`open "${firstUrl}" --headless --session ${session}`);
-    await librettoCli(
-      `exec "const p = await context.newPage(); await p.goto('${secondUrl}')" --session ${session}`,
-    );
-
-    const pages = await librettoCli(`pages --session ${session}`);
-    const firstPageId = pages.stdout
-      .split("\n")
-      .find((line) => line.includes("compact-snapshot-page-cache-first"))
-      ?.match(/id=(\S+)/)?.[1];
-    const secondPageId = pages.stdout
-      .split("\n")
-      .find((line) => line.includes("compact-snapshot-page-cache-second"))
-      ?.match(/id=(\S+)/)?.[1];
-    expect(firstPageId).toBeTruthy();
-    expect(secondPageId).toBeTruthy();
-
-    const firstSnapshot = await librettoCli(
-      `snapshot --session ${session} --page ${firstPageId}`,
-    );
-    const ref = firstSnapshot.stdout.match(/<button ref="([^"]+)"/)?.[1];
-    expect(ref).toBeTruthy();
-
-    const secondScopedSnapshot = await librettoCli(
-      `snapshot ${ref} --session ${session} --page ${secondPageId}`,
-    );
-    expect(secondScopedSnapshot.stderr).toContain("No compact snapshot is cached");
-  }, 45_000);
-
-  test("compact snapshot ref fails before a full compact snapshot is cached", async ({
-    librettoCli,
-    workspacePath,
-  }) => {
-    const session = "daemon-ipc-compact-snapshot-ref-missing";
+    const session = "daemon-ipc-compact-snapshot-ref-fresh";
     const url = await writeFixturePage(
       workspacePath,
-      "compact-snapshot-ref-missing",
-      "Compact Snapshot Missing Ref Cache Test",
-      `<main><button>Save Changes</button></main>`,
+      "compact-snapshot-ref-fresh",
+      "Compact Snapshot Fresh Ref Test",
+      `<main><h1>Before Heading</h1><button>Save Changes</button></main>`,
     );
 
     await librettoCli(`open "${url}" --headless --session ${session}`);
 
-    const result = await librettoCli(`snapshot l1 --session ${session}`);
-    expect(result.stderr).toContain("No compact snapshot is cached");
-    expect(result.stderr).toContain(`snapshot --session ${session}`);
+    const mutate = await librettoCli(
+      `exec "await page.locator('button').evaluate((node) => { node.textContent = 'Updated Button'; })" --session ${session}`,
+    );
+    expect(mutate.stdout).toContain("Executed successfully");
+
+    const after = await librettoCli(`snapshot --session ${session}`);
+    expect(after.stdout).toContain("Updated Button");
+    const ref = after.stdout.match(/<button ref="([^"]+)"/)?.[1];
+    expect(ref).toBeTruthy();
+
+    const scopedSnapshot = await librettoCli(
+      `snapshot ${ref} --session ${session}`,
+    );
+    expect(scopedSnapshot.stdout).toContain("Updated Button");
+    expect(scopedSnapshot.stdout).not.toContain("Save Changes");
   }, 45_000);
 
   test("compact exec omits page changes unless --diff-snapshot is set", async ({
@@ -483,33 +448,7 @@ throw new Error('expected late exec failure');
     expect(withoutFlag.stdout).not.toContain("Page changes:");
   }, 45_000);
 
-  test("compact exec diff uses the snapshot cache as its before state", async ({
-    librettoCli,
-    workspacePath,
-  }) => {
-    const session = "daemon-ipc-compact-exec-cached-diff";
-    const url = await writeFixturePage(
-      workspacePath,
-      "compact-exec-cached-diff",
-      "Compact Exec Cached Diff Test",
-      `<main><h1>Before Heading</h1><button>Save Changes</button></main>`,
-    );
-
-    await librettoCli(`open "${url}" --headless --session ${session}`);
-
-    const beforeSnapshot = await librettoCli(`snapshot --session ${session}`);
-    expect(beforeSnapshot.stdout).toContain("Before Heading");
-
-    const result = await librettoCli(
-      `exec "await page.locator('h1').evaluate((node) => { node.textContent = 'After Heading'; })" --session ${session} --diff-snapshot`,
-    );
-    expect(result.stdout).toContain("Executed successfully");
-    expect(result.stdout).toContain("Page changes:");
-    expect(result.stdout).toContain("Before Heading");
-    expect(result.stdout).toContain("After Heading");
-  }, 45_000);
-
-  test("compact exec diff captures a before state when no snapshot is cached", async ({
+  test("compact exec diff captures a fresh before and after tree", async ({
     librettoCli,
     workspacePath,
   }) => {
@@ -518,17 +457,18 @@ throw new Error('expected late exec failure');
       workspacePath,
       "compact-exec-fresh-diff",
       "Compact Exec Fresh Diff Test",
-      `<main><h1>Stable Heading</h1></main>`,
+      `<main><h1>Before Heading</h1></main>`,
     );
 
     await librettoCli(`open "${url}" --headless --session ${session}`);
 
     const result = await librettoCli(
-      `exec "await page.locator('main').evaluate((node) => node.insertAdjacentHTML('beforeend', '<p>New Content</p>'))" --session ${session} --diff-snapshot`,
+      `exec "await page.locator('h1').evaluate((node) => { node.textContent = 'After Heading'; })" --session ${session} --diff-snapshot`,
     );
     expect(result.stdout).toContain("Executed successfully");
     expect(result.stdout).toContain("Page changes:");
-    expect(result.stdout).toContain("New Content");
+    expect(result.stdout).toContain("Before Heading");
+    expect(result.stdout).toContain("After Heading");
   }, 45_000);
 
   test("compact exec preserves successful results when diff capture fails", async ({
@@ -553,23 +493,19 @@ throw new Error('expected late exec failure');
     expect(result.stderr).not.toContain("Target page, context or browser has been closed");
   }, 45_000);
 
-  test("readonly-exec does not print page changes or invalidate the snapshot cache", async ({
+  test("readonly-exec does not print page changes", async ({
     librettoCli,
     workspacePath,
   }) => {
-    const session = "daemon-ipc-compact-readonly-cache";
+    const session = "daemon-ipc-compact-readonly-exec";
     const url = await writeFixturePage(
       workspacePath,
-      "compact-readonly-cache",
-      "Compact Readonly Cache Test",
-      `<main><h1>Readonly Heading</h1><button>Cache Target</button></main>`,
+      "compact-readonly-exec",
+      "Compact Readonly Exec Test",
+      `<main><h1>Readonly Heading</h1><button>Keep Target</button></main>`,
     );
 
     await librettoCli(`open "${url}" --headless --session ${session}`);
-
-    const fullSnapshot = await librettoCli(`snapshot --session ${session}`);
-    const ref = fullSnapshot.stdout.match(/<button ref="([^"]+)"/)?.[1];
-    expect(ref).toBeTruthy();
 
     const readonly = await librettoCli(
       `readonly-exec "return await page.locator('h1').textContent()" --session ${session}`,
@@ -577,10 +513,8 @@ throw new Error('expected late exec failure');
     expect(readonly.stdout).toContain("Readonly Heading");
     expect(readonly.stdout).not.toContain("Page changes:");
 
-    const scopedSnapshot = await librettoCli(
-      `snapshot ${ref} --session ${session}`,
-    );
-    expect(scopedSnapshot.stdout).toContain("Cache Target");
+    const snapshot = await librettoCli(`snapshot --session ${session}`);
+    expect(snapshot.stdout).toContain("Keep Target");
   }, 45_000);
 
   test("exec without --page targets the original page after a workflow opens another page", async ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Make accessibility-tree snapshot diffs on `exec` / `browser_exec` **opt-in** via `--diff-snapshot` / `diffSnapshot: true` (default off skips before/after capture work).
- Always capture a fresh compact accessibility tree for `snapshot` / `snapshot <ref>` and for opt-in exec diffs — no daemon or session snapshot-tree cache.
- Keep post-exec settle when a non-empty domain navigation policy is active (blocked navigations), even if diffs are off.
- Remove unused CDP fallback paths for `exec` / `readonly-exec` and unused CDP `connect()` helpers (daemon-backed paths remain).
- Update skill, CLI/docs, website copy, and tests for the opt-in contract.
- Record the July 29 Kernel `browser-tools` benchmark re-run in `packages/browser-tools/benchmarks/RESULTS.md` (23/26; anti-bot fails on Reddit/Walmart/Yelp).

## Benchmark note

Kernel opt-in re-run: **23/26**, 1.59M tokens, $2.78, 88.6s avg. Prior Browser Use best for `browser-tools` was 24/26 / 1.45M / $2.53 / 85.9s. Gap is mostly one long Walmart bot check; agents used `diffSnapshot` on only ~11% of execs.

## Test plan

- [x] `pnpm -s type-check`
- [x] Targeted libretto daemon-ipc + browser-tools tools specs
- [x] Manual CLI smoke earlier in PR; cache-removal covered by daemon-ipc snapshot/ref tests
- [x] browser-tools evals (7/7) earlier in PR
- [x] Kernel harness benchmark (23/26)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eb3aaa2-54d3-4fcc-9030-78678b7c2745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eb3aaa2-54d3-4fcc-9030-78678b7c2745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

