### PR TITLE
Allow safe frame inspection in readonly exec

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -59,7 +59,7 @@ libretto pages --session failed-job-debug
 
 #### Helpers
 
-- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `frames()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). `frames()` returns read-only `Frame` proxies, including from `childFrames()` and `parentFrame()`. Anything that mutates a page or frame (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
 - `state` — the current Libretto session state object.
 - `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
 - `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
@@ -71,6 +71,7 @@ Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` 
 ```bash
 libretto readonly-exec "return page.url()" --session failed-job-debug
 libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
+libretto readonly-exec "return await page.frames()[1]?.getByRole('heading').textContent()" --session failed-job-debug
 
 # HTTP GET inspection
 echo "const r = await get('https://api.example.com/status'); return await r.json()" \

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -59,7 +59,7 @@ libretto pages --session failed-job-debug
 
 #### Helpers
 
-- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `frames()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). `frames()` returns read-only `Frame` proxies, including from `childFrames()` and `parentFrame()`. Anything that mutates a page or frame (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
 - `state` — the current Libretto session state object.
 - `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
 - `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
@@ -71,6 +71,7 @@ Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` 
 ```bash
 libretto readonly-exec "return page.url()" --session failed-job-debug
 libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
+libretto readonly-exec "return await page.frames()[1]?.getByRole('heading').textContent()" --session failed-job-debug
 
 # HTTP GET inspection
 echo "const r = await get('https://api.example.com/status'); return await r.json()" \

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -59,7 +59,7 @@ libretto pages --session failed-job-debug
 
 #### Helpers
 
-- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). Anything that mutates the page (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
+- `page` — a read-only Playwright `Page` proxy. Standard Playwright read methods work normally (`url()`, `title()`, `content()`, `frames()`, `getByRole()`, `locator()`, `textContent()`, `isVisible()`, `count()`, `scrollIntoViewIfNeeded()`, etc.). `frames()` returns read-only `Frame` proxies, including from `childFrames()` and `parentFrame()`. Anything that mutates a page or frame (`click`, `fill`, `goto`, `evaluate`, `keyboard`, `mouse`) is blocked.
 - `state` — the current Libretto session state object.
 - `get(url, options?)` — HTTP client restricted to **GET and HEAD** requests. Replaces `fetch`, which is blocked in readonly mode. Any request with a body or a non-GET/HEAD method throws `ReadonlyExecDenied`.
 - `scrollBy(deltaX, deltaY)` — scroll the viewport by pixel offset. Use this to inspect content below the fold without targeting a specific element.
@@ -71,6 +71,7 @@ Standard JS globals `console`, `URL`, `Buffer`, `setTimeout`, and `setInterval` 
 ```bash
 libretto readonly-exec "return page.url()" --session failed-job-debug
 libretto readonly-exec "return await page.getByRole('heading').first().textContent()" --session failed-job-debug
+libretto readonly-exec "return await page.frames()[1]?.getByRole('heading').textContent()" --session failed-job-debug
 
 # HTTP GET inspection
 echo "const r = await get('https://api.example.com/status'); return await r.json()" \

--- a/packages/libretto/src/cli/core/readonly-exec.ts
+++ b/packages/libretto/src/cli/core/readonly-exec.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "playwright";
+import type { Frame, Locator, Page } from "playwright";
 
 const PAGE_READ_METHODS = new Set([
   "url",
@@ -21,6 +21,7 @@ const PAGE_LOCATOR_FACTORY_METHODS = new Set([
   "getByTitle",
   "getByTestId",
 ]);
+const PAGE_FRAME_COLLECTION_METHODS = new Set(["frames"]);
 
 const PAGE_ALLOWED_PROPERTIES = new Set<string>([]);
 
@@ -66,6 +67,32 @@ const LOCATOR_SCROLL_METHODS = new Set(["scrollIntoViewIfNeeded"]);
 
 const LOCATOR_ALLOWED_PROPERTIES = new Set<string>([]);
 
+const FRAME_READ_METHODS = new Set([
+  "url",
+  "name",
+  "title",
+  "content",
+  "isDetached",
+  "waitForLoadState",
+  "waitForURL",
+]);
+
+const FRAME_LOCATOR_FACTORY_METHODS = new Set([
+  "locator",
+  "getByRole",
+  "getByText",
+  "getByLabel",
+  "getByPlaceholder",
+  "getByAltText",
+  "getByTitle",
+  "getByTestId",
+]);
+
+const FRAME_COLLECTION_METHODS = new Set(["childFrames"]);
+const FRAME_PARENT_METHODS = new Set(["parentFrame"]);
+const FRAME_PAGE_METHODS = new Set(["page"]);
+const FRAME_ALLOWED_PROPERTIES = new Set<string>([]);
+
 type ReadonlyExecOptions = {
   onActivity?: () => void;
   console?: Console;
@@ -73,6 +100,7 @@ type ReadonlyExecOptions = {
 
 const readonlyPageCache = new WeakMap<Page, Page>();
 const readonlyLocatorCache = new WeakMap<Locator, Locator>();
+const readonlyFrameCache = new WeakMap<Frame, Frame>();
 
 function markActivity(onActivity?: () => void): void {
   onActivity?.();
@@ -85,7 +113,10 @@ export class ReadonlyExecDeniedError extends Error {
   }
 }
 
-function denyOperation(targetName: "page" | "locator", method: string): never {
+function denyOperation(
+  targetName: "page" | "locator" | "frame",
+  method: string,
+): never {
   throw new ReadonlyExecDeniedError(
     `${targetName}.${method} is blocked in readonly-exec`,
   );
@@ -153,6 +184,79 @@ export function wrapLocatorForReadonlyExec(
   return proxy as Locator;
 }
 
+export function wrapFrameForReadonlyExec(
+  frame: Frame,
+  options: ReadonlyExecOptions = {},
+): Frame {
+  const cached = readonlyFrameCache.get(frame);
+  if (cached) return cached;
+
+  const proxy = new Proxy(frame, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string") {
+        return Reflect.get(target, prop, receiver);
+      }
+
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== "function") {
+        if (FRAME_ALLOWED_PROPERTIES.has(prop)) {
+          return value;
+        }
+        return denyOperation("frame", prop);
+      }
+
+      if (FRAME_READ_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const result = value.apply(target, args);
+          markActivity(options.onActivity);
+          return result;
+        };
+      }
+
+      if (FRAME_LOCATOR_FACTORY_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const locator = value.apply(target, args) as Locator;
+          markActivity(options.onActivity);
+          return wrapLocatorForReadonlyExec(locator, options);
+        };
+      }
+
+      if (FRAME_COLLECTION_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const frames = value.apply(target, args) as Frame[];
+          markActivity(options.onActivity);
+          return frames.map((childFrame) =>
+            wrapFrameForReadonlyExec(childFrame, options),
+          );
+        };
+      }
+
+      if (FRAME_PARENT_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const parentFrame = value.apply(target, args) as Frame | null;
+          markActivity(options.onActivity);
+          return parentFrame
+            ? wrapFrameForReadonlyExec(parentFrame, options)
+            : null;
+        };
+      }
+
+      if (FRAME_PAGE_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const page = value.apply(target, args) as Page;
+          markActivity(options.onActivity);
+          return wrapPageForReadonlyExec(page, options);
+        };
+      }
+
+      return (..._args: unknown[]) => denyOperation("frame", prop);
+    },
+  });
+
+  readonlyFrameCache.set(frame, proxy as Frame);
+  return proxy as Frame;
+}
+
 export function wrapPageForReadonlyExec(
   page: Page,
   options: ReadonlyExecOptions = {},
@@ -187,6 +291,16 @@ export function wrapPageForReadonlyExec(
           const locator = value.apply(target, args) as Locator;
           markActivity(options.onActivity);
           return wrapLocatorForReadonlyExec(locator, options);
+        };
+      }
+
+      if (PAGE_FRAME_COLLECTION_METHODS.has(prop)) {
+        return (...args: unknown[]) => {
+          const frames = value.apply(target, args) as Frame[];
+          markActivity(options.onActivity);
+          return frames.map((frame) =>
+            wrapFrameForReadonlyExec(frame, options),
+          );
         };
       }
 

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -474,7 +474,7 @@ describe("state-driven CLI subprocess behavior", () => {
         "<html>",
         "<head><title>Readonly Frames</title></head>",
         "<body>",
-        '<iframe name="details" srcdoc="<h1>Frame heading</h1><input value=\'unchanged\' />"></iframe>',
+        '<iframe name="details" srcdoc="<h1>Frame heading</h1><input value=\'unchanged\' /><iframe name=\'nested\' srcdoc=\'<p>Nested frame</p>\'></iframe>"></iframe>',
         "</body>",
         "</html>",
       ].join(""),
@@ -491,11 +491,14 @@ describe("state-driven CLI subprocess behavior", () => {
         "const frames = page.frames();",
         "const child = frames.find((frame) => frame.name() === 'details');",
         "if (!child) throw new Error('Expected details frame');",
+        "const nested = child.childFrames()[0];",
+        "if (!nested) throw new Error('Expected nested frame');",
         "const parent = child.parentFrame();",
         "return {",
         "  frameCount: frames.length,",
         "  heading: await child.getByRole('heading').textContent(),",
         "  inputValue: await child.locator('input').inputValue(),",
+        "  nestedText: await nested.getByText('Nested frame').textContent(),",
         "  parentUrl: parent?.url(),",
         "  childFrameCount: child.childFrames().length,",
         "  pageUrl: child.page().url(),",
@@ -504,11 +507,12 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(inspection.stderr).toBe("");
     expect(parseJsonStdout<Record<string, unknown>>(inspection.stdout)).toEqual({
-      frameCount: 2,
+      frameCount: 3,
       heading: "Frame heading",
       inputValue: "unchanged",
+      nestedText: "Nested frame",
       parentUrl: fileUrl,
-      childFrameCount: 0,
+      childFrameCount: 1,
       pageUrl: fileUrl,
     });
 
@@ -517,6 +521,27 @@ describe("state-driven CLI subprocess behavior", () => {
     );
     expect(blockedMutation.stderr).toContain(
       "ReadonlyExecDenied: frame.goto is blocked in readonly-exec",
+    );
+
+    const blockedParentMutation = await librettoCli(
+      `readonly-exec "await page.frames()[1].parentFrame().goto('https://example.com')" --session ${session}`,
+    );
+    expect(blockedParentMutation.stderr).toContain(
+      "ReadonlyExecDenied: frame.goto is blocked in readonly-exec",
+    );
+
+    const blockedNestedMutation = await librettoCli(
+      `readonly-exec "await page.frames()[1].childFrames()[0].goto('https://example.com')" --session ${session}`,
+    );
+    expect(blockedNestedMutation.stderr).toContain(
+      "ReadonlyExecDenied: frame.goto is blocked in readonly-exec",
+    );
+
+    const blockedPageMutation = await librettoCli(
+      `readonly-exec "await page.frames()[1].page().goto('https://example.com')" --session ${session}`,
+    );
+    expect(blockedPageMutation.stderr).toContain(
+      "ReadonlyExecDenied: page.goto is blocked in readonly-exec",
     );
 
     const unchanged = await librettoCli(

--- a/packages/libretto/test/stateful.spec.ts
+++ b/packages/libretto/test/stateful.spec.ts
@@ -460,6 +460,72 @@ describe("state-driven CLI subprocess behavior", () => {
     });
   }, 60_000);
 
+  test("readonly-exec inspects frames without exposing mutations", async ({
+    librettoCli,
+    workspacePath,
+  }) => {
+    const session = "readonly-exec-frames";
+    const htmlPath = workspacePath("fixtures", "readonly-frames.html");
+    await mkdir(workspacePath("fixtures"), { recursive: true });
+    await writeFile(
+      htmlPath,
+      [
+        "<!doctype html>",
+        "<html>",
+        "<head><title>Readonly Frames</title></head>",
+        "<body>",
+        '<iframe name="details" srcdoc="<h1>Frame heading</h1><input value=\'unchanged\' />"></iframe>',
+        "</body>",
+        "</html>",
+      ].join(""),
+      "utf8",
+    );
+
+    const fileUrl = pathToFileURL(htmlPath).href;
+    await librettoCli(`open "${fileUrl}" --headless --session ${session}`);
+
+    const inspection = await librettoCli(
+      `readonly-exec - --session ${session}`,
+      undefined,
+      [
+        "const frames = page.frames();",
+        "const child = frames.find((frame) => frame.name() === 'details');",
+        "if (!child) throw new Error('Expected details frame');",
+        "const parent = child.parentFrame();",
+        "return {",
+        "  frameCount: frames.length,",
+        "  heading: await child.getByRole('heading').textContent(),",
+        "  inputValue: await child.locator('input').inputValue(),",
+        "  parentUrl: parent?.url(),",
+        "  childFrameCount: child.childFrames().length,",
+        "  pageUrl: child.page().url(),",
+        "};",
+      ].join("\n"),
+    );
+    expect(inspection.stderr).toBe("");
+    expect(parseJsonStdout<Record<string, unknown>>(inspection.stdout)).toEqual({
+      frameCount: 2,
+      heading: "Frame heading",
+      inputValue: "unchanged",
+      parentUrl: fileUrl,
+      childFrameCount: 0,
+      pageUrl: fileUrl,
+    });
+
+    const blockedMutation = await librettoCli(
+      `readonly-exec "await page.frames()[1].goto('https://example.com')" --session ${session}`,
+    );
+    expect(blockedMutation.stderr).toContain(
+      "ReadonlyExecDenied: frame.goto is blocked in readonly-exec",
+    );
+
+    const unchanged = await librettoCli(
+      `readonly-exec "return await page.frames()[1].locator('input').inputValue()" --session ${session}`,
+    );
+    expect(unchanged.stderr).toBe("");
+    expect(unchanged.stdout.trim()).toBe("unchanged");
+  }, 60_000);
+
   test("readonly-exec denies mutating Playwright APIs", async ({
     librettoCli,
     workspacePath,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow `page.frames()` in `readonly-exec`
- wrap returned frames and recursive `childFrames()`, `parentFrame()`, and `page()` access in read-only proxies
- document frame inspection
- cover frame reads plus direct and recursive blocked navigation

## Testing
- `pnpm -s --filter libretto exec vitest run test/stateful.spec.ts -t "readonly-exec"` — 6 passed
- `pnpm -s --filter libretto type-check` — passed
- `pnpm -s lint` — passed
- `pnpm -s check:mirrors` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a140a1c-c318-456b-9017-58165c94b330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a140a1c-c318-456b-9017-58165c94b330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

