### PR TITLE
Promote Playwright timeout Call-log reasons into agent error headlines

### DIFF
--- a/packages/browser-tools/src/errors.spec.ts
+++ b/packages/browser-tools/src/errors.spec.ts
@@ -1,0 +1,132 @@
+import { chromium, errors } from "playwright";
+import { describe, expect, it } from "vitest";
+import {
+	enrichPlaywrightTimeoutMessage,
+	errorMessage,
+	isPlaywrightTimeoutError,
+} from "./errors.js";
+
+const HIDDEN_CLICK_TIMEOUT = `
+locator.click: Timeout 800ms exceeded.
+Call log:
+  - waiting for locator('#t')
+    - locator resolved to <button id="t">Hidden</button>
+  - attempting click action
+    2 × waiting for element to be visible, enabled and stable
+      - element is not visible
+    - retrying click action
+      - waiting 20ms
+`.trim();
+
+const OVERLAY_CLICK_TIMEOUT = `
+locator.click: Timeout 800ms exceeded.
+Call log:
+  - waiting for locator('#t')
+    - locator resolved to <button id="t">Target</button>
+  - attempting click action
+    2 × waiting for element to be visible, enabled and stable
+      - element is visible, enabled and stable
+      - scrolling into view if needed
+      - done scrolling
+      - <div id="overlay" aria-label="Cookie banner"></div> intercepts pointer events
+    - retrying click action
+      - waiting 20ms
+`.trim();
+
+const DISABLED_CLICK_TIMEOUT = `
+locator.click: Timeout 800ms exceeded.
+Call log:
+  - waiting for locator('#t')
+    - locator resolved to <button id="t" disabled>Disabled</button>
+  - attempting click action
+      - element is not enabled
+`.trim();
+
+describe("isPlaywrightTimeoutError", () => {
+	it("recognizes Playwright errors.TimeoutError by instanceof", () => {
+		const error = new errors.TimeoutError("Timeout 800ms exceeded.");
+		expect(isPlaywrightTimeoutError(error)).toBe(true);
+	});
+
+	it("recognizes re-wrapped TimeoutError by name + message shape", () => {
+		const error = new Error("locator.click: Timeout 800ms exceeded.");
+		error.name = "TimeoutError";
+		expect(isPlaywrightTimeoutError(error)).toBe(true);
+	});
+
+	it("rejects ordinary errors", () => {
+		expect(isPlaywrightTimeoutError(new Error("boom"))).toBe(false);
+		expect(isPlaywrightTimeoutError("Timeout 800ms exceeded.")).toBe(false);
+	});
+});
+
+describe("enrichPlaywrightTimeoutMessage", () => {
+	it("promotes a hidden-element Call-log reason into the headline with a tip", () => {
+		const enriched = enrichPlaywrightTimeoutMessage(HIDDEN_CLICK_TIMEOUT);
+		expect(enriched.split("\n")[0]).toBe(
+			"locator.click: Timeout 800ms exceeded. Element is not visible — it may be hidden by CSS, inside a collapsed <details>, inactive tab, or closed accordion. Reveal it first, then retry.",
+		);
+		expect(enriched).toContain("Call log:");
+		expect(enriched).toContain("element is not visible");
+	});
+
+	it("promotes an intercepting element into the headline with a next step", () => {
+		const enriched = enrichPlaywrightTimeoutMessage(OVERLAY_CLICK_TIMEOUT);
+		expect(enriched.split("\n")[0]).toBe(
+			'locator.click: Timeout 800ms exceeded. <div id="overlay" aria-label="Cookie banner"></div> intercepts pointer events — call browser_snapshot and interact with the covering element (modal/overlay), then retry.',
+		);
+	});
+
+	it("promotes disabled / not-enabled reasons without inventing tips", () => {
+		const enriched = enrichPlaywrightTimeoutMessage(DISABLED_CLICK_TIMEOUT);
+		expect(enriched.split("\n")[0]).toBe(
+			"locator.click: Timeout 800ms exceeded. Element is not enabled",
+		);
+	});
+
+	it("leaves already-enriched headlines alone", () => {
+		const already =
+			"locator.click: Timeout 800ms exceeded. Element is not stable\nCall log:\n  - element is not stable";
+		expect(enrichPlaywrightTimeoutMessage(already)).toBe(already);
+	});
+
+	it("leaves not-found timeouts without an actionability reason alone", () => {
+		const notFound = `
+locator.click: Timeout 800ms exceeded.
+Call log:
+  - waiting for locator('#missing')
+`.trim();
+		expect(enrichPlaywrightTimeoutMessage(notFound)).toBe(notFound);
+	});
+});
+
+describe("errorMessage", () => {
+	it("enriches TimeoutError instances from a live Playwright click", async () => {
+		const browser = await chromium.launch({ headless: true });
+		const page = await browser.newPage();
+		page.setDefaultTimeout(500);
+		await page.setContent(
+			`<button id="t">Target</button><div id="overlay" style="position:fixed;inset:0"></div>`,
+		);
+
+		let thrown: unknown;
+		try {
+			await page.locator("#t").click();
+		} catch (error) {
+			thrown = error;
+		}
+		await browser.close();
+
+		expect(thrown).toBeInstanceOf(errors.TimeoutError);
+		const formatted = errorMessage(thrown);
+		expect(formatted.split("\n")[0]).toMatch(
+			/^locator\.click: Timeout 500ms exceeded\. <div id="overlay"><\/div> intercepts pointer events —/,
+		);
+		expect(formatted).toContain("browser_snapshot");
+	});
+
+	it("passes through non-timeout errors unchanged", () => {
+		expect(errorMessage(new Error("boom"))).toBe("boom");
+		expect(errorMessage("plain")).toBe("plain");
+	});
+});

--- a/packages/browser-tools/src/errors.ts
+++ b/packages/browser-tools/src/errors.ts
@@ -1,4 +1,109 @@
+import { errors } from "playwright";
+
+const TIMEOUT_EXCEEDED_PREFIX = /^(.*?Timeout \d+ms exceeded\.)(.*)$/;
+
+const ACTIONABILITY_PATTERNS: RegExp[] = [
+	/^element is not (?:visible|enabled|stable|editable)$/i,
+	/^element is outside of the viewport$/i,
+	/^did not find some options$/i,
+	/^option being selected is not enabled$/i,
+	/^.+ intercepts pointer events$/i,
+];
+
+/**
+ * True for Playwright action/navigation timeouts.
+ * Prefer `instanceof errors.TimeoutError`; also accept the `name` fallback for
+ * re-wrapped or cross-realm errors that lose the prototype.
+ */
+export function isPlaywrightTimeoutError(error: unknown): error is Error {
+	if (!(error instanceof Error)) return false;
+	if (error instanceof errors.TimeoutError) return true;
+	return (
+		error.name === "TimeoutError" &&
+		/Timeout \d+ms exceeded/i.test(error.message)
+	);
+}
+
+/**
+ * Promote the last Call-log actionability failure into the timeout headline,
+ * matching the agent-facing improvement in Playwriter's Playwright fork — but
+ * done client-side against stock Playwright messages.
+ */
+export function enrichPlaywrightTimeoutMessage(message: string): string {
+	const lines = message.split("\n");
+	const firstLine = lines[0] ?? "";
+	const match = firstLine.match(TIMEOUT_EXCEEDED_PREFIX);
+	if (!match) return message;
+
+	const [, timeoutPrefix = "", existingReason = ""] = match;
+	if (existingReason.trim()) return message;
+
+	const callLogStart = lines.findIndex((line) => line.trim() === "Call log:");
+	const callLogText =
+		callLogStart >= 0 ? lines.slice(callLogStart + 1).join("\n") : message;
+	const rawReason = lastActionabilityReason(callLogText);
+	if (!rawReason) return message;
+
+	lines[0] = `${timeoutPrefix} ${formatActionabilityReason(rawReason)}`;
+	return lines.join("\n");
+}
+
 /** Format an unknown thrown value for agent-facing tool error strings. */
 export function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	const message = error instanceof Error ? error.message : String(error);
+	if (!isPlaywrightTimeoutError(error) && !isTimeoutErrorMessage(message)) {
+		return message;
+	}
+	return enrichPlaywrightTimeoutMessage(message);
+}
+
+function isTimeoutErrorMessage(message: string): boolean {
+	return (
+		/Timeout \d+ms exceeded/i.test(message) && message.includes("Call log:")
+	);
+}
+
+function lastActionabilityReason(callLogText: string): string | null {
+	let last: string | null = null;
+	for (const rawLine of callLogText.split("\n")) {
+		const line = rawLine.replace(/^\s*-\s*/, "").trim();
+		if (!line) continue;
+		if (ACTIONABILITY_PATTERNS.some((pattern) => pattern.test(line))) {
+			last = line;
+		}
+	}
+	return last;
+}
+
+function formatActionabilityReason(raw: string): string {
+	const normalized = raw.replace(/\s+/g, " ").trim();
+	const lower = normalized.toLowerCase();
+
+	if (lower === "element is not visible") {
+		return (
+			"Element is not visible — it may be hidden by CSS, inside a collapsed " +
+			"<details>, inactive tab, or closed accordion. Reveal it first, then retry."
+		);
+	}
+
+	if (lower.endsWith("intercepts pointer events")) {
+		return (
+			`${normalized} — call browser_snapshot and interact with the covering ` +
+			"element (modal/overlay), then retry."
+		);
+	}
+
+	if (lower.startsWith("element is not ")) {
+		return `Element is not ${normalized.slice("element is not ".length)}`;
+	}
+	if (lower === "element is outside of the viewport") {
+		return "Element is outside of the viewport";
+	}
+	if (lower === "did not find some options") {
+		return "Did not find some options";
+	}
+	if (lower === "option being selected is not enabled") {
+		return "Option being selected is not enabled";
+	}
+	return normalized;
 }

--- a/packages/libretto/src/cli/core/daemon/exec.ts
+++ b/packages/libretto/src/cli/core/daemon/exec.ts
@@ -1,5 +1,6 @@
 import type { Page } from "playwright";
 import { format, formatWithOptions, type InspectOptions } from "node:util";
+import { formatPlaywrightErrorMessage } from "../../../shared/errors/playwright-timeout.js";
 import { installInstrumentation } from "../../../shared/instrumentation/index.js";
 import { compileExecFunction } from "../exec-compiler.js";
 import { createReadonlyExecHelpers } from "../readonly-exec.js";
@@ -66,7 +67,10 @@ export async function handleExec(
 
   const result = await execRepl.run(code, helpers);
   if (!result.ok) {
-    throw new DaemonExecError(result.error.message, result.output);
+    throw new DaemonExecError(
+      formatPlaywrightErrorMessage(result.error),
+      result.output,
+    );
   }
   return { result: result.result, output: result.output };
 }
@@ -86,7 +90,7 @@ export async function handleReadonlyExec(
     return { result, output: buffered.output };
   } catch (error) {
     throw new DaemonExecError(
-      error instanceof Error ? error.message : String(error),
+      formatPlaywrightErrorMessage(error),
       buffered.output,
     );
   }

--- a/packages/libretto/src/shared/errors/playwright-timeout.spec.ts
+++ b/packages/libretto/src/shared/errors/playwright-timeout.spec.ts
@@ -1,0 +1,37 @@
+import { errors } from "playwright";
+import { describe, expect, it } from "vitest";
+import {
+  enrichPlaywrightTimeoutMessage,
+  formatPlaywrightErrorMessage,
+  isPlaywrightTimeoutError,
+} from "./playwright-timeout.js";
+
+const OVERLAY_CLICK_TIMEOUT = `
+locator.click: Timeout 800ms exceeded.
+Call log:
+  - waiting for locator('#t')
+  - attempting click action
+      - <div id="overlay"></div> intercepts pointer events
+`.trim();
+
+describe("playwright timeout enrichment", () => {
+  it("detects TimeoutError via instanceof errors.TimeoutError", () => {
+    expect(
+      isPlaywrightTimeoutError(new errors.TimeoutError("Timeout 1ms exceeded.")),
+    ).toBe(true);
+  });
+
+  it("promotes Call-log intercept reasons into the headline for CLI agents", () => {
+    const enriched = enrichPlaywrightTimeoutMessage(OVERLAY_CLICK_TIMEOUT);
+    expect(enriched.split("\n")[0]).toBe(
+      'locator.click: Timeout 800ms exceeded. <div id="overlay"></div> intercepts pointer events — run libretto snapshot and interact with the covering element (modal/overlay), then retry.',
+    );
+  });
+
+  it("formats TimeoutError-shaped messages through formatPlaywrightErrorMessage", () => {
+    const error = new errors.TimeoutError(OVERLAY_CLICK_TIMEOUT);
+    expect(formatPlaywrightErrorMessage(error).split("\n")[0]).toContain(
+      "intercepts pointer events — run libretto snapshot",
+    );
+  });
+});

--- a/packages/libretto/src/shared/errors/playwright-timeout.ts
+++ b/packages/libretto/src/shared/errors/playwright-timeout.ts
@@ -1,0 +1,109 @@
+import { errors } from "playwright";
+
+const TIMEOUT_EXCEEDED_PREFIX = /^(.*?Timeout \d+ms exceeded\.)(.*)$/;
+
+const ACTIONABILITY_PATTERNS: RegExp[] = [
+  /^element is not (?:visible|enabled|stable|editable)$/i,
+  /^element is outside of the viewport$/i,
+  /^did not find some options$/i,
+  /^option being selected is not enabled$/i,
+  /^.+ intercepts pointer events$/i,
+];
+
+/**
+ * True for Playwright action/navigation timeouts.
+ * Prefer `instanceof errors.TimeoutError`; also accept the `name` fallback for
+ * re-wrapped or cross-realm errors that lose the prototype.
+ */
+export function isPlaywrightTimeoutError(error: unknown): error is Error {
+  if (!(error instanceof Error)) return false;
+  if (error instanceof errors.TimeoutError) return true;
+  return (
+    error.name === "TimeoutError" &&
+    /Timeout \d+ms exceeded/i.test(error.message)
+  );
+}
+
+/**
+ * Promote the last Call-log actionability failure into the timeout headline.
+ * Stock Playwright keeps the reason only in the Call log; this lifts it into
+ * the first line so agents see it immediately.
+ */
+export function enrichPlaywrightTimeoutMessage(message: string): string {
+  const lines = message.split("\n");
+  const firstLine = lines[0] ?? "";
+  const match = firstLine.match(TIMEOUT_EXCEEDED_PREFIX);
+  if (!match) return message;
+
+  const [, timeoutPrefix = "", existingReason = ""] = match;
+  if (existingReason.trim()) return message;
+
+  const callLogStart = lines.findIndex((line) => line.trim() === "Call log:");
+  const callLogText =
+    callLogStart >= 0 ? lines.slice(callLogStart + 1).join("\n") : message;
+  const rawReason = lastActionabilityReason(callLogText);
+  if (!rawReason) return message;
+
+  lines[0] = `${timeoutPrefix} ${formatActionabilityReason(rawReason)}`;
+  return lines.join("\n");
+}
+
+/** Format thrown values for agent-facing Libretto CLI / daemon error strings. */
+export function formatPlaywrightErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!isPlaywrightTimeoutError(error) && !isTimeoutErrorMessage(message)) {
+    return message;
+  }
+  return enrichPlaywrightTimeoutMessage(message);
+}
+
+function isTimeoutErrorMessage(message: string): boolean {
+  return (
+    /Timeout \d+ms exceeded/i.test(message) && message.includes("Call log:")
+  );
+}
+
+function lastActionabilityReason(callLogText: string): string | null {
+  let last: string | null = null;
+  for (const rawLine of callLogText.split("\n")) {
+    const line = rawLine.replace(/^\s*-\s*/, "").trim();
+    if (!line) continue;
+    if (ACTIONABILITY_PATTERNS.some((pattern) => pattern.test(line))) {
+      last = line;
+    }
+  }
+  return last;
+}
+
+function formatActionabilityReason(raw: string): string {
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  const lower = normalized.toLowerCase();
+
+  if (lower === "element is not visible") {
+    return (
+      "Element is not visible — it may be hidden by CSS, inside a collapsed " +
+      "<details>, inactive tab, or closed accordion. Reveal it first, then retry."
+    );
+  }
+
+  if (lower.endsWith("intercepts pointer events")) {
+    return (
+      `${normalized} — run libretto snapshot and interact with the covering ` +
+      "element (modal/overlay), then retry."
+    );
+  }
+
+  if (lower.startsWith("element is not ")) {
+    return `Element is not ${normalized.slice("element is not ".length)}`;
+  }
+  if (lower === "element is outside of the viewport") {
+    return "Element is outside of the viewport";
+  }
+  if (lower === "did not find some options") {
+    return "Did not find some options";
+  }
+  if (lower === "option being selected is not enabled") {
+    return "Option being selected is not enabled";
+  }
+  return normalized;
+}

--- a/packages/libretto/src/shared/instrumentation/errors.ts
+++ b/packages/libretto/src/shared/instrumentation/errors.ts
@@ -1,17 +1,42 @@
 import type { Page, Locator } from "playwright";
+import {
+  enrichPlaywrightTimeoutMessage,
+  isPlaywrightTimeoutError,
+} from "../errors/playwright-timeout.js";
 
 /**
- * Enrich a timeout error from a pointer action (click/dblclick/hover) with
- * diagnostic information about why the action may have failed.
+ * Enrich a timeout error from a pointer action (click/dblclick/hover).
  *
- * Mutates err.message in-place to append the enrichment.
- * Best-effort: if any probe fails, we skip that check silently.
+ * Prefer Playwright's own Call-log actionability reason (promoted into the
+ * timeout headline). Fall back to live page probes only when the Call log has
+ * no actionability line.
+ *
+ * Mutates err.message in-place. Best-effort: probe failures are ignored.
  */
 export async function enrichTimeoutError(
   err: any,
   locator: Locator,
   page: Page,
 ): Promise<void> {
+  if (!err || typeof err.message !== "string") return;
+
+  const before = err.message as string;
+  const fromCallLog = enrichPlaywrightTimeoutMessage(before);
+  if (fromCallLog !== before) {
+    err.message = fromCallLog;
+    return;
+  }
+
+  if (!isPlaywrightTimeoutError(err) && !/Timeout \d+ms exceeded/i.test(before)) {
+    return;
+  }
+
+  // Headline already has a reason, or Call log had none — only probe as fallback
+  // when the headline is still a bare timeout.
+  if (!/Timeout \d+ms exceeded\.\s*$/m.test(before.split("\n")[0] ?? "")) {
+    return;
+  }
+
   const reasons: string[] = [];
 
   try {
@@ -20,7 +45,6 @@ export async function enrichTimeoutError(
       reasons.push("Element is not visible");
     }
 
-    // isInViewport is available in modern Playwright but may not exist in older versions
     if (typeof (locator as any).isInViewport === "function") {
       const inViewport = await (locator as any)
         .isInViewport()
@@ -35,7 +59,6 @@ export async function enrichTimeoutError(
       reasons.push("Element is not enabled (disabled)");
     }
 
-    // If the element appears visible and in viewport, check for intercepting elements
     if (reasons.length === 0) {
       const box = await locator.boundingBox().catch(() => null);
       if (box) {
@@ -50,7 +73,6 @@ export async function enrichTimeoutError(
               const topEl = els[0];
               if (!topEl) return null;
 
-              // Build a brief preview of the intercepting element
               const tag = topEl.tagName.toLowerCase();
               const id = topEl.id ? `#${topEl.id}` : "";
               const cls = topEl.className

--- a/packages/libretto/src/shared/instrumentation/instrument.ts
+++ b/packages/libretto/src/shared/instrumentation/instrument.ts
@@ -14,6 +14,7 @@ import {
   showHighlight,
   clearHighlights,
 } from "../visualization/highlight.js";
+import { isPlaywrightTimeoutError } from "../errors/playwright-timeout.js";
 import { enrichTimeoutError } from "./errors.js";
 
 export type InstrumentationOptions = {
@@ -139,7 +140,7 @@ function wrapLocatorActions(
           void enqueue(page, () => visualizeAfterAction(page));
         }
         // Enrich timeout errors for pointer actions
-        if (POINTER_ACTIONS.has(method) && isTimeoutError(err)) {
+        if (POINTER_ACTIONS.has(method) && isPlaywrightTimeoutError(err)) {
           await enrichTimeoutError(err, locator, page);
         }
         throw err;
@@ -254,15 +255,6 @@ function instrumentFrameLocator(
   return frameLocator;
 }
 
-function isTimeoutError(err: any): boolean {
-  if (!err || typeof err.message !== "string") return false;
-  return (
-    err.message.includes("Timeout") ||
-    err.message.includes("timeout") ||
-    err.name === "TimeoutError"
-  );
-}
-
 const PAGE_LOCATOR_FACTORIES = [
   "locator",
   "getByRole",
@@ -332,7 +324,7 @@ export async function installInstrumentation(
         }
         if (
           POINTER_ACTIONS.has(method) &&
-          isTimeoutError(err) &&
+          isPlaywrightTimeoutError(err) &&
           typeof args[0] === "string"
         ) {
           await enrichTimeoutError(err, page.locator(args[0]), page);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stock Playwright already records why a click/fill timed out (`element is not visible`, `<div …> intercepts pointer events`, etc.), but that reason sits in the Call log under a bare `Timeout Nms exceeded.` headline. Playwriter’s Playwright fork lifts the last actionability failure into the first line; we do the same client-side against stock Playwright.

- Detect timeouts with `instanceof errors.TimeoutError` (plus a `name`/`message` fallback for re-wrapped errors)
- Promote the last Call-log actionability line into the timeout headline
- Add short next-step tips for hidden elements and pointer interception
- Wire through `browser-tools` `errorMessage()` (used by `browser_exec`) and Libretto daemon `exec` / `readonly-exec`
- Instrumentation timeout enrichment now prefers the Call-log headline rewrite before falling back to live page probes

## Example

Before:

```text
locator.click: Timeout 800ms exceeded.
Call log:
  ...
  - <div id="overlay"></div> intercepts pointer events
```

After:

```text
locator.click: Timeout 800ms exceeded. <div id="overlay"></div> intercepts pointer events — call browser_snapshot and interact with the covering element (modal/overlay), then retry.
Call log:
  ...
```

## Test plan

- [x] `packages/browser-tools` unit + live click coverage in `errors.spec.ts`
- [x] `packages/libretto` unit coverage in `playwright-timeout.spec.ts`
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aca6c701-4b80-4401-aefe-a9312373b00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aca6c701-4b80-4401-aefe-a9312373b00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

