### PR TITLE
Scope accessibility snapshots to open modal dialogs

### DIFF
--- a/packages/browser-tools/src/snapshot/capture-snapshot.ts
+++ b/packages/browser-tools/src/snapshot/capture-snapshot.ts
@@ -70,6 +70,8 @@ const REFS_BY_ROLE = new Set([
   "menuitem",
   "tab",
   "slider",
+  "dialog",
+  "alertdialog",
 ]);
 
 const INTERESTING_ATTRIBUTES = new Set([
@@ -84,6 +86,7 @@ const INTERESTING_ATTRIBUTES = new Set([
   "href",
   "src",
   "aria-label",
+  "aria-modal",
   "aria-expanded",
   "aria-pressed",
   "aria-selected",
@@ -557,8 +560,42 @@ function buildSnapshotTree(
   }
 
   const roots = [...byId.values()].filter((node) => !childIds.has(node.nodeId));
-  for (const root of roots) annotateSubtreeSize(root);
-  return roots;
+  const scopedRoots = scopeRootsToOpenModal(roots);
+  for (const root of scopedRoots) annotateSubtreeSize(root);
+  return scopedRoots;
+}
+
+/**
+ * When an open modal/dialog is present (Chromium AX `modal: true`), use that
+ * node as the snapshot root so agents see the focus-trapped UI instead of the
+ * inert page behind it.
+ */
+function scopeRootsToOpenModal(
+  roots: MutableSnapshotNode[],
+): MutableSnapshotNode[] {
+  const modals: MutableSnapshotNode[] = [];
+
+  function visit(node: MutableSnapshotNode): void {
+    if (isOpenModalNode(node)) modals.push(node);
+    for (const child of node.children) visit(child);
+  }
+
+  for (const root of roots) visit(root);
+  if (modals.length === 0) return roots;
+
+  // Last modal in tree order is typically the topmost / most recently opened.
+  const modal = modals[modals.length - 1]!;
+  modal.parent = null;
+  return [modal];
+}
+
+function isOpenModalNode(node: MutableSnapshotNode): boolean {
+  if (node.ignored) return false;
+  if (node.properties.modal === true) return true;
+  return (
+    (node.role === "dialog" || node.role === "alertdialog") &&
+    node.attributes["aria-modal"] === "true"
+  );
 }
 
 function annotateSubtreeSize(node: MutableSnapshotNode): number {

--- a/packages/browser-tools/src/snapshot/render-snapshot.ts
+++ b/packages/browser-tools/src/snapshot/render-snapshot.ts
@@ -24,6 +24,8 @@ const PRESERVE_CHILDREN_BY_ROLE = new Set([
   "list",
   "table",
   "tabpanel",
+  "dialog",
+  "alertdialog",
 ]);
 
 const FLATTEN_ROLES = new Set([
@@ -86,6 +88,8 @@ const KEEP_ROLES = new Set([
   "option",
   "tab",
   "slider",
+  "dialog",
+  "alertdialog",
 ]);
 
 const BLOCK_FLATTEN_ROLES = new Set([

--- a/packages/browser-tools/src/snapshot/snapshot.spec.ts
+++ b/packages/browser-tools/src/snapshot/snapshot.spec.ts
@@ -128,6 +128,39 @@ describe("renderSnapshot", () => {
 		);
 	});
 
+	test("scopes the snapshot root to an open aria-modal dialog", async ({
+		expectSnapshot,
+	}) => {
+		await expectSnapshot(
+			outdent`
+				<!doctype html>
+				<title>Shop</title>
+				<main>
+					<h1>Checkout</h1>
+					<button>Pay now</button>
+					<p>Order total $42</p>
+				</main>
+				<div role="dialog" aria-modal="true" aria-label="Confirm delete">
+					<p>Delete this item?</p>
+					<button>Cancel</button>
+					<button>Delete</button>
+				</div>
+			`,
+			outdent`
+				<page title="Shop" url="about:blank">
+					<frame index="0" url="about:blank">
+						<dialog ref="l1">
+							Confirm delete
+							Delete this item?
+							<button ref="l2">Cancel</button>
+							<button ref="l3">Delete</button>
+						</dialog>
+					</frame>
+				</page>
+			`,
+		);
+	});
+
 	test("compacts low-value wrappers, clickable generics, single-child chains, and long child lists", async ({
 		expectSnapshot,
 	}) => {

--- a/packages/libretto/src/shared/snapshot/capture-snapshot.ts
+++ b/packages/libretto/src/shared/snapshot/capture-snapshot.ts
@@ -36,6 +36,8 @@ const REFS_BY_ROLE = new Set([
   "menuitem",
   "tab",
   "slider",
+  "dialog",
+  "alertdialog",
 ]);
 
 const INTERESTING_ATTRIBUTES = new Set([
@@ -50,6 +52,7 @@ const INTERESTING_ATTRIBUTES = new Set([
   "href",
   "src",
   "aria-label",
+  "aria-modal",
   "aria-expanded",
   "aria-pressed",
   "aria-selected",
@@ -523,8 +526,42 @@ function buildSnapshotTree(
   }
 
   const roots = [...byId.values()].filter((node) => !childIds.has(node.nodeId));
-  for (const root of roots) annotateSubtreeSize(root);
-  return roots;
+  const scopedRoots = scopeRootsToOpenModal(roots);
+  for (const root of scopedRoots) annotateSubtreeSize(root);
+  return scopedRoots;
+}
+
+/**
+ * When an open modal/dialog is present (Chromium AX `modal: true`), use that
+ * node as the snapshot root so agents see the focus-trapped UI instead of the
+ * inert page behind it.
+ */
+function scopeRootsToOpenModal(
+  roots: MutableSnapshotNode[],
+): MutableSnapshotNode[] {
+  const modals: MutableSnapshotNode[] = [];
+
+  function visit(node: MutableSnapshotNode): void {
+    if (isOpenModalNode(node)) modals.push(node);
+    for (const child of node.children) visit(child);
+  }
+
+  for (const root of roots) visit(root);
+  if (modals.length === 0) return roots;
+
+  // Last modal in tree order is typically the topmost / most recently opened.
+  const modal = modals[modals.length - 1]!;
+  modal.parent = null;
+  return [modal];
+}
+
+function isOpenModalNode(node: MutableSnapshotNode): boolean {
+  if (node.ignored) return false;
+  if (node.properties.modal === true) return true;
+  return (
+    (node.role === "dialog" || node.role === "alertdialog") &&
+    node.attributes["aria-modal"] === "true"
+  );
 }
 
 function annotateSubtreeSize(node: MutableSnapshotNode): number {

--- a/packages/libretto/src/shared/snapshot/render-snapshot.ts
+++ b/packages/libretto/src/shared/snapshot/render-snapshot.ts
@@ -24,6 +24,8 @@ const PRESERVE_CHILDREN_BY_ROLE = new Set([
   "list",
   "table",
   "tabpanel",
+  "dialog",
+  "alertdialog",
 ]);
 
 const FLATTEN_ROLES = new Set([
@@ -86,6 +88,8 @@ const KEEP_ROLES = new Set([
   "option",
   "tab",
   "slider",
+  "dialog",
+  "alertdialog",
 ]);
 
 const BLOCK_FLATTEN_ROLES = new Set([

--- a/packages/libretto/src/shared/snapshot/snapshot.spec.ts
+++ b/packages/libretto/src/shared/snapshot/snapshot.spec.ts
@@ -204,6 +204,39 @@ describe("renderSnapshot", () => {
     );
   });
 
+  test("scopes the snapshot root to an open aria-modal dialog", async ({
+    expectSnapshot,
+  }) => {
+    await expectSnapshot(
+      `
+      <!doctype html>
+      <title>Shop</title>
+      <main>
+        <h1>Checkout</h1>
+        <button>Pay now</button>
+        <p>Order total $42</p>
+      </main>
+      <div role="dialog" aria-modal="true" aria-label="Confirm delete">
+        <p>Delete this item?</p>
+        <button>Cancel</button>
+        <button>Delete</button>
+      </div>
+    `,
+      `
+      <page title="Shop" url="<page-url>">
+      	<frame index="0" url="<page-url>">
+      		<dialog ref="l1">
+      			Confirm delete
+      			Delete this item?
+      			<button ref="l2">Cancel</button>
+      			<button ref="l3">Delete</button>
+      		</dialog>
+      	</frame>
+      </page>
+    `,
+    );
+  });
+
   test("compacts low-value wrappers, clickable generics, single-child chains, and long child lists", async ({
     expectSnapshot,
   }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a modal dialog is open, snapshot currently still roots at the document and often keeps inert page content (or flattens away the dialog role). Agents then see `Pay now` / checkout chrome behind a focus-trapped overlay.

This scopes each frame’s snapshot roots to the open modal when Chromium’s accessibility tree marks a node `modal: true` (native `<dialog>.showModal()`, `role="dialog" aria-modal="true"`, `role="alertdialog" aria-modal="true"`). `dialog` / `alertdialog` are also kept as rendered roles so the modal itself is the tree root.

## Before / after (`aria-modal` confirm dialog)

**Before** — page behind the modal stays in the tree; dialog role is flattened; truncation can hide modal actions:

```text
<page title="Shop" url="…">
  <frame …>
    <document ref="l1">
      Shop
      <main ref="l2">
        # Checkout
        <button ref="l4">Pay now</button>
        Order total $42
      </main>
      Delete this item?
      <button ref="l6">Cancel</button>
      [Truncated 1 more element. Interactive elements: <button ref="l7">Delete</button>]
    </document>
  </frame>
</page>
```

**After** — modal is the root:

```text
<page title="Shop" url="…">
  <frame …>
    <dialog ref="l1">
      Confirm delete
      Delete this item?
      <button ref="l2">Cancel</button>
      <button ref="l3">Delete</button>
    </dialog>
  </frame>
</page>
```

## Test plan

- [x] Unit coverage: open `aria-modal` dialog scopes snapshot root
- [x] Manual before/after for aria-modal, native `<dialog>`, and alertdialog
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aca6c701-4b80-4401-aefe-a9312373b00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aca6c701-4b80-4401-aefe-a9312373b00e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

