### PR TITLE
Skip onboarding after Chrome extension signup

### DIFF
--- a/apps/website/src/SignInPage.tsx
+++ b/apps/website/src/SignInPage.tsx
@@ -154,8 +154,9 @@ export function SignInPage() {
       return true;
     }
     window.history.replaceState(null, "", withoutCliLoginParams());
+    const statusAfterApproval = await getAuthStatus();
     window.location.assign(
-      await resolvePostAuthRedirect(statusBeforeApproval, null),
+      await resolvePostAuthRedirect(statusAfterApproval, null),
     );
     return true;
   }

--- a/apps/website/src/VerifyEmailPage.tsx
+++ b/apps/website/src/VerifyEmailPage.tsx
@@ -52,6 +52,8 @@ export function VerifyEmailPage() {
             returnTo: getSafeReturnTo(),
             hasCliLoginParams: Boolean(getCliLoginParams()),
             approveCliLogin: approveCliLoginIfPresent,
+            getHasTenantAfterApproval: async () =>
+              (await getAuthStatus()).hasTenant,
           });
           if (cancelled) return;
           if (!redirectTo) {

--- a/apps/website/src/verifyEmailFlow.spec.ts
+++ b/apps/website/src/verifyEmailFlow.spec.ts
@@ -88,6 +88,18 @@ describe("redirectAfterVerifiedEmail", () => {
     ).resolves.toBe("/dashboard");
   });
 
+  it("uses tenant status refreshed after browser login approval", async () => {
+    await expect(
+      redirectAfterVerifiedEmail({
+        hasTenant: false,
+        returnTo: null,
+        hasCliLoginParams: true,
+        approveCliLogin: async () => true,
+        getHasTenantAfterApproval: async () => true,
+      }),
+    ).resolves.toBe("/dashboard");
+  });
+
   it("preserves dashboard return targets for an existing tenant", async () => {
     await expect(
       redirectAfterVerifiedEmail({

--- a/apps/website/src/verifyEmailFlow.ts
+++ b/apps/website/src/verifyEmailFlow.ts
@@ -5,15 +5,20 @@ export async function redirectAfterVerifiedEmail(input: {
   returnTo: string | null;
   hasCliLoginParams: boolean;
   approveCliLogin: () => Promise<boolean>;
+  getHasTenantAfterApproval?: () => Promise<boolean>;
 }): Promise<string | null> {
+  let hasTenant = input.hasTenant;
   if (input.hasCliLoginParams) {
     const approved = await input.approveCliLogin().catch(() => false);
     if (!approved) return null;
+    if (input.getHasTenantAfterApproval) {
+      hasTenant = await input.getHasTenantAfterApproval();
+    }
   }
 
   return postAuthRedirect({
     emailVerified: true,
-    hasTenant: input.hasTenant,
+    hasTenant,
     returnTo: input.returnTo,
   });
 }


### PR DESCRIPTION
## Summary
- refresh tenant status after browser-login approval
- redirect extension signups with an auto-created tenant to the dashboard
- preserve manual onboarding for normal website and CLI signups

## Dependencies
- Backend tenant provisioning: https://github.com/saffron-health/libretto-cloud/pull/211
- Extension signup source and auth behavior: https://github.com/saffron-health/chrome-extension/pull/19

## Tests
- `pnpm exec vitest run --root ../../apps/website src/verifyEmailFlow.spec.ts`
- `pnpm --dir ../../apps/website type-check`
- `pnpm exec oxlint --type-aware apps/website/src/SignInPage.tsx apps/website/src/VerifyEmailPage.tsx apps/website/src/verifyEmailFlow.ts apps/website/src/verifyEmailFlow.spec.ts`