### PR TITLE
Add Libretto privacy policy page

### DIFF
--- a/apps/website/public/sitemap.xml
+++ b/apps/website/public/sitemap.xml
@@ -17,6 +17,10 @@
     <lastmod>2026-07-15</lastmod>
   </url>
   <url>
+    <loc>https://libretto.sh/privacy</loc>
+    <lastmod>2026-07-29</lastmod>
+  </url>
+  <url>
     <loc>https://libretto.sh/blog</loc>
     <lastmod>2026-06-18</lastmod>
   </url>

--- a/apps/website/src/PrivacyPage.tsx
+++ b/apps/website/src/PrivacyPage.tsx
@@ -1,0 +1,133 @@
+import { Footer } from "./components/Footer";
+import { Navbar } from "./components/Navbar";
+import { Text } from "./components/Text";
+
+const sectionClass = "space-y-3";
+const listClass = "list-disc space-y-2 pl-5 text-muted";
+
+export function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-base text-ink">
+      <Navbar />
+      <main className="mx-auto max-w-[800px] px-6 py-16 md:px-8 md:py-24">
+        <Text
+          as="h1"
+          size="5xl"
+          style="serif"
+          className="tracking-[-0.04em]"
+          htmlStyle={{ fontWeight: 300, lineHeight: 1 }}
+        >
+          Privacy policy
+        </Text>
+        <Text as="p" size="sm" className="mt-4 text-faint">
+          Last updated July 29, 2026
+        </Text>
+
+        <div className="mt-12 space-y-10 leading-relaxed">
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Scope
+            </Text>
+            <Text as="p" className="text-muted">
+              This policy explains how Libretto handles data through libretto.sh, Libretto Cloud,
+              and the Libretto Chrome extension.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Data we handle
+            </Text>
+            <ul className={listClass}>
+              <li>Account details, such as your email address.</li>
+              <li>
+                Authentication data, including Libretto sessions and credentials you choose to save
+                for an automation.
+              </li>
+              <li>
+                Automation data, such as prompts, workflows, schedules, run activity, and results.
+              </li>
+              <li>
+                Content and interactions from browser tabs involved in a recording or local task
+                that you start. This may include URLs, page content, screenshots, form values, and
+                browser actions needed to complete the task.
+              </li>
+              <li>
+                Basic website analytics and service logs used to operate, secure, and improve
+                Libretto.
+              </li>
+            </ul>
+            <Text as="p" className="text-muted">
+              The Chrome extension does not monitor general browsing outside tasks that you start.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              How we use data
+            </Text>
+            <ul className={listClass}>
+              <li>Authenticate accounts and provide the Libretto service.</li>
+              <li>Create, run, schedule, and troubleshoot automations.</li>
+              <li>Send task results and notifications that you request.</li>
+              <li>Protect the service and measure its reliability.</li>
+            </ul>
+            <Text as="p" className="text-muted">
+              We do not sell user data or use it for personalized advertising, creditworthiness, or
+              lending.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Service providers
+            </Text>
+            <Text as="p" className="text-muted">
+              We share data only with service providers needed to run Libretto, such as cloud
+              hosting, AI model inference, browser execution, analytics, and email delivery
+              providers. They may process data only to provide those services to us. We may also
+              disclose data when required by law or needed to protect Libretto and its users.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Security and retention
+            </Text>
+            <Text as="p" className="text-muted">
+              We encrypt data in transit. Saved automation credentials are encrypted at rest. We
+              keep account and automation data while your account is active or as needed to provide
+              the service, meet legal duties, resolve disputes, and protect the service. You can
+              delete supported items from the Libretto dashboard or contact us to request deletion
+              of your account data.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Chrome Web Store Limited Use
+            </Text>
+            <Text as="p" className="text-muted">
+              The use of information received from Google APIs will adhere to the Chrome Web Store
+              User Data Policy, including the Limited Use requirements.
+            </Text>
+          </section>
+
+          <section className={sectionClass}>
+            <Text as="h2" size="xl" className="text-accent-bright">
+              Contact
+            </Text>
+            <Text as="p" className="text-muted">
+              For privacy questions, email{" "}
+              <a className="text-accent-bright underline" href="mailto:team@libretto.sh">
+                team@libretto.sh
+              </a>
+              .
+            </Text>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -60,6 +60,9 @@ export function Footer() {
             <a href="/blog" className={linkClass} data-fathom-event="Footer blog click">
               Blog
             </a>
+            <a href="/privacy" className={linkClass} data-fathom-event="Footer privacy click">
+              Privacy
+            </a>
             <a
               href="/cli#comparisons"
               className={linkClass}

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as SigninRouteImport } from './routes/signin'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as InviteRouteImport } from './routes/invite'
 import { Route as DebugAgentsRouteImport } from './routes/debug-agents'
@@ -39,6 +40,11 @@ const VerifyEmailRoute = VerifyEmailRouteImport.update({
 const SigninRoute = SigninRouteImport.update({
   id: '/signin',
   path: '/signin',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnboardingRoute = OnboardingRouteImport.update({
@@ -148,6 +154,7 @@ export interface FileRoutesByFullPath {
   '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
+  '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
   '/blog/$slug': typeof BlogSlugRoute
@@ -170,6 +177,7 @@ export interface FileRoutesByTo {
   '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
+  '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
   '/blog/$slug': typeof BlogSlugRoute
@@ -194,6 +202,7 @@ export interface FileRoutesById {
   '/debug-agents': typeof DebugAgentsRoute
   '/invite': typeof InviteRoute
   '/onboarding': typeof OnboardingRoute
+  '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
   '/blog/$slug': typeof BlogSlugRoute
@@ -219,6 +228,7 @@ export interface FileRouteTypes {
     | '/debug-agents'
     | '/invite'
     | '/onboarding'
+    | '/privacy'
     | '/signin'
     | '/verify-email'
     | '/blog/$slug'
@@ -241,6 +251,7 @@ export interface FileRouteTypes {
     | '/debug-agents'
     | '/invite'
     | '/onboarding'
+    | '/privacy'
     | '/signin'
     | '/verify-email'
     | '/blog/$slug'
@@ -264,6 +275,7 @@ export interface FileRouteTypes {
     | '/debug-agents'
     | '/invite'
     | '/onboarding'
+    | '/privacy'
     | '/signin'
     | '/verify-email'
     | '/blog/$slug'
@@ -288,6 +300,7 @@ export interface RootRouteChildren {
   DebugAgentsRoute: typeof DebugAgentsRoute
   InviteRoute: typeof InviteRoute
   OnboardingRoute: typeof OnboardingRoute
+  PrivacyRoute: typeof PrivacyRoute
   SigninRoute: typeof SigninRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
   DashboardSectionRoute: typeof DashboardSectionRoute
@@ -314,6 +327,13 @@ declare module '@tanstack/react-router' {
       path: '/signin'
       fullPath: '/signin'
       preLoaderRoute: typeof SigninRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/onboarding': {
@@ -476,6 +496,7 @@ const rootRouteChildren: RootRouteChildren = {
   DebugAgentsRoute: DebugAgentsRoute,
   InviteRoute: InviteRoute,
   OnboardingRoute: OnboardingRoute,
+  PrivacyRoute: PrivacyRoute,
   SigninRoute: SigninRoute,
   VerifyEmailRoute: VerifyEmailRoute,
   DashboardSectionRoute: DashboardSectionRoute,

--- a/apps/website/src/routes/privacy.tsx
+++ b/apps/website/src/routes/privacy.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PrivacyPage } from "../PrivacyPage";
+
+const title = "Privacy Policy | Libretto";
+const description = "How Libretto collects, uses, shares, and protects data.";
+const url = "https://libretto.sh/privacy";
+
+export const Route = createFileRoute("/privacy")({
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:type", content: "website" },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: url },
+      { name: "twitter:card", content: "summary" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+    ],
+    links: [{ rel: "canonical", href: url }],
+  }),
+  component: PrivacyPage,
+});


### PR DESCRIPTION
## Summary
- add a public privacy policy at `/privacy` covering Libretto Cloud and the Chrome extension
- disclose browser-task data handling, service providers, retention, and Chrome Web Store Limited Use compliance
- link the policy from the site footer and sitemap

## Validation
- `pnpm --dir apps/website build`
- focused Oxlint checks
- desktop and mobile visual review