### PR TITLE
Add Browser Tools MCP stdio binary

### DIFF
--- a/docs/browser-tools/adapters/hermes.mdx
+++ b/docs/browser-tools/adapters/hermes.mdx
@@ -1,0 +1,56 @@
+---
+title: Hermes Agent
+sidebarTitle: Hermes
+"og:image": "https://libretto.sh/docs/og/browser-tools/adapters/hermes.png"
+---
+
+> Use Browser Tools with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) over MCP.
+
+Hermes loads MCP servers from `~/.hermes/config.yaml`. Point it at the Browser Tools stdio binary, then disable Hermes' built-in browser toolset so the agent uses Browser Tools instead of `browser_navigate` / `browser_click` / ….
+
+## Install
+
+```bash theme={null}
+npx playwright install chromium
+```
+
+## Configure
+
+```yaml theme={null}
+mcp_servers:
+  libretto:
+    command: npx
+    args: ["-y", "libretto-browser-tools"]
+
+agent:
+  disabled_toolsets:
+    - browser
+```
+
+Reload MCP after editing config (`/reload-mcp` in a Hermes session, or restart Hermes).
+
+Pass CLI flags in `args` when you need a headed browser or domain policy:
+
+```yaml theme={null}
+mcp_servers:
+  libretto:
+    command: npx
+    args:
+      - "-y"
+      - "libretto-browser-tools"
+      - "--headed"
+      - "--allowed-domain"
+      - "example.com"
+```
+
+## What the agent gets
+
+Six tools: `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`. Hermes prefixes MCP tools with the server name (for example `mcp_libretto_browser_open`).
+
+See [Tools](/browser-tools/tools) for inputs and outputs, and [MCP](/browser-tools/adapters/mcp) for flags and the library API.
+
+## See also
+
+- [MCP adapter](/browser-tools/adapters/mcp) — stdio binary and library registration
+- [OpenClaw](/browser-tools/adapters/openclaw) — same binary on OpenClaw
+- [Hermes MCP docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)

--- a/docs/browser-tools/adapters/mcp.mdx
+++ b/docs/browser-tools/adapters/mcp.mdx
@@ -6,16 +6,68 @@ sidebarTitle: MCP
 
 > Expose browser tools to MCP clients and gateways.
 
-Import from `libretto-browser-tools/mcp`. Install the optional peer dependency `@modelcontextprotocol/sdk`.
+## Quickstart (stdio binary)
+
+Install Chromium once, then point any MCP client at the package binary:
 
 ```bash theme={null}
-pnpm add libretto-browser-tools @modelcontextprotocol/sdk
 npx playwright install chromium
 ```
 
-## registerMcpBrowserTools
+```json theme={null}
+{
+  "mcpServers": {
+    "libretto-browser-tools": {
+      "command": "npx",
+      "args": ["-y", "libretto-browser-tools"]
+    }
+  }
+}
+```
 
-Registers all six browser tools on a caller-owned `McpServer`. Your host owns the transport, authentication, and server lifecycle.
+Equivalent forms: `npx -y libretto-browser-tools mcp`, or `npx -y libretto-browser-tools --headed` for a visible browser.
+
+Flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--headed` | Show the browser window (default is headless) |
+| `--allowed-domain <host>` | Restrict http(s) navigations to this host (repeatable) |
+| `--blocked-domain <host>` | Block http(s) navigations to this host (repeatable) |
+
+The server exposes `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`.
+
+### Hermes
+
+Add the server under `mcp_servers` in `~/.hermes/config.yaml`. To use Browser Tools instead of Hermes' built-in browser stack, disable the `browser` toolset:
+
+```yaml theme={null}
+mcp_servers:
+  libretto:
+    command: npx
+    args: ["-y", "libretto-browser-tools"]
+
+agent:
+  disabled_toolsets:
+    - browser
+```
+
+### OpenClaw
+
+```bash theme={null}
+openclaw mcp add libretto -- npx -y libretto-browser-tools
+```
+
+Disable OpenClaw's bundled browser plugin if you want the agent to use only Browser Tools (see [OpenClaw browser docs](https://docs.openclaw.ai/tools/browser)).
+
+## Library: registerMcpBrowserTools
+
+Import from `libretto-browser-tools/mcp` when you own the MCP server and transport. Install the package (the MCP SDK is included as a dependency).
+
+```bash theme={null}
+pnpm add libretto-browser-tools
+npx playwright install chromium
+```
 
 ```typescript theme={null}
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/docs/browser-tools/adapters/mcp.mdx
+++ b/docs/browser-tools/adapters/mcp.mdx
@@ -37,28 +37,10 @@ Flags:
 
 The server exposes `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`.
 
-### Hermes
+Host-specific setup:
 
-Add the server under `mcp_servers` in `~/.hermes/config.yaml`. To use Browser Tools instead of Hermes' built-in browser stack, disable the `browser` toolset:
-
-```yaml theme={null}
-mcp_servers:
-  libretto:
-    command: npx
-    args: ["-y", "libretto-browser-tools"]
-
-agent:
-  disabled_toolsets:
-    - browser
-```
-
-### OpenClaw
-
-```bash theme={null}
-openclaw mcp add libretto -- npx -y libretto-browser-tools
-```
-
-Disable OpenClaw's bundled browser plugin if you want the agent to use only Browser Tools (see [OpenClaw browser docs](https://docs.openclaw.ai/tools/browser)).
+- [Hermes Agent](/browser-tools/adapters/hermes)
+- [OpenClaw](/browser-tools/adapters/openclaw)
 
 ## Library: registerMcpBrowserTools
 
@@ -115,4 +97,6 @@ The adapter publishes safety annotations for each tool. `browser_exec` is marked
 ## See also
 
 - [Tools](/browser-tools/tools) — inputs and outputs for each tool
+- [Hermes](/browser-tools/adapters/hermes) — Hermes Agent install
+- [OpenClaw](/browser-tools/adapters/openclaw) — OpenClaw install
 - [Custom adapters](/browser-tools/adapters/custom) — wrap `createBrowserTools` for another framework

--- a/docs/browser-tools/adapters/openclaw.mdx
+++ b/docs/browser-tools/adapters/openclaw.mdx
@@ -1,0 +1,56 @@
+---
+title: OpenClaw
+sidebarTitle: OpenClaw
+"og:image": "https://libretto.sh/docs/og/browser-tools/adapters/openclaw.png"
+---
+
+> Use Browser Tools with [OpenClaw](https://docs.openclaw.ai) over MCP.
+
+OpenClaw can load the Browser Tools stdio binary as an MCP server. Disable OpenClaw's bundled browser plugin if you want the agent to use only Browser Tools instead of the native `browser` tool.
+
+## Install
+
+```bash theme={null}
+npx playwright install chromium
+openclaw mcp add libretto -- npx -y libretto-browser-tools
+```
+
+Or add the server in the Control UI under MCP settings (`/settings/mcp`).
+
+Pass flags after the package name when you need a headed browser or domain policy:
+
+```bash theme={null}
+openclaw mcp add libretto -- npx -y libretto-browser-tools --headed
+```
+
+## Disable the bundled browser
+
+To stop the agent from using OpenClaw's built-in browser stack:
+
+```json5 theme={null}
+{
+  plugins: {
+    entries: {
+      browser: {
+        enabled: false,
+      },
+    },
+  },
+}
+```
+
+Restart the Gateway after changing plugin config. See [OpenClaw browser docs](https://docs.openclaw.ai/tools/browser) for plugin control details.
+
+## What the agent gets
+
+Six tools: `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`.
+
+Browser Tools launches an agent-owned Chromium session. It does not replace OpenClaw's Chrome extension path for driving signed-in tabs in your personal browser.
+
+See [Tools](/browser-tools/tools) for inputs and outputs, and [MCP](/browser-tools/adapters/mcp) for flags and the library API.
+
+## See also
+
+- [MCP adapter](/browser-tools/adapters/mcp) — stdio binary and library registration
+- [Hermes](/browser-tools/adapters/hermes) — same binary on Hermes Agent
+- [OpenClaw MCP CLI](https://docs.openclaw.ai/cli/mcp)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -134,6 +134,8 @@
               "browser-tools/adapters/ai-sdk",
               "browser-tools/adapters/pi",
               "browser-tools/adapters/mcp",
+              "browser-tools/adapters/hermes",
+              "browser-tools/adapters/openclaw",
               "browser-tools/adapters/custom"
             ]
           },

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -97,7 +97,7 @@ npx playwright install chromium
 }
 ```
 
-See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for Hermes, OpenClaw, flags, and the library API.
+See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for flags and the library API. Host guides: [Hermes](https://libretto.sh/docs/browser-tools/adapters/hermes), [OpenClaw](https://libretto.sh/docs/browser-tools/adapters/openclaw).
 
 ## Docs
 

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -8,7 +8,7 @@
   <br/>
   <br/>
   <h3>Browser Tools SDK gives any AI agent a real browser.</h3>
-  <p>Six tools to open, inspect, and drive browsers from AI SDK, Pi, or your own agent loop.</p>
+  <p>Six tools to open, inspect, and drive browsers from AI SDK, Pi, MCP, or your own agent loop.</p>
   <p>
     <a href="https://libretto.sh/docs/browser-tools/quickstart">Quickstart</a> •
     <a href="https://libretto.sh/docs/browser-tools/quickstart">Documentation</a> •
@@ -78,11 +78,32 @@ Browserbase and Steel expose provider IDs but not durable names. Libretto needs 
 
 Profiles contain signed-in browser state. Do not commit profile data. Changes persist only after `browser_close` or graceful `dispose()`. Do not open concurrent writable sessions against the same profile.
 
+## MCP server
+
+Point any MCP client at the package binary:
+
+```bash
+npx playwright install chromium
+```
+
+```json
+{
+  "mcpServers": {
+    "libretto-browser-tools": {
+      "command": "npx",
+      "args": ["-y", "libretto-browser-tools"]
+    }
+  }
+}
+```
+
+See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for Hermes, OpenClaw, flags, and the library API.
+
 ## Docs
 
 - Product page: https://libretto.sh/browser-tools
 - Quickstart: https://libretto.sh/docs/browser-tools/quickstart
-- Adapters: [AI SDK](https://libretto.sh/docs/browser-tools/adapters/ai-sdk), [Pi](https://libretto.sh/docs/browser-tools/adapters/pi), [Custom](https://libretto.sh/docs/browser-tools/adapters/custom)
+- Adapters: [AI SDK](https://libretto.sh/docs/browser-tools/adapters/ai-sdk), [Pi](https://libretto.sh/docs/browser-tools/adapters/pi), [MCP](https://libretto.sh/docs/browser-tools/adapters/mcp), [Custom](https://libretto.sh/docs/browser-tools/adapters/custom)
 - Providers: https://libretto.sh/docs/browser-tools/providers/overview
 
 ## License

--- a/packages/browser-tools/package.json
+++ b/packages/browser-tools/package.json
@@ -17,6 +17,9 @@
     "dist",
     "src"
   ],
+  "bin": {
+    "libretto-browser-tools": "./dist/cli/index.js"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -75,6 +78,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@standard-schema/spec": "^1.0.0",
     "errore": "^0.14.1",
     "playwright": "^1.58.2",
@@ -83,14 +87,10 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.3",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {
-      "optional": true
-    },
-    "@modelcontextprotocol/sdk": {
       "optional": true
     },
     "ai": {
@@ -99,7 +99,6 @@
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.6",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/cli": "^0.1.17",
     "@types/node": "^25.5.0",
     "affordance": "workspace:*",

--- a/packages/browser-tools/src/cli/cli.spec.ts
+++ b/packages/browser-tools/src/cli/cli.spec.ts
@@ -1,0 +1,139 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import { getHelpText, parseCliArgs } from "./parse-args.js";
+
+const cliEntry = fileURLToPath(new URL("./index.ts", import.meta.url));
+const tsxCli = fileURLToPath(
+	new URL("../../node_modules/tsx/dist/cli.mjs", import.meta.url),
+);
+
+test("help text tells the user how to wire an MCP client", () => {
+	const help = getHelpText();
+	expect(help).toContain("libretto-browser-tools");
+	expect(help).toContain('args ["-y", "libretto-browser-tools"]');
+	expect(help).toContain("npx playwright install chromium");
+});
+
+test("parseCliArgs accepts bare invocation and mcp subcommand with domain flags", () => {
+	expect(parseCliArgs([])).toEqual({
+		kind: "mcp",
+		options: {
+			headless: true,
+			allowedDomains: [],
+			blockedDomains: [],
+		},
+	});
+	expect(parseCliArgs(["mcp", "--headed", "--allowed-domain", "example.com"])).toEqual({
+		kind: "mcp",
+		options: {
+			headless: false,
+			allowedDomains: ["example.com"],
+			blockedDomains: [],
+		},
+	});
+	expect(parseCliArgs(["--blocked-domain=ads.example.com"])).toEqual({
+		kind: "mcp",
+		options: {
+			headless: true,
+			allowedDomains: [],
+			blockedDomains: ["ads.example.com"],
+		},
+	});
+});
+
+test("parseCliArgs reports unknown flags with recovery text", () => {
+	const parsed = parseCliArgs(["--wat"]);
+	expect(parsed).toMatchObject({
+		kind: "error",
+		message: "Unknown argument: --wat",
+	});
+	if (parsed.kind === "error") {
+		expect(parsed.recovery).toContain("--help");
+	}
+});
+
+test("stdio MCP binary lists tools and runs Playwright against a page", async () => {
+	const transport = new StdioClientTransport({
+		command: process.execPath,
+		args: [tsxCli, cliEntry, "--headless"],
+		stderr: "pipe",
+	});
+	const client = new Client({
+		name: "libretto-browser-tools-cli-test",
+		version: "1.0.0",
+	});
+	await client.connect(transport);
+
+	const listed = await client.listTools();
+	expect(listed.tools.map((tool) => tool.name).sort()).toEqual([
+		"browser_close",
+		"browser_connect",
+		"browser_exec",
+		"browser_open",
+		"browser_snapshot",
+		"browser_status",
+	]);
+
+	const opened = CallToolResultSchema.parse(
+		await client.callTool({
+			name: "browser_open",
+			arguments: {
+				url: "data:text/html,<title>hello from mcp cli</title>",
+				authProfile: false,
+			},
+		}),
+	);
+	expect(opened.isError).not.toBe(true);
+	const openText = opened.content.find((part) => part.type === "text");
+	expect(openText?.type).toBe("text");
+	if (openText?.type !== "text") {
+		throw new Error("expected text content from browser_open");
+	}
+	const openPayload = JSON.parse(openText.text) as {
+		ok: boolean;
+		sessionId: string;
+	};
+	expect(openPayload).toMatchObject({ ok: true });
+
+	const executed = CallToolResultSchema.parse(
+		await client.callTool({
+			name: "browser_exec",
+			arguments: {
+				sessionId: openPayload.sessionId,
+				code: "return await page.title();",
+			},
+		}),
+	);
+	expect(executed.isError).not.toBe(true);
+	const execText = executed.content.find((part) => part.type === "text");
+	expect(execText?.type).toBe("text");
+	if (execText?.type !== "text") {
+		throw new Error("expected text content from browser_exec");
+	}
+	expect(JSON.parse(execText.text)).toMatchObject({
+		ok: true,
+		result: "hello from mcp cli",
+	});
+
+	await client.close();
+});
+
+test("--help prints usage on stderr without starting an MCP server", async () => {
+	const child = spawn(process.execPath, [tsxCli, cliEntry, "--help"], {
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const stderrChunks: Buffer[] = [];
+	child.stderr.on("data", (chunk: Buffer) => {
+		stderrChunks.push(chunk);
+	});
+	await new Promise<void>((resolve) => {
+		child.once("close", () => resolve());
+	});
+	const stderr = Buffer.concat(stderrChunks).toString("utf8");
+	expect(stderr).toContain("Start a stdio MCP server");
+	expect(stderr).toContain('args ["-y", "libretto-browser-tools"]');
+});

--- a/packages/browser-tools/src/cli/index.ts
+++ b/packages/browser-tools/src/cli/index.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCli } from "./run-cli.js";
+
+void runCli(process.argv.slice(2));

--- a/packages/browser-tools/src/cli/parse-args.ts
+++ b/packages/browser-tools/src/cli/parse-args.ts
@@ -1,0 +1,135 @@
+export type McpCliOptions = {
+	headless: boolean;
+	allowedDomains: string[];
+	blockedDomains: string[];
+};
+
+export type ParsedCli =
+	| { kind: "help" }
+	| { kind: "error"; message: string; recovery: string }
+	| { kind: "mcp"; options: McpCliOptions };
+
+const HELP = `Start a stdio MCP server that exposes Libretto browser tools.
+
+Usage:
+  libretto-browser-tools [mcp] [options]
+
+Options:
+  --headed                 Show the browser window (default: headless)
+  --allowed-domain <host>  Allow http(s) navigation to this host (repeatable)
+  --blocked-domain <host>  Block http(s) navigation to this host (repeatable)
+  -h, --help               Show this help
+
+Examples:
+  npx -y libretto-browser-tools
+  npx -y libretto-browser-tools mcp --headed
+  npx -y libretto-browser-tools --allowed-domain example.com
+
+Configure an MCP client with command "npx" and args ["-y", "libretto-browser-tools"].
+Install Chromium once with: npx playwright install chromium
+`;
+
+export function getHelpText(): string {
+	return HELP;
+}
+
+/**
+ * Parse CLI argv (without the node executable or script path).
+ */
+export function parseCliArgs(argv: readonly string[]): ParsedCli {
+	const tokens = [...argv];
+	if (tokens[0] === "mcp") {
+		tokens.shift();
+	}
+
+	let headless = true;
+	const allowedDomains: string[] = [];
+	const blockedDomains: string[] = [];
+
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i];
+		if (token === undefined) break;
+
+		if (token === "-h" || token === "--help" || token === "help") {
+			return { kind: "help" };
+		}
+
+		if (token === "--headed") {
+			headless = false;
+			continue;
+		}
+
+		if (token === "--headless") {
+			headless = true;
+			continue;
+		}
+
+		if (token === "--allowed-domain") {
+			const value = tokens[++i];
+			if (value === undefined || value.startsWith("-")) {
+				return {
+					kind: "error",
+					message: "Missing value for --allowed-domain.",
+					recovery:
+						"Pass a hostname after the flag, for example `--allowed-domain example.com`.",
+				};
+			}
+			allowedDomains.push(value);
+			continue;
+		}
+
+		if (token.startsWith("--allowed-domain=")) {
+			const value = token.slice("--allowed-domain=".length);
+			if (value.length === 0) {
+				return {
+					kind: "error",
+					message: "Missing value for --allowed-domain.",
+					recovery:
+						"Pass a hostname after the flag, for example `--allowed-domain=example.com`.",
+				};
+			}
+			allowedDomains.push(value);
+			continue;
+		}
+
+		if (token === "--blocked-domain") {
+			const value = tokens[++i];
+			if (value === undefined || value.startsWith("-")) {
+				return {
+					kind: "error",
+					message: "Missing value for --blocked-domain.",
+					recovery:
+						"Pass a hostname after the flag, for example `--blocked-domain ads.example.com`.",
+				};
+			}
+			blockedDomains.push(value);
+			continue;
+		}
+
+		if (token.startsWith("--blocked-domain=")) {
+			const value = token.slice("--blocked-domain=".length);
+			if (value.length === 0) {
+				return {
+					kind: "error",
+					message: "Missing value for --blocked-domain.",
+					recovery:
+						"Pass a hostname after the flag, for example `--blocked-domain=ads.example.com`.",
+				};
+			}
+			blockedDomains.push(value);
+			continue;
+		}
+
+		return {
+			kind: "error",
+			message: `Unknown argument: ${token}`,
+			recovery:
+				"Remove the unknown argument, or run `libretto-browser-tools --help` for usage.",
+		};
+	}
+
+	return {
+		kind: "mcp",
+		options: { headless, allowedDomains, blockedDomains },
+	};
+}

--- a/packages/browser-tools/src/cli/run-cli.ts
+++ b/packages/browser-tools/src/cli/run-cli.ts
@@ -1,0 +1,25 @@
+import { getHelpText, parseCliArgs } from "./parse-args.js";
+import { startMcpStdioServer } from "./run-mcp.js";
+
+/**
+ * CLI entry used by the package bin. Writes help and errors to stderr so they
+ * do not corrupt the MCP stdio protocol on stdout.
+ */
+export async function runCli(argv: readonly string[]): Promise<void> {
+	const parsed = parseCliArgs(argv);
+
+	if (parsed.kind === "help") {
+		process.stderr.write(`${getHelpText()}\n`);
+		return;
+	}
+
+	if (parsed.kind === "error") {
+		process.stderr.write(
+			`${parsed.message}\n${parsed.recovery}\n\n${getHelpText()}\n`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	await startMcpStdioServer(parsed.options);
+}

--- a/packages/browser-tools/src/cli/run-mcp.ts
+++ b/packages/browser-tools/src/cli/run-mcp.ts
@@ -1,0 +1,68 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerMcpBrowserTools } from "../adapters/mcp/index.js";
+import { LocalBrowserProvider } from "../providers/local.js";
+import type { McpCliOptions } from "./parse-args.js";
+
+const require = createRequire(fileURLToPath(import.meta.url));
+
+function readPackageVersion(): string {
+	try {
+		const pkg = require("../../package.json") as { version?: string };
+		return pkg.version ?? "0.0.0";
+	} catch {
+		return "0.0.0";
+	}
+}
+
+/**
+ * Start the stdio MCP server and keep the process alive until the transport
+ * closes or the process receives SIGINT/SIGTERM.
+ */
+export async function startMcpStdioServer(
+	options: McpCliOptions,
+): Promise<void> {
+	const server = new McpServer({
+		name: "libretto-browser-tools",
+		version: readPackageVersion(),
+	});
+	const toolkit = registerMcpBrowserTools(
+		server,
+		new LocalBrowserProvider({ headless: options.headless }),
+		{
+			allowedDomains:
+				options.allowedDomains.length > 0
+					? options.allowedDomains
+					: undefined,
+			blockedDomains:
+				options.blockedDomains.length > 0
+					? options.blockedDomains
+					: undefined,
+		},
+	);
+
+	let shuttingDown = false;
+	async function shutdown(): Promise<void> {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		await server.close().catch(() => undefined);
+		await toolkit.dispose();
+	}
+
+	process.once("SIGINT", () => {
+		void shutdown().finally(() => process.exit(0));
+	});
+	process.once("SIGTERM", () => {
+		void shutdown().finally(() => process.exit(0));
+	});
+
+	const transport = new StdioServerTransport();
+	transport.onclose = () => {
+		void shutdown().finally(() => {
+			if (!process.exitCode) process.exit(0);
+		});
+	};
+	await server.connect(transport);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
 
   packages/browser-tools:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -265,9 +268,6 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.80.6
         version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
       '@playwright/cli':
         specifier: ^0.1.17
         version: 0.1.17

--- a/specs/browser-tools-mcp-binary-spec.md
+++ b/specs/browser-tools-mcp-binary-spec.md
@@ -38,7 +38,7 @@ Add a CLI entry that creates `McpServer`, registers tools via existing `register
 - [x] Flags: `--headed`, `--allowed-domain` (repeatable), `--blocked-domain` (repeatable), `--help`
 - [x] Accept optional `mcp` subcommand; bare invocation also starts the server (Playwright MCP-style).
 - [x] Default headless.
-- [x] Update `docs/browser-tools/adapters/mcp.mdx` with npx / Hermes / OpenClaw config snippets.
+- [x] Update `docs/browser-tools/adapters/mcp.mdx` with the npx install snippet; add host pages for Hermes and OpenClaw.
 - [x] Tests: parse-args user-visible errors; spawn CLI over stdio and list tools / open+exec.
 
 Success criteria:

--- a/specs/browser-tools-mcp-binary-spec.md
+++ b/specs/browser-tools-mcp-binary-spec.md
@@ -1,0 +1,48 @@
+# Browser Tools MCP binary
+
+## Problem overview
+
+Hosts such as Hermes and OpenClaw can load Browser Tools over MCP, but `libretto-browser-tools` only exports `registerMcpBrowserTools` for callers who own the server. Users cannot `npx` a ready MCP process.
+
+## Solution overview
+
+Ship a package `bin` that starts a stdio MCP server with the six browser tools and a local Chromium provider.
+
+## Goals
+
+- User runs `npx -y libretto-browser-tools` (or `… mcp`) and an MCP client can list and call the six tools.
+- User can pass `--headed` / domain-policy flags without writing a custom server script.
+- Docs show the npx install snippet for MCP clients.
+
+## Non-goals
+
+- OpenClaw native plugin (later phase).
+- Hermes-specific packaging.
+- Cloud browser providers in the CLI.
+- HTTP / SSE MCP transport.
+
+## Implementation plan
+
+### Phase 1: MCP stdio binary
+
+Add a CLI entry that creates `McpServer`, registers tools via existing `registerMcpBrowserTools`, connects `StdioServerTransport`, and disposes on shutdown.
+
+```typescript
+// packages/browser-tools/src/cli/index.ts
+#!/usr/bin/env node
+// parse argv → LocalBrowserProvider + domain options → registerMcpBrowserTools → stdio
+```
+
+- [x] `package.json` `bin`: `libretto-browser-tools` → `./dist/cli/index.js`
+- [x] Move `@modelcontextprotocol/sdk` from optional peer to a runtime dependency so `npx` works.
+- [x] Flags: `--headed`, `--allowed-domain` (repeatable), `--blocked-domain` (repeatable), `--help`
+- [x] Accept optional `mcp` subcommand; bare invocation also starts the server (Playwright MCP-style).
+- [x] Default headless.
+- [x] Update `docs/browser-tools/adapters/mcp.mdx` with npx / Hermes / OpenClaw config snippets.
+- [x] Tests: parse-args user-visible errors; spawn CLI over stdio and list tools / open+exec.
+
+Success criteria:
+
+- [x] `pnpm --filter libretto-browser-tools test` passes.
+- [x] `pnpm --filter libretto-browser-tools type-check` passes.
+- [x] Spawning the CLI with an MCP stdio client lists the six tool names.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of Browser Tools for Hermes/OpenClaw: a packaged MCP stdio binary, plus separate host docs pages.

Users can point any MCP client at:

```json
{
  "mcpServers": {
    "libretto-browser-tools": {
      "command": "npx",
      "args": ["-y", "libretto-browser-tools"]
    }
  }
}
```

### Changes

- `bin`: `libretto-browser-tools` → starts stdio MCP with the six tools + local Chromium
- Flags: `--headed`, `--allowed-domain`, `--blocked-domain`, `--help`
- Optional `mcp` subcommand; bare invocation also starts the server
- `@modelcontextprotocol/sdk` moved to a runtime dependency so `npx` works
- Docs:
  - [MCP](docs/browser-tools/adapters/mcp.mdx) — binary + library API
  - [Hermes](docs/browser-tools/adapters/hermes.mdx) — Hermes install
  - [OpenClaw](docs/browser-tools/adapters/openclaw.mdx) — OpenClaw install
- Spec: `specs/browser-tools-mcp-binary-spec.md`

### Next phase

OpenClaw native plugin (ClawHub install).

### Test plan

- [x] `pnpm --filter libretto-browser-tools type-check`
- [x] `pnpm --filter libretto-browser-tools test`
- [x] CLI stdio MCP client lists tools and runs `browser_open` / `browser_exec`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

