### PR TITLE
Reject empty browser page identifiers

### DIFF
--- a/packages/browser-tools/src/session-registry.ts
+++ b/packages/browser-tools/src/session-registry.ts
@@ -309,7 +309,7 @@ export class SessionRegistry {
 
 	getCurrentPage(sessionId: string, pageId?: string): Page {
 		const entry = this.requireSession(sessionId);
-		if (pageId) {
+		if (pageId !== undefined) {
 			const page = entry.pageById.get(pageId);
 			if (!page || page.isClosed()) {
 				throw new Error(

--- a/packages/browser-tools/src/tools/exec.ts
+++ b/packages/browser-tools/src/tools/exec.ts
@@ -23,6 +23,8 @@ const execInputSchema = z.object({
 		),
 	pageId: z
 		.string()
+		.trim()
+		.min(1)
 		.optional()
 		.describe(
 			'Optional page ID from browser_status. Defaults to the most recently opened tab.',

--- a/packages/browser-tools/src/tools/snapshot.ts
+++ b/packages/browser-tools/src/tools/snapshot.ts
@@ -16,6 +16,8 @@ const snapshotInputSchema = z.object({
 		.describe("When true, also return a PNG screenshot as base64 bytes."),
 	pageId: z
 		.string()
+		.trim()
+		.min(1)
 		.optional()
 		.describe(
 			'Optional page ID from browser_status. Defaults to the most recently opened tab.',

--- a/packages/browser-tools/src/tools/status.ts
+++ b/packages/browser-tools/src/tools/status.ts
@@ -11,6 +11,8 @@ const statusInputSchema = z.object({
 		.describe('Session ID from browser_open or browser_connect, e.g. "ses-4f2a".'),
 	pageId: z
 		.string()
+		.trim()
+		.min(1)
 		.optional()
 		.describe('Page ID from browser_status, e.g. "page-a1b2".'),
 });

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -704,6 +704,26 @@ test("browser_exec returns ok false for a stale page ID", async ({
 	expect(result.error).toMatch(/browser_status/);
 });
 
+test("browser_exec does not treat an empty page ID as the current page", async ({
+	openTool,
+	execTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>current-page</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await execTool.execute({
+		sessionId: opened.sessionId,
+		pageId: "",
+		code: "return page.title()",
+	});
+	expect(result.ok).toBe(false);
+	if (result.ok) return;
+	expect(result.error).toMatch(/Unknown page ID/);
+	expect(result.error).toMatch(/browser_status/);
+});
+
 test("browser_snapshot returns ok false for a stale page ID", async ({
 	openTool,
 	snapshotTool,


### PR DESCRIPTION
## Summary
- Reject empty or whitespace-only page IDs in browser tool schemas.
- Stop treating an explicitly empty page ID as the current page.
- Add regression coverage for empty page targeting.

## Test plan
- pnpm --filter libretto-browser-tools test -- src/tools/tools.spec.ts
- pnpm --filter libretto-browser-tools type-check