### PR TITLE
Add MiniMax provider to model resolver and debugging agent

### DIFF
--- a/docs/reference/runtime/playwright-debugger.mdx
+++ b/docs/reference/runtime/playwright-debugger.mdx
@@ -34,7 +34,11 @@ const playwrightDebugger = createPlaywrightDebugger({
 
 The `agent.model` value uses Libretto's `provider/model-id` convention. For
 example, `openai/gpt-5.4` resolves to provider `openai` and model id `gpt-5.4`.
-The first version supports `openai/...` and `anthropic/...`.
+Supported providers are `openai/...`, `anthropic/...`, and `minimax/...`.
+
+MiniMax is OpenAI-compatible by default. Set `MINIMAX_API_STYLE=anthropic` to
+use the Anthropic-compatible endpoint, and `MINIMAX_REGION=cn` to target the
+China host (`api.minimaxi.com`) instead of the global host (`api.minimax.io`).
 
 Initialize this debugger once at module scope. At the existing failure point,
 await `debugFailure()` with the error and the live `Page` before Playwright
@@ -103,6 +107,8 @@ Set the provider API key in the environment where the Playwright script runs:
 export OPENAI_API_KEY=...
 # or
 export ANTHROPIC_API_KEY=...
+# or
+export MINIMAX_API_KEY=...
 ```
 
 You can also pass `agent.apiKey` directly when the key is provided by your

--- a/packages/libretto/src/cli/core/resolve-model.ts
+++ b/packages/libretto/src/cli/core/resolve-model.ts
@@ -1,6 +1,12 @@
 import type { LanguageModel } from "ai";
 
-export type Provider = "google" | "vertex" | "anthropic" | "openai" | "openrouter";
+export type Provider =
+  | "google"
+  | "vertex"
+  | "anthropic"
+  | "openai"
+  | "openrouter"
+  | "minimax";
 
 const GEMINI_API_KEY_ENV_VARS = [
   "GEMINI_API_KEY",
@@ -12,6 +18,26 @@ const VERTEX_PROJECT_ENV_VARS = [
   "GCLOUD_PROJECT",
 ] as const;
 
+// MiniMax exposes OpenAI-compatible and Anthropic-compatible endpoints. The
+// global endpoint (api.minimax.io) and the China endpoint (api.minimaxi.com)
+// share the same path layout: the OpenAI-compatible base is `${host}/v1` and
+// the Anthropic-compatible base is `${host}/anthropic`.
+const MINIMAX_GLOBAL_HOST = "https://api.minimax.io";
+const MINIMAX_CHINA_HOST = "https://api.minimaxi.com";
+
+function isMinimaxChinaRegion(): boolean {
+  const region = process.env.MINIMAX_REGION?.trim().toLowerCase();
+  return region === "cn" || region === "cn_zh" || region === "china";
+}
+
+function resolveMinimaxOpenAiBaseUrl(): string {
+  return `${isMinimaxChinaRegion() ? MINIMAX_CHINA_HOST : MINIMAX_GLOBAL_HOST}/v1`;
+}
+
+function resolveMinimaxAnthropicBaseUrl(): string {
+  return `${isMinimaxChinaRegion() ? MINIMAX_CHINA_HOST : MINIMAX_GLOBAL_HOST}/anthropic`;
+}
+
 const SUPPORTED_PROVIDER_ALIASES = {
   google: "google",
   gemini: "google",
@@ -20,6 +46,7 @@ const SUPPORTED_PROVIDER_ALIASES = {
   codex: "openai",
   openai: "openai",
   openrouter: "openrouter",
+  minimax: "minimax",
 } as const satisfies Record<string, Provider>;
 
 function readFirstEnvValue(
@@ -52,7 +79,7 @@ export function parseModel(model: string): {
 
   if (!provider) {
     throw new Error(
-      `Unsupported provider "${providerInput}". Supported providers: openai/codex, anthropic, google (Gemini API), vertex, and openrouter.`,
+      `Unsupported provider "${providerInput}". Supported providers: openai/codex, anthropic, google (Gemini API), vertex, openrouter, and minimax.`,
     );
   }
 
@@ -74,6 +101,8 @@ export function hasProviderCredentials(
       return Boolean(env.OPENAI_API_KEY?.trim());
     case "openrouter":
       return Boolean(env.OPENROUTER_API_KEY?.trim());
+    case "minimax":
+      return Boolean(env.MINIMAX_API_KEY?.trim());
   }
 }
 
@@ -91,6 +120,9 @@ export function missingProviderCredentialsMessage(provider: Provider): string {
     }
     case "openrouter": {
       return "OpenRouter API key is missing. Set OPENROUTER_API_KEY.";
+    }
+    case "minimax": {
+      return "MiniMax API key is missing. Set MINIMAX_API_KEY.";
     }
   }
 }
@@ -155,6 +187,33 @@ async function getProviderModel(
         baseURL: "https://openrouter.ai/api/v1",
       });
       return openrouter(modelId);
+    }
+    case "minimax": {
+      const apiKey = process.env.MINIMAX_API_KEY?.trim();
+      if (!apiKey) {
+        throw new Error(missingProviderCredentialsMessage(provider));
+      }
+      // MiniMax models are reachable through either the OpenAI-compatible
+      // endpoint (default) or the Anthropic-compatible endpoint. Set
+      // MINIMAX_API_STYLE=anthropic to use the Anthropic-compatible base.
+      const useAnthropicStyle =
+        process.env.MINIMAX_API_STYLE?.trim().toLowerCase() === "anthropic";
+      if (useAnthropicStyle) {
+        // oxlint-disable-next-line libretto/no-await-import -- Human-approved: we don't want to import unless the user is using that subagent.
+        const { createAnthropic } = await import("@ai-sdk/anthropic");
+        const anthropic = createAnthropic({
+          apiKey,
+          baseURL: resolveMinimaxAnthropicBaseUrl(),
+        });
+        return anthropic(modelId);
+      }
+      // oxlint-disable-next-line libretto/no-await-import -- Human-approved: we don't want to import unless the user is using that subagent.
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      const minimax = createOpenAI({
+        apiKey,
+        baseURL: resolveMinimaxOpenAiBaseUrl(),
+      });
+      return minimax(modelId);
     }
   }
 }

--- a/packages/playwright-debugger/src/index.ts
+++ b/packages/playwright-debugger/src/index.ts
@@ -14,7 +14,12 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createAiSdkBrowserToolsForPage } from "libretto-browser-tools/ai-sdk";
 import type { Page } from "playwright";
 
-export type SupportedAgentProvider = "anthropic" | "openai";
+export type SupportedAgentProvider = "anthropic" | "openai" | "minimax";
+
+function isMinimaxChinaRegion(): boolean {
+  const region = process.env.MINIMAX_REGION?.trim().toLowerCase();
+  return region === "cn" || region === "cn_zh" || region === "china";
+}
 
 export type GitHubDebuggerConfig = {
   owner: string;
@@ -290,9 +295,13 @@ export function parseAgentModel(model: string): {
   if (!modelId) {
     throw new Error(`Invalid agent model "${model}". Model id cannot be empty.`);
   }
-  if (provider !== "openai" && provider !== "anthropic") {
+  if (
+    provider !== "openai" &&
+    provider !== "anthropic" &&
+    provider !== "minimax"
+  ) {
     throw new Error(
-      `Unsupported agent model provider "${provider}". Supported providers: openai, anthropic.`,
+      `Unsupported agent model provider "${provider}". Supported providers: openai, anthropic, minimax.`,
     );
   }
   return { provider, modelId };
@@ -617,6 +626,31 @@ async function resolveLanguageModel(
       throw new Error("OpenAI API key is missing. Set OPENAI_API_KEY or agent.apiKey.");
     }
     return createOpenAI({ apiKey })(model.modelId);
+  }
+
+  if (model.provider === "minimax") {
+    const minimaxApiKey =
+      apiKeyOverride ?? process.env.MINIMAX_API_KEY?.trim();
+    if (!minimaxApiKey) {
+      throw new Error(
+        "MiniMax API key is missing. Set MINIMAX_API_KEY or agent.apiKey.",
+      );
+    }
+    const host = isMinimaxChinaRegion()
+      ? "https://api.minimaxi.com"
+      : "https://api.minimax.io";
+    const useAnthropicStyle =
+      process.env.MINIMAX_API_STYLE?.trim().toLowerCase() === "anthropic";
+    if (useAnthropicStyle) {
+      return createAnthropic({
+        apiKey: minimaxApiKey,
+        baseURL: `${host}/anthropic`,
+      })(model.modelId);
+    }
+    return createOpenAI({
+      apiKey: minimaxApiKey,
+      baseURL: `${host}/v1`,
+    })(model.modelId);
   }
 
   const apiKey = apiKeyOverride ?? process.env.ANTHROPIC_API_KEY?.trim();

--- a/packages/playwright-debugger/test/debugger.spec.ts
+++ b/packages/playwright-debugger/test/debugger.spec.ts
@@ -42,6 +42,10 @@ describe("parseAgentModel", () => {
       provider: "anthropic",
       modelId: "claude-sonnet-4-6",
     });
+    expect(parseAgentModel("minimax/MiniMax-M3")).toEqual({
+      provider: "minimax",
+      modelId: "MiniMax-M3",
+    });
   });
 
   it("rejects unsupported provider strings", () => {


### PR DESCRIPTION
Reason: provider-add — Libretto's executable model resolver and browser-debugging agent omitted MiniMax.

## What changed

Add the MiniMax provider to both model-resolution entry points, using MiniMax's OpenAI-compatible and Anthropic-compatible endpoints with global and China hosts. MiniMax model ids (for example MiniMax-M3) are passed straight through as `provider/model-id` — no model names are hardcoded.

- `packages/libretto/src/cli/core/resolve-model.ts`
  - `Provider` type gains `"minimax"`; `SUPPORTED_PROVIDER_ALIASES` accepts `minimax`.
  - `parseModel` lists MiniMax in the supported-providers error message.
  - `hasProviderCredentials` checks `MINIMAX_API_KEY`; `missingProviderCredentialsMessage` returns a MiniMax-specific message.
  - `getProviderModel` resolves MiniMax through `@ai-sdk/openai` against `${host}/v1` by default, or `@ai-sdk/anthropic` against `${host}/anthropic` when `MINIMAX_API_STYLE=anthropic`. The host is the global `api.minimax.io` unless `MINIMAX_REGION` is set to a China value (`cn` / `cn_zh` / `china`), in which case it uses `api.minimaxi.com`.

- `packages/playwright-debugger/src/index.ts`
  - `SupportedAgentProvider` gains `"minimax"`; `parseAgentModel` accepts it and lists it in the supported-providers error.
  - `resolveLanguageModel` resolves a MiniMax model through `createOpenAI` (`${host}/v1`) by default, or `createAnthropic` (`${host}/anthropic`) when `MINIMAX_API_STYLE=anthropic`, with the same global/China host selection and the same `agent.apiKey` override convention as the existing OpenAI/Anthropic branches.

- `packages/playwright-debugger/test/debugger.spec.ts`
  - `parseAgentModel` now parses `minimax/MiniMax-M3` to `{ provider: "minimax", modelId: "MiniMax-M3" }`.

- `docs/reference/runtime/playwright-debugger.mdx`
  - Lists MiniMax as a supported provider, documents `MINIMAX_API_STYLE` and `MINIMAX_REGION`, and adds `MINIMAX_API_KEY` to the model-keys example.

## Checks

- `packages/playwright-debugger`: `tsc --noEmit` (type-check) passed; `vitest run test/debugger.spec.ts` passed (9 tests).
- `packages/libretto`: `tsc --noEmit` (type-check) passed; `vitest run test/ai-config.spec.ts test/credentials.spec.ts` passed (9 tests).
- `oxlint --type-aware` on the changed source files passed.
