### PR TITLE
Add browser_search tool to browser-tools SDK

### DIFF
--- a/docs/browser-tools/adapters/ai-sdk.mdx
+++ b/docs/browser-tools/adapters/ai-sdk.mdx
@@ -15,7 +15,7 @@ npx playwright install chromium
 
 ## createAiSdkBrowserTools
 
-Wraps the six browser tools as AI SDK tools for `generateText` / `streamText` / `ToolLoopAgent`.
+Wraps the seven browser tools as AI SDK tools for `generateText` / `streamText` / `ToolLoopAgent`.
 
 ```typescript theme={null}
 import { anthropic } from "@ai-sdk/anthropic";
@@ -57,7 +57,7 @@ Attach tools to an existing Playwright `Page` without owning browser lifecycle:
 import { createAiSdkBrowserToolsForPage } from "libretto-browser-tools/ai-sdk";
 
 const { sessionId, tools, dispose } = createAiSdkBrowserToolsForPage(page);
-// tools: browser_exec, browser_snapshot, browser_status
+// tools: browser_exec, browser_snapshot, browser_search, browser_status
 await dispose(); // detaches tools; does not close the page
 ```
 

--- a/docs/browser-tools/adapters/custom.mdx
+++ b/docs/browser-tools/adapters/custom.mdx
@@ -15,7 +15,7 @@ import { LocalBrowserProvider } from "libretto-browser-tools";
 const { tools, dispose } = createBrowserTools(new LocalBrowserProvider());
 
 // Each entry is a BrowserTool: { name, description, inputSchema, execute }
-const { browser_open, browser_exec, browser_snapshot, browser_status, browser_close, browser_connect } =
+const { browser_open, browser_exec, browser_snapshot, browser_search, browser_status, browser_close, browser_connect } =
   tools;
 
 // Map into your framework, for example:
@@ -33,4 +33,4 @@ const { browser_open, browser_exec, browser_snapshot, browser_status, browser_cl
 
 Always expose `dispose()` from the host so leftover sessions close when the agent loop ends. For snapshot screenshots, the base tool returns `{ base64, mimeType: "image/png" }` — convert that into your framework's multimodal content type if needed (see the [AI SDK](/browser-tools/adapters/ai-sdk), [Pi](/browser-tools/adapters/pi), and [MCP](/browser-tools/adapters/mcp) adapters).
 
-Borrowed-page toolkits use `createBrowserToolsForPage(page)` and only include `browser_exec`, `browser_snapshot`, and `browser_status`.
+Borrowed-page toolkits use `createBrowserToolsForPage(page)` and only include `browser_exec`, `browser_snapshot`, `browser_search`, and `browser_status`.

--- a/docs/browser-tools/adapters/mcp.mdx
+++ b/docs/browser-tools/adapters/mcp.mdx
@@ -15,7 +15,7 @@ npx playwright install chromium
 
 ## registerMcpBrowserTools
 
-Registers all six browser tools on a caller-owned `McpServer`. Your host owns the transport, authentication, and server lifecycle.
+Registers all seven browser tools on a caller-owned `McpServer`. Your host owns the transport, authentication, and server lifecycle.
 
 ```typescript theme={null}
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/docs/browser-tools/adapters/pi.mdx
+++ b/docs/browser-tools/adapters/pi.mdx
@@ -15,7 +15,7 @@ npx playwright install chromium
 
 ## createPiBrowserTools
 
-Wraps the six browser tools as Pi `ToolDefinition`s. Pass them to `createAgentSession` as `customTools`.
+Wraps the seven browser tools as Pi `ToolDefinition`s. Pass them to `createAgentSession` as `customTools`.
 
 ```typescript theme={null}
 import {

--- a/docs/browser-tools/advanced.mdx
+++ b/docs/browser-tools/advanced.mdx
@@ -35,7 +35,7 @@ import { createBrowserToolsForPage } from "libretto-browser-tools";
 // or: createAiSdkBrowserToolsForPage from "libretto-browser-tools/ai-sdk"
 
 const { sessionId, tools, dispose } = createBrowserToolsForPage(page);
-// tools: browser_exec, browser_snapshot, browser_status only
+// tools: browser_exec, browser_snapshot, browser_search, browser_status only
 await dispose(); // detaches tools; does not close page / context / browser
 ```
 

--- a/docs/browser-tools/quickstart.mdx
+++ b/docs/browser-tools/quickstart.mdx
@@ -43,7 +43,7 @@ const { tools, dispose } = createAiSdkBrowserTools(
 );
 ```
 
-The agent can call `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`.
+The agent can call `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_search`, `browser_status`, and `browser_close`.
 
   </Step>
 

--- a/docs/browser-tools/tools.mdx
+++ b/docs/browser-tools/tools.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Tools
 "og:image": "https://libretto.sh/docs/og/browser-tools/tools.png"
 ---
 
-> Reference for the six browser tools agents call.
+> Reference for the seven browser tools agents call.
 
 Every tool returns the same envelope: `{ ok: true, ...payload }` on success, or `{ ok: false, error }` for model-fixable failures (unknown session ID, thrown Playwright code). Errors include a next step when possible. Host misconfiguration (missing API keys) and [domain policy](/browser-tools/advanced#domain-policy) violations throw instead of returning `{ ok: false }`.
 
@@ -95,6 +95,24 @@ Capture the current page as a compact text accessibility tree. Nodes include `re
 </ParamField>
 
 Success: `{ ok: true, tree, screenshot? }`.
+
+## browser_search
+
+Search the current page's condensed HTML snapshot with a JavaScript regex. Returns matching regions with surrounding context. Use this when you need markup the accessibility tree may omit — for example `data-*` attributes, hidden fields, or raw tag structure.
+
+<ParamField path="sessionId" type="string" required>
+  Session ID from `browser_open` or `browser_connect`.
+</ParamField>
+
+<ParamField path="pattern" type="string" required>
+  JavaScript regex pattern (RegExp source string) to search for in the formatted HTML.
+</ParamField>
+
+<ParamField path="pageId" type="string">
+  Optional page ID from `browser_status`. Defaults to the most recently opened tab.
+</ParamField>
+
+Success: `{ ok: true, matches, matchCount }`. Each match includes `startLine`, `endLine`, and `lines` (the matching region plus context). An empty `matches` array means nothing matched.
 
 ## browser_status
 

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -41,7 +41,7 @@ import { LocalBrowserProvider } from "libretto-browser-tools";
 
 const { tools, dispose } = createAiSdkBrowserTools(new LocalBrowserProvider());
 // The agent can now call browser_open, browser_connect, browser_exec,
-// browser_snapshot, browser_status, and browser_close.
+// browser_snapshot, browser_search, browser_status, and browser_close.
 
 const result = await generateText({
   model: anthropic("claude-sonnet-4-5"),

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -46,7 +46,11 @@ July 30, 2026. Run `2026-07-30T22-05-43-142Z-167296`. Agents could call the new 
 
 Failures were anti-bot: Walmart and Yelp. Agents called `browser_search` 22 times across 16 of 26 cases. Tool mix: `browser_open` 26, `browser_exec` 112, `browser_snapshot` 48, `browser_search` 22, `browser_close` 26.
 
+Excluding the three chronic anti-bot cases (Reddit, Walmart, Yelp): **23/23 passed**, **1.57M tokens**, **$2.80**, avg duration 61.8s, 210 tool calls. Those three alone cost 179k tokens / $0.38.
+
 Compared with the July 29 Kernel opt-in-diff run (23/26), this run passed one more case (Reddit succeeded) and finished faster on average (64.0s vs 88.6s). Token and cost totals were higher ($3.17 vs $2.78). Provider and live anti-bot state vary between runs, so the comparison is not causal for `browser_search`.
+
+Reddit, Walmart, and Yelp are now commented out in `cases.ts` so future suite runs skip them.
 
 ## Prior `browser-tools` run (Kernel, opt-in diffs)
 

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -48,6 +48,20 @@ Failures were anti-bot: Walmart and Yelp. Agents called `browser_search` 22 time
 
 Excluding the three chronic anti-bot cases (Reddit, Walmart, Yelp): **23/23 passed**, **1.57M tokens**, **$2.80**, avg duration 61.8s, 210 tool calls. Those three alone cost 179k tokens / $0.38.
 
+### Same 23 cases without `browser_search`
+
+July 30, 2026. Run `2026-07-30T22-31-15-567Z-0565d8`. Same Kernel provider and case list, with `BENCHMARK_EXCLUDE_TOOLS=browser_search`.
+
+| Metric | With search | Without search | Delta |
+|---|---:|---:|---:|
+| Passed | 23/23 | 22/23 | −1 (Zillow anti-bot) |
+| Agent tokens | 1.57M | 1.34M | −14% |
+| Agent cost | $2.80 | $2.37 | −15% |
+| Avg duration | 61.8s | 65.7s | +3.9s |
+| Tool calls | 210 | 206 | −4 |
+
+Without search, agents used more `browser_exec` (114 vs 103) and slightly more `browser_snapshot` (45 vs 41). With search they made 20 `browser_search` calls. The no-search failure was Zillow’s Press & Hold challenge; the with-search run passed Zillow.
+
 Compared with the July 29 Kernel opt-in-diff run (23/26), this run passed one more case (Reddit succeeded) and finished faster on average (64.0s vs 88.6s). Token and cost totals were higher ($3.17 vs $2.78). Provider and live anti-bot state vary between runs, so the comparison is not causal for `browser_search`.
 
 Reddit, Walmart, and Yelp are now commented out in `cases.ts` so future suite runs skip them.

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # Browser harness benchmark results
 
-Results from three full Browser Use Cloud runs completed July 17–20, 2026, plus a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in.
+Results from three full Browser Use Cloud runs completed July 17–20, 2026, a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in, and a July 30, 2026 Kernel re-run after adding `browser_search`.
 
 ## Methodology
 
@@ -9,6 +9,7 @@ Results from three full Browser Use Cloud runs completed July 17–20, 2026, plu
 - GPT-5.6 Sol ran through the Pi agent with concurrency 5.
 - July 17–20 runs used Browser Use Cloud with a US proxy. Every full run scheduled 104 attempts: 26 tasks per harness.
 - The July 29 re-run used Kernel and only the `browser-tools` harness (26 attempts), with opt-in `diffSnapshot` on `browser_exec`.
+- The July 30 re-run used Kernel and only the `browser-tools` harness after adding `browser_search`.
 - A separate judge scored raw Pi events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
 - Cost, token, duration, and tool-call metrics below cover the task agent, not the judge.
 
@@ -29,7 +30,25 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
-## Latest `browser-tools` run (Kernel, opt-in diffs)
+## Latest `browser-tools` run (Kernel, with `browser_search`)
+
+July 30, 2026. Run `2026-07-30T22-05-43-142Z-167296`. Agents could call the new `browser_search` HTML regex tool alongside the existing tools.
+
+| Metric | Value |
+|---|---:|
+| Passed | 24/26 |
+| Completed | 26/26 |
+| Avg duration | 64.0s |
+| Agent tokens | 1.75M |
+| Agent cost | $3.17 |
+| Tool calls | 234 |
+| Wall time | 7m 7s |
+
+Failures were anti-bot: Walmart and Yelp. Agents called `browser_search` 22 times across 16 of 26 cases. Tool mix: `browser_open` 26, `browser_exec` 112, `browser_snapshot` 48, `browser_search` 22, `browser_close` 26.
+
+Compared with the July 29 Kernel opt-in-diff run (23/26), this run passed one more case (Reddit succeeded) and finished faster on average (64.0s vs 88.6s). Token and cost totals were higher ($3.17 vs $2.78). Provider and live anti-bot state vary between runs, so the comparison is not causal for `browser_search`.
+
+## Prior `browser-tools` run (Kernel, opt-in diffs)
 
 July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: true`.
 

--- a/packages/browser-tools/benchmarks/cases.ts
+++ b/packages/browser-tools/benchmarks/cases.ts
@@ -24,18 +24,20 @@ export const WEBSITE_CASES: WebsiteCase[] = [
 		name: "youtube playwright tutorial search",
 		task: 'Search YouTube for "Playwright tutorial". Tell me the title of the first video result.',
 	},
-	{
-		name: "reddit browser automation thread",
-		task: 'Search Reddit for "browser automation". Open one relevant thread and summarize the top comment.',
-	},
+	// Chronically blocked by anti-bot in Kernel/Browser Use runs — skip for now.
+	// {
+	// 	name: "reddit browser automation thread",
+	// 	task: 'Search Reddit for "browser automation". Open one relevant thread and summarize the top comment.',
+	// },
 	{
 		name: "amazon wireless mouse search",
 		task: 'Search Amazon for "wireless mouse". Tell me the name and price of the first organic result.',
 	},
-	{
-		name: "walmart paper towels search",
-		task: 'Search Walmart for "paper towels". Tell me the first product name, price, and whether pickup is available.',
-	},
+	// Chronically blocked by anti-bot in Kernel/Browser Use runs — skip for now.
+	// {
+	// 	name: "walmart paper towels search",
+	// 	task: 'Search Walmart for "paper towels". Tell me the first product name, price, and whether pickup is available.',
+	// },
 	{
 		name: "target coffee maker search",
 		task: 'Search Target for "coffee maker". Tell me the first product name, price, and rating.',
@@ -72,10 +74,11 @@ export const WEBSITE_CASES: WebsiteCase[] = [
 		name: "realtor.com denver homes search",
 		task: "Search Realtor.com for homes in Denver. Tell me the first listing price and number of bedrooms.",
 	},
-	{
-		name: "yelp brooklyn coffee shops search",
-		task: "Search Yelp for coffee shops in Brooklyn. Tell me the first business name, rating, and review count.",
-	},
+	// Chronically blocked by anti-bot in Kernel/Browser Use runs — skip for now.
+	// {
+	// 	name: "yelp brooklyn coffee shops search",
+	// 	task: "Search Yelp for coffee shops in Brooklyn. Tell me the first business name, rating, and review count.",
+	// },
 	{
 		name: "linkedin public job search",
 		task: 'Search LinkedIn for "browser automation engineer". Tell me if public results are visible without signing in.',

--- a/packages/browser-tools/benchmarks/harness/browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/browser-tools.ts
@@ -12,12 +12,22 @@ export async function runBrowserToolsHarness(
 	provider: BrowserProviderName,
 ): Promise<SessionRun> {
 	const toolkit = createPiBrowserTools(createBenchmarkBrowserProvider(provider));
+	const exclude = new Set(
+		(process.env.BENCHMARK_EXCLUDE_TOOLS ?? "")
+			.split(",")
+			.map((name) => name.trim())
+			.filter(Boolean),
+	);
+	const customTools =
+		exclude.size === 0
+			? toolkit.tools
+			: toolkit.tools.filter((tool) => !exclude.has(tool.name));
 	let run: SessionRun;
 	try {
 		run = await runBrowserTask({
 			task,
 			workspace,
-			customTools: toolkit.tools,
+			customTools,
 			appendSystemPrompt: [
 				"Use the provided browser tools to complete the task. Before giving your final answer, close every browser session you opened with browser_close.",
 			],

--- a/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.spec.ts
@@ -88,7 +88,7 @@ const borrowedPageTest = base.extend<{
 	},
 });
 
-test("createAiSdkBrowserTools exposes all six browser tools", ({
+test("createAiSdkBrowserTools exposes all seven browser tools", ({
 	toolkit,
 }) => {
 	expect(Object.keys(toolkit.tools).sort()).toEqual([
@@ -96,6 +96,7 @@ test("createAiSdkBrowserTools exposes all six browser tools", ({
 		"browser_connect",
 		"browser_exec",
 		"browser_open",
+		"browser_search",
 		"browser_snapshot",
 		"browser_status",
 	]);
@@ -113,6 +114,7 @@ borrowedPageTest(
 		const toolkit = createAiSdkBrowserToolsForPage(page);
 		expect(Object.keys(toolkit.tools).sort()).toEqual([
 			"browser_exec",
+			"browser_search",
 			"browser_snapshot",
 			"browser_status",
 		]);

--- a/packages/browser-tools/src/adapters/ai-sdk/index.ts
+++ b/packages/browser-tools/src/adapters/ai-sdk/index.ts
@@ -26,6 +26,7 @@ export function createAiSdkBrowserTools(
 		browser_open,
 		browser_exec,
 		browser_snapshot,
+		browser_search,
 		browser_status,
 		browser_close,
 		browser_connect,
@@ -47,6 +48,11 @@ export function createAiSdkBrowserTools(
 				inputSchema: browser_snapshot.inputSchema,
 				execute: (input) => browser_snapshot.execute(input),
 				toModelOutput: snapshotToModelOutput,
+			}),
+			browser_search: tool({
+				description: browser_search.description,
+				inputSchema: browser_search.inputSchema,
+				execute: (input) => browser_search.execute(input),
 			}),
 			browser_status: tool({
 				description: browser_status.description,
@@ -74,7 +80,8 @@ export function createAiSdkBrowserToolsForPage(page: Page): {
 	dispose(): Promise<BrowserCleanupError | null>;
 } {
 	const base = createBrowserToolsForPage(page);
-	const { browser_exec, browser_snapshot, browser_status } = base.tools;
+	const { browser_exec, browser_snapshot, browser_search, browser_status } =
+		base.tools;
 	return {
 		sessionId: base.sessionId,
 		tools: {
@@ -88,6 +95,11 @@ export function createAiSdkBrowserToolsForPage(page: Page): {
 				inputSchema: browser_snapshot.inputSchema,
 				execute: (input) => browser_snapshot.execute(input),
 				toModelOutput: snapshotToModelOutput,
+			}),
+			browser_search: tool({
+				description: browser_search.description,
+				inputSchema: browser_search.inputSchema,
+				execute: (input) => browser_search.execute(input),
 			}),
 			browser_status: tool({
 				description: browser_status.description,

--- a/packages/browser-tools/src/adapters/mcp/index.spec.ts
+++ b/packages/browser-tools/src/adapters/mcp/index.spec.ts
@@ -42,7 +42,7 @@ const test = base.extend<{ mcp: McpFixture }>({
 	},
 });
 
-test("MCP clients discover all six browser tools with safety annotations", async ({
+test("MCP clients discover all seven browser tools with safety annotations", async ({
 	mcp,
 }) => {
 	const listed = await mcp.client.listTools();
@@ -52,11 +52,20 @@ test("MCP clients discover all six browser tools with safety annotations", async
 		"browser_connect",
 		"browser_exec",
 		"browser_open",
+		"browser_search",
 		"browser_snapshot",
 		"browser_status",
 	]);
 	expect(
 		listed.tools.find((tool) => tool.name === "browser_snapshot")?.annotations,
+	).toMatchObject({
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	});
+	expect(
+		listed.tools.find((tool) => tool.name === "browser_search")?.annotations,
 	).toMatchObject({
 		readOnlyHint: true,
 		destructiveHint: false,

--- a/packages/browser-tools/src/adapters/mcp/index.ts
+++ b/packages/browser-tools/src/adapters/mcp/index.ts
@@ -82,6 +82,7 @@ export function registerMcpBrowserTools(
 		browser_open,
 		browser_exec,
 		browser_snapshot,
+		browser_search,
 		browser_status,
 		browser_close,
 		browser_connect,
@@ -130,6 +131,21 @@ export function registerMcpBrowserTools(
 			},
 		},
 		async (input) => snapshotResult(await browser_snapshot.execute(input)),
+	);
+
+	server.registerTool(
+		browser_search.name,
+		{
+			description: browser_search.description,
+			inputSchema: browser_search.inputSchema,
+			annotations: {
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+		},
+		async (input) => textResult(await browser_search.execute(input)),
 	);
 
 	server.registerTool(

--- a/packages/browser-tools/src/adapters/pi/index.spec.ts
+++ b/packages/browser-tools/src/adapters/pi/index.spec.ts
@@ -39,12 +39,13 @@ const test = base.extend<{ toolkit: PiBrowserToolkit }>({
 	},
 });
 
-test("createPiBrowserTools exposes all six browser tools", ({ toolkit }) => {
+test("createPiBrowserTools exposes all seven browser tools", ({ toolkit }) => {
 	expect(toolkit.tools.map((tool) => tool.name).sort()).toEqual([
 		"browser_close",
 		"browser_connect",
 		"browser_exec",
 		"browser_open",
+		"browser_search",
 		"browser_snapshot",
 		"browser_status",
 	]);

--- a/packages/browser-tools/src/adapters/pi/index.ts
+++ b/packages/browser-tools/src/adapters/pi/index.ts
@@ -88,6 +88,7 @@ export function createPiBrowserTools(
 			toPiTool(base.tools.browser_open),
 			toPiTool(base.tools.browser_exec),
 			toPiTool(base.tools.browser_snapshot, snapshotContent),
+			toPiTool(base.tools.browser_search),
 			toPiTool(base.tools.browser_status),
 			toPiTool(base.tools.browser_close),
 			toPiTool(base.tools.browser_connect),

--- a/packages/browser-tools/src/create-browser-tools.ts
+++ b/packages/browser-tools/src/create-browser-tools.ts
@@ -13,6 +13,8 @@ import type { ExecTool } from "./tools/exec.js";
 import { createExecTool } from "./tools/exec.js";
 import type { OpenTool } from "./tools/open.js";
 import { createOpenTool } from "./tools/open.js";
+import type { SearchTool } from "./tools/search.js";
+import { createSearchTool } from "./tools/search.js";
 import type { SnapshotTool } from "./tools/snapshot.js";
 import { createSnapshotTool } from "./tools/snapshot.js";
 import type { StatusTool } from "./tools/status.js";
@@ -23,6 +25,7 @@ export type BrowserToolkit = {
 		browser_open: OpenTool;
 		browser_exec: ExecTool;
 		browser_snapshot: SnapshotTool;
+		browser_search: SearchTool;
 		browser_status: StatusTool;
 		browser_close: CloseTool;
 		browser_connect: ConnectTool;
@@ -38,6 +41,7 @@ export type BorrowedPageBrowserToolkit = {
 	tools: {
 		browser_exec: ExecTool;
 		browser_snapshot: SnapshotTool;
+		browser_search: SearchTool;
 		browser_status: StatusTool;
 	};
 	/** Detaches tools without closing the caller-owned page, context, or browser. */
@@ -58,6 +62,7 @@ export function createBrowserTools(
 			browser_open: createOpenTool(registry),
 			browser_exec: createExecTool(registry),
 			browser_snapshot: createSnapshotTool(registry),
+			browser_search: createSearchTool(registry),
 			browser_status: createStatusTool(registry),
 			browser_close: createCloseTool(registry),
 			browser_connect: createConnectTool(registry),
@@ -74,6 +79,7 @@ export function createBrowserToolsForPage(page: Page): BorrowedPageBrowserToolki
 		tools: {
 			browser_exec: createExecTool(registry),
 			browser_snapshot: createSnapshotTool(registry),
+			browser_search: createSearchTool(registry),
 			browser_status: createStatusTool(registry),
 		},
 		dispose: () => registry.dispose(),

--- a/packages/browser-tools/src/html-search/condense-dom.ts
+++ b/packages/browser-tools/src/html-search/condense-dom.ts
@@ -1,0 +1,535 @@
+/**
+ * DOM condensation — reduces serialized HTML for LLM consumption.
+ *
+ * All rules run unconditionally (no tiers). The function operates on
+ * already-serialized HTML strings (the output of `page.content()`),
+ * not a browser-side DOM walk or parsed DOM tree.
+ *
+ * Rules applied in order:
+ *   1.  Noscript blocks — remove entirely
+ *   2.  HTML comments — remove entirely
+ *   3.  Script contents — hollow out, keep tags + useful attributes
+ *   4.  Style contents — hollow out, keep tags + useful attributes
+ *   5.  Embedded binary data — replace base64 data URIs
+ *   6.  Attribute allowlist — keep trusted attrs, special-case class/style/URLs
+ *   7.  SVG elements — collapse to single tag, extract title/desc
+ *   8.  Inline style properties — keep only layout-relevant props
+ *   9.  Non-semantic class names — filter or delete class values
+ *  10.  (Cross-reference IDs — preserved, no action needed)
+ *  11.  Framework-internal and SVG visual attributes — remove
+ *  12.  Whitespace — collapse (preserve <pre> content)
+ */
+
+import {
+  filterSemanticClasses,
+  INTERACTIVE_ROLE_NAMES,
+  INTERACTIVE_TAG_NAMES,
+  TEST_ATTRIBUTE_NAMES,
+  TRUSTED_ATTRIBUTE_NAMES,
+} from "./dom-semantics.js";
+
+export type CondenseDomResult = {
+  /** The condensed HTML string. Valid, parseable HTML. */
+  html: string;
+  /** Character count of the input. */
+  originalLength: number;
+  /** Character count of the output. */
+  condensedLength: number;
+  /** Characters removed, keyed by rule name. */
+  reductions: Record<string, number>;
+};
+
+type ParsedAttribute = {
+  name: string;
+  rawToken: string;
+  value: string | null;
+};
+
+const TEST_ATTRS: Set<string> = new Set(TEST_ATTRIBUTE_NAMES);
+const TRUSTED_ATTRS: Set<string> = new Set(TRUSTED_ATTRIBUTE_NAMES);
+const STATE_ATTRS = new Set([
+  "disabled",
+  "hidden",
+  "inert",
+  "readonly",
+  "required",
+  "checked",
+  "selected",
+  "open",
+  "multiple",
+]);
+const BOOLEAN_ATTRS = new Set([...STATE_ATTRS, "async", "defer", "nomodule"]);
+const EMPTY_VALUE_DROP_ATTRS = new Set([
+  "alt",
+  "autocomplete",
+  "href",
+  "action",
+  "method",
+  "name",
+  "placeholder",
+  "src",
+  "tabindex",
+  "title",
+  "type",
+]);
+const URL_ATTRS = new Set(["href", "src", "action"]);
+const SCRIPT_ATTRS = new Set([
+  "src",
+  "type",
+  "id",
+  "defer",
+  "async",
+  "crossorigin",
+  "integrity",
+  "nomodule",
+  "referrerpolicy",
+]);
+const STYLE_TAG_ATTRS = new Set(["media", "type", "nonce", "title"]);
+const INTERACTIVE_TAGS: Set<string> = new Set(INTERACTIVE_TAG_NAMES);
+const INTERACTIVE_ROLES: Set<string> = new Set(INTERACTIVE_ROLE_NAMES);
+const OPEN_TAG_PATTERN =
+  /<([a-zA-Z][\w:-]*)(\s(?:[^"'<>/]|"[^"]*"|'[^']*')*)?\s*(\/?)>/g;
+
+export function condenseDom(html: string): CondenseDomResult {
+  const originalLength = html.length;
+  const reductions: Record<string, number> = {};
+
+  function track(label: string, before: string, after: string): string {
+    const diff = before.length - after.length;
+    if (diff > 0) {
+      reductions[label] = (reductions[label] ?? 0) + diff;
+    }
+    return after;
+  }
+
+  let result = html;
+
+  // ── Rule 1: Noscript blocks ──────────────────────────────────────────
+  result = track(
+    "noscript",
+    result,
+    result.replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ""),
+  );
+
+  // ── Rule 2: HTML comments ────────────────────────────────────────────
+  result = track(
+    "comments",
+    result,
+    result.replace(/<!--[\s\S]*?(?:-->|$)/g, ""),
+  );
+
+  // ── Rule 3: Script contents ──────────────────────────────────────────
+  result = track(
+    "scripts",
+    result,
+    result.replace(
+      /(<script\b[^>]*>)([\s\S]*?)(<\/script(?:\s[^>]*)?>)/gi,
+      (_match, open: string, content: string, close: string) => {
+        if (!content.trim()) return `${open}${close}`;
+        const isDataScript =
+          /type\s*=\s*["']application\/(json|ld\+json)["']/i.test(open);
+        if (isDataScript) {
+          return `${open}[JSON data, ${content.length} chars]${close}`;
+        }
+        return `${open}[script, ${content.length} chars]${close}`;
+      },
+    ),
+  );
+
+  // ── Rule 4: Style contents ───────────────────────────────────────────
+  result = track(
+    "styles",
+    result,
+    result.replace(
+      /(<style\b[^>]*>)([\s\S]*?)(<\/style(?:\s[^>]*)?>)/gi,
+      (_match, open: string, content: string, close: string) => {
+        if (!content.trim()) return `${open}${close}`;
+        return `${open}[CSS, ${content.length} chars]${close}`;
+      },
+    ),
+  );
+
+  // ── Rule 5: Embedded binary data ─────────────────────────────────────
+  result = track(
+    "base64",
+    result,
+    result.replace(
+      /(src|href)\s*=\s*["'](data:[^;]+;base64,)[A-Za-z0-9+/=]{100,}["']/gi,
+      (_match, attr: string, prefix: string) => {
+        const mime = prefix.replace("data:", "").replace(";base64,", "");
+        return `${attr}="[base64 ${mime}]"`;
+      },
+    ),
+  );
+
+  // ── Rule 6: Attribute allowlist ──────────────────────────────────────
+  result = track("attribute-allowlist", result, rewriteTagAttributes(result));
+
+  // ── Rule 7: SVG elements ─────────────────────────────────────────────
+  // Collapse each <svg> to a single tag, preserving key attributes.
+  // Extract <title>/<desc> text as aria-label if none exists.
+  // Iterate from innermost to outermost to handle nested SVGs correctly.
+  const svgPattern = /<svg\b([^>]*)>((?:(?!<svg\b)[\s\S])*?)<\/svg>/gi;
+  result = track(
+    "svg-collapse",
+    result,
+    (() => {
+      let prev: string;
+      let current = result;
+      do {
+        prev = current;
+        current = current.replace(
+          svgPattern,
+          (_match, attrs: string, inner: string) => {
+            const keepAttrs: string[] = [];
+            const attrPatterns = [
+              "id",
+              "class",
+              "role",
+              "aria-label",
+              "aria-hidden",
+              "title",
+              "data-testid",
+            ];
+            for (const name of attrPatterns) {
+              const attrToken = findAttributeToken(attrs, name);
+              if (attrToken) keepAttrs.push(attrToken);
+            }
+
+            const hasAriaLabel = /aria-label\s*=/i.test(attrs);
+            if (!hasAriaLabel) {
+              const titleMatch = inner.match(/<title[^>]*>([^<]+)<\/title>/i);
+              const descMatch = inner.match(/<desc[^>]*>([^<]+)<\/desc>/i);
+              const labelText =
+                titleMatch?.[1]?.trim() || descMatch?.[1]?.trim();
+              if (labelText) {
+                keepAttrs.push(
+                  `aria-label="${escapeHtmlAttribute(labelText)}"`,
+                );
+              }
+            }
+
+            const attrStr =
+              keepAttrs.length > 0 ? ` ${keepAttrs.join(" ")}` : "";
+            return `<svg${attrStr}><!-- [icon] --></svg>`;
+          },
+        );
+        svgPattern.lastIndex = 0;
+      } while (current !== prev);
+      return current;
+    })(),
+  );
+
+  // ── Rule 8: Inline style properties ──────────────────────────────────
+  // Keep only layout-relevant properties.
+  const layoutProps =
+    /(?:^|;)\s*(?:display|visibility|opacity|pointer-events|position|z-index|overflow)(?:-[a-z]+)?\s*:[^;"]*/gi;
+
+  result = track(
+    "inline-styles",
+    result,
+    result.replace(
+      /\sstyle\s*=\s*["']([^"']*)["']/gi,
+      (_match, value: string) => {
+        const kept: string[] = [];
+        let propMatch: RegExpExecArray | null;
+        layoutProps.lastIndex = 0;
+        while ((propMatch = layoutProps.exec(value)) !== null) {
+          kept.push(propMatch[0].replace(/^[;\s]+/, "").trim());
+        }
+        if (kept.length === 0) return "";
+        return ` style="${kept.join("; ")}"`;
+      },
+    ),
+  );
+
+  // ── Rule 9: Non-semantic class names ─────────────────────────────────
+  result = track(
+    "obfuscated-classes",
+    result,
+    result.replace(
+      /\sclass\s*=\s*["']([^"']*)["']/gi,
+      (_match, value: string) => {
+        const filtered = filterSemanticClasses(value);
+        if (!filtered) return "";
+        return ` class="${filtered}"`;
+      },
+    ),
+  );
+
+  // ── Rule 10: Cross-reference IDs — no action, preserved by default ──
+
+  // ── Rule 11: Framework-internal and SVG visual attributes ────────────
+  const removableAttrs =
+    /\s(?:xmlns(?::[a-z]+)?|xml:space|xml:lang|fill|stroke|stroke-width|stroke-linecap|stroke-linejoin|stroke-miterlimit|stroke-dasharray|stroke-dashoffset|stroke-opacity|fill-opacity|clip-rule|fill-rule|focusable)\s*=\s*["'][^"']*["']/gi;
+  result = track(
+    "framework-svg-attrs",
+    result,
+    result.replace(removableAttrs, ""),
+  );
+
+  // ── Rule 12: Whitespace ──────────────────────────────────────────────
+  // Collapse runs of spaces/tabs to a single space, multiple blank lines
+  // to a single newline. Preserve <pre> content.
+  const preBlocks: string[] = [];
+  result = result.replace(
+    /(<pre\b[^>]*>)([\s\S]*?)(<\/pre>)/gi,
+    (_match, open: string, content: string, close: string) => {
+      const idx = preBlocks.length;
+      preBlocks.push(`${open}${content}${close}`);
+      return `__PRE_PLACEHOLDER_${idx}__`;
+    },
+  );
+
+  result = track(
+    "whitespace",
+    result,
+    result.replace(/[ \t]+/g, " ").replace(/\n\s*\n/g, "\n"),
+  );
+
+  for (let i = 0; i < preBlocks.length; i++) {
+    const placeholder = `__PRE_PLACEHOLDER_${i}__`;
+    const preBlock = preBlocks[i]!;
+    result = result.replace(placeholder, () => preBlock);
+  }
+
+  return {
+    html: result,
+    originalLength,
+    condensedLength: result.length,
+    reductions,
+  };
+}
+
+function rewriteTagAttributes(html: string): string {
+  return html.replace(
+    OPEN_TAG_PATTERN,
+    (
+      match,
+      rawTagName: string,
+      rawAttrs: string | undefined,
+      selfClosing: string,
+    ) => {
+      const tagName = rawTagName.toLowerCase();
+      if (!rawAttrs?.trim()) return match;
+
+      const attrs = parseAttributes(rawAttrs);
+      if (attrs.length === 0) return match;
+
+      const interactive = isInteractiveElement(tagName, attrs);
+      const kept = attrs
+        .map((attr) => keepAttribute(tagName, attr, interactive))
+        .filter((value): value is string => value !== null);
+
+      const attrStr = kept.length > 0 ? ` ${kept.join(" ")}` : "";
+      const closing = selfClosing ? " /" : "";
+      return `<${rawTagName}${attrStr}${closing}>`;
+    },
+  );
+}
+
+function keepAttribute(
+  tagName: string,
+  attr: ParsedAttribute,
+  interactive: boolean,
+): string | null {
+  const name = attr.name.toLowerCase();
+  const value = attr.value;
+
+  if (name === "class") {
+    if (!value?.trim()) return null;
+    const filtered = filterSemanticClasses(value);
+    if (!filtered) return null;
+    return serializeAttribute(attr.name, filtered);
+  }
+
+  if (name === "style") {
+    if (!value?.trim()) return null;
+    return serializeAttribute(attr.name, value);
+  }
+
+  if (name.startsWith("aria-")) {
+    if (!value?.trim()) return null;
+    return attr.rawToken;
+  }
+
+  if (TEST_ATTRS.has(name)) {
+    if (!value?.trim()) return null;
+    return attr.rawToken;
+  }
+
+  if (tagName === "script" && SCRIPT_ATTRS.has(name)) {
+    return serializePreservedAttribute(attr);
+  }
+
+  if (tagName === "style" && STYLE_TAG_ATTRS.has(name)) {
+    if (!value?.trim()) return null;
+    return attr.rawToken;
+  }
+
+  if (STATE_ATTRS.has(name)) {
+    return serializePreservedAttribute(attr);
+  }
+
+  if (URL_ATTRS.has(name)) {
+    if (!value?.trim()) return null;
+    const normalized = normalizeUrlValue(value);
+    if (normalized === value) return attr.rawToken;
+    return serializeAttribute(attr.name, normalized);
+  }
+
+  if (TRUSTED_ATTRS.has(name)) {
+    if (shouldDropEmptyValue(name, value)) return null;
+    return serializePreservedAttribute(attr);
+  }
+
+  if (shouldKeepCustomDataAttribute(tagName, name, value, interactive)) {
+    return attr.rawToken;
+  }
+
+  return null;
+}
+
+function serializePreservedAttribute(attr: ParsedAttribute): string | null {
+  if (BOOLEAN_ATTRS.has(attr.name.toLowerCase())) {
+    return attr.rawToken;
+  }
+  if (attr.value === null) return attr.rawToken;
+  return attr.rawToken;
+}
+
+function shouldDropEmptyValue(name: string, value: string | null): boolean {
+  if (value === null) return false;
+  if (value.trim()) return false;
+  if (name.startsWith("aria-")) return true;
+  return EMPTY_VALUE_DROP_ATTRS.has(name);
+}
+
+function normalizeUrlValue(value: string): string {
+  const loweredValue = value.trim().toLowerCase();
+  if (loweredValue.startsWith("blob:")) return "blob:[omitted]";
+  if (loweredValue.startsWith("javascript:")) return "javascript:[omitted]";
+  if (loweredValue.startsWith("vbscript:")) return "vbscript:[omitted]";
+  if (loweredValue.startsWith("data:")) return "data:[omitted]";
+  if (value.length <= 160) return value;
+
+  try {
+    const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(value);
+    const parsed = isAbsolute
+      ? new URL(value)
+      : new URL(value, "https://condensed.local");
+
+    const prefix = isAbsolute
+      ? `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+      : `${parsed.pathname}${parsed.hash}`;
+    const query = parsed.search ? "?[query omitted]" : "";
+    return `${prefix}${query}`;
+  } catch {
+    return `${value.slice(0, 96)}[omitted]`;
+  }
+}
+
+function parseAttributes(rawAttrs: string): ParsedAttribute[] {
+  const attrs: ParsedAttribute[] = [];
+  const attrPattern =
+    /([^\s"'<>\/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = attrPattern.exec(rawAttrs)) !== null) {
+    const name = match[1];
+    if (!name) continue;
+    attrs.push({
+      name,
+      rawToken: match[0]!.trim(),
+      value: match[2] ?? match[3] ?? match[4] ?? null,
+    });
+  }
+
+  return attrs;
+}
+
+function isInteractiveElement(
+  tagName: string,
+  attrs: ParsedAttribute[],
+): boolean {
+  if (INTERACTIVE_TAGS.has(tagName)) return true;
+
+  for (const attr of attrs) {
+    const name = attr.name.toLowerCase();
+    if (name === "tabindex" || name === "contenteditable") return true;
+    if (name !== "role") continue;
+
+    const role = attr.value?.trim().toLowerCase();
+    if (role && INTERACTIVE_ROLES.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function shouldKeepCustomDataAttribute(
+  tagName: string,
+  attrName: string,
+  value: string | null,
+  interactive: boolean,
+): boolean {
+  if (!interactive) return false;
+  if (!attrName.startsWith("data-")) return false;
+  if (TEST_ATTRS.has(attrName)) return false;
+  if (!value?.trim()) return false;
+  if (value.length > 80) return false;
+  if (tagName === "script" || tagName === "style") return false;
+
+  const key = attrName.slice("data-".length);
+  if (!looksMeaningfulToken(key)) return false;
+  if (!looksMeaningfulDataValue(value)) return false;
+
+  return true;
+}
+
+function looksMeaningfulToken(value: string): boolean {
+  if (!/^[a-z][a-z0-9-]{1,40}$/i.test(value)) return false;
+  if (!/[a-z]{3}/i.test(value)) return false;
+  if (
+    /(track|metric|telemetry|analytics|component|display|loaded|token|dps|color|screen|strict|rehydr|fetch)/i.test(
+      value,
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function looksMeaningfulDataValue(value: string): boolean {
+  if (value.length > 80) return false;
+  if (/[<>]/.test(value)) return false;
+  if (/https?:\/\//i.test(value)) return false;
+  return /^[a-z0-9:_./ -]+$/i.test(value);
+}
+
+function findAttributeToken(attrs: string, name: string): string | null {
+  const match = attrs.match(
+    new RegExp(
+      `(?:^|\\s)(${escapeRegExp(name)}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s"'=<>\\x60]+))?)`,
+      "i",
+    ),
+  );
+  return match?.[1] ?? null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function serializeAttribute(name: string, value: string): string {
+  return `${name}="${escapeHtmlAttribute(value)}"`;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/browser-tools/src/html-search/dom-semantics.ts
+++ b/packages/browser-tools/src/html-search/dom-semantics.ts
@@ -1,0 +1,67 @@
+export const TEST_ATTRIBUTE_NAMES = [
+  "data-testid",
+  "data-test",
+  "data-qa",
+  "data-cy",
+] as const;
+
+export const TRUSTED_ATTRIBUTE_NAMES = [
+  "id",
+  "name",
+  "for",
+  "tabindex",
+  "contenteditable",
+  "role",
+  "title",
+  "alt",
+  "type",
+  "value",
+  "placeholder",
+  "autocomplete",
+  "href",
+  "action",
+  "method",
+  "src",
+] as const;
+
+export const INTERACTIVE_TAG_NAMES = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "form",
+  "details",
+  "dialog",
+  "label",
+] as const;
+
+export const INTERACTIVE_ROLE_NAMES = [
+  "button",
+  "link",
+  "tab",
+  "menuitem",
+  "checkbox",
+  "radio",
+  "switch",
+  "slider",
+  "combobox",
+] as const;
+
+export function filterSemanticClasses(value: string): string {
+  const classes = value.split(/\s+/).filter(Boolean);
+  const kept = classes.filter((cls) => !isObfuscatedClass(cls));
+  return kept.join(" ");
+}
+
+export function isObfuscatedClass(cls: string): boolean {
+  if (cls.length > 80) return true;
+  if (/^_?[0-9a-f]{6,}$/i.test(cls)) return true;
+  if (/^[a-z]+_[0-9a-f]{4,}$/i.test(cls)) return true;
+
+  const digits = (cls.match(/[0-9]/g) || []).length;
+  const letters = (cls.match(/[a-zA-Z]/g) || []).length;
+  if (cls.length >= 6 && digits >= letters * 0.5 && digits >= 2) return true;
+
+  return false;
+}

--- a/packages/browser-tools/src/html-search/search-html.spec.ts
+++ b/packages/browser-tools/src/html-search/search-html.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { formatHtmlForSearch, searchFormattedHtml } from "./search-html.js";
+
+describe("HTML search", () => {
+  test("formats condensed HTML before searching", () => {
+    const formatted = formatHtmlForSearch(
+      '<!doctype html><html><body><main><p data-testid="target">Needle</p></main></body></html>',
+    );
+
+    expect(formatted).toContain('<p data-testid="target">');
+    expect(formatted).toContain("Needle");
+  });
+
+  test("returns merged matching regions with context", () => {
+    const formatted = [
+      "<html>",
+      "<body>",
+      "<main>",
+      "<section>",
+      "<h1>Heading</h1>",
+      '<p class="target">Needle</p>',
+      "<p>More content</p>",
+      "</section>",
+      "</main>",
+      "</body>",
+      "</html>",
+    ].join("\n");
+
+    const matches = searchFormattedHtml(formatted, "Needle", 2);
+
+    expect(matches).toEqual([
+      {
+        startLine: 4,
+        endLine: 8,
+        lines: [
+          "<section>",
+          "<h1>Heading</h1>",
+          '<p class="target">Needle</p>',
+          "<p>More content</p>",
+          "</section>",
+        ],
+      },
+    ]);
+  });
+
+  test("limits matching regions before adding context", () => {
+    const formatted = Array.from(
+      { length: 12 },
+      (_value, index) => `<p>Needle ${index}</p>`,
+    ).join("\n");
+
+    const matches = searchFormattedHtml(formatted, "Needle", 0, 8);
+
+    expect(matches).toEqual([
+      {
+        startLine: 1,
+        endLine: 8,
+        lines: Array.from(
+          { length: 8 },
+          (_value, index) => `<p>Needle ${index}</p>`,
+        ),
+      },
+    ]);
+  });
+});

--- a/packages/browser-tools/src/html-search/search-html.ts
+++ b/packages/browser-tools/src/html-search/search-html.ts
@@ -1,0 +1,75 @@
+import { condenseDom } from "./condense-dom.js";
+
+const DEFAULT_CONTEXT_LINES = 4;
+const DEFAULT_MATCH_LIMIT = 8;
+
+export type SearchHtmlMatch = {
+  startLine: number;
+  endLine: number;
+  lines: string[];
+};
+
+export function formatHtmlForSearch(html: string): string {
+  const condensed = condenseDom(html).html;
+  const separated = condensed
+    .replace(/>\s+</g, ">\n<")
+    .replace(/(<[^/!][^>]*>)([^<\n][\s\S]*?)(<\/[^>]+>)/g, "$1\n$2\n$3");
+
+  const lines = separated
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let indent = 0;
+  return lines
+    .map((line) => {
+      if (/^<\//.test(line)) indent = Math.max(0, indent - 1);
+      const formatted = `${"  ".repeat(indent)}${line}`;
+      if (isOpeningTag(line)) indent += 1;
+      return formatted;
+    })
+    .join("\n");
+}
+
+export function searchFormattedHtml(
+  formattedHtml: string,
+  pattern: string,
+  contextLines = DEFAULT_CONTEXT_LINES,
+  matchLimit = DEFAULT_MATCH_LIMIT,
+): SearchHtmlMatch[] {
+  const regex = new RegExp(pattern);
+  const lines = formattedHtml.split("\n");
+  const matchingIndexes = lines
+    .map((line, index) => (regex.test(line) ? index : -1))
+    .filter((index) => index >= 0)
+    .slice(0, matchLimit);
+
+  const matches: SearchHtmlMatch[] = [];
+  for (const matchingIndex of matchingIndexes) {
+    const startLine = Math.max(0, matchingIndex - contextLines);
+    const endLine = Math.min(lines.length - 1, matchingIndex + contextLines);
+    const previous = matches.at(-1);
+    if (previous && startLine <= previous.endLine) {
+      previous.endLine = Math.max(previous.endLine, endLine + 1);
+      previous.lines = lines.slice(previous.startLine - 1, previous.endLine);
+      continue;
+    }
+    matches.push({
+      startLine: startLine + 1,
+      endLine: endLine + 1,
+      lines: lines.slice(startLine, endLine + 1),
+    });
+  }
+  return matches;
+}
+
+function isOpeningTag(line: string): boolean {
+  return (
+    /^<[^/!?][^>]*>$/.test(line) &&
+    !/\/>$/.test(line) &&
+    !/^<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b/i.test(
+      line,
+    ) &&
+    !/^<[^>]+>.*<\/[^>]+>$/.test(line)
+  );
+}

--- a/packages/browser-tools/src/index.ts
+++ b/packages/browser-tools/src/index.ts
@@ -31,3 +31,9 @@ export type {
 	SnapshotToolOutput,
 	SnapshotScreenshot,
 } from "./tools/snapshot.js";
+export type {
+	SearchTool,
+	SearchToolInput,
+	SearchToolOutput,
+	SearchMatch,
+} from "./tools/search.js";

--- a/packages/browser-tools/src/tools/search.ts
+++ b/packages/browser-tools/src/tools/search.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { errorMessage } from "../errors.js";
+import {
+	formatHtmlForSearch,
+	searchFormattedHtml,
+	type SearchHtmlMatch,
+} from "../html-search/search-html.js";
+import type { SessionRegistry } from "../session-registry.js";
+import type { BrowserTool, ToolResult } from "../tool.js";
+
+const searchInputSchema = z.object({
+	sessionId: z
+		.string()
+		.describe('Session ID returned by browser_open, e.g. "ses-4f2a".'),
+	pattern: z
+		.string()
+		.describe(
+			"JavaScript regex pattern to search for in the formatted HTML snapshot.",
+		),
+	pageId: z
+		.string()
+		.optional()
+		.describe(
+			"Optional page ID from browser_status. Defaults to the most recently opened tab.",
+		),
+});
+
+export type SearchToolInput = z.infer<typeof searchInputSchema>;
+
+export type SearchMatch = SearchHtmlMatch;
+
+export type SearchToolOutput = {
+	matches: SearchMatch[];
+	matchCount: number;
+};
+
+export type SearchTool = {
+	inputSchema: typeof searchInputSchema;
+} & BrowserTool<SearchToolInput, SearchToolOutput>;
+
+function isInvalidRegExpError(err: unknown): boolean {
+	return err instanceof SyntaxError;
+}
+
+export function createSearchTool(registry: SessionRegistry): SearchTool {
+	return {
+		name: "browser_search",
+		description:
+			"Search the current page's condensed HTML snapshot with a JavaScript " +
+			"regex. Returns matching regions with surrounding context. Use this to " +
+			"find attributes, text, or markup that the accessibility tree may omit " +
+			"(for example data-* attrs, hidden fields, or raw tag structure).",
+		inputSchema: searchInputSchema,
+		async execute({
+			sessionId,
+			pattern,
+			pageId,
+		}): Promise<ToolResult<SearchToolOutput>> {
+			let page;
+			try {
+				page = registry.getCurrentPage(sessionId, pageId);
+			} catch (err) {
+				return {
+					ok: false,
+					error:
+						`${errorMessage(err)}. Call browser_open to get a session ID, ` +
+						"then pass it to browser_search.",
+				};
+			}
+
+			try {
+				const html = await page.content();
+				const formattedHtml = formatHtmlForSearch(html);
+				const matches = searchFormattedHtml(formattedHtml, pattern);
+				return {
+					ok: true,
+					matches,
+					matchCount: matches.length,
+				};
+			} catch (err) {
+				if (isInvalidRegExpError(err)) {
+					return {
+						ok: false,
+						error:
+							`Invalid JavaScript regex pattern /${pattern}/ (${errorMessage(err)}). ` +
+							"Pass a valid RegExp source string — for example `data-testid=\"submit\"` " +
+							"or `class=\"[^\"]*btn[^\"]*\"`.",
+					};
+				}
+				return {
+					ok: false,
+					error:
+						`Could not search page HTML (${errorMessage(err)}). ` +
+						"Try browser_status to see open pages, or browser_open if the session ended.",
+				};
+			}
+		},
+	};
+}

--- a/packages/browser-tools/src/tools/tools.spec.ts
+++ b/packages/browser-tools/src/tools/tools.spec.ts
@@ -12,6 +12,7 @@ import { createCloseTool } from "./close.js";
 import { createConnectTool } from "./connect.js";
 import { createExecTool } from "./exec.js";
 import { createOpenTool } from "./open.js";
+import { createSearchTool } from "./search.js";
 import { createSnapshotTool } from "./snapshot.js";
 import { createStatusTool } from "./status.js";
 
@@ -55,6 +56,7 @@ const test = base.extend<{
 	openTool: ReturnType<typeof createOpenTool>;
 	execTool: ReturnType<typeof createExecTool>;
 	snapshotTool: ReturnType<typeof createSnapshotTool>;
+	searchTool: ReturnType<typeof createSearchTool>;
 	statusTool: ReturnType<typeof createStatusTool>;
 	closeTool: ReturnType<typeof createCloseTool>;
 	connectTool: ReturnType<typeof createConnectTool>;
@@ -90,6 +92,9 @@ const test = base.extend<{
 	},
 	snapshotTool: async ({ registry }, use) => {
 		await use(createSnapshotTool(registry));
+	},
+	searchTool: async ({ registry }, use) => {
+		await use(createSearchTool(registry));
 	},
 	externalBrowser: async ({}, use) => {
 		const port = await pickFreePort();
@@ -721,4 +726,76 @@ test("browser_snapshot returns ok false for a stale page ID", async ({
 	if (result.ok) return;
 	expect(result.error).toMatch(/page-nope/);
 	expect(result.error).toMatch(/browser_status/);
+});
+
+test("browser_search returns matching HTML regions with context", async ({
+	openTool,
+	searchTool,
+}) => {
+	const opened = await openTool.execute({
+		url:
+			"data:text/html," +
+			encodeURIComponent(
+				'<!doctype html><html><body><main><p data-testid="target">Needle</p></main></body></html>',
+			),
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await searchTool.execute({
+		sessionId: opened.sessionId,
+		pattern: "Needle",
+	});
+	expect(result.ok).toBe(true);
+	if (!result.ok) return;
+	expect(result.matchCount).toBeGreaterThan(0);
+	expect(result.matches[0]?.lines.join("\n")).toContain("Needle");
+	expect(result.matches[0]?.lines.join("\n")).toContain('data-testid="target"');
+});
+
+test("browser_search returns an empty match list when nothing matches", async ({
+	openTool,
+	searchTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>empty</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await searchTool.execute({
+		sessionId: opened.sessionId,
+		pattern: "this-string-is-not-on-the-page",
+	});
+	expect(result).toEqual({ ok: true, matches: [], matchCount: 0 });
+});
+
+test("browser_search returns ok false for an invalid regex", async ({
+	openTool,
+	searchTool,
+}) => {
+	const opened = await openTool.execute({
+		url: "data:text/html,<title>regex</title>",
+	});
+	if (!opened.ok) throw new Error(opened.error);
+
+	const result = await searchTool.execute({
+		sessionId: opened.sessionId,
+		pattern: "(",
+	});
+	expect(result.ok).toBe(false);
+	if (result.ok) return;
+	expect(result.error).toMatch(/Invalid JavaScript regex/);
+	expect(result.error).toMatch(/valid RegExp/);
+});
+
+test("browser_search returns ok false for an unknown session ID", async ({
+	searchTool,
+}) => {
+	const result = await searchTool.execute({
+		sessionId: "ses-missing",
+		pattern: "Needle",
+	});
+	expect(result.ok).toBe(false);
+	if (result.ok) return;
+	expect(result.error).toMatch(/ses-missing/);
+	expect(result.error).toMatch(/browser_open/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `browser_search`, a read-only tool that greps the current page's condensed HTML with a JavaScript regex — the same pipeline as the Libretto CLI `search` experiment.
- Wires the tool through base / borrowed-page toolkits and AI SDK / Pi / MCP adapters.
- Comments out Reddit, Walmart, and Yelp benchmark cases (chronic anti-bot blockers).
- Adds `BENCHMARK_EXCLUDE_TOOLS` for harness A/B runs.

## Benchmarks (Kernel, July 30) — 23 cases

Same case list (Reddit / Walmart / Yelp excluded), with vs without `browser_search`:

| Metric | With search | Without search | Delta |
|---|---:|---:|---:|
| Passed | 23/23 | 22/23 | −1 (Zillow anti-bot) |
| Agent tokens | 1.57M | 1.34M | −14% |
| Agent cost | $2.80 | $2.37 | −15% |
| Avg duration | 61.8s | 65.7s | +3.9s |
| Tool calls | 210 | 206 | −4 |

Without search: more `browser_exec` (114 vs 103) and snapshots (45 vs 41). With search: 20 `browser_search` calls. Details in `packages/browser-tools/benchmarks/RESULTS.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19184a83-9601-42c2-a85c-f4e01e79ac6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19184a83-9601-42c2-a85c-f4e01e79ac6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

