### PR TITLE
Use authenticated website API routes

### DIFF
--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -329,10 +329,6 @@ function PrAgentSetupEmptyTable() {
   );
 }
 
-function isApiKeyRequiredError(error: string): boolean {
-  return /api key.*required/i.test(error);
-}
-
 function LoadingTable() {
   return (
     <div className="border-t border-rule px-5 py-16 text-center text-sm text-muted">
@@ -593,16 +589,7 @@ function WorkflowsTable() {
           fathomEvent="Empty workflows copy cloud setup prompt click"
         />
       )}
-      {error &&
-        (isApiKeyRequiredError(error) ? (
-          <CloudSetupEmptyTable
-            title="No workflows yet."
-            action="create your first cloud workflow"
-            fathomEvent="Empty workflows copy cloud setup prompt click"
-          />
-        ) : (
-          <EmptyTable message={error} />
-        ))}
+      {error && <EmptyTable message={error} />}
     </TableShell>
   );
 }
@@ -725,16 +712,7 @@ function SchedulesTable() {
           fathomEvent="Empty schedules copy cloud setup prompt click"
         />
       )}
-      {error &&
-        (isApiKeyRequiredError(error) ? (
-          <CloudSetupEmptyTable
-            title="No schedules yet."
-            action="create and schedule a cloud workflow"
-            fathomEvent="Empty schedules copy cloud setup prompt click"
-          />
-        ) : (
-          <EmptyTable message={error} />
-        ))}
+      {error && <EmptyTable message={error} />}
     </TableShell>
   );
 }
@@ -814,16 +792,7 @@ function WorkflowRunsTable() {
           fathomEvent="Empty workflow runs copy cloud setup prompt click"
         />
       )}
-      {error &&
-        (isApiKeyRequiredError(error) ? (
-          <CloudSetupEmptyTable
-            title="No workflow runs yet."
-            action="create and run a cloud workflow"
-            fathomEvent="Empty workflow runs copy cloud setup prompt click"
-          />
-        ) : (
-          <EmptyTable message={error} />
-        ))}
+      {error && <EmptyTable message={error} />}
     </TableShell>
   );
 }
@@ -909,16 +878,7 @@ function BrowserSessionsTable() {
           fathomEvent="Empty browser sessions copy cloud setup prompt click"
         />
       )}
-      {error &&
-        (isApiKeyRequiredError(error) ? (
-          <CloudSetupEmptyTable
-            title="No browser sessions yet."
-            action="start a hosted browser session"
-            fathomEvent="Empty browser sessions copy cloud setup prompt click"
-          />
-        ) : (
-          <EmptyTable message={error} />
-        ))}
+      {error && <EmptyTable message={error} />}
     </TableShell>
   );
 }
@@ -975,12 +935,7 @@ function ConnectedReposTable() {
       </table>
       {rows === null && !error && <LoadingTable />}
       {rows?.length === 0 && <PrAgentSetupEmptyTable />}
-      {error &&
-        (isApiKeyRequiredError(error) ? (
-          <PrAgentSetupEmptyTable />
-        ) : (
-          <EmptyTable message={error} />
-        ))}
+      {error && <EmptyTable message={error} />}
     </TableShell>
   );
 }

--- a/apps/website/src/GitHubSetupPage.tsx
+++ b/apps/website/src/GitHubSetupPage.tsx
@@ -4,24 +4,6 @@ import { Navbar } from "./components/Navbar";
 import { getAuthStatus, getCloudSession, orpcCall } from "./cloudApi";
 import { GitHubIcon } from "./icons";
 
-type GitHubRepository = {
-  id: string;
-  owner: string;
-  name: string;
-  full_name: string;
-  private: boolean;
-};
-
-type InstallationRepositoriesResponse = {
-  installation: {
-    id: string;
-    account_login: string;
-    account_type: string;
-    repository_selection: string;
-  };
-  repositories: GitHubRepository[];
-};
-
 function currentReturnTo(): string {
   const url = new URL(window.location.href);
   return `${url.pathname}${url.search}${url.hash}`;
@@ -78,11 +60,11 @@ export function GitHubSetupPage() {
 
         if (installationId) {
           try {
-            await orpcCall<InstallationRepositoriesResponse>(
-              "/v1/github/syncInstallation",
+            const result = await orpcCall<{ url: string }>(
+              "/v1/github/createInstallationConnectUrl",
               { installation_id: installationId },
             );
-            window.location.assign("/dashboard/connected_repos");
+            window.location.assign(result.url);
           } catch (err) {
             setError(
               err instanceof Error


### PR DESCRIPTION
## Summary
- stop masking API authentication failures as empty dashboard tables
- send GitHub installation setup through the tenant-authorized OAuth flow
- preserve genuine empty-table setup prompts when requests succeed with no rows

## Validation
- `pnpm website:build`