### PR TITLE
Expand Hermes Browser Tools docs

### DIFF
--- a/docs/browser-tools/adapters/hermes.mdx
+++ b/docs/browser-tools/adapters/hermes.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Hermes
 
 > Use Browser Tools with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) over MCP.
 
-Point Hermes at the Browser Tools stdio binary to give the agent Playwright control through six tools (`browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, `browser_close`) instead of Hermes' built-in `browser_*` stack.
+Point Hermes at the Browser Tools stdio binary to replace Hermes' built-in `browser_*` stack with six Playwright tools (`browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, `browser_close`). Compact accessibility snapshots and a smaller tool surface usually use fewer tokens than Hermes' native browser tools.
 
 ## Requirements
 
@@ -71,23 +71,17 @@ See [Tools](/browser-tools/tools) for inputs and outputs, and [MCP](/browser-too
 
 Disable the `browser` toolset so Hermes does not keep its native `browser_navigate` / `browser_click` / … tools alongside Browser Tools.
 
-Hermes puts `web_search` in that same toolset as a quick-lookup fallback. Disabling `browser` therefore removes that `web_search` too. Search and page extract still come from Hermes' separate `web` toolset (`web_search`, `web_extract`) when that toolset stays enabled — the default on `hermes-cli`.
-
-You can also leave the native browser enabled and ask Hermes to use the MCP tools by name. Prefer disabling when you want Browser Tools to be the only browser stack.
+Leave Hermes' separate `web` toolset enabled (the default on `hermes-cli`). It provides `web_search` and `web_extract`, so disabling `browser` does not turn off search.
 
 ## Auth profiles
 
-Local sessions keep signed-in state in auth profiles under `~/.libretto/browser-tools/profiles/` on the Hermes host.
+Local sessions keep signed-in browser state in profiles under `~/.libretto/browser-tools/profiles/` on the Hermes host. The agent can reuse that state across runs so you do not have to sign in every time.
 
-- Omit `authProfile` (or pass a name such as `"work"`) on `browser_open` to reuse that profile.
-- Pass `authProfile: false` for an ephemeral session.
-- Changes persist only after `browser_close` (or graceful MCP shutdown). Do not open two writable sessions against the same profile at once.
-
-To sign in once: run with `--headed`, open a named profile, complete login in the window, then close the session. Later headless runs reuse the cookies.
+To sign in once, run the MCP server with `--headed`, ask the agent to open a browser session for the site, complete login in the window yourself, then ask it to close the session. Later headless runs reuse the cookies. Profile changes save only on a clean close; do not share profile directories across untrusted users.
 
 ## Security
 
-`browser_exec` runs Playwright and JavaScript in the MCP process — not inside a browser sandbox. Treat the Hermes host as the trust boundary: domain allow/block flags limit http(s) requests in the managed browser context, but they do not confine `browser_exec` itself. Profiles hold account cookies; do not share them across untrusted users.
+`browser_exec` runs Playwright and JavaScript in the MCP process — not inside a browser sandbox. Treat the Hermes host as the trust boundary: domain allow/block flags limit http(s) requests in the managed browser context, but they do not confine `browser_exec` itself.
 
 ## Cloud providers
 
@@ -100,8 +94,8 @@ The stock `libretto-browser-tools` binary always uses the local provider. Kernel
 | Server fails to start / Chromium missing | Run `npx playwright install chromium` (add `--with-deps` on Linux). |
 | Headed browser errors with no display | Drop `--headed`, or run Hermes where a display is available. |
 | Native browser tools still win | Confirm `agent.disabled_toolsets` includes `browser`, then reload MCP. |
-| Stale `sessionId` after idle | Hermes may recycle the MCP process; open a new session. |
-| Login state missing after a crash | Profiles save on graceful close only; sign in again. |
+| Browser sessions stop working after idle | Hermes may recycle the MCP process; ask the agent to open a fresh session. |
+| Login state missing after a crash | Profiles save on graceful close only; sign in again with `--headed`. |
 
 ## See also
 

--- a/docs/browser-tools/adapters/hermes.mdx
+++ b/docs/browser-tools/adapters/hermes.mdx
@@ -6,15 +6,30 @@ sidebarTitle: Hermes
 
 > Use Browser Tools with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) over MCP.
 
-Hermes loads MCP servers from `~/.hermes/config.yaml`. Point it at the Browser Tools stdio binary, then disable Hermes' built-in browser toolset so the agent uses Browser Tools instead of `browser_navigate` / `browser_click` / ….
+Point Hermes at the Browser Tools stdio binary to give the agent Playwright control through six tools (`browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, `browser_close`) instead of Hermes' built-in `browser_*` stack.
 
-## Install
+## Requirements
+
+The MCP binary runs a [local Chromium](/browser-tools/providers/local) session on the machine that launches the server (the Hermes host).
+
+- Node.js 18+ with `npx`
+- Playwright Chromium once per machine:
 
 ```bash theme={null}
 npx playwright install chromium
 ```
 
-## Configure
+On Linux hosts missing browser system libraries, use:
+
+```bash theme={null}
+npx playwright install --with-deps chromium
+```
+
+Headless is the default. `--headed` needs a graphical display on that same host — it does not open a window on your laptop when Hermes runs remotely.
+
+## Install and configure
+
+Add the server in `~/.hermes/config.yaml`:
 
 ```yaml theme={null}
 mcp_servers:
@@ -27,9 +42,16 @@ agent:
     - browser
 ```
 
-Reload MCP after editing config (`/reload-mcp` in a Hermes session, or restart Hermes).
+Or:
 
-Pass CLI flags in `args` when you need a headed browser or domain policy:
+```bash theme={null}
+hermes mcp add libretto --command npx --args -y --args libretto-browser-tools
+hermes tools disable browser
+```
+
+Reload MCP after changing config (`/reload-mcp` in a Hermes session, or restart Hermes). Confirm the server with `hermes mcp test libretto`.
+
+Pass flags in `args` for a visible browser or [domain policy](/browser-tools/advanced):
 
 ```yaml theme={null}
 mcp_servers:
@@ -43,14 +65,48 @@ mcp_servers:
       - "example.com"
 ```
 
-## What the agent gets
-
-Six tools: `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`. Hermes prefixes MCP tools with the server name (for example `mcp_libretto_browser_open`).
-
 See [Tools](/browser-tools/tools) for inputs and outputs, and [MCP](/browser-tools/adapters/mcp) for flags and the library API.
+
+## Disable Hermes' built-in browser
+
+Disable the `browser` toolset so Hermes does not keep its native `browser_navigate` / `browser_click` / … tools alongside Browser Tools.
+
+Hermes puts `web_search` in that same toolset as a quick-lookup fallback. Disabling `browser` therefore removes that `web_search` too. Search and page extract still come from Hermes' separate `web` toolset (`web_search`, `web_extract`) when that toolset stays enabled — the default on `hermes-cli`.
+
+You can also leave the native browser enabled and ask Hermes to use the MCP tools by name. Prefer disabling when you want Browser Tools to be the only browser stack.
+
+## Auth profiles
+
+Local sessions keep signed-in state in auth profiles under `~/.libretto/browser-tools/profiles/` on the Hermes host.
+
+- Omit `authProfile` (or pass a name such as `"work"`) on `browser_open` to reuse that profile.
+- Pass `authProfile: false` for an ephemeral session.
+- Changes persist only after `browser_close` (or graceful MCP shutdown). Do not open two writable sessions against the same profile at once.
+
+To sign in once: run with `--headed`, open a named profile, complete login in the window, then close the session. Later headless runs reuse the cookies.
+
+## Security
+
+`browser_exec` runs Playwright and JavaScript in the MCP process — not inside a browser sandbox. Treat the Hermes host as the trust boundary: domain allow/block flags limit http(s) requests in the managed browser context, but they do not confine `browser_exec` itself. Profiles hold account cookies; do not share them across untrusted users.
+
+## Cloud providers
+
+The stock `libretto-browser-tools` binary always uses the local provider. Kernel, Browserbase, Browser Use, Steel, and Libretto Cloud need a custom MCP server that calls [`registerMcpBrowserTools`](/browser-tools/adapters/mcp) with that provider. Setting cloud API keys on the stock binary has no effect.
+
+## Troubleshooting
+
+| Symptom | What to try |
+| --- | --- |
+| Server fails to start / Chromium missing | Run `npx playwright install chromium` (add `--with-deps` on Linux). |
+| Headed browser errors with no display | Drop `--headed`, or run Hermes where a display is available. |
+| Native browser tools still win | Confirm `agent.disabled_toolsets` includes `browser`, then reload MCP. |
+| Stale `sessionId` after idle | Hermes may recycle the MCP process; open a new session. |
+| Login state missing after a crash | Profiles save on graceful close only; sign in again. |
 
 ## See also
 
 - [MCP adapter](/browser-tools/adapters/mcp) — stdio binary and library registration
+- [Local provider](/browser-tools/providers/local) — Chromium install and options
 - [OpenClaw](/browser-tools/adapters/openclaw) — same binary on OpenClaw
 - [Hermes MCP docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)
+- [Hermes toolsets](https://hermes-agent.nousresearch.com/docs/reference/toolsets-reference)

--- a/docs/browser-tools/adapters/mcp.mdx
+++ b/docs/browser-tools/adapters/mcp.mdx
@@ -39,7 +39,7 @@ The server exposes `browser_open`, `browser_connect`, `browser_exec`, `browser_s
 
 Host-specific setup:
 
-- [Hermes Agent](/browser-tools/adapters/hermes)
+- [Hermes Agent](/browser-tools/agents/hermes)
 - [OpenClaw](/browser-tools/adapters/openclaw)
 
 ## Library: registerMcpBrowserTools
@@ -97,6 +97,6 @@ The adapter publishes safety annotations for each tool. `browser_exec` is marked
 ## See also
 
 - [Tools](/browser-tools/tools) — inputs and outputs for each tool
-- [Hermes](/browser-tools/adapters/hermes) — Hermes Agent install
+- [Hermes](/browser-tools/agents/hermes) — Hermes Agent install
 - [OpenClaw](/browser-tools/adapters/openclaw) — OpenClaw install
 - [Custom adapters](/browser-tools/adapters/custom) — wrap `createBrowserTools` for another framework

--- a/docs/browser-tools/adapters/openclaw.mdx
+++ b/docs/browser-tools/adapters/openclaw.mdx
@@ -52,5 +52,5 @@ See [Tools](/browser-tools/tools) for inputs and outputs, and [MCP](/browser-too
 ## See also
 
 - [MCP adapter](/browser-tools/adapters/mcp) — stdio binary and library registration
-- [Hermes](/browser-tools/adapters/hermes) — same binary on Hermes Agent
+- [Hermes](/browser-tools/agents/hermes) — same binary on Hermes Agent
 - [OpenClaw MCP CLI](https://docs.openclaw.ai/cli/mcp)

--- a/docs/browser-tools/agents/hermes.mdx
+++ b/docs/browser-tools/agents/hermes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hermes Agent
 sidebarTitle: Hermes
-"og:image": "https://libretto.sh/docs/og/browser-tools/adapters/hermes.png"
+"og:image": "https://libretto.sh/docs/og/browser-tools/agents/hermes.png"
 ---
 
 > Use Browser Tools with [Hermes Agent](https://hermes-agent.nousresearch.com/docs) over MCP.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -134,9 +134,14 @@
               "browser-tools/adapters/ai-sdk",
               "browser-tools/adapters/pi",
               "browser-tools/adapters/mcp",
-              "browser-tools/adapters/hermes",
               "browser-tools/adapters/openclaw",
               "browser-tools/adapters/custom"
+            ]
+          },
+          {
+            "group": "Agents",
+            "pages": [
+              "browser-tools/agents/hermes"
             ]
           },
           {

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -97,7 +97,7 @@ npx playwright install chromium
 }
 ```
 
-See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for flags and the library API. Host guides: [Hermes](https://libretto.sh/docs/browser-tools/adapters/hermes), [OpenClaw](https://libretto.sh/docs/browser-tools/adapters/openclaw).
+See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for flags and the library API. Host guides: [Hermes](https://libretto.sh/docs/browser-tools/agents/hermes), [OpenClaw](https://libretto.sh/docs/browser-tools/adapters/openclaw).
 
 ## Docs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the Hermes Browser Tools guide and moves it into its own Agents section.

### Changes

- Expand Hermes page: requirements, install, disable native browser (keep `web` search), auth profiles, security, cloud limits, troubleshooting
- Move page to `docs/browser-tools/agents/hermes.mdx`
- Add Browser Tools **Agents** nav group; leave OpenClaw under Adapters for now
- Update MCP / OpenClaw / README links

## Test plan

- [ ] Confirm Agents group appears in Browser Tools sidebar
- [ ] Confirm `/docs/browser-tools/agents/hermes` resolves
- [ ] Confirm old adapter links updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

