### PR TITLE
Add --provider flag to Browser Tools MCP binary

### DIFF
--- a/docs/browser-tools/adapters/mcp.mdx
+++ b/docs/browser-tools/adapters/mcp.mdx
@@ -25,15 +25,18 @@ npx playwright install chromium
 }
 ```
 
-Equivalent forms: `npx -y libretto-browser-tools mcp`, or `npx -y libretto-browser-tools --headed` for a visible browser.
+Equivalent forms: `npx -y libretto-browser-tools mcp`, `npx -y libretto-browser-tools --headed` for a visible local browser, or `npx -y libretto-browser-tools --provider kernel` for a cloud provider.
 
 Flags:
 
 | Flag | Effect |
 | --- | --- |
-| `--headed` | Show the browser window (default is headless) |
+| `--provider <name>` | Browser provider: `local` (default), `kernel`, `browserbase`, `browser-use`, `steel`, `libretto-cloud` |
+| `--headed` | Show the browser window (default is headless). Applies to `local`, `kernel`, and `libretto-cloud` |
 | `--allowed-domain <host>` | Restrict http(s) navigations to this host (repeatable) |
 | `--blocked-domain <host>` | Block http(s) navigations to this host (repeatable) |
+
+Cloud providers read API keys from the MCP server environment (for example `KERNEL_API_KEY`, `BROWSERBASE_API_KEY`, `BROWSER_USE_API_KEY`, `STEEL_API_KEY`, `LIBRETTO_API_KEY`). See each [provider](/browser-tools/providers/overview) page for required variables. Local Chromium (`npx playwright install chromium`) is only required for `--provider local`.
 
 The server exposes `browser_open`, `browser_connect`, `browser_exec`, `browser_snapshot`, `browser_status`, and `browser_close`.
 

--- a/docs/browser-tools/adapters/openclaw.mdx
+++ b/docs/browser-tools/adapters/openclaw.mdx
@@ -17,11 +17,14 @@ openclaw mcp add libretto -- npx -y libretto-browser-tools
 
 Or add the server in the Control UI under MCP settings (`/settings/mcp`).
 
-Pass flags after the package name when you need a headed browser or domain policy:
+Pass flags after the package name when you need a headed browser, a cloud provider, or domain policy:
 
 ```bash theme={null}
 openclaw mcp add libretto -- npx -y libretto-browser-tools --headed
+openclaw mcp add libretto -- npx -y libretto-browser-tools --provider kernel
 ```
+
+Cloud providers read API keys from the Gateway environment (for example `KERNEL_API_KEY`). See [MCP](/browser-tools/adapters/mcp) for provider names and required variables.
 
 ## Disable the bundled browser
 

--- a/docs/browser-tools/agents/hermes.mdx
+++ b/docs/browser-tools/agents/hermes.mdx
@@ -85,13 +85,23 @@ To sign in once, run the MCP server with `--headed`, ask the agent to open a bro
 
 ## Cloud providers
 
-The stock `libretto-browser-tools` binary always uses the local provider. Kernel, Browserbase, Browser Use, Steel, and Libretto Cloud need a custom MCP server that calls [`registerMcpBrowserTools`](/browser-tools/adapters/mcp) with that provider. Setting cloud API keys on the stock binary has no effect.
+Pass `--provider` to use a [cloud browser](/browser-tools/providers/overview) instead of local Chromium:
+
+```yaml theme={null}
+mcp_servers:
+  libretto:
+    command: npx
+    args: ["-y", "libretto-browser-tools", "--provider", "kernel"]
+```
+
+Put the provider API key in Hermes' environment (for example `KERNEL_API_KEY` in `~/.hermes/.env`). Supported names: `local`, `kernel`, `browserbase`, `browser-use`, `steel`, `libretto-cloud`.
 
 ## Troubleshooting
 
 | Symptom | What to try |
 | --- | --- |
-| Server fails to start / Chromium missing | Run `npx playwright install chromium` (add `--with-deps` on Linux). |
+| Server fails to start / Chromium missing | For `--provider local`, run `npx playwright install chromium` (add `--with-deps` on Linux). |
+| Missing cloud API key | Set the provider key in Hermes env (for example `KERNEL_API_KEY`), or use `--provider local`. |
 | Headed browser errors with no display | Drop `--headed`, or run Hermes where a display is available. |
 | Native browser tools still win | Confirm `agent.disabled_toolsets` includes `browser`, then reload MCP. |
 | Browser sessions stop working after idle | Hermes may recycle the MCP process; ask the agent to open a fresh session. |

--- a/packages/browser-tools/README.md
+++ b/packages/browser-tools/README.md
@@ -97,7 +97,7 @@ npx playwright install chromium
 }
 ```
 
-See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for flags and the library API. Host guides: [Hermes](https://libretto.sh/docs/browser-tools/agents/hermes), [OpenClaw](https://libretto.sh/docs/browser-tools/adapters/openclaw).
+See the [MCP adapter docs](https://libretto.sh/docs/browser-tools/adapters/mcp) for flags (including `--provider`) and the library API. Host guides: [Hermes](https://libretto.sh/docs/browser-tools/agents/hermes), [OpenClaw](https://libretto.sh/docs/browser-tools/adapters/openclaw).
 
 ## Docs
 

--- a/packages/browser-tools/src/cli/cli.spec.ts
+++ b/packages/browser-tools/src/cli/cli.spec.ts
@@ -4,6 +4,7 @@ import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
+import { createCliBrowserProvider } from "./create-cli-provider.js";
 import { getHelpText, parseCliArgs } from "./parse-args.js";
 
 const cliEntry = fileURLToPath(new URL("./index.ts", import.meta.url));
@@ -15,6 +16,8 @@ test("help text tells the user how to wire an MCP client", () => {
 	const help = getHelpText();
 	expect(help).toContain("libretto-browser-tools");
 	expect(help).toContain('args ["-y", "libretto-browser-tools"]');
+	expect(help).toContain("--provider");
+	expect(help).toContain("kernel");
 	expect(help).toContain("npx playwright install chromium");
 });
 
@@ -22,14 +25,18 @@ test("parseCliArgs accepts bare invocation and mcp subcommand with domain flags"
 	expect(parseCliArgs([])).toEqual({
 		kind: "mcp",
 		options: {
+			provider: "local",
 			headless: true,
 			allowedDomains: [],
 			blockedDomains: [],
 		},
 	});
-	expect(parseCliArgs(["mcp", "--headed", "--allowed-domain", "example.com"])).toEqual({
+	expect(
+		parseCliArgs(["mcp", "--headed", "--allowed-domain", "example.com"]),
+	).toEqual({
 		kind: "mcp",
 		options: {
+			provider: "local",
 			headless: false,
 			allowedDomains: ["example.com"],
 			blockedDomains: [],
@@ -38,22 +45,70 @@ test("parseCliArgs accepts bare invocation and mcp subcommand with domain flags"
 	expect(parseCliArgs(["--blocked-domain=ads.example.com"])).toEqual({
 		kind: "mcp",
 		options: {
+			provider: "local",
 			headless: true,
 			allowedDomains: [],
 			blockedDomains: ["ads.example.com"],
 		},
 	});
+	expect(parseCliArgs(["--provider", "kernel"])).toEqual({
+		kind: "mcp",
+		options: {
+			provider: "kernel",
+			headless: true,
+			allowedDomains: [],
+			blockedDomains: [],
+		},
+	});
+	expect(parseCliArgs(["--provider=libretto-cloud"])).toEqual({
+		kind: "mcp",
+		options: {
+			provider: "libretto-cloud",
+			headless: true,
+			allowedDomains: [],
+			blockedDomains: [],
+		},
+	});
 });
 
-test("parseCliArgs reports unknown flags with recovery text", () => {
-	const parsed = parseCliArgs(["--wat"]);
-	expect(parsed).toMatchObject({
+test("parseCliArgs reports unknown flags and providers with recovery text", () => {
+	const unknownFlag = parseCliArgs(["--wat"]);
+	expect(unknownFlag).toMatchObject({
 		kind: "error",
 		message: "Unknown argument: --wat",
 	});
-	if (parsed.kind === "error") {
-		expect(parsed.recovery).toContain("--help");
+	if (unknownFlag.kind === "error") {
+		expect(unknownFlag.recovery).toContain("--help");
 	}
+
+	const unknownProvider = parseCliArgs(["--provider", "camofox"]);
+	expect(unknownProvider).toMatchObject({
+		kind: "error",
+		message: "Unknown provider: camofox",
+	});
+	if (unknownProvider.kind === "error") {
+		expect(unknownProvider.recovery).toContain("kernel");
+	}
+});
+
+test("createCliBrowserProvider reports missing cloud credentials", () => {
+	const previous = process.env.KERNEL_API_KEY;
+	delete process.env.KERNEL_API_KEY;
+	const provider = createCliBrowserProvider({
+		provider: "kernel",
+		headless: true,
+	});
+	if (previous === undefined) {
+		delete process.env.KERNEL_API_KEY;
+	} else {
+		process.env.KERNEL_API_KEY = previous;
+	}
+	expect(provider).toBeInstanceOf(Error);
+	if (!(provider instanceof Error)) {
+		throw new Error("expected missing KERNEL_API_KEY to return Error");
+	}
+	expect(provider.message).toContain("KERNEL_API_KEY");
+	expect(provider.message).toContain("--provider local");
 });
 
 test("stdio MCP binary lists tools and runs Playwright against a page", async () => {

--- a/packages/browser-tools/src/cli/create-cli-provider.ts
+++ b/packages/browser-tools/src/cli/create-cli-provider.ts
@@ -1,0 +1,70 @@
+import { errorMessage } from "../errors.js";
+import type { BrowserProvider } from "../provider.js";
+import { BrowserbaseBrowserProvider } from "../providers/browserbase.js";
+import { BrowserUseBrowserProvider } from "../providers/browser-use.js";
+import { KernelBrowserProvider } from "../providers/kernel.js";
+import { LibrettoCloudBrowserProvider } from "../providers/libretto-cloud.js";
+import { LocalBrowserProvider } from "../providers/local.js";
+import { SteelBrowserProvider } from "../providers/steel.js";
+
+export const CLI_PROVIDER_NAMES = [
+	"local",
+	"kernel",
+	"browserbase",
+	"browser-use",
+	"steel",
+	"libretto-cloud",
+] as const;
+
+export type CliProviderName = (typeof CLI_PROVIDER_NAMES)[number];
+
+const HEADLESS_PROVIDERS = new Set<CliProviderName>([
+	"local",
+	"kernel",
+	"libretto-cloud",
+]);
+
+export function isCliProviderName(value: string): value is CliProviderName {
+	return (CLI_PROVIDER_NAMES as readonly string[]).includes(value);
+}
+
+export function providerSupportsHeadless(provider: CliProviderName): boolean {
+	return HEADLESS_PROVIDERS.has(provider);
+}
+
+export function formatCliProviderList(): string {
+	return CLI_PROVIDER_NAMES.join(", ");
+}
+
+/**
+ * Build the BrowserProvider for the MCP CLI. Cloud providers read API keys from
+ * the process environment. Returns Error when credentials are missing or the
+ * provider rejects the options.
+ */
+export function createCliBrowserProvider(options: {
+	provider: CliProviderName;
+	headless: boolean;
+}): BrowserProvider | Error {
+	try {
+		switch (options.provider) {
+			case "local":
+				return new LocalBrowserProvider({ headless: options.headless });
+			case "kernel":
+				return new KernelBrowserProvider({ headless: options.headless });
+			case "libretto-cloud":
+				return new LibrettoCloudBrowserProvider({
+					headless: options.headless,
+				});
+			case "browserbase":
+				return new BrowserbaseBrowserProvider();
+			case "browser-use":
+				return new BrowserUseBrowserProvider();
+			case "steel":
+				return new SteelBrowserProvider();
+		}
+	} catch (error) {
+		return new Error(
+			`${errorMessage(error)} Set the provider API key in the MCP server environment, or pass --provider local.`,
+		);
+	}
+}

--- a/packages/browser-tools/src/cli/parse-args.ts
+++ b/packages/browser-tools/src/cli/parse-args.ts
@@ -1,4 +1,11 @@
+import {
+	formatCliProviderList,
+	isCliProviderName,
+	type CliProviderName,
+} from "./create-cli-provider.js";
+
 export type McpCliOptions = {
+	provider: CliProviderName;
 	headless: boolean;
 	allowedDomains: string[];
 	blockedDomains: string[];
@@ -15,22 +22,39 @@ Usage:
   libretto-browser-tools [mcp] [options]
 
 Options:
+  --provider <name>        Browser provider (default: local)
+                           ${formatCliProviderList()}
   --headed                 Show the browser window (default: headless)
   --allowed-domain <host>  Allow http(s) navigation to this host (repeatable)
   --blocked-domain <host>  Block http(s) navigation to this host (repeatable)
   -h, --help               Show this help
 
+Cloud providers read API keys from the environment (for example KERNEL_API_KEY).
+--headed applies to local, kernel, and libretto-cloud.
+
 Examples:
   npx -y libretto-browser-tools
   npx -y libretto-browser-tools mcp --headed
+  npx -y libretto-browser-tools --provider kernel
   npx -y libretto-browser-tools --allowed-domain example.com
 
 Configure an MCP client with command "npx" and args ["-y", "libretto-browser-tools"].
-Install Chromium once with: npx playwright install chromium
+Install Chromium once for --provider local: npx playwright install chromium
 `;
 
 export function getHelpText(): string {
 	return HELP;
+}
+
+function missingFlagValue(
+	flag: string,
+	example: string,
+): Extract<ParsedCli, { kind: "error" }> {
+	return {
+		kind: "error",
+		message: `Missing value for ${flag}.`,
+		recovery: `Pass a value after the flag, for example \`${example}\`.`,
+	};
 }
 
 /**
@@ -42,6 +66,7 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 		tokens.shift();
 	}
 
+	let provider: CliProviderName = "local";
 	let headless = true;
 	const allowedDomains: string[] = [];
 	const blockedDomains: string[] = [];
@@ -64,15 +89,51 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 			continue;
 		}
 
+		if (token === "--provider") {
+			const value = tokens[++i];
+			if (value === undefined || value.startsWith("-")) {
+				return missingFlagValue(
+					"--provider",
+					`--provider kernel`,
+				);
+			}
+			if (!isCliProviderName(value)) {
+				return {
+					kind: "error",
+					message: `Unknown provider: ${value}`,
+					recovery: `Use one of: ${formatCliProviderList()}.`,
+				};
+			}
+			provider = value;
+			continue;
+		}
+
+		if (token.startsWith("--provider=")) {
+			const value = token.slice("--provider=".length);
+			if (value.length === 0) {
+				return missingFlagValue(
+					"--provider",
+					`--provider=kernel`,
+				);
+			}
+			if (!isCliProviderName(value)) {
+				return {
+					kind: "error",
+					message: `Unknown provider: ${value}`,
+					recovery: `Use one of: ${formatCliProviderList()}.`,
+				};
+			}
+			provider = value;
+			continue;
+		}
+
 		if (token === "--allowed-domain") {
 			const value = tokens[++i];
 			if (value === undefined || value.startsWith("-")) {
-				return {
-					kind: "error",
-					message: "Missing value for --allowed-domain.",
-					recovery:
-						"Pass a hostname after the flag, for example `--allowed-domain example.com`.",
-				};
+				return missingFlagValue(
+					"--allowed-domain",
+					`--allowed-domain example.com`,
+				);
 			}
 			allowedDomains.push(value);
 			continue;
@@ -81,12 +142,10 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 		if (token.startsWith("--allowed-domain=")) {
 			const value = token.slice("--allowed-domain=".length);
 			if (value.length === 0) {
-				return {
-					kind: "error",
-					message: "Missing value for --allowed-domain.",
-					recovery:
-						"Pass a hostname after the flag, for example `--allowed-domain=example.com`.",
-				};
+				return missingFlagValue(
+					"--allowed-domain",
+					`--allowed-domain=example.com`,
+				);
 			}
 			allowedDomains.push(value);
 			continue;
@@ -95,12 +154,10 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 		if (token === "--blocked-domain") {
 			const value = tokens[++i];
 			if (value === undefined || value.startsWith("-")) {
-				return {
-					kind: "error",
-					message: "Missing value for --blocked-domain.",
-					recovery:
-						"Pass a hostname after the flag, for example `--blocked-domain ads.example.com`.",
-				};
+				return missingFlagValue(
+					"--blocked-domain",
+					`--blocked-domain ads.example.com`,
+				);
 			}
 			blockedDomains.push(value);
 			continue;
@@ -109,12 +166,10 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 		if (token.startsWith("--blocked-domain=")) {
 			const value = token.slice("--blocked-domain=".length);
 			if (value.length === 0) {
-				return {
-					kind: "error",
-					message: "Missing value for --blocked-domain.",
-					recovery:
-						"Pass a hostname after the flag, for example `--blocked-domain=ads.example.com`.",
-				};
+				return missingFlagValue(
+					"--blocked-domain",
+					`--blocked-domain=ads.example.com`,
+				);
 			}
 			blockedDomains.push(value);
 			continue;
@@ -130,6 +185,6 @@ export function parseCliArgs(argv: readonly string[]): ParsedCli {
 
 	return {
 		kind: "mcp",
-		options: { headless, allowedDomains, blockedDomains },
+		options: { provider, headless, allowedDomains, blockedDomains },
 	};
 }

--- a/packages/browser-tools/src/cli/run-cli.ts
+++ b/packages/browser-tools/src/cli/run-cli.ts
@@ -21,5 +21,11 @@ export async function runCli(argv: readonly string[]): Promise<void> {
 		return;
 	}
 
-	await startMcpStdioServer(parsed.options);
+	const started = await startMcpStdioServer(parsed.options);
+	if (started instanceof Error) {
+		process.stderr.write(
+			`${started.message}\n\n${getHelpText()}\n`,
+		);
+		process.exitCode = 1;
+	}
 }

--- a/packages/browser-tools/src/cli/run-mcp.ts
+++ b/packages/browser-tools/src/cli/run-mcp.ts
@@ -3,7 +3,10 @@ import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerMcpBrowserTools } from "../adapters/mcp/index.js";
-import { LocalBrowserProvider } from "../providers/local.js";
+import {
+	createCliBrowserProvider,
+	providerSupportsHeadless,
+} from "./create-cli-provider.js";
 import type { McpCliOptions } from "./parse-args.js";
 
 const require = createRequire(fileURLToPath(import.meta.url));
@@ -23,25 +26,31 @@ function readPackageVersion(): string {
  */
 export async function startMcpStdioServer(
 	options: McpCliOptions,
-): Promise<void> {
+): Promise<Error | void> {
+	const provider = createCliBrowserProvider({
+		provider: options.provider,
+		headless: options.headless,
+	});
+	if (provider instanceof Error) {
+		return provider;
+	}
+
+	if (!options.headless && !providerSupportsHeadless(options.provider)) {
+		process.stderr.write(
+			`--headed is ignored for --provider ${options.provider}; that provider has no headed mode in this CLI.\n`,
+		);
+	}
+
 	const server = new McpServer({
 		name: "libretto-browser-tools",
 		version: readPackageVersion(),
 	});
-	const toolkit = registerMcpBrowserTools(
-		server,
-		new LocalBrowserProvider({ headless: options.headless }),
-		{
-			allowedDomains:
-				options.allowedDomains.length > 0
-					? options.allowedDomains
-					: undefined,
-			blockedDomains:
-				options.blockedDomains.length > 0
-					? options.blockedDomains
-					: undefined,
-		},
-	);
+	const toolkit = registerMcpBrowserTools(server, provider, {
+		allowedDomains:
+			options.allowedDomains.length > 0 ? options.allowedDomains : undefined,
+		blockedDomains:
+			options.blockedDomains.length > 0 ? options.blockedDomains : undefined,
+	});
 
 	let shuttingDown = false;
 	async function shutdown(): Promise<void> {

--- a/specs/browser-tools-mcp-binary-spec.md
+++ b/specs/browser-tools-mcp-binary-spec.md
@@ -6,20 +6,20 @@ Hosts such as Hermes and OpenClaw can load Browser Tools over MCP, but `libretto
 
 ## Solution overview
 
-Ship a package `bin` that starts a stdio MCP server with the six browser tools and a local Chromium provider.
+Ship a package `bin` that starts a stdio MCP server with the six browser tools. Default provider is local Chromium; `--provider` selects Kernel, Browserbase, Browser Use, Steel, or Libretto Cloud (credentials from the environment).
 
 ## Goals
 
 - User runs `npx -y libretto-browser-tools` (or `… mcp`) and an MCP client can list and call the six tools.
-- User can pass `--headed` / domain-policy flags without writing a custom server script.
+- User can pass `--headed` / domain-policy / `--provider` flags without writing a custom server script.
 - Docs show the npx install snippet for MCP clients.
 
 ## Non-goals
 
 - OpenClaw native plugin (later phase).
 - Hermes-specific packaging.
-- Cloud browser providers in the CLI.
 - HTTP / SSE MCP transport.
+- Per-provider CLI flags beyond `--provider` and `--headed` (proxy IDs, recording, etc. stay on env / library constructors).
 
 ## Implementation plan
 
@@ -46,3 +46,17 @@ Success criteria:
 - [x] `pnpm --filter libretto-browser-tools test` passes.
 - [x] `pnpm --filter libretto-browser-tools type-check` passes.
 - [x] Spawning the CLI with an MCP stdio client lists the six tool names.
+
+### Phase 2: `--provider` for cloud browsers
+
+- [x] Flag `--provider <name>` with values `local` (default), `kernel`, `browserbase`, `browser-use`, `steel`, `libretto-cloud`.
+- [x] Construct the matching provider; cloud credentials from env only.
+- [x] `--headed` applies to local, kernel, and libretto-cloud; warn when ignored for other providers.
+- [x] Actionable parse/startup errors for unknown providers and missing API keys.
+- [x] Docs: MCP flags table + Hermes cloud section.
+- [x] Tests: parse `--provider`, unknown provider recovery, missing `KERNEL_API_KEY`.
+
+Success criteria:
+
+- [x] `pnpm --filter libretto-browser-tools test` passes.
+- [x] `pnpm --filter libretto-browser-tools type-check` passes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `--provider` to the `libretto-browser-tools` MCP binary so Hermes/OpenClaw (and any MCP client) can select cloud browsers without a custom server script.

```bash
npx -y libretto-browser-tools --provider kernel
# KERNEL_API_KEY from the MCP host environment
```

### Changes

- `--provider local|kernel|browserbase|browser-use|steel|libretto-cloud` (default `local`)
- Cloud credentials from env only; missing keys fail with recovery text
- `--headed` for local / kernel / libretto-cloud; stderr warning when ignored elsewhere
- Docs: MCP flags, Hermes cloud section, OpenClaw example
- Spec phase 2 marked done

## Test plan

- [x] `pnpm --filter libretto-browser-tools type-check`
- [x] `pnpm --filter libretto-browser-tools test`
- [ ] Optional: live Hermes turn with `--provider kernel` and `KERNEL_API_KEY`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

