### PR TITLE
Spec: run workflows against external CDP with `run --cdp`

### DIFF
--- a/.agents/skills/external-electron-apps/SKILL.md
+++ b/.agents/skills/external-electron-apps/SKILL.md
@@ -17,6 +17,7 @@ Do not default to this for this repository's own Electron app unless the user ex
 4. Verify targets with `npx libretto pages --session <session>`.
 5. Run interactions with `npx libretto exec "<code>" --session <session>`.
 6. Capture evidence with `npx libretto snapshot --session <session>`.
+7. When a reusable workflow file is ready, execute it with `npx libretto run ./workflow.ts --cdp http://127.0.0.1:<port>` (optional `--page page-N`).
 
 ## Launch examples
 
@@ -77,6 +78,15 @@ Electron apps often have multiple windows/pages. Use `pages` to list them and `-
 npx libretto pages --session slack-desktop
 npx libretto exec --session slack-desktop --page <page-id> "return await page.url()"
 npx libretto snapshot --session slack-desktop --page <page-id>
+```
+
+## Scripted workflows
+
+After interactive discovery, run a default-exported `workflow()` against the same CDP endpoint. Libretto navigates to the workflow `startUrl` before the handler. Closing the Libretto session does not quit the Electron app.
+
+```bash
+npx libretto run ./slack-workflow.ts --cdp http://127.0.0.1:9222
+npx libretto run ./slack-workflow.ts --cdp http://127.0.0.1:9222 --page page-1
 ```
 
 ## Troubleshooting

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -167,6 +167,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
 - Insert `await pause(session)` statements in the workflow file when you need to stop at specific states for interactive debugging, like breakpoints in the browser flow.
@@ -176,6 +178,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ```bash
 npx libretto run ./integration.ts --params '{"status":"open"}'
 npx libretto run ./integration.ts --provider libretto-cloud
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222 --page page-1
 npx libretto run ./integration.ts --read-only
 npx libretto run ./integration.ts --stay-open-on-success
 ```

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -167,6 +167,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
 - Insert `await pause(session)` statements in the workflow file when you need to stop at specific states for interactive debugging, like breakpoints in the browser flow.
@@ -176,6 +178,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ```bash
 npx libretto run ./integration.ts --params '{"status":"open"}'
 npx libretto run ./integration.ts --provider libretto-cloud
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222 --page page-1
 npx libretto run ./integration.ts --read-only
 npx libretto run ./integration.ts --stay-open-on-success
 ```

--- a/docs/reference/cli/open-and-connect.mdx
+++ b/docs/reference/cli/open-and-connect.mdx
@@ -154,6 +154,8 @@ npx libretto connect ws://127.0.0.1:9223 --session another-session
 - You are driving an Electron app exposed over CDP.
 - You want to attach to a remote browser in a CI environment that has already navigated to the right state.
 
+For executing a default-exported `workflow()` file against that same CDP endpoint without an interactive session first, use [`run --cdp`](/reference/cli/run-and-resume#run-against-an-external-cdp-browser) instead.
+
 #### Flags
 
 <ParamField path="cdp-url" type="string" required>

--- a/docs/reference/cli/run-and-resume.mdx
+++ b/docs/reference/cli/run-and-resume.mdx
@@ -69,7 +69,21 @@ npx libretto run <file> [flags]
 <ParamField path="--provider" type="string">
   Browser provider to use for this run. Must be `local`, `kernel`, `browserbase`,
   `steel`, or `libretto-cloud`. Overrides `LIBRETTO_PROVIDER` and the `provider` setting
-  in `.libretto/config.json`.
+  in `.libretto/config.json`. Cannot be combined with `--cdp`.
+</ParamField>
+
+<ParamField path="--cdp" type="string">
+  Connect to an existing Chrome DevTools Protocol endpoint instead of launching a
+  browser. Use this for Electron apps or Chrome started with
+  `--remote-debugging-port`. Cannot be combined with `--provider`, `--headed`,
+  `--headless`, or `--viewport`. Libretto still navigates to the workflow
+  `startUrl` before the handler runs. Closing the Libretto session disconnects
+  from CDP and does not terminate the remote browser.
+</ParamField>
+
+<ParamField path="--page" type="string">
+  When using `--cdp`, target a specific discovered page id such as `page-0` or
+  `page-1`. Omit to use the default (last operational page). Requires `--cdp`.
 </ParamField>
 
 <Info>
@@ -78,6 +92,18 @@ npx libretto run <file> [flags]
   providers](/alternative-providers/overview) for Kernel, Browserbase, Steel, AWS, and
   GCP setup.
 </Info>
+
+#### Run against an external CDP browser
+
+Use `--cdp` when the browser already exists (Electron, remote debugging Chrome, CI browser). Use interactive [`connect`](/reference/cli/open-and-connect#connect) to explore with `exec` / `snapshot`; use `run --cdp` to execute a workflow file against that same endpoint.
+
+```bash theme={null}
+# Chrome or Electron started with --remote-debugging-port=9222
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222
+
+# Target a specific window/page (ids from `libretto pages` on a connect session)
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222 --page page-1
+```
 
 #### Behavior on failure
 
@@ -123,6 +149,9 @@ npx libretto run ./integration.ts --params-file ./params.json
 
 # Run with explicit session name for post-failure inspection
 npx libretto run ./integration.ts --session debug-flow --headed
+
+# Run against an external CDP / Electron browser
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222
 ```
 
 ---

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -167,6 +167,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.
 - Insert `await pause(session)` statements in the workflow file when you need to stop at specific states for interactive debugging, like breakpoints in the browser flow.
@@ -176,6 +178,8 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 ```bash
 npx libretto run ./integration.ts --params '{"status":"open"}'
 npx libretto run ./integration.ts --provider libretto-cloud
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222
+npx libretto run ./integration.ts --cdp http://127.0.0.1:9222 --page page-1
 npx libretto run ./integration.ts --read-only
 npx libretto run ./integration.ts --stay-open-on-success
 ```

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -63,6 +63,7 @@ type RunIntegrationCommandRequest = {
   accessMode: SessionAccessMode;
   providerName?: string;
   cdpEndpoint?: string;
+  pageId?: string;
   stayOpenOnSuccess: boolean;
   tsconfigPath?: string;
   experiments: Experiments;
@@ -73,13 +74,18 @@ const require = moduleBuiltin.createRequire(import.meta.url);
 
 export function createRunBrowserConfig(args: {
   cdpEndpoint?: string;
+  pageId?: string;
   providerName?: string;
   headless: boolean;
   viewport?: { width: number; height: number };
   windowPosition?: WindowPositionConfig;
 }): DaemonConfig["browser"] {
   if (args.cdpEndpoint) {
-    return { kind: "connect", cdpEndpoint: args.cdpEndpoint };
+    return {
+      kind: "connect",
+      cdpEndpoint: args.cdpEndpoint,
+      ...(args.pageId ? { pageId: args.pageId } : {}),
+    };
   }
   if (args.providerName) {
     return {
@@ -664,7 +670,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH] [--provider <provider> | --cdp <url>]`;
+const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH] [--provider <provider> | --cdp <url>] [--page <id>]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [
@@ -712,6 +718,9 @@ export const runInput = SimpleCLI.input({
     cdp: SimpleCLI.option(z.string().optional(), {
       help: "Connect to an existing CDP endpoint instead of launching a browser",
     }),
+    page: pageOption(
+      "Target a specific page id when using --cdp (page-0, page-1, …)",
+    ),
   },
 })
   .refine(
@@ -738,6 +747,10 @@ export const runInput = SimpleCLI.input({
     (input) =>
       !(input.cdp && (input.headed || input.headless || input.viewport)),
     "--cdp connects to an existing browser, so --headed, --headless, and --viewport do not apply. Drop those flags or omit --cdp.",
+  )
+  .refine(
+    (input) => !(input.page && !input.cdp),
+    "--page requires --cdp. Pass --cdp <url> to target a page on an external browser.",
   );
 
 function resolveRunParams(
@@ -836,6 +849,7 @@ export const runCommand = SimpleCLI.command({
         accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
         providerName: daemonProviderName,
         cdpEndpoint,
+        pageId: input.page,
         stayOpenOnSuccess: input.stayOpenOnSuccess,
         experiments: ctx.experiments,
       },

--- a/packages/libretto/src/cli/commands/execution.ts
+++ b/packages/libretto/src/cli/commands/execution.ts
@@ -62,6 +62,7 @@ type RunIntegrationCommandRequest = {
   windowPosition?: WindowPositionConfig;
   accessMode: SessionAccessMode;
   providerName?: string;
+  cdpEndpoint?: string;
   stayOpenOnSuccess: boolean;
   tsconfigPath?: string;
   experiments: Experiments;
@@ -71,11 +72,15 @@ type ExecMode = "exec" | "readonly-exec";
 const require = moduleBuiltin.createRequire(import.meta.url);
 
 export function createRunBrowserConfig(args: {
+  cdpEndpoint?: string;
   providerName?: string;
   headless: boolean;
   viewport?: { width: number; height: number };
   windowPosition?: WindowPositionConfig;
 }): DaemonConfig["browser"] {
+  if (args.cdpEndpoint) {
+    return { kind: "connect", cdpEndpoint: args.cdpEndpoint };
+  }
   if (args.providerName) {
     return {
       kind: "provider",
@@ -93,6 +98,31 @@ export function createRunBrowserConfig(args: {
       ? { windowPosition: args.windowPosition }
       : {}),
   };
+}
+
+function parseCdpEndpoint(cdpUrl: string): { endpoint: string; port: number } {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(cdpUrl);
+  } catch {
+    throw new Error(
+      [
+        `Invalid CDP URL: ${cdpUrl}`,
+        ``,
+        `Expected an HTTP or WebSocket URL pointing to a Chrome DevTools Protocol endpoint, for example:`,
+        `  libretto run ./workflow.ts --cdp http://127.0.0.1:9222`,
+        `  libretto run ./workflow.ts --cdp ws://127.0.0.1:9222/devtools/browser/<id>`,
+      ].join("\n"),
+    );
+  }
+
+  const port = parsedUrl.port
+    ? Number(parsedUrl.port)
+    : parsedUrl.protocol === "https:" || parsedUrl.protocol === "wss:"
+      ? 443
+      : 80;
+
+  return { endpoint: parsedUrl.href, port };
 }
 
 function writeDaemonExecOutput(output?: { stdout: string; stderr: string }) {
@@ -469,11 +499,15 @@ async function runIntegrationFromFile(
     handlers,
   });
 
+  const cdpEndpoint = args.cdpEndpoint ?? provider?.cdpEndpoint;
+  const cdpPort = args.cdpEndpoint
+    ? parseCdpEndpoint(args.cdpEndpoint).port
+    : 0;
   writeSessionState(
     {
-      port: 0,
+      port: cdpPort,
       pid,
-      cdpEndpoint: provider?.cdpEndpoint,
+      cdpEndpoint,
       session: args.session,
       startedAt: new Date().toISOString(),
       status: "active",
@@ -630,7 +664,7 @@ export const readonlyExecCommand = SimpleCLI.command({
     });
   });
 
-const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH] [--provider <provider>]`;
+const runUsage = `Usage: libretto run <integrationFile> [--params <json> | --params-file <path>] [--tsconfig <path>] [--headed|--headless] [--read-only|--write-access] [--no-visualize] [--stay-open-on-success] [--viewport WxH] [--provider <provider> | --cdp <url>]`;
 
 export const runInput = SimpleCLI.input({
   positionals: [
@@ -675,6 +709,9 @@ export const runInput = SimpleCLI.input({
       help: "Browser provider (local, kernel, browserbase, steel)",
       aliases: ["-p"],
     }),
+    cdp: SimpleCLI.option(z.string().optional(), {
+      help: "Connect to an existing CDP endpoint instead of launching a browser",
+    }),
   },
 })
   .refine(
@@ -692,6 +729,15 @@ export const runInput = SimpleCLI.input({
   .refine(
     (input) => !(input.readOnly && input.writeAccess),
     "Cannot pass both --read-only and --write-access.",
+  )
+  .refine(
+    (input) => !(input.cdp && input.provider),
+    "Pass either --cdp or --provider, not both.",
+  )
+  .refine(
+    (input) =>
+      !(input.cdp && (input.headed || input.headless || input.viewport)),
+    "--cdp connects to an existing browser, so --headed, --headless, and --viewport do not apply. Drop those flags or omit --cdp.",
   );
 
 function resolveRunParams(
@@ -727,20 +773,29 @@ export const runCommand = SimpleCLI.command({
     assertSessionAvailableForStart(ctx.session, ctx.logger);
 
     const params = resolveRunParams(input.params, input.paramsFile);
+    const visualize = !input.noVisualize;
+    const cdpEndpoint = input.cdp
+      ? parseCdpEndpoint(input.cdp).endpoint
+      : undefined;
+
     const headlessMode = input.headed
       ? false
       : input.headless
         ? true
         : undefined;
-    const visualize = !input.noVisualize;
     const cliViewport = parseViewportArg(input.viewport);
     const configViewport = readLibrettoConfig().viewport;
     // Only pass an explicit CLI/config viewport into provider runs so workflow
     // viewport metadata can fill in. Local launches still resolve a default.
     const explicitViewport = cliViewport ?? configViewport;
-    const viewport = resolveViewport(cliViewport, ctx.logger);
+    const viewport = cdpEndpoint
+      ? undefined
+      : resolveViewport(cliViewport, ctx.logger);
 
-    const providerName = resolveProviderName(input.provider);
+    // --cdp owns the browser source; ignore config/env provider selection.
+    const providerName = cdpEndpoint
+      ? "local"
+      : resolveProviderName(input.provider);
     const daemonProviderName = providerName === "local" ? undefined : providerName;
     if (daemonProviderName) {
       console.log(
@@ -751,11 +806,18 @@ export const runCommand = SimpleCLI.command({
       });
       console.log(`Connecting to ${providerName} browser...`);
     }
+    if (cdpEndpoint) {
+      console.log(
+        `Connecting to CDP endpoint at ${cdpEndpoint} (session: ${ctx.session})...`,
+      );
+      ctx.logger.info("run-cdp-session-requested", { cdpEndpoint });
+    }
 
     const headless = headlessMode ?? false;
-    const windowPosition = headless
-      ? undefined
-      : resolveWindowPosition(ctx.logger);
+    const windowPosition =
+      cdpEndpoint || headless
+        ? undefined
+        : resolveWindowPosition(ctx.logger);
 
     await runIntegrationFromFile(
       {
@@ -765,10 +827,15 @@ export const runCommand = SimpleCLI.command({
         tsconfigPath: input.tsconfig,
         headless,
         visualize,
-        viewport: daemonProviderName ? explicitViewport : viewport,
+        viewport: cdpEndpoint
+          ? undefined
+          : daemonProviderName
+            ? explicitViewport
+            : viewport,
         windowPosition,
         accessMode: input.readOnly ? "read-only" : input.writeAccess ? "write-access" : (readLibrettoConfig().sessionMode ?? "write-access"),
         providerName: daemonProviderName,
+        cdpEndpoint,
         stayOpenOnSuccess: input.stayOpenOnSuccess,
         experiments: ctx.experiments,
       },

--- a/packages/libretto/src/cli/core/daemon/config.ts
+++ b/packages/libretto/src/cli/core/daemon/config.ts
@@ -29,6 +29,8 @@ export type DaemonBrowserConnectConfig = {
   kind: "connect";
   cdpEndpoint: string;
   initialUrl?: string;
+  /** Target page id (`page-0`, `page-1`, …) among pages discovered at connect. */
+  pageId?: string;
 };
 
 /**
@@ -86,4 +88,14 @@ export function applyWorkflowStartUrlToBrowserConfig(
     return browser;
   }
   return { ...browser, initialUrl: startUrl };
+}
+
+/**
+ * Resolve a connect-time `--page` id to an index among discovered pages.
+ * Accepts `page-0` / `page-1` (stable initial ids) or bare `0` / `1`.
+ */
+export function parseConnectPageIndex(pageId: string): number | undefined {
+  const match = /^(?:page-)?(\d+)$/.exec(pageId);
+  if (!match) return undefined;
+  return Number(match[1]);
 }

--- a/packages/libretto/src/cli/core/daemon/config.ts
+++ b/packages/libretto/src/cli/core/daemon/config.ts
@@ -69,3 +69,21 @@ export type DaemonConfig = {
     | DaemonBrowserProviderConfig;
   workflow?: DaemonWorkflowConfig;
 };
+
+/**
+ * Copy workflow `startUrl` onto launch/connect `initialUrl` when the CLI did
+ * not already set one. Provider configs use a separate `startUrl` field.
+ */
+export function applyWorkflowStartUrlToBrowserConfig(
+  browser: DaemonConfig["browser"],
+  startUrl: string | undefined,
+): DaemonConfig["browser"] {
+  if (
+    !startUrl ||
+    (browser.kind !== "launch" && browser.kind !== "connect") ||
+    browser.initialUrl
+  ) {
+    return browser;
+  }
+  return { ...browser, initialUrl: startUrl };
+}

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -79,6 +79,7 @@ import {
   type DaemonBrowserConnectConfig,
   type DaemonBrowserProviderConfig,
   type DaemonWorkflowConfig,
+  applyWorkflowStartUrlToBrowserConfig,
 } from "./config.js";
 import type { Experiments } from "../experiments.js";
 import { getCloudProviderApi } from "../providers/index.js";
@@ -967,15 +968,11 @@ async function main(): Promise<void> {
           // Explicit daemon/CLI viewport wins over workflow viewport.
           viewport: config.browser.viewport ?? loadedWorkflow.viewport,
         };
-      } else if (
-        config.browser.kind === "launch" &&
-        loadedWorkflow.startUrl &&
-        !config.browser.initialUrl
-      ) {
-        browserConfig = {
-          ...config.browser,
-          initialUrl: loadedWorkflow.startUrl,
-        };
+      } else {
+        browserConfig = applyWorkflowStartUrlToBrowserConfig(
+          config.browser,
+          loadedWorkflow.startUrl,
+        );
       }
     } catch (error) {
       throw new UserFacingStartupError(

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -80,6 +80,7 @@ import {
   type DaemonBrowserProviderConfig,
   type DaemonWorkflowConfig,
   applyWorkflowStartUrlToBrowserConfig,
+  parseConnectPageIndex,
 } from "./config.js";
 import type { Experiments } from "../experiments.js";
 import { getCloudProviderApi } from "../providers/index.js";
@@ -175,8 +176,11 @@ class BrowserDaemon {
     });
   }
 
-  private trackPage(page: Page): string {
-    const id = `page-${Math.random().toString(36).slice(2, 5)}`;
+  private trackPage(page: Page, preferredId?: string): string {
+    const id =
+      preferredId && !this.pageById.has(preferredId)
+        ? preferredId
+        : `page-${Math.random().toString(36).slice(2, 5)}`;
     this.pageById.set(id, page);
     page.on("close", () => this.pageById.delete(id));
     return id;
@@ -285,9 +289,11 @@ class BrowserDaemon {
 
     // Action logging and page tracking must be registered before optional
     // navigation so popups opened during the initial load are visible to IPC.
-    for (const p of initialPages) {
+    // Initial pages get stable page-0..page-N ids so run --cdp --page can target
+    // the same window another CDP daemon listed via `pages`.
+    for (const [index, p] of initialPages.entries()) {
       wrapPageForActionLogging(p, session);
-      daemon.trackPage(p);
+      daemon.trackPage(p, `page-${index}`);
     }
     await Promise.all(
       initialPages.map((initialPage) =>
@@ -435,10 +441,29 @@ class BrowserDaemon {
     const context =
       contexts.length > 0 ? contexts[0] : await browser.newContext();
     const operationalPages = context.pages().filter(isOperationalPage);
-    const page =
-      operationalPages.length > 0
-        ? operationalPages[operationalPages.length - 1]
-        : await context.newPage();
+    let page: Page;
+    if (config.pageId) {
+      const pageIndex = parseConnectPageIndex(config.pageId);
+      if (
+        pageIndex === undefined ||
+        pageIndex < 0 ||
+        pageIndex >= operationalPages.length
+      ) {
+        throw new UserFacingStartupError(
+          [
+            `Page "${config.pageId}" was not found while connecting to ${config.cdpEndpoint}.`,
+            `Discovered ${operationalPages.length} page(s) (use page-0 .. page-${Math.max(operationalPages.length - 1, 0)}).`,
+            `List pages on an interactive session with: libretto connect ${config.cdpEndpoint} && libretto pages`,
+          ].join(" "),
+        );
+      }
+      page = operationalPages[pageIndex];
+    } else {
+      page =
+        operationalPages.length > 0
+          ? operationalPages[operationalPages.length - 1]
+          : await context.newPage();
+    }
 
     const daemon = await BrowserDaemon.initialize({
       session,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -541,10 +541,27 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("--read-only");
     expect(result.stdout).toContain("--no-visualize");
     expect(result.stdout).toContain("--stay-open-on-success");
+    expect(result.stdout).toContain("--cdp");
     expect(result.stdout).toContain(
       "Disable ghost cursor + highlight visualization in headed mode",
     );
     expect(result.stderr).toBe("");
+  });
+
+  test("run rejects --cdp with launch-only flags", async ({ librettoCli }) => {
+    const withHeadless = await librettoCli(
+      "run ./missing-workflow.ts --cdp http://127.0.0.1:9222 --headless",
+    );
+    expect(withHeadless.stderr).toContain("--cdp");
+    expect(withHeadless.stderr).toContain("--headed");
+    expect(withHeadless.stderr).toContain("--headless");
+    expect(withHeadless.stderr).toContain("--viewport");
+
+    const withProvider = await librettoCli(
+      "run ./missing-workflow.ts --cdp http://127.0.0.1:9222 --provider kernel",
+    );
+    expect(withProvider.stderr).toContain("--cdp");
+    expect(withProvider.stderr).toContain("--provider");
   });
 
   test("prints session-mode help", async ({ librettoCli }) => {

--- a/packages/libretto/test/daemon-workflow-start-url.spec.ts
+++ b/packages/libretto/test/daemon-workflow-start-url.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { applyWorkflowStartUrlToBrowserConfig } from "../src/cli/core/daemon/config.js";
+import {
+  applyWorkflowStartUrlToBrowserConfig,
+  parseConnectPageIndex,
+} from "../src/cli/core/daemon/config.js";
 
 describe("applyWorkflowStartUrlToBrowserConfig", () => {
   it("copies startUrl onto connect initialUrl for CDP workflow runs", () => {
@@ -62,5 +65,18 @@ describe("applyWorkflowStartUrlToBrowserConfig", () => {
     expect(
       applyWorkflowStartUrlToBrowserConfig(provider, "https://example.com/start"),
     ).toBe(provider);
+  });
+});
+
+describe("parseConnectPageIndex", () => {
+  it("parses page-N and bare numeric ids", () => {
+    expect(parseConnectPageIndex("page-0")).toBe(0);
+    expect(parseConnectPageIndex("page-2")).toBe(2);
+    expect(parseConnectPageIndex("1")).toBe(1);
+  });
+
+  it("rejects non-index page ids", () => {
+    expect(parseConnectPageIndex("page-ab")).toBeUndefined();
+    expect(parseConnectPageIndex("MISSING")).toBeUndefined();
   });
 });

--- a/packages/libretto/test/daemon-workflow-start-url.spec.ts
+++ b/packages/libretto/test/daemon-workflow-start-url.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { applyWorkflowStartUrlToBrowserConfig } from "../src/cli/core/daemon/config.js";
+
+describe("applyWorkflowStartUrlToBrowserConfig", () => {
+  it("copies startUrl onto connect initialUrl for CDP workflow runs", () => {
+    expect(
+      applyWorkflowStartUrlToBrowserConfig(
+        {
+          kind: "connect",
+          cdpEndpoint: "http://127.0.0.1:9222/",
+        },
+        "https://example.com/start",
+      ),
+    ).toEqual({
+      kind: "connect",
+      cdpEndpoint: "http://127.0.0.1:9222/",
+      initialUrl: "https://example.com/start",
+    });
+  });
+
+  it("copies startUrl onto launch initialUrl", () => {
+    expect(
+      applyWorkflowStartUrlToBrowserConfig(
+        {
+          kind: "launch",
+          headed: false,
+          viewport: { width: 1366, height: 768 },
+        },
+        "https://example.com/start",
+      ),
+    ).toEqual({
+      kind: "launch",
+      headed: false,
+      viewport: { width: 1366, height: 768 },
+      initialUrl: "https://example.com/start",
+    });
+  });
+
+  it("does not overwrite an explicit initialUrl", () => {
+    expect(
+      applyWorkflowStartUrlToBrowserConfig(
+        {
+          kind: "connect",
+          cdpEndpoint: "http://127.0.0.1:9222/",
+          initialUrl: "https://example.com/explicit",
+        },
+        "https://example.com/start",
+      ),
+    ).toEqual({
+      kind: "connect",
+      cdpEndpoint: "http://127.0.0.1:9222/",
+      initialUrl: "https://example.com/explicit",
+    });
+  });
+
+  it("leaves provider configs unchanged", () => {
+    const provider = {
+      kind: "provider" as const,
+      providerName: "kernel",
+      headless: true,
+    };
+    expect(
+      applyWorkflowStartUrlToBrowserConfig(provider, "https://example.com/start"),
+    ).toBe(provider);
+  });
+});

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -63,6 +63,7 @@ export default workflow(
     workspacePath,
   }) => {
     const sourceSession = "run-cdp-page-source";
+    const probeSession = "run-cdp-page-probe";
     const runSession = "run-cdp-page-target";
 
     const opened = await librettoCli(
@@ -74,22 +75,26 @@ export default workflow(
       `exec "const p = await context.newPage(); await p.goto('data:text/html,<body>page-one</body>'), context.pages().length" --session ${sourceSession}`,
     );
 
-    const sourcePages = await librettoCli(`pages --session ${sourceSession}`);
-    expect(sourcePages.stderr).toBe("");
-    expect(sourcePages.stdout).toContain("id=page-0");
-    expect(sourcePages.stdout).toContain("page-one");
-    const pageLines = sourcePages.stdout
-      .trimEnd()
-      .split("\n")
-      .filter((line) => line.startsWith("  id="));
-    expect(pageLines).toHaveLength(2);
-
     const sourceState = JSON.parse(
       await readFile(
         workspacePath(".libretto", "sessions", sourceSession, "state.json"),
         "utf8",
       ),
     ) as { port: number };
+
+    // Probe with connect so page-N ids match the order run --cdp will see.
+    await librettoCli(
+      `connect http://127.0.0.1:${sourceState.port} --session ${probeSession}`,
+    );
+    const probePages = await librettoCli(`pages --session ${probeSession}`);
+    expect(probePages.stderr).toBe("");
+    const pageOneLine = probePages.stdout
+      .split("\n")
+      .find((line) => line.includes("page-one"));
+    expect(pageOneLine).toBeTruthy();
+    const pageOneId = pageOneLine!.match(/id=([^\s]+)/)?.[1];
+    expect(pageOneId).toMatch(/^page-\d+$/);
+    await librettoCli(`close --session ${probeSession}`);
 
     const integrationFilePath = await writeWorkflow(
       "integration-run-cdp-page.mjs",
@@ -105,16 +110,18 @@ export default workflow(
     );
 
     const result = await librettoCli(
-      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession} --page page-1`,
+      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession} --page ${pageOneId}`,
     );
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Integration completed.");
     expect(result.stdout).toContain("CDP_PAGE_URL https://example.com/user/");
 
-    // page-1 received startUrl; the other discovered page should still show page-one.
     const afterPages = await librettoCli(`pages --session ${sourceSession}`);
     expect(afterPages.stdout).toContain("https://example.com/user/");
-    expect(afterPages.stdout).toContain("page-one");
+    expect(afterPages.stdout).not.toContain("page-one");
+    expect(afterPages.stdout).toMatch(
+      /id=page-0 url=https:\/\/example\.com\/?(?: |\n|$)/,
+    );
   }, 90_000);
 
   test("run --cdp --stay-open-on-success keeps the Libretto session for inspection", async ({

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -57,6 +57,66 @@ export default workflow(
     expect(() => process.kill(sourceState.pid, 0)).not.toThrow();
   }, 90_000);
 
+  test("run --cdp --page targets a specific discovered page", async ({
+    librettoCli,
+    writeWorkflow,
+    workspacePath,
+  }) => {
+    const sourceSession = "run-cdp-page-source";
+    const runSession = "run-cdp-page-target";
+
+    const opened = await librettoCli(
+      `open https://example.com --headless --session ${sourceSession}`,
+    );
+    expect(opened.stdout).toContain("Browser open");
+
+    await librettoCli(
+      `exec "const p = await context.newPage(); await p.goto('data:text/html,<body>page-one</body>'), context.pages().length" --session ${sourceSession}`,
+    );
+
+    const sourcePages = await librettoCli(`pages --session ${sourceSession}`);
+    expect(sourcePages.stderr).toBe("");
+    expect(sourcePages.stdout).toContain("id=page-0");
+    expect(sourcePages.stdout).toContain("page-one");
+    const pageLines = sourcePages.stdout
+      .trimEnd()
+      .split("\n")
+      .filter((line) => line.startsWith("  id="));
+    expect(pageLines).toHaveLength(2);
+
+    const sourceState = JSON.parse(
+      await readFile(
+        workspacePath(".libretto", "sessions", sourceSession, "state.json"),
+        "utf8",
+      ),
+    ) as { port: number };
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp-page.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: "https://example.com/user/" },
+  async ({ page }) => {
+    console.log("CDP_PAGE_URL", page.url());
+  },
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession} --page page-1`,
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Integration completed.");
+    expect(result.stdout).toContain("CDP_PAGE_URL https://example.com/user/");
+
+    // page-1 received startUrl; the other discovered page should still show page-one.
+    const afterPages = await librettoCli(`pages --session ${sourceSession}`);
+    expect(afterPages.stdout).toContain("https://example.com/user/");
+    expect(afterPages.stdout).toContain("page-one");
+  }, 90_000);
+
   test("run --cdp --stay-open-on-success keeps the Libretto session for inspection", async ({
     librettoCli,
     writeWorkflow,

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -1,0 +1,105 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect } from "vitest";
+import { test } from "./fixtures";
+
+describe("run --cdp", () => {
+  test("executes a workflow against an external CDP browser and leaves it alive", async ({
+    librettoCli,
+    writeWorkflow,
+    workspacePath,
+  }) => {
+    const sourceSession = "run-cdp-source";
+    const runSession = "run-cdp-workflow";
+
+    await librettoCli(
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+
+    const sourceState = JSON.parse(
+      await readFile(
+        workspacePath(".libretto", "sessions", sourceSession, "state.json"),
+        "utf8",
+      ),
+    ) as { port: number; pid: number };
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: "https://example.com/" },
+  async ({ page }) => {
+    console.log("CDP_RUN_URL", page.url());
+    console.log("CDP_RUN_TITLE", await page.title());
+  },
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession}`,
+    );
+    expect(result.stdout).toContain("Connecting to CDP endpoint");
+    expect(result.stdout).toContain("CDP_RUN_URL https://example.com/");
+    expect(result.stdout).toContain("CDP_RUN_TITLE Example Domain");
+    expect(result.stdout).toContain("Integration completed.");
+
+    const missingRunSession = await librettoCli(`pages --session ${runSession}`);
+    expect(missingRunSession.stderr).toContain(
+      `No session "${runSession}" found.`,
+    );
+    expect(missingRunSession.stderr).toContain(`Active sessions:`);
+    expect(missingRunSession.stderr).toContain(sourceSession);
+
+    // Source open session still owns the live browser.
+    const sourcePages = await librettoCli(`pages --session ${sourceSession}`);
+    expect(sourcePages.stdout).toContain("example.com");
+    expect(() => process.kill(sourceState.pid, 0)).not.toThrow();
+  }, 90_000);
+
+  test("run --cdp --stay-open-on-success keeps the Libretto session for inspection", async ({
+    librettoCli,
+    writeWorkflow,
+    workspacePath,
+  }) => {
+    const sourceSession = "run-cdp-stay-open-source";
+    const runSession = "run-cdp-stay-open";
+
+    await librettoCli(
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+
+    const sourceState = JSON.parse(
+      await readFile(
+        workspacePath(".libretto", "sessions", sourceSession, "state.json"),
+        "utf8",
+      ),
+    ) as { port: number };
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp-stay-open.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: "https://example.com/" },
+  async ({ page }) => {
+    console.log("CDP_STAY_OPEN", await page.title());
+  },
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession} --stay-open-on-success`,
+    );
+    expect(result.stdout).toContain("CDP_STAY_OPEN Example Domain");
+    expect(result.stdout).toContain("Integration completed.");
+    expect(result.stdout).toContain("Browser is still open");
+
+    const pages = await librettoCli(`pages --session ${runSession}`);
+    expect(pages.stdout).toContain("example.com");
+
+    const snapshot = await librettoCli(`snapshot --session ${runSession}`);
+    expect(snapshot.stdout).toMatch(/Example Domain|example\.com/i);
+  }, 90_000);
+});

--- a/packages/libretto/test/run-window-position.spec.ts
+++ b/packages/libretto/test/run-window-position.spec.ts
@@ -100,4 +100,18 @@ describe("createRunBrowserConfig", () => {
       cdpEndpoint: "http://127.0.0.1:9222/",
     });
   });
+
+  it("passes page id through to CDP connect config", () => {
+    expect(
+      createRunBrowserConfig({
+        cdpEndpoint: "http://127.0.0.1:9222/",
+        pageId: "page-1",
+        headless: true,
+      }),
+    ).toEqual({
+      kind: "connect",
+      cdpEndpoint: "http://127.0.0.1:9222/",
+      pageId: "page-1",
+    });
+  });
 });

--- a/packages/libretto/test/run-window-position.spec.ts
+++ b/packages/libretto/test/run-window-position.spec.ts
@@ -85,4 +85,19 @@ describe("createRunBrowserConfig", () => {
       headless: false,
     });
   });
+
+  it("uses connect config for CDP workflow runs", () => {
+    expect(
+      createRunBrowserConfig({
+        cdpEndpoint: "http://127.0.0.1:9222/",
+        headless: true,
+        viewport: { width: 1440, height: 900 },
+        windowPosition: { x: 536, y: 33 },
+        providerName: "kernel",
+      }),
+    ).toEqual({
+      kind: "connect",
+      cdpEndpoint: "http://127.0.0.1:9222/",
+    });
+  });
 });

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -113,25 +113,30 @@ Daemon `main` calls this for non-provider browser configs after loading the work
 
 Prove the primary Electron/CDP path: external Chromium with remote debugging, `run --cdp`, navigation to `startUrl`, workflow completion, remote browser still alive after Libretto disconnects.
 
+Tests live in `packages/libretto/test/run-cdp.spec.ts`. They start a CDP-capable browser via `libretto open --headless`, then point `run --cdp` at that port (same pattern as connect E2E). Flag-conflict coverage for `--cdp` + `--provider` / `--headless` is in `packages/libretto/test/basic.spec.ts`.
+
 ```ts
-// packages/libretto/test/... (follow docs/tests-guide.md)
-test("run --cdp executes workflow against an external CDP browser", async ({
-  ...
+// packages/libretto/test/run-cdp.spec.ts
+test("executes a workflow against an external CDP browser and leaves it alive", async ({
+  librettoCli,
+  writeWorkflow,
+  workspacePath,
 }) => {
-  // Launch Chromium with --remote-debugging-port (or reuse test helper).
-  // libretto run ./wf.ts --cdp http://127.0.0.1:<port> --session run-cdp
-  // Assert workflow output / success.
-  // Assert remote browser process still running after run completes.
-  // Assert Libretto session is closed (unless --stay-open-on-success).
+  await librettoCli(`open about:blank --headless --session ${sourceSession}`);
+  // read CDP port from source session state
+  await librettoCli(
+    `run "${integrationFilePath}" --cdp http://127.0.0.1:${port} --session ${runSession}`,
+  );
+  // assert startUrl navigation + source browser still alive
 });
 ```
 
-- [ ] Add an integration test that starts a CDP-enabled Chromium, runs a small workflow with `startUrl` via `run --cdp`, and asserts success.
-- [ ] Assert the workflow landed on `startUrl` (handler checks `page.url()` or equivalent).
-- [ ] Assert a normal successful CDP run disconnects the Libretto session without killing the CDP browser process.
-- [ ] Assert `--stay-open-on-success` leaves a daemon-backed session usable with `pages` / `snapshot` against the same CDP browser.
-- [ ] Assert conflicting flags (`--cdp` + `--provider`, `--cdp` + `--headless`) fail with actionable errors.
-- [ ] Run the new tests with the project's existing test command for this package.
+- [x] Add an integration test that starts a CDP-enabled Chromium, runs a small workflow with `startUrl` via `run --cdp`, and asserts success.
+- [x] Assert the workflow landed on `startUrl` (handler checks `page.url()` or equivalent).
+- [x] Assert a normal successful CDP run disconnects the Libretto session without killing the CDP browser process.
+- [x] Assert `--stay-open-on-success` leaves a daemon-backed session usable with `pages` / `snapshot` against the same CDP browser.
+- [x] Assert conflicting flags (`--cdp` + `--provider`, `--cdp` + `--headless`) fail with actionable errors.
+- [x] Run the new tests with the project's existing test command for this package.
 
 ### Phase 4: Optional `--page` for multi-target CDP browsers
 

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -86,28 +86,28 @@ export function createRunBrowserConfig(args: {
 Connect+workflow must navigate to `startUrl` before the handler, matching local and provider `run` behavior. Today only `launch` gets `initialUrl` from workflow metadata.
 
 ```ts
-// packages/libretto/src/cli/core/daemon/daemon.ts
-if (config.browser.kind === "provider") {
-  browserConfig = {
-    ...config.browser,
-    // ... existing startUrl / gpu / viewport merge ...
-  };
-} else if (
-  (config.browser.kind === "launch" || config.browser.kind === "connect") &&
-  loadedWorkflow.startUrl &&
-  !config.browser.initialUrl
-) {
-  browserConfig = {
-    ...config.browser,
-    initialUrl: loadedWorkflow.startUrl,
-  };
+// packages/libretto/src/cli/core/daemon/config.ts
+export function applyWorkflowStartUrlToBrowserConfig(
+  browser: DaemonConfig["browser"],
+  startUrl: string | undefined,
+): DaemonConfig["browser"] {
+  if (
+    !startUrl ||
+    (browser.kind !== "launch" && browser.kind !== "connect") ||
+    browser.initialUrl
+  ) {
+    return browser;
+  }
+  return { ...browser, initialUrl: startUrl };
 }
 ```
 
-- [ ] Extend the workflow `startUrl` → `initialUrl` merge to `kind: "connect"` (not only `launch`).
-- [ ] Keep requiring `startUrl` on the workflow; do not add a CDP exception that skips navigation.
-- [ ] Add a focused unit/integration assertion that a connect+workflow daemon config ends up with `initialUrl` equal to the workflow `startUrl`.
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+Daemon `main` calls this for non-provider browser configs after loading the workflow.
+
+- [x] Extend the workflow `startUrl` → `initialUrl` merge to `kind: "connect"` (not only `launch`).
+- [x] Keep requiring `startUrl` on the workflow; do not add a CDP exception that skips navigation.
+- [x] Add a focused unit/integration assertion that a connect+workflow daemon config ends up with `initialUrl` equal to the workflow `startUrl`.
+- [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 3: End-to-end `run --cdp` coverage
 

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -142,26 +142,37 @@ test("executes a workflow against an external CDP browser and leaves it alive", 
 
 Electron and multi-window Chrome often expose several pages. Let `run --cdp` select which page gets `startUrl` navigation and becomes `ctx.page`.
 
+Initial pages discovered at daemon start are tracked as stable `page-0` .. `page-N` ids (later popups still get random ids). `run --cdp --page page-1` selects by that index among pages found at connect time, so the id matches what `pages` shows on another CDP session attached to the same browser.
+
 ```ts
+// packages/libretto/src/cli/core/daemon/config.ts
+export type DaemonBrowserConnectConfig = {
+  kind: "connect";
+  cdpEndpoint: string;
+  initialUrl?: string;
+  pageId?: string;
+};
+
 // packages/libretto/src/cli/core/daemon/daemon.ts
-// Before navigateUrl / startWorkflow, when pageId is provided:
-const targetPage = daemon.resolveTargetPage(pageId);
-// use targetPage for goto(startUrl) and WorkflowController page
+if (config.pageId) {
+  const pageIndex = parseConnectPageIndex(config.pageId);
+  // select operationalPages[pageIndex] before initialize + startUrl navigation
+}
 ```
 
-- [ ] Add optional `--page` to `run` (same id form as `exec` / `snapshot`).
-- [ ] Plumb `pageId` through daemon workflow start so navigation and `WorkflowController` use that page.
-- [ ] On unknown page id, fail with the same next-step style as `exec` (`libretto pages --session ...`).
-- [ ] When `--page` is omitted, keep current connect default (last operational page, or create one).
-- [ ] Add a test with two pages on one CDP browser: `run --cdp --page <id>` targets the chosen page.
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+- [x] Add optional `--page` to `run` (same id form as `exec` / `snapshot`).
+- [x] Plumb `pageId` through daemon workflow start so navigation and `WorkflowController` use that page.
+- [x] On unknown page id, fail with the same next-step style as `exec` (`libretto pages --session ...`).
+- [x] When `--page` is omitted, keep current connect default (last operational page, or create one).
+- [x] Add a test with two pages on one CDP browser: `run --cdp --page <id>` targets the chosen page.
+- [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 5: Docs and skill guidance
 
 Document the scripted CDP path without changing the interactive `connect` story.
 
-- [ ] Update `docs/reference/cli/run-and-resume.mdx` with `--cdp`, `--page`, lifecycle notes, and an Electron/CDP example.
-- [ ] Update `docs/reference/cli/open-and-connect.mdx` to point scripted workflow execution at `run --cdp`.
-- [ ] Update `packages/libretto/skills/libretto/SKILL.md` run-modes / commands: use `run --cdp` for workflows on external CDP; keep `connect` for explore/`exec`.
-- [ ] Update `.agents/skills/external-electron-apps/SKILL.md` with a `run --cdp` example after interactive discovery.
-- [ ] Run `pnpm sync:mirrors` if skill mirrors need regeneration; run `pnpm check:mirrors`.
+- [x] Update `docs/reference/cli/run-and-resume.mdx` with `--cdp`, `--page`, lifecycle notes, and an Electron/CDP example.
+- [x] Update `docs/reference/cli/open-and-connect.mdx` to point scripted workflow execution at `run --cdp`.
+- [x] Update `packages/libretto/skills/libretto/SKILL.md` run-modes / commands: use `run --cdp` for workflows on external CDP; keep `connect` for explore/`exec`.
+- [x] Update `.agents/skills/external-electron-apps/SKILL.md` with a `run --cdp` example after interactive discovery.
+- [x] Run `pnpm sync:mirrors` if skill mirrors need regeneration; run `pnpm check:mirrors`.

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -1,0 +1,162 @@
+## Problem overview
+
+`libretto run` can launch local Chromium or create a cloud provider browser, but it cannot execute a workflow against an already-running CDP endpoint (Chrome with `--remote-debugging-port`, Electron apps, CI browsers). Users must `connect` for interactive `exec`/`snapshot` only; there is no way to run a default-exported `workflow()` file on that external browser.
+
+## Solution overview
+
+Add `--cdp <url>` to `libretto run` as a third browser source alongside local launch and `--provider`. The command spawns a daemon with existing `browser.kind: "connect"` plus a workflow config, navigates to the workflow's required `startUrl`, then runs the handler. `connect` stays the interactive attach path; this spec does not add workflow attach to an already-open Libretto session.
+
+## Goals
+
+- `libretto run ./workflow.ts --cdp http://127.0.0.1:9222` connects over CDP, opens the workflow `startUrl`, and runs the default-exported workflow.
+- Workflow `startUrl` remains required and is navigated before the handler, including on CDP runs.
+- CDP runs never terminate the remote browser or Electron app on success, failure, or `close`.
+- `--cdp` is mutually exclusive with `--provider` and with local-only launch flags that do not apply (`--headed`/`--headless`, `--viewport`).
+- Optional `--page <id>` selects which existing CDP page receives navigation and the workflow `page` context.
+
+## Non-goals
+
+- No migrations or backfills.
+- No `run --session` attach to a live Libretto daemon created by `open`/`connect` (separate feature).
+- No `connect --run` flag or new top-level command.
+- No change to `workflow()` requiring `startUrl`.
+- No generalized workflow job queue; still one workflow invocation per daemon session.
+- No Electron-specific launcher (user still starts the app with `--remote-debugging-port`).
+
+## Important files/docs/websites for implementation
+
+- `packages/libretto/src/cli/commands/execution.ts` — `run` CLI input, `createRunBrowserConfig`, `runIntegrationFromFile`; add `--cdp` / `--page` and wire connect browser config.
+- `packages/libretto/src/cli/core/daemon/config.ts` — `DaemonBrowserConnectConfig` already exists (`kind: "connect"`, `cdpEndpoint`, `initialUrl`).
+- `packages/libretto/src/cli/core/daemon/daemon.ts` — `connectToEndpoint` already navigates `initialUrl`; workflow bootstrap today only copies `startUrl` onto `launch`, not `connect`.
+- `packages/libretto/src/cli/core/workflow-runner/runner.ts` — `WorkflowController` receives the daemon's chosen `page`.
+- `packages/libretto/src/cli/core/browser.ts` — `runConnect` reference for CDP URL probing and externally-managed session semantics.
+- `packages/libretto/test/basic.spec.ts` / `packages/libretto/test/daemon-ipc.spec.ts` — patterns for `run` and daemon-backed sessions.
+- `docs/reference/cli/run-and-resume.mdx` — document `--cdp` and `--page`.
+- `docs/reference/cli/open-and-connect.mdx` — cross-link: interactive `connect` vs scripted `run --cdp`.
+- `packages/libretto/skills/libretto/SKILL.md` — agent guidance for Electron/CDP workflow runs (source of truth; then `pnpm sync:mirrors`).
+- `.agents/skills/external-electron-apps/SKILL.md` — today ends at `exec`; add `run --cdp` for scripted workflows.
+
+## Implementation
+
+### Phase 1: Accept `--cdp` on `run` and spawn a connect+workflow daemon
+
+Expose CDP as a browser source on `run` using the daemon's existing `kind: "connect"` config. Reject flag combinations that cannot apply to an external browser.
+
+```ts
+// packages/libretto/src/cli/commands/execution.ts
+export function createRunBrowserConfig(args: {
+  cdpEndpoint?: string;
+  providerName?: string;
+  headless: boolean;
+  viewport?: { width: number; height: number };
+  windowPosition?: WindowPositionConfig;
+}): DaemonConfig["browser"] {
+  if (args.cdpEndpoint) {
+    return { kind: "connect", cdpEndpoint: args.cdpEndpoint };
+  }
+  if (args.providerName) {
+    return {
+      kind: "provider",
+      providerName: args.providerName,
+      headless: args.headless,
+      ...(args.viewport ? { viewport: args.viewport } : {}),
+    };
+  }
+  return {
+    kind: "launch",
+    headed: !args.headless,
+    viewport: args.viewport ?? { width: 1366, height: 768 },
+    ...(!args.headless && args.windowPosition
+      ? { windowPosition: args.windowPosition }
+      : {}),
+  };
+}
+```
+
+- [ ] Add optional `--cdp` string option to `runInput` (CDP HTTP or WebSocket URL).
+- [ ] Refine: cannot pass `--cdp` with `--provider` / `-p`.
+- [ ] Refine: cannot pass `--cdp` with `--headed`, `--headless`, or `--viewport` (error must say those only apply when Libretto launches the browser; drop them or omit `--cdp`).
+- [ ] Pass `cdpEndpoint` through `runIntegrationFromFile` into `createRunBrowserConfig`.
+- [ ] When `--cdp` is set, mark the session as externally managed the same way `connect` does (disconnect on close; do not kill the remote process).
+- [ ] Update `run` usage/help text to include `--cdp`.
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+
+### Phase 2: Apply workflow `startUrl` to CDP connect runs
+
+Connect+workflow must navigate to `startUrl` before the handler, matching local and provider `run` behavior. Today only `launch` gets `initialUrl` from workflow metadata.
+
+```ts
+// packages/libretto/src/cli/core/daemon/daemon.ts
+if (config.browser.kind === "provider") {
+  browserConfig = {
+    ...config.browser,
+    // ... existing startUrl / gpu / viewport merge ...
+  };
+} else if (
+  (config.browser.kind === "launch" || config.browser.kind === "connect") &&
+  loadedWorkflow.startUrl &&
+  !config.browser.initialUrl
+) {
+  browserConfig = {
+    ...config.browser,
+    initialUrl: loadedWorkflow.startUrl,
+  };
+}
+```
+
+- [ ] Extend the workflow `startUrl` → `initialUrl` merge to `kind: "connect"` (not only `launch`).
+- [ ] Keep requiring `startUrl` on the workflow; do not add a CDP exception that skips navigation.
+- [ ] Add a focused unit/integration assertion that a connect+workflow daemon config ends up with `initialUrl` equal to the workflow `startUrl`.
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+
+### Phase 3: End-to-end `run --cdp` coverage
+
+Prove the primary Electron/CDP path: external Chromium with remote debugging, `run --cdp`, navigation to `startUrl`, workflow completion, remote browser still alive after Libretto disconnects.
+
+```ts
+// packages/libretto/test/... (follow docs/tests-guide.md)
+test("run --cdp executes workflow against an external CDP browser", async ({
+  ...
+}) => {
+  // Launch Chromium with --remote-debugging-port (or reuse test helper).
+  // libretto run ./wf.ts --cdp http://127.0.0.1:<port> --session run-cdp
+  // Assert workflow output / success.
+  // Assert remote browser process still running after run completes.
+  // Assert Libretto session is closed (unless --stay-open-on-success).
+});
+```
+
+- [ ] Add an integration test that starts a CDP-enabled Chromium, runs a small workflow with `startUrl` via `run --cdp`, and asserts success.
+- [ ] Assert the workflow landed on `startUrl` (handler checks `page.url()` or equivalent).
+- [ ] Assert a normal successful CDP run disconnects the Libretto session without killing the CDP browser process.
+- [ ] Assert `--stay-open-on-success` leaves a daemon-backed session usable with `pages` / `snapshot` against the same CDP browser.
+- [ ] Assert conflicting flags (`--cdp` + `--provider`, `--cdp` + `--headless`) fail with actionable errors.
+- [ ] Run the new tests with the project's existing test command for this package.
+
+### Phase 4: Optional `--page` for multi-target CDP browsers
+
+Electron and multi-window Chrome often expose several pages. Let `run --cdp` select which page gets `startUrl` navigation and becomes `ctx.page`.
+
+```ts
+// packages/libretto/src/cli/core/daemon/daemon.ts
+// Before navigateUrl / startWorkflow, when pageId is provided:
+const targetPage = daemon.resolveTargetPage(pageId);
+// use targetPage for goto(startUrl) and WorkflowController page
+```
+
+- [ ] Add optional `--page` to `run` (same id form as `exec` / `snapshot`).
+- [ ] Plumb `pageId` through daemon workflow start so navigation and `WorkflowController` use that page.
+- [ ] On unknown page id, fail with the same next-step style as `exec` (`libretto pages --session ...`).
+- [ ] When `--page` is omitted, keep current connect default (last operational page, or create one).
+- [ ] Add a test with two pages on one CDP browser: `run --cdp --page <id>` targets the chosen page.
+- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+
+### Phase 5: Docs and skill guidance
+
+Document the scripted CDP path without changing the interactive `connect` story.
+
+- [ ] Update `docs/reference/cli/run-and-resume.mdx` with `--cdp`, `--page`, lifecycle notes, and an Electron/CDP example.
+- [ ] Update `docs/reference/cli/open-and-connect.mdx` to point scripted workflow execution at `run --cdp`.
+- [ ] Update `packages/libretto/skills/libretto/SKILL.md` run-modes / commands: use `run --cdp` for workflows on external CDP; keep `connect` for explore/`exec`.
+- [ ] Update `.agents/skills/external-electron-apps/SKILL.md` with a `run --cdp` example after interactive discovery.
+- [ ] Run `pnpm sync:mirrors` if skill mirrors need regeneration; run `pnpm check:mirrors`.

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -73,13 +73,13 @@ export function createRunBrowserConfig(args: {
 }
 ```
 
-- [ ] Add optional `--cdp` string option to `runInput` (CDP HTTP or WebSocket URL).
-- [ ] Refine: cannot pass `--cdp` with `--provider` / `-p`.
-- [ ] Refine: cannot pass `--cdp` with `--headed`, `--headless`, or `--viewport` (error must say those only apply when Libretto launches the browser; drop them or omit `--cdp`).
-- [ ] Pass `cdpEndpoint` through `runIntegrationFromFile` into `createRunBrowserConfig`.
-- [ ] When `--cdp` is set, mark the session as externally managed the same way `connect` does (disconnect on close; do not kill the remote process).
-- [ ] Update `run` usage/help text to include `--cdp`.
-- [ ] Verify `pnpm -s type-check --filter=libretto` passes.
+- [x] Add optional `--cdp` string option to `runInput` (CDP HTTP or WebSocket URL).
+- [x] Refine: cannot pass `--cdp` with `--provider` / `-p`.
+- [x] Refine: cannot pass `--cdp` with `--headed`, `--headless`, or `--viewport` (error must say those only apply when Libretto launches the browser; drop them or omit `--cdp`).
+- [x] Pass `cdpEndpoint` through `runIntegrationFromFile` into `createRunBrowserConfig`.
+- [x] When `--cdp` is set, mark the session as externally managed the same way `connect` does (disconnect on close; do not kill the remote process).
+- [x] Update `run` usage/help text to include `--cdp`.
+- [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 2: Apply workflow `startUrl` to CDP connect runs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `libretto run --cdp` so workflows can run against an external CDP/Electron browser without launching Chromium.

- `--cdp <url>` is a browser source on `run` (alongside local launch and `--provider`)
- Workflow `startUrl` is still required and navigated before the handler
- Optional `--page page-N` selects among pages discovered at connect time
- Closing the Libretto session disconnects CDP; it does not kill the remote app
- Docs + skills updated; `connect` remains the interactive explore path

## Status

- [x] Spec (`specs/run-cdp-workflow-spec.md`)
- [x] Phase 1: `--cdp` CLI + connect+workflow daemon spawn + flag conflicts
- [x] Phase 2: apply `startUrl` to connect runs
- [x] Phase 3: end-to-end CDP tests
- [x] Phase 4: `--page`
- [x] Phase 5: docs/skills

## Primary UX

```bash
libretto run ./workflow.ts --cdp http://127.0.0.1:9222
libretto run ./workflow.ts --cdp http://127.0.0.1:9222 --page page-1
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625b0362-871c-422a-8a59-4bb9568a6ec5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625b0362-871c-422a-8a59-4bb9568a6ec5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

