### PR TITLE
release: v0.6.40

### DIFF
--- a/.agents/skills/libretto-readonly/SKILL.md
+++ b/.agents/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Read-Only Works

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Works

--- a/.claude/skills/libretto-readonly/SKILL.md
+++ b/.claude/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Read-Only Works

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Works

--- a/packages/create-libretto/package.json
+++ b/packages/create-libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-libretto",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "description": "Create and set up a Libretto project",
   "license": "MIT",
   "repository": {

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libretto",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "description": "AI-powered browser automation library and CLI built on Playwright",
   "license": "MIT",
   "homepage": "https://libretto.sh",

--- a/packages/libretto/skills/libretto-readonly/SKILL.md
+++ b/packages/libretto/skills/libretto-readonly/SKILL.md
@@ -4,7 +4,7 @@ description: "Read-only Libretto workflow for diagnosing live browser state with
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Read-Only Works

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -4,7 +4,7 @@ description: "Browser automation CLI for building, maintaining, and running brow
 license: MIT
 metadata:
   author: saffron-health
-  version: "0.6.39"
+  version: "0.6.40"
 ---
 
 ## How Libretto Works


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- release libretto v0.6.40

Notable changes since v0.6.39:
- `libretto run --cdp` to execute workflows against external CDP/Electron browsers
- Browser Tools MCP `--provider` flag
- Hermes and OpenClaw Browser Tools docs under Agents

## Verification

- pnpm --filter libretto type-check
- pnpm --filter libretto test

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625b0362-871c-422a-8a59-4bb9568a6ec5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625b0362-871c-422a-8a59-4bb9568a6ec5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

