### PR TITLE
Skip startUrl navigation on run --cdp

### DIFF
--- a/.agents/skills/external-electron-apps/SKILL.md
+++ b/.agents/skills/external-electron-apps/SKILL.md
@@ -82,7 +82,7 @@ npx libretto snapshot --session slack-desktop --page <page-id>
 
 ## Scripted workflows
 
-After interactive discovery, run a default-exported `workflow()` against the same CDP endpoint. Libretto navigates to the workflow `startUrl` before the handler. Closing the Libretto session does not quit the Electron app.
+After interactive discovery, run a default-exported `workflow()` against the same CDP endpoint. Libretto attaches to the selected page without navigating to workflow `startUrl`, so leave the app on the target screen first (or navigate in the handler). Closing the Libretto session does not quit the Electron app.
 
 ```bash
 npx libretto run ./slack-workflow.ts --cdp http://127.0.0.1:9222

--- a/.agents/skills/libretto/SKILL.md
+++ b/.agents/skills/libretto/SKILL.md
@@ -27,7 +27,7 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
-Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers).
+Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler when Libretto launches the browser; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers). `run --cdp` attaches without navigating, so leave the existing page as-is or navigate inside the handler.
 
 ## CAPTCHA Handling
 
@@ -167,7 +167,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
-- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto attaches without navigating to workflow `startUrl`, preserving the page URL and auth state. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page becomes `ctx.page`.
 - Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.

--- a/.agents/skills/libretto/references/code-generation-rules.md
+++ b/.agents/skills/libretto/references/code-generation-rules.md
@@ -26,14 +26,15 @@ const outputSchema = z.object({
 export default workflow("myWorkflow", {
   input: inputSchema,
   output: outputSchema,
-  // Always declare the entry URL. Libretto opens it before the handler runs
-  // (and before CDP attach on Kernel / cloud providers).
+  // Always declare the entry URL. On launch/provider runs Libretto opens it
+  // before the handler (and before CDP attach on Kernel / cloud providers).
+  // run --cdp does not navigate to startUrl.
   startUrl: "https://example.com",
   handler: async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
-    // Do not page.goto(startUrl) here — the browser is already on startUrl.
+    // Do not page.goto(startUrl) here on launch/provider runs — already there.
     await pause(session);
 
     return { results: [] };

--- a/.claude/skills/libretto/SKILL.md
+++ b/.claude/skills/libretto/SKILL.md
@@ -27,7 +27,7 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
-Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers).
+Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler when Libretto launches the browser; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers). `run --cdp` attaches without navigating, so leave the existing page as-is or navigate inside the handler.
 
 ## CAPTCHA Handling
 
@@ -167,7 +167,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
-- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto attaches without navigating to workflow `startUrl`, preserving the page URL and auth state. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page becomes `ctx.page`.
 - Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.

--- a/.claude/skills/libretto/references/code-generation-rules.md
+++ b/.claude/skills/libretto/references/code-generation-rules.md
@@ -26,14 +26,15 @@ const outputSchema = z.object({
 export default workflow("myWorkflow", {
   input: inputSchema,
   output: outputSchema,
-  // Always declare the entry URL. Libretto opens it before the handler runs
-  // (and before CDP attach on Kernel / cloud providers).
+  // Always declare the entry URL. On launch/provider runs Libretto opens it
+  // before the handler (and before CDP attach on Kernel / cloud providers).
+  // run --cdp does not navigate to startUrl.
   startUrl: "https://example.com",
   handler: async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
-    // Do not page.goto(startUrl) here — the browser is already on startUrl.
+    // Do not page.goto(startUrl) here on launch/provider runs — already there.
     await pause(session);
 
     return { results: [] };

--- a/docs/reference/cli/run-and-resume.mdx
+++ b/docs/reference/cli/run-and-resume.mdx
@@ -76,9 +76,10 @@ npx libretto run <file> [flags]
   Connect to an existing Chrome DevTools Protocol endpoint instead of launching a
   browser. Use this for Electron apps or Chrome started with
   `--remote-debugging-port`. Cannot be combined with `--provider`, `--headed`,
-  `--headless`, or `--viewport`. Libretto still navigates to the workflow
-  `startUrl` before the handler runs. Closing the Libretto session disconnects
-  from CDP and does not terminate the remote browser.
+  `--headless`, or `--viewport`. Libretto attaches to the selected page without
+  navigating to workflow `startUrl`, so the existing URL and authentication
+  state stay intact. Closing the Libretto session disconnects from CDP and does
+  not terminate the remote browser.
 </ParamField>
 
 <ParamField path="--page" type="string">
@@ -95,7 +96,7 @@ npx libretto run <file> [flags]
 
 #### Run against an external CDP browser
 
-Use `--cdp` when the browser already exists (Electron, remote debugging Chrome, CI browser). Use interactive [`connect`](/reference/cli/open-and-connect#connect) to explore with `exec` / `snapshot`; use `run --cdp` to execute a workflow file against that same endpoint.
+Use `--cdp` when the browser already exists (Electron, remote debugging Chrome, CI browser). Use interactive [`connect`](/reference/cli/open-and-connect#connect) to explore with `exec` / `snapshot`; use `run --cdp` to execute a workflow file against that same endpoint. Unlike a normal `run`, `--cdp` does not open workflow `startUrl` — put the browser on the page you want before the run, or navigate inside the handler.
 
 ```bash theme={null}
 # Chrome or Electron started with --remote-debugging-port=9222

--- a/docs/reference/runtime/workflow.mdx
+++ b/docs/reference/runtime/workflow.mdx
@@ -95,7 +95,7 @@ The CLI compiles the file with `tsx`, launches a Chromium browser, and calls you
 
 #### Browser launch options
 
-Always declare `startUrl` on every workflow. It is the entry URL Libretto opens before the handler runs. Kernel and Libretto Cloud preload it at browser create time (before CDP attach). Browserbase and Steel open it immediately after CDP connect.
+Always declare `startUrl` on every workflow. It is the entry URL Libretto opens before the handler runs when Libretto launches the browser (local Chromium or a provider session). Kernel and Libretto Cloud preload it at browser create time (before CDP attach). Browserbase and Steel open it immediately after CDP connect. `run --cdp` attaches to an existing page and does not navigate to `startUrl`.
 
 ```typescript theme={null}
 export default workflow(
@@ -114,10 +114,12 @@ export default workflow(
 ```
 
 <ParamField path="startUrl" type="string">
-  Entry URL for the workflow. Declare this on every workflow. Libretto opens it
-  before the handler runs. On Kernel, Libretto sends it as `start_url` at
-  session create time and does not navigate again after connect. Prefer this
-  over an initial `page.goto` in the handler.
+  Entry URL for the workflow. Declare this on every workflow. When Libretto
+  launches the browser, it opens this URL before the handler runs. On Kernel,
+  Libretto sends it as `start_url` at session create time and does not navigate
+  again after connect. `run --cdp` leaves the existing page URL unchanged.
+  Prefer this over an initial `page.goto` in the handler for launch and provider
+  runs.
 </ParamField>
 
 <ParamField path="gpu" type="boolean">

--- a/packages/libretto/skills/libretto/SKILL.md
+++ b/packages/libretto/skills/libretto/SKILL.md
@@ -27,7 +27,7 @@ Mix strategies freely across steps on a site.
 
 Prefer to enter sites at a user-facing URL (homepage, login, etc.) on the first navigation — deep URLs on a cold session are commonly blocked by edge bot protection.
 
-Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers).
+Always declare that entry URL as workflow `startUrl`. Do not open the same URL again with `page.goto` at the top of the handler when Libretto launches the browser; Libretto loads `startUrl` before the handler runs (and before CDP attach on Kernel / cloud providers). `run --cdp` attaches without navigating, so leave the existing page as-is or navigate inside the handler.
 
 ## CAPTCHA Handling
 
@@ -167,7 +167,7 @@ npx libretto exec --session debug-example --page <page-id> "await page.url()"
 - Workflows define their input shape with a Zod schema (see `references/code-generation-rules.md`). `run` validates `--params` against that schema before calling the handler and prints a clear field-by-field error if the input doesn't match.
 - Successful runs close the browser by default. Pass `--stay-open-on-success` when you need to inspect the completed state with `pages`, `snapshot`, or `exec`.
 - Use `--provider <name>` when validating behavior in that provider's browser runtime.
-- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto still navigates to workflow `startUrl`. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page receives navigation.
+- Use `--cdp <url>` to run a workflow against an existing CDP endpoint (Electron or Chrome with `--remote-debugging-port`). Libretto attaches without navigating to workflow `startUrl`, preserving the page URL and auth state. Do not pass `--provider`, `--headed`, `--headless`, or `--viewport` with `--cdp`. Optional `--page page-N` selects which discovered page becomes `ctx.page`.
 - Prefer `connect` + `exec` / `snapshot` for interactive exploration of an external CDP browser; use `run --cdp` once the workflow file is ready.
 - Pass `--read-only` if the preserved session should come back locked for follow-up terminal inspection after the workflow run.
 - If the workflow fails, Libretto keeps the browser open. Inspect the failed state with `snapshot` and `exec` before editing code.

--- a/packages/libretto/skills/libretto/references/code-generation-rules.md
+++ b/packages/libretto/skills/libretto/references/code-generation-rules.md
@@ -26,14 +26,15 @@ const outputSchema = z.object({
 export default workflow("myWorkflow", {
   input: inputSchema,
   output: outputSchema,
-  // Always declare the entry URL. Libretto opens it before the handler runs
-  // (and before CDP attach on Kernel / cloud providers).
+  // Always declare the entry URL. On launch/provider runs Libretto opens it
+  // before the handler (and before CDP attach on Kernel / cloud providers).
+  // run --cdp does not navigate to startUrl.
   startUrl: "https://example.com",
   handler: async (ctx: LibrettoWorkflowContext, input) => {
     const { session, page } = ctx;
 
     console.log("workflow-start", { session, query: input.query });
-    // Do not page.goto(startUrl) here — the browser is already on startUrl.
+    // Do not page.goto(startUrl) here on launch/provider runs — already there.
     await pause(session);
 
     return { results: [] };

--- a/packages/libretto/src/cli/core/daemon/config.ts
+++ b/packages/libretto/src/cli/core/daemon/config.ts
@@ -73,18 +73,16 @@ export type DaemonConfig = {
 };
 
 /**
- * Copy workflow `startUrl` onto launch/connect `initialUrl` when the CLI did
- * not already set one. Provider configs use a separate `startUrl` field.
+ * Copy workflow `startUrl` onto launch `initialUrl` when the CLI did not
+ * already set one. Connect/CDP runs attach without navigating so existing page
+ * URL and auth state stay intact. Provider configs use a separate `startUrl`
+ * field.
  */
 export function applyWorkflowStartUrlToBrowserConfig(
   browser: DaemonConfig["browser"],
   startUrl: string | undefined,
 ): DaemonConfig["browser"] {
-  if (
-    !startUrl ||
-    (browser.kind !== "launch" && browser.kind !== "connect") ||
-    browser.initialUrl
-  ) {
+  if (!startUrl || browser.kind !== "launch" || browser.initialUrl) {
     return browser;
   }
   return { ...browser, initialUrl: startUrl };

--- a/packages/libretto/test/daemon-workflow-start-url.spec.ts
+++ b/packages/libretto/test/daemon-workflow-start-url.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../src/cli/core/daemon/config.js";
 
 describe("applyWorkflowStartUrlToBrowserConfig", () => {
-  it("copies startUrl onto connect initialUrl for CDP workflow runs", () => {
+  it("does not copy startUrl onto connect initialUrl for CDP workflow runs", () => {
     expect(
       applyWorkflowStartUrlToBrowserConfig(
         {
@@ -17,7 +17,6 @@ describe("applyWorkflowStartUrlToBrowserConfig", () => {
     ).toEqual({
       kind: "connect",
       cdpEndpoint: "http://127.0.0.1:9222/",
-      initialUrl: "https://example.com/start",
     });
   });
 
@@ -39,21 +38,44 @@ describe("applyWorkflowStartUrlToBrowserConfig", () => {
     });
   });
 
-  it("does not overwrite an explicit initialUrl", () => {
+  it("does not overwrite an explicit launch initialUrl", () => {
     expect(
       applyWorkflowStartUrlToBrowserConfig(
         {
-          kind: "connect",
-          cdpEndpoint: "http://127.0.0.1:9222/",
+          kind: "launch",
+          headed: false,
+          viewport: { width: 1366, height: 768 },
           initialUrl: "https://example.com/explicit",
         },
         "https://example.com/start",
       ),
     ).toEqual({
-      kind: "connect",
-      cdpEndpoint: "http://127.0.0.1:9222/",
+      kind: "launch",
+      headed: false,
+      viewport: { width: 1366, height: 768 },
       initialUrl: "https://example.com/explicit",
     });
+  });
+
+  it("leaves connect configs unchanged when startUrl is missing", () => {
+    const connect = {
+      kind: "connect" as const,
+      cdpEndpoint: "http://127.0.0.1:9222/",
+    };
+    expect(applyWorkflowStartUrlToBrowserConfig(connect, undefined)).toBe(
+      connect,
+    );
+  });
+
+  it("leaves launch configs unchanged when startUrl is missing", () => {
+    const launch = {
+      kind: "launch" as const,
+      headed: false,
+      viewport: { width: 1366, height: 768 },
+    };
+    expect(applyWorkflowStartUrlToBrowserConfig(launch, undefined)).toBe(
+      launch,
+    );
   });
 
   it("leaves provider configs unchanged", () => {

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect } from "vitest";
 import { test } from "./fixtures";
 
 describe("run --cdp", () => {
-  test("executes a workflow against an external CDP browser and leaves it alive", async ({
+  test("attaches without navigating away from the existing page", async ({
     librettoCli,
     writeWorkflow,
     workspacePath,
@@ -12,7 +12,7 @@ describe("run --cdp", () => {
     const runSession = "run-cdp-workflow";
 
     await librettoCli(
-      `open about:blank --headless --session ${sourceSession}`,
+      `open data:text/html,<title>CDP Existing</title><body>keep-me</body> --headless --session ${sourceSession}`,
     );
 
     const sourceState = JSON.parse(
@@ -31,6 +31,7 @@ export default workflow(
   async ({ page }) => {
     console.log("CDP_RUN_URL", page.url());
     console.log("CDP_RUN_TITLE", await page.title());
+    console.log("CDP_RUN_BODY", await page.locator("body").innerText());
   },
 );
 `,
@@ -40,8 +41,9 @@ export default workflow(
       `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession}`,
     );
     expect(result.stdout).toContain("Connecting to CDP endpoint");
-    expect(result.stdout).toContain("CDP_RUN_URL https://example.com/");
-    expect(result.stdout).toContain("CDP_RUN_TITLE Example Domain");
+    expect(result.stdout).toContain("CDP_RUN_TITLE CDP Existing");
+    expect(result.stdout).toContain("CDP_RUN_BODY keep-me");
+    expect(result.stdout).not.toContain("CDP_RUN_URL https://example.com/");
     expect(result.stdout).toContain("Integration completed.");
 
     const missingRunSession = await librettoCli(`pages --session ${runSession}`);
@@ -51,13 +53,14 @@ export default workflow(
     expect(missingRunSession.stderr).toContain(`Active sessions:`);
     expect(missingRunSession.stderr).toContain(sourceSession);
 
-    // Source open session still owns the live browser.
+    // Source open session still owns the live browser on the original page.
     const sourcePages = await librettoCli(`pages --session ${sourceSession}`);
-    expect(sourcePages.stdout).toContain("example.com");
+    expect(sourcePages.stdout).toContain("keep-me");
+    expect(sourcePages.stdout).not.toContain("example.com");
     expect(() => process.kill(sourceState.pid, 0)).not.toThrow();
   }, 90_000);
 
-  test("run --cdp --page targets a specific discovered page", async ({
+  test("run --cdp --page targets a specific discovered page without navigating", async ({
     librettoCli,
     writeWorkflow,
     workspacePath,
@@ -104,6 +107,7 @@ export default workflow(
   { startUrl: "https://example.com/user/" },
   async ({ page }) => {
     console.log("CDP_PAGE_URL", page.url());
+    console.log("CDP_PAGE_BODY", await page.locator("body").innerText());
   },
 );
 `,
@@ -114,11 +118,14 @@ export default workflow(
     );
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Integration completed.");
-    expect(result.stdout).toContain("CDP_PAGE_URL https://example.com/user/");
+    expect(result.stdout).toContain("CDP_PAGE_BODY page-one");
+    expect(result.stdout).not.toContain(
+      "CDP_PAGE_URL https://example.com/user/",
+    );
 
     const afterPages = await librettoCli(`pages --session ${sourceSession}`);
-    expect(afterPages.stdout).toContain("https://example.com/user/");
-    expect(afterPages.stdout).not.toContain("page-one");
+    expect(afterPages.stdout).toContain("page-one");
+    expect(afterPages.stdout).not.toContain("https://example.com/user/");
     expect(afterPages.stdout).toMatch(
       /id=page-0 url=https:\/\/example\.com\/?(?: |\n|$)/,
     );
@@ -133,7 +140,7 @@ export default workflow(
     const runSession = "run-cdp-stay-open";
 
     await librettoCli(
-      `open about:blank --headless --session ${sourceSession}`,
+      `open data:text/html,<title>Stay Open CDP</title><body>inspect-me</body> --headless --session ${sourceSession}`,
     );
 
     const sourceState = JSON.parse(
@@ -159,14 +166,99 @@ export default workflow(
     const result = await librettoCli(
       `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession} --stay-open-on-success`,
     );
-    expect(result.stdout).toContain("CDP_STAY_OPEN Example Domain");
+    expect(result.stdout).toContain("CDP_STAY_OPEN Stay Open CDP");
     expect(result.stdout).toContain("Integration completed.");
     expect(result.stdout).toContain("Browser is still open");
 
     const pages = await librettoCli(`pages --session ${runSession}`);
-    expect(pages.stdout).toContain("example.com");
+    expect(pages.stdout).toContain("inspect-me");
+    expect(pages.stdout).not.toContain("example.com");
 
     const snapshot = await librettoCli(`snapshot --session ${runSession}`);
-    expect(snapshot.stdout).toMatch(/Example Domain|example\.com/i);
+    expect(snapshot.stdout).toMatch(/Stay Open CDP|inspect-me/i);
+  }, 90_000);
+
+  test("run --cdp without startUrl still attaches and runs the handler", async ({
+    librettoCli,
+    writeWorkflow,
+    workspacePath,
+  }) => {
+    const sourceSession = "run-cdp-no-starturl-source";
+    const runSession = "run-cdp-no-starturl";
+
+    await librettoCli(
+      `open data:text/html,<title>No StartUrl</title><body>ready</body> --headless --session ${sourceSession}`,
+    );
+
+    const sourceState = JSON.parse(
+      await readFile(
+        workspacePath(".libretto", "sessions", sourceSession, "state.json"),
+        "utf8",
+      ),
+    ) as { port: number };
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp-no-starturl.mjs",
+      `
+export default workflow("main", async ({ page }) => {
+  console.log("CDP_NO_STARTURL", await page.title());
+});
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp http://127.0.0.1:${sourceState.port} --session ${runSession}`,
+    );
+    expect(result.stdout).toContain("CDP_NO_STARTURL No StartUrl");
+    expect(result.stdout).toContain("Integration completed.");
+  }, 90_000);
+});
+
+describe("run launch startUrl", () => {
+  test("navigates to workflow startUrl when Libretto launches the browser", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-launch-starturl.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: "https://example.com/" },
+  async ({ page }) => {
+    console.log("LAUNCH_RUN_URL", page.url());
+    console.log("LAUNCH_RUN_TITLE", await page.title());
+  },
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session run-launch-starturl --headless`,
+    );
+    expect(result.stdout).toContain("LAUNCH_RUN_URL https://example.com/");
+    expect(result.stdout).toContain("LAUNCH_RUN_TITLE Example Domain");
+    expect(result.stdout).toContain("Integration completed.");
+  }, 90_000);
+
+  test("runs without startUrl when Libretto launches the browser", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-launch-no-starturl.mjs",
+      `
+export default workflow("main", async ({ page }) => {
+  console.log("LAUNCH_NO_STARTURL", page.url());
+});
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session run-launch-no-starturl --headless`,
+    );
+    expect(result.stdout).toContain("LAUNCH_NO_STARTURL");
+    expect(result.stdout).not.toContain("example.com");
+    expect(result.stdout).toContain("Integration completed.");
   }, 90_000);
 });

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -12,7 +12,10 @@ describe("run --cdp", () => {
     const runSession = "run-cdp-workflow";
 
     await librettoCli(
-      `open data:text/html,<title>CDP Existing</title><body>keep-me</body> --headless --session ${sourceSession}`,
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+    await librettoCli(
+      `exec "await page.setContent('<title>CDP Existing</title><body>keep-me</body>'), await page.title()" --session ${sourceSession}`,
     );
 
     const sourceState = JSON.parse(
@@ -55,7 +58,7 @@ export default workflow(
 
     // Source open session still owns the live browser on the original page.
     const sourcePages = await librettoCli(`pages --session ${sourceSession}`);
-    expect(sourcePages.stdout).toContain("keep-me");
+    expect(sourcePages.stdout).toContain("about:blank");
     expect(sourcePages.stdout).not.toContain("example.com");
     expect(() => process.kill(sourceState.pid, 0)).not.toThrow();
   }, 90_000);
@@ -140,7 +143,10 @@ export default workflow(
     const runSession = "run-cdp-stay-open";
 
     await librettoCli(
-      `open data:text/html,<title>Stay Open CDP</title><body>inspect-me</body> --headless --session ${sourceSession}`,
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+    await librettoCli(
+      `exec "await page.setContent('<title>Stay Open CDP</title><body>inspect-me</body>'), await page.title()" --session ${sourceSession}`,
     );
 
     const sourceState = JSON.parse(
@@ -171,7 +177,7 @@ export default workflow(
     expect(result.stdout).toContain("Browser is still open");
 
     const pages = await librettoCli(`pages --session ${runSession}`);
-    expect(pages.stdout).toContain("inspect-me");
+    expect(pages.stdout).toContain("about:blank");
     expect(pages.stdout).not.toContain("example.com");
 
     const snapshot = await librettoCli(`snapshot --session ${runSession}`);
@@ -187,7 +193,10 @@ export default workflow(
     const runSession = "run-cdp-no-starturl";
 
     await librettoCli(
-      `open data:text/html,<title>No StartUrl</title><body>ready</body> --headless --session ${sourceSession}`,
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+    await librettoCli(
+      `exec "await page.setContent('<title>No StartUrl</title><body>ready</body>'), await page.title()" --session ${sourceSession}`,
     );
 
     const sourceState = JSON.parse(

--- a/specs/run-cdp-workflow-spec.md
+++ b/specs/run-cdp-workflow-spec.md
@@ -4,15 +4,15 @@
 
 ## Solution overview
 
-Add `--cdp <url>` to `libretto run` as a third browser source alongside local launch and `--provider`. The command spawns a daemon with existing `browser.kind: "connect"` plus a workflow config, navigates to the workflow's required `startUrl`, then runs the handler. `connect` stays the interactive attach path; this spec does not add workflow attach to an already-open Libretto session.
+Add `--cdp <url>` to `libretto run` as a third browser source alongside local launch and `--provider`. The command spawns a daemon with existing `browser.kind: "connect"` plus a workflow config, attaches to the selected page without navigating to `startUrl`, then runs the handler. `connect` stays the interactive attach path; this spec does not add workflow attach to an already-open Libretto session.
 
 ## Goals
 
-- `libretto run ./workflow.ts --cdp http://127.0.0.1:9222` connects over CDP, opens the workflow `startUrl`, and runs the default-exported workflow.
-- Workflow `startUrl` remains required and is navigated before the handler, including on CDP runs.
+- `libretto run ./workflow.ts --cdp http://127.0.0.1:9222` connects over CDP, attaches to the existing page without changing its URL, and runs the default-exported workflow.
+- Workflow `startUrl` remains declared for launch/provider runs; `run --cdp` does not navigate to it so existing page URL and auth state stay intact.
 - CDP runs never terminate the remote browser or Electron app on success, failure, or `close`.
 - `--cdp` is mutually exclusive with `--provider` and with local-only launch flags that do not apply (`--headed`/`--headless`, `--viewport`).
-- Optional `--page <id>` selects which existing CDP page receives navigation and the workflow `page` context.
+- Optional `--page <id>` selects which existing CDP page becomes the workflow `page` context.
 
 ## Non-goals
 
@@ -81,9 +81,9 @@ export function createRunBrowserConfig(args: {
 - [x] Update `run` usage/help text to include `--cdp`.
 - [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
-### Phase 2: Apply workflow `startUrl` to CDP connect runs
+### Phase 2: Do not apply workflow `startUrl` to CDP connect runs
 
-Connect+workflow must navigate to `startUrl` before the handler, matching local and provider `run` behavior. Today only `launch` gets `initialUrl` from workflow metadata.
+Launch and provider `run` still open `startUrl` before the handler. Connect/CDP workflow runs must attach without navigation so the existing page URL and authentication state remain intact. Automatic CDP navigation discarded useful state and could hit Libretto's navigation timeout before the handler began.
 
 ```ts
 // packages/libretto/src/cli/core/daemon/config.ts
@@ -91,11 +91,7 @@ export function applyWorkflowStartUrlToBrowserConfig(
   browser: DaemonConfig["browser"],
   startUrl: string | undefined,
 ): DaemonConfig["browser"] {
-  if (
-    !startUrl ||
-    (browser.kind !== "launch" && browser.kind !== "connect") ||
-    browser.initialUrl
-  ) {
+  if (!startUrl || browser.kind !== "launch" || browser.initialUrl) {
     return browser;
   }
   return { ...browser, initialUrl: startUrl };
@@ -104,35 +100,36 @@ export function applyWorkflowStartUrlToBrowserConfig(
 
 Daemon `main` calls this for non-provider browser configs after loading the workflow.
 
-- [x] Extend the workflow `startUrl` → `initialUrl` merge to `kind: "connect"` (not only `launch`).
-- [x] Keep requiring `startUrl` on the workflow; do not add a CDP exception that skips navigation.
-- [x] Add a focused unit/integration assertion that a connect+workflow daemon config ends up with `initialUrl` equal to the workflow `startUrl`.
+- [x] Apply workflow `startUrl` → `initialUrl` only for `kind: "launch"` (not `connect`).
+- [x] Keep requiring/declaring `startUrl` on workflows for launch and provider runs; CDP attach skips navigation.
+- [x] Add a focused unit assertion that a connect+workflow daemon config does not gain `initialUrl` from workflow `startUrl`.
 - [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 3: End-to-end `run --cdp` coverage
 
-Prove the primary Electron/CDP path: external Chromium with remote debugging, `run --cdp`, navigation to `startUrl`, workflow completion, remote browser still alive after Libretto disconnects.
+Prove the primary Electron/CDP path: external Chromium with remote debugging, `run --cdp`, attach without `startUrl` navigation, workflow completion, remote browser still alive after Libretto disconnects.
 
-Tests live in `packages/libretto/test/run-cdp.spec.ts`. They start a CDP-capable browser via `libretto open --headless`, then point `run --cdp` at that port (same pattern as connect E2E). Flag-conflict coverage for `--cdp` + `--provider` / `--headless` is in `packages/libretto/test/basic.spec.ts`.
+Tests live in `packages/libretto/test/run-cdp.spec.ts`. They start a CDP-capable browser via `libretto open --headless`, then point `run --cdp` at that port (same pattern as connect E2E). Flag-conflict coverage for `--cdp` + `--provider` / `--headless` is in `packages/libretto/test/basic.spec.ts`. Launch-mode `startUrl` navigation stays covered in the same file.
 
 ```ts
 // packages/libretto/test/run-cdp.spec.ts
-test("executes a workflow against an external CDP browser and leaves it alive", async ({
+test("attaches without navigating away from the existing page", async ({
   librettoCli,
   writeWorkflow,
   workspacePath,
 }) => {
-  await librettoCli(`open about:blank --headless --session ${sourceSession}`);
+  await librettoCli(`open data:text/html,... --headless --session ${sourceSession}`);
   // read CDP port from source session state
   await librettoCli(
     `run "${integrationFilePath}" --cdp http://127.0.0.1:${port} --session ${runSession}`,
   );
-  // assert startUrl navigation + source browser still alive
+  // assert existing page preserved + source browser still alive
 });
 ```
 
-- [x] Add an integration test that starts a CDP-enabled Chromium, runs a small workflow with `startUrl` via `run --cdp`, and asserts success.
-- [x] Assert the workflow landed on `startUrl` (handler checks `page.url()` or equivalent).
+- [x] Add an integration test that starts a CDP-enabled Chromium, runs a small workflow with `startUrl` via `run --cdp`, and asserts success without navigating to `startUrl`.
+- [x] Assert the workflow stays on the pre-existing page (handler checks `page.url()` / title / body).
+- [x] Assert launch-mode `run` still navigates to workflow `startUrl`.
 - [x] Assert a normal successful CDP run disconnects the Libretto session without killing the CDP browser process.
 - [x] Assert `--stay-open-on-success` leaves a daemon-backed session usable with `pages` / `snapshot` against the same CDP browser.
 - [x] Assert conflicting flags (`--cdp` + `--provider`, `--cdp` + `--headless`) fail with actionable errors.
@@ -140,7 +137,7 @@ test("executes a workflow against an external CDP browser and leaves it alive", 
 
 ### Phase 4: Optional `--page` for multi-target CDP browsers
 
-Electron and multi-window Chrome often expose several pages. Let `run --cdp` select which page gets `startUrl` navigation and becomes `ctx.page`.
+Electron and multi-window Chrome often expose several pages. Let `run --cdp` select which page becomes `ctx.page` (without navigating away from that page's current URL).
 
 Initial pages discovered at daemon start are tracked as stable `page-0` .. `page-N` ids (later popups still get random ids). `run --cdp --page page-1` selects by that index among pages found at connect time, so the id matches what `pages` shows on another CDP session attached to the same browser.
 
@@ -156,20 +153,20 @@ export type DaemonBrowserConnectConfig = {
 // packages/libretto/src/cli/core/daemon/daemon.ts
 if (config.pageId) {
   const pageIndex = parseConnectPageIndex(config.pageId);
-  // select operationalPages[pageIndex] before initialize + startUrl navigation
+  // select operationalPages[pageIndex] before initialize (no startUrl navigation)
 }
 ```
 
 - [x] Add optional `--page` to `run` (same id form as `exec` / `snapshot`).
-- [x] Plumb `pageId` through daemon workflow start so navigation and `WorkflowController` use that page.
+- [x] Plumb `pageId` through daemon workflow start so `WorkflowController` uses that page.
 - [x] On unknown page id, fail with the same next-step style as `exec` (`libretto pages --session ...`).
 - [x] When `--page` is omitted, keep current connect default (last operational page, or create one).
-- [x] Add a test with two pages on one CDP browser: `run --cdp --page <id>` targets the chosen page.
+- [x] Add a test with two pages on one CDP browser: `run --cdp --page <id>` targets the chosen page without navigating.
 - [x] Verify `pnpm -s type-check --filter=libretto` passes.
 
 ### Phase 5: Docs and skill guidance
 
-Document the scripted CDP path without changing the interactive `connect` story.
+Document the scripted CDP path without changing the interactive `connect` story. Document that `run --cdp` does not navigate to workflow `startUrl`.
 
 - [x] Update `docs/reference/cli/run-and-resume.mdx` with `--cdp`, `--page`, lifecycle notes, and an Electron/CDP example.
 - [x] Update `docs/reference/cli/open-and-connect.mdx` to point scripted workflow execution at `run --cdp`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `run --cdp` attaches to the selected existing page without navigating to workflow `startUrl`, preserving URL and auth state.
- Launch-mode `run` still applies `startUrl` before the handler (provider preload paths unchanged).
- Unit and integration tests cover launch vs CDP/connect, including workflows without `startUrl`.
- Docs, skill guidance, and the `run --cdp` spec now describe attach-without-navigation behavior.

## Why
Automatic CDP navigation discarded useful page state and could fail on Libretto's navigation timeout before the workflow handler began.

## Verification
- `pnpm -s type-check --filter=libretto`
- `pnpm -s --filter libretto exec vitest run test/daemon-workflow-start-url.spec.ts test/run-cdp.spec.ts` (14 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91f4778f-dd93-48cd-9c9c-9b17472e53b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91f4778f-dd93-48cd-9c9c-9b17472e53b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

