### PR TITLE
Surface daemon startup failures instead of generic exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ pnpm -s cli
 - Do not add new dependencies without asking.
 - Do not remove or comment out code to "clean up" without asking — it may be there for a reason.
 - When code prints user-facing Libretto CLI commands, use the native `libretto` command in examples and guidance.
-- Errore adoption is incremental. Do not use Errore by default. Use it only when a task or existing code path explicitly opts in; the browser-tools auth-profile work is currently opted in. Before editing an opted-in path, read the `errore` skill. Keep existing public thrown-error contracts unless the task explicitly changes them.
+- Errore adoption is incremental. Do not use Errore by default. Use it only when a task or existing code path explicitly opts in; the browser-tools auth-profile work and the libretto daemon startup path (`packages/libretto/src/cli/core/daemon/daemon.ts`) are currently opted in. Before editing an opted-in path, read the `errore` skill. Keep existing public thrown-error contracts unless the task explicitly changes them.
 
 ## Testing
 

--- a/packages/libretto/package.json
+++ b/packages/libretto/package.json
@@ -81,6 +81,7 @@
     "@ai-sdk/openai": "^3.0.66",
     "affordance": "workspace:^",
     "ai": "^6.0.116",
+    "errore": "^0.14.1",
     "esbuild": "^0.27.0",
     "playwright": "catalog:",
     "tsx": "^4.21.0",

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -1033,8 +1033,8 @@ async function main(): Promise<Error | void> {
     const workflow = config.workflow;
     const loaded = await loadDefaultWorkflow(
       getAbsoluteIntegrationPath(workflow.integrationPath),
-    ).catch(
-      (cause: unknown) => new Error(firstLine(cause), { cause }),
+    ).catch((cause: unknown) =>
+      cause instanceof Error ? cause : new Error(String(cause), { cause }),
     );
     if (loaded instanceof Error) return loaded;
 
@@ -1042,7 +1042,8 @@ async function main(): Promise<Error | void> {
       try: () => {
         validateWorkflowInput(loaded, workflow.params ?? {});
       },
-      catch: (cause) => new Error(firstLine(cause), { cause }),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(String(cause), { cause }),
     });
     if (validated instanceof Error) return validated;
     loadedWorkflow = loaded;
@@ -1148,9 +1149,9 @@ async function main(): Promise<Error | void> {
 }
 
 async function reportStartupError(error: Error): Promise<never> {
-  const message = firstLine(error);
-  // Prefer the original failure (via cause) for the session log; IPC gets the
-  // wrapped message so the parent shows operation + endpoint context.
+  // Keep the full message — auth/workflow guidance is often multi-line.
+  // Playwright call logs only appear when we put firstLine() into $detail.
+  const message = error.message;
   const logged = error.cause !== undefined ? error.cause : error;
   console.error(
     logged instanceof Error ? (logged.stack ?? String(logged)) : String(logged),

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -123,6 +123,32 @@ class UserFacingStartupError extends Error {
   }
 }
 
+function startupErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function startupErrorSummary(error: unknown): string {
+  const message = startupErrorMessage(error);
+  return message.split("\n", 1)[0] ?? message;
+}
+
+async function connectOverCdp(cdpEndpoint: string): Promise<Browser> {
+  try {
+    return await chromium.connectOverCDP(cdpEndpoint);
+  } catch (error) {
+    // Parent redirects child stderr into the session log file.
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    throw new UserFacingStartupError(
+      [
+        `Failed to connect to CDP endpoint ${cdpEndpoint}: ${startupErrorSummary(error)}.`,
+        "Confirm the target is listening and that this process can reach it",
+        "(sandbox, firewall, or network policy may block the connection).",
+      ].join(" "),
+    );
+  }
+}
+
 function resolveAuthProfileStorageStatePath(args: {
   authProfileName?: string;
   session: string;
@@ -379,18 +405,29 @@ class BrowserDaemon {
       ? `--window-position=${config.windowPosition.x},${config.windowPosition.y}`
       : undefined;
 
-    const browser = await chromium.launch({
-      headless: !config.headed,
-      args: [
-        "--disable-blink-features=AutomationControlled",
-        ...(config.remoteDebuggingPort
-          ? [`--remote-debugging-port=${config.remoteDebuggingPort}`]
-          : []),
-        "--remote-debugging-address=127.0.0.1",
-        "--no-focus-on-check",
-        ...(windowPositionArg ? [windowPositionArg] : []),
-      ],
-    });
+    let browser: Browser;
+    try {
+      browser = await chromium.launch({
+        headless: !config.headed,
+        args: [
+          "--disable-blink-features=AutomationControlled",
+          ...(config.remoteDebuggingPort
+            ? [`--remote-debugging-port=${config.remoteDebuggingPort}`]
+            : []),
+          "--remote-debugging-address=127.0.0.1",
+          "--no-focus-on-check",
+          ...(windowPositionArg ? [windowPositionArg] : []),
+        ],
+      });
+    } catch (error) {
+      // Parent redirects child stderr into the session log file.
+      console.error(
+        error instanceof Error ? (error.stack ?? error.message) : String(error),
+      );
+      throw new UserFacingStartupError(
+        `Failed to launch Chromium: ${startupErrorSummary(error)}`,
+      );
+    }
 
     const context = await browser.newContext({
       ...(storageStatePath ? { storageState: storageStatePath } : {}),
@@ -435,7 +472,7 @@ class BrowserDaemon {
     browser: DaemonBrowserConnectConfig;
   }): Promise<BrowserDaemon> {
     const { session, browser: config } = args;
-    const browser = await chromium.connectOverCDP(config.cdpEndpoint);
+    const browser = await connectOverCdp(config.cdpEndpoint);
 
     // Discover existing contexts and pages.
     const contexts = browser.contexts();
@@ -509,9 +546,7 @@ class BrowserDaemon {
         gpu: config.gpu,
         viewport: config.viewport,
       });
-      const browser = await chromium.connectOverCDP(
-        providerSession.cdpEndpoint,
-      );
+      const browser = await connectOverCdp(providerSession.cdpEndpoint);
 
       const contexts = browser.contexts();
       const context =
@@ -1081,20 +1116,40 @@ async function main(): Promise<void> {
   // letting the process exit naturally.
 }
 
-function reportStartupError(error: unknown): never {
-  if (error instanceof UserFacingStartupError) {
-    process.send?.({
-      type: "startup-error",
-      message: error.message,
-    });
-  }
+async function reportStartupError(error: unknown): Promise<never> {
+  const message = startupErrorMessage(error);
+  // Parent redirects child stderr into the session log file.
+  console.error(error instanceof Error ? (error.stack ?? message) : message);
+
+  await new Promise<void>((resolve) => {
+    if (typeof process.send !== "function") {
+      resolve();
+      return;
+    }
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    try {
+      process.send({ type: "startup-error", message }, done);
+    } catch {
+      done();
+      return;
+    }
+    // If IPC is broken, do not hang forever waiting for the callback.
+    setTimeout(done, 250);
+  });
+
   process.exit(
     process.exitCode && process.exitCode !== 0 ? process.exitCode : 1,
   );
+  throw new Error("unreachable");
 }
 
 try {
   await main();
 } catch (error) {
-  reportStartupError(error);
+  await reportStartupError(error);
 }

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -526,7 +526,6 @@ class BrowserDaemon {
     experiments: Experiments;
     browser: DaemonBrowserProviderConfig;
   }) {
-    await using cleanup = new errore.AsyncDisposableStack();
     const { session, browser: config } = args;
     const provider = getCloudProviderApi(config.providerName);
     let providerSession: ProviderSession | undefined;
@@ -534,100 +533,105 @@ class BrowserDaemon {
       provider,
       getProviderSession: () => providerSession,
     });
-    cleanup.defer(async () => {
+
+    const result = await errore.tryAsync({
+      try: async () => {
+        const startUrl = config.startUrl ?? config.initialUrl;
+        const created = await provider
+          .createSession({
+            authProfileName: config.authProfileName,
+            authProfilePersist: config.authProfilePersist,
+            headless: config.headless,
+            startUrl,
+            gpu: config.gpu,
+            viewport: config.viewport,
+          })
+          .catch(
+            (cause: unknown) =>
+              new Error(
+                `Failed to create ${config.providerName} session: ${firstLine(cause)}`,
+                { cause },
+              ),
+          );
+        if (created instanceof Error) return created;
+        providerSession = created;
+
+        const browser = await chromium
+          .connectOverCDP(created.cdpEndpoint)
+          .catch(
+            (cause: unknown) =>
+              new CdpConnectError({
+                cdpEndpoint: created.cdpEndpoint,
+                detail: firstLine(cause),
+                cause,
+              }),
+          );
+        if (browser instanceof Error) return browser;
+
+        const contexts = browser.contexts();
+        const context =
+          contexts.length > 0 ? contexts[0] : await browser.newContext();
+        const operationalPages = context.pages().filter(isOperationalPage);
+        const page =
+          operationalPages.length > 0
+            ? operationalPages[operationalPages.length - 1]
+            : await context.newPage();
+
+        const daemon = await BrowserDaemon.initialize({
+          session,
+          experiments: args.experiments,
+          externallyManaged: true,
+          browser,
+          context,
+          page,
+          initialPages: operationalPages.length > 0 ? operationalPages : [page],
+          // Providers that preload start_url before CDP attach must not get a
+          // second page.goto — that re-triggers bot detection on some sites.
+          // Providers without create-time start_url still navigate here so
+          // workflow startUrl works without a first-handler page.goto.
+          navigateUrl: created.startUrlPreloaded ? undefined : startUrl,
+          readyProvider: {
+            name: config.providerName,
+            sessionId: created.sessionId,
+            cdpEndpoint: created.cdpEndpoint,
+            liveViewUrl: created.liveViewUrl,
+            recordingUrl: created.recordingUrl,
+          },
+          providerSession: {
+            provider,
+            name: config.providerName,
+            sessionId: created.sessionId,
+            recordingUrl: created.recordingUrl,
+          },
+          beforeReady: startupCleanup.dispose,
+        });
+
+        daemon.logger.info("child-provider-connected", {
+          provider: config.providerName,
+          sessionId: created.sessionId,
+          url: config.initialUrl,
+          startUrl,
+          startUrlPreloaded: created.startUrlPreloaded === true,
+          gpu: config.gpu,
+          viewport: config.viewport,
+          pid: process.pid,
+          session,
+        });
+
+        return daemon;
+      },
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(String(cause), { cause }),
+    });
+
+    if (result instanceof Error) {
       startupCleanup.dispose();
       if (providerSession) {
         await provider.closeSession(providerSession.sessionId);
       }
-    });
-
-    const startUrl = config.startUrl ?? config.initialUrl;
-    const created = await provider
-      .createSession({
-        authProfileName: config.authProfileName,
-        authProfilePersist: config.authProfilePersist,
-        headless: config.headless,
-        startUrl,
-        gpu: config.gpu,
-        viewport: config.viewport,
-      })
-      .catch(
-        (cause: unknown) =>
-          new Error(
-            `Failed to create ${config.providerName} session: ${firstLine(cause)}`,
-            { cause },
-          ),
-      );
-    if (created instanceof Error) return created;
-    providerSession = created;
-
-    const browser = await chromium
-      .connectOverCDP(created.cdpEndpoint)
-      .catch(
-        (cause: unknown) =>
-          new CdpConnectError({
-            cdpEndpoint: created.cdpEndpoint,
-            detail: firstLine(cause),
-            cause,
-          }),
-      );
-    if (browser instanceof Error) return browser;
-
-    const contexts = browser.contexts();
-    const context =
-      contexts.length > 0 ? contexts[0] : await browser.newContext();
-    const operationalPages = context.pages().filter(isOperationalPage);
-    const page =
-      operationalPages.length > 0
-        ? operationalPages[operationalPages.length - 1]
-        : await context.newPage();
-
-    const daemon = await BrowserDaemon.initialize({
-      session,
-      experiments: args.experiments,
-      externallyManaged: true,
-      browser,
-      context,
-      page,
-      initialPages: operationalPages.length > 0 ? operationalPages : [page],
-      // Providers that preload start_url before CDP attach must not get a
-      // second page.goto — that re-triggers bot detection on some sites.
-      // Providers without create-time start_url still navigate here so
-      // workflow startUrl works without a first-handler page.goto.
-      navigateUrl: created.startUrlPreloaded ? undefined : startUrl,
-      readyProvider: {
-        name: config.providerName,
-        sessionId: created.sessionId,
-        cdpEndpoint: created.cdpEndpoint,
-        liveViewUrl: created.liveViewUrl,
-        recordingUrl: created.recordingUrl,
-      },
-      providerSession: {
-        provider,
-        name: config.providerName,
-        sessionId: created.sessionId,
-        recordingUrl: created.recordingUrl,
-      },
-      beforeReady: () => {
-        // Daemon owns the provider session now — drop failure-path cleanup.
-        cleanup.move();
-        startupCleanup.dispose();
-      },
-    });
-
-    daemon.logger.info("child-provider-connected", {
-      provider: config.providerName,
-      sessionId: created.sessionId,
-      url: config.initialUrl,
-      startUrl,
-      startUrlPreloaded: created.startUrlPreloaded === true,
-      gpu: config.gpu,
-      viewport: config.viewport,
-      pid: process.pid,
-      session,
-    });
-
-    return daemon;
+      return result;
+    }
+    return result;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -116,37 +116,20 @@ async function waitForSessionState(session: string): Promise<void> {
   );
 }
 
-class UserFacingStartupError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "UserFacingStartupError";
-  }
-}
-
-function startupErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
-}
-
-function startupErrorSummary(error: unknown): string {
-  const message = startupErrorMessage(error);
+function firstLine(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
   return message.split("\n", 1)[0] ?? message;
 }
 
-async function connectOverCdp(cdpEndpoint: string): Promise<Browser> {
-  try {
-    return await chromium.connectOverCDP(cdpEndpoint);
-  } catch (error) {
-    // Parent redirects child stderr into the session log file.
-    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
-    throw new UserFacingStartupError(
-      [
-        `Failed to connect to CDP endpoint ${cdpEndpoint}: ${startupErrorSummary(error)}.`,
-        "Confirm the target is listening and that this process can reach it",
-        "(sandbox, firewall, or network policy may block the connection).",
-      ].join(" "),
-    );
-  }
+function failedToConnectCdp(cdpEndpoint: string, error: unknown): Error {
+  return new Error(
+    [
+      `Failed to connect to CDP endpoint ${cdpEndpoint}: ${firstLine(error)}.`,
+      "Confirm the target is listening and that this process can reach it",
+      "(sandbox, firewall, or network policy may block the connection).",
+    ].join(" "),
+    { cause: error },
+  );
 }
 
 function resolveAuthProfileStorageStatePath(args: {
@@ -157,7 +140,7 @@ function resolveAuthProfileStorageStatePath(args: {
   const profileName = normalizeProfileName(args.authProfileName);
   const profilePath = getProfilePath(profileName);
   if (!hasProfile(profileName)) {
-    throw new UserFacingStartupError(
+    throw new Error(
       formatMissingLocalAuthProfileMessage({
         profileName,
         profilePath,
@@ -420,13 +403,9 @@ class BrowserDaemon {
         ],
       });
     } catch (error) {
-      // Parent redirects child stderr into the session log file.
-      console.error(
-        error instanceof Error ? (error.stack ?? error.message) : String(error),
-      );
-      throw new UserFacingStartupError(
-        `Failed to launch Chromium: ${startupErrorSummary(error)}`,
-      );
+      throw new Error(`Failed to launch Chromium: ${firstLine(error)}`, {
+        cause: error,
+      });
     }
 
     const context = await browser.newContext({
@@ -472,7 +451,12 @@ class BrowserDaemon {
     browser: DaemonBrowserConnectConfig;
   }): Promise<BrowserDaemon> {
     const { session, browser: config } = args;
-    const browser = await connectOverCdp(config.cdpEndpoint);
+    let browser: Browser;
+    try {
+      browser = await chromium.connectOverCDP(config.cdpEndpoint);
+    } catch (error) {
+      throw failedToConnectCdp(config.cdpEndpoint, error);
+    }
 
     // Discover existing contexts and pages.
     const contexts = browser.contexts();
@@ -487,7 +471,7 @@ class BrowserDaemon {
         pageIndex < 0 ||
         pageIndex >= operationalPages.length
       ) {
-        throw new UserFacingStartupError(
+        throw new Error(
           [
             `Page "${config.pageId}" was not found while connecting to ${config.cdpEndpoint}.`,
             `Discovered ${operationalPages.length} page(s) (use page-0 .. page-${Math.max(operationalPages.length - 1, 0)}).`,
@@ -546,7 +530,12 @@ class BrowserDaemon {
         gpu: config.gpu,
         viewport: config.viewport,
       });
-      const browser = await connectOverCdp(providerSession.cdpEndpoint);
+      let browser: Browser;
+      try {
+        browser = await chromium.connectOverCDP(providerSession.cdpEndpoint);
+      } catch (error) {
+        throw failedToConnectCdp(providerSession.cdpEndpoint, error);
+      }
 
       const contexts = browser.contexts();
       const context =
@@ -1036,9 +1025,7 @@ async function main(): Promise<void> {
         );
       }
     } catch (error) {
-      throw new UserFacingStartupError(
-        error instanceof Error ? error.message : String(error),
-      );
+      throw new Error(firstLine(error), { cause: error });
     }
   }
 
@@ -1117,30 +1104,21 @@ async function main(): Promise<void> {
 }
 
 async function reportStartupError(error: unknown): Promise<never> {
-  const message = startupErrorMessage(error);
-  // Parent redirects child stderr into the session log file.
-  console.error(error instanceof Error ? (error.stack ?? message) : message);
+  const message = firstLine(error);
+  // Prefer the original failure (via cause) for the session log; IPC gets the
+  // wrapped message so the parent shows operation + endpoint context.
+  const logged =
+    error instanceof Error && error.cause !== undefined ? error.cause : error;
+  console.error(
+    logged instanceof Error ? (logged.stack ?? String(logged)) : String(logged),
+  );
 
-  await new Promise<void>((resolve) => {
-    if (typeof process.send !== "function") {
-      resolve();
-      return;
-    }
-    let settled = false;
-    const done = (): void => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    try {
-      process.send({ type: "startup-error", message }, done);
-    } catch {
-      done();
-      return;
-    }
-    // If IPC is broken, do not hang forever waiting for the callback.
-    setTimeout(done, 250);
-  });
+  if (typeof process.send === "function") {
+    await new Promise<void>((resolve) => {
+      process.send!({ type: "startup-error", message }, () => resolve());
+      setTimeout(resolve, 250);
+    });
+  }
 
   process.exit(
     process.exitCode && process.exitCode !== 0 ? process.exitCode : 1,

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -526,6 +526,7 @@ class BrowserDaemon {
     experiments: Experiments;
     browser: DaemonBrowserProviderConfig;
   }) {
+    await using cleanup = new errore.AsyncDisposableStack();
     const { session, browser: config } = args;
     const provider = getCloudProviderApi(config.providerName);
     let providerSession: ProviderSession | undefined;
@@ -533,103 +534,100 @@ class BrowserDaemon {
       provider,
       getProviderSession: () => providerSession,
     });
-
-    const result = await (async () => {
-      const startUrl = config.startUrl ?? config.initialUrl;
-      const created = await provider
-        .createSession({
-          authProfileName: config.authProfileName,
-          authProfilePersist: config.authProfilePersist,
-          headless: config.headless,
-          startUrl,
-          gpu: config.gpu,
-          viewport: config.viewport,
-        })
-        .catch(
-          (cause: unknown) =>
-            new Error(
-              `Failed to create ${config.providerName} session: ${firstLine(cause)}`,
-              { cause },
-            ),
-        );
-      if (created instanceof Error) return created;
-      providerSession = created;
-
-      const browser = await chromium
-        .connectOverCDP(created.cdpEndpoint)
-        .catch(
-          (cause: unknown) =>
-            new CdpConnectError({
-              cdpEndpoint: created.cdpEndpoint,
-              detail: firstLine(cause),
-              cause,
-            }),
-        );
-      if (browser instanceof Error) return browser;
-
-      const contexts = browser.contexts();
-      const context =
-        contexts.length > 0 ? contexts[0] : await browser.newContext();
-      const operationalPages = context.pages().filter(isOperationalPage);
-      const page =
-        operationalPages.length > 0
-          ? operationalPages[operationalPages.length - 1]
-          : await context.newPage();
-
-      const daemon = await BrowserDaemon.initialize({
-        session,
-        experiments: args.experiments,
-        externallyManaged: true,
-        browser,
-        context,
-        page,
-        initialPages: operationalPages.length > 0 ? operationalPages : [page],
-        // Providers that preload start_url before CDP attach must not get a
-        // second page.goto — that re-triggers bot detection on some sites.
-        // Providers without create-time start_url still navigate here so
-        // workflow startUrl works without a first-handler page.goto.
-        navigateUrl: created.startUrlPreloaded ? undefined : startUrl,
-        readyProvider: {
-          name: config.providerName,
-          sessionId: created.sessionId,
-          cdpEndpoint: created.cdpEndpoint,
-          liveViewUrl: created.liveViewUrl,
-          recordingUrl: created.recordingUrl,
-        },
-        providerSession: {
-          provider,
-          name: config.providerName,
-          sessionId: created.sessionId,
-          recordingUrl: created.recordingUrl,
-        },
-        beforeReady: startupCleanup.dispose,
-      });
-
-      daemon.logger.info("child-provider-connected", {
-        provider: config.providerName,
-        sessionId: created.sessionId,
-        url: config.initialUrl,
-        startUrl,
-        startUrlPreloaded: created.startUrlPreloaded === true,
-        gpu: config.gpu,
-        viewport: config.viewport,
-        pid: process.pid,
-        session,
-      });
-
-      return daemon;
-    })().catch((cause: unknown) =>
-      cause instanceof Error ? cause : new Error(String(cause), { cause }),
-    );
-
-    if (result instanceof Error) {
+    cleanup.defer(async () => {
       startupCleanup.dispose();
       if (providerSession) {
         await provider.closeSession(providerSession.sessionId);
       }
-      return result;
-    }
-    return result;
+    });
+
+    const startUrl = config.startUrl ?? config.initialUrl;
+    const created = await provider
+      .createSession({
+        authProfileName: config.authProfileName,
+        authProfilePersist: config.authProfilePersist,
+        headless: config.headless,
+        startUrl,
+        gpu: config.gpu,
+        viewport: config.viewport,
+      })
+      .catch(
+        (cause: unknown) =>
+          new Error(
+            `Failed to create ${config.providerName} session: ${firstLine(cause)}`,
+            { cause },
+          ),
+      );
+    if (created instanceof Error) return created;
+    providerSession = created;
+
+    const browser = await chromium
+      .connectOverCDP(created.cdpEndpoint)
+      .catch(
+        (cause: unknown) =>
+          new CdpConnectError({
+            cdpEndpoint: created.cdpEndpoint,
+            detail: firstLine(cause),
+            cause,
+          }),
+      );
+    if (browser instanceof Error) return browser;
+
+    const contexts = browser.contexts();
+    const context =
+      contexts.length > 0 ? contexts[0] : await browser.newContext();
+    const operationalPages = context.pages().filter(isOperationalPage);
+    const page =
+      operationalPages.length > 0
+        ? operationalPages[operationalPages.length - 1]
+        : await context.newPage();
+
+    const daemon = await BrowserDaemon.initialize({
+      session,
+      experiments: args.experiments,
+      externallyManaged: true,
+      browser,
+      context,
+      page,
+      initialPages: operationalPages.length > 0 ? operationalPages : [page],
+      // Providers that preload start_url before CDP attach must not get a
+      // second page.goto — that re-triggers bot detection on some sites.
+      // Providers without create-time start_url still navigate here so
+      // workflow startUrl works without a first-handler page.goto.
+      navigateUrl: created.startUrlPreloaded ? undefined : startUrl,
+      readyProvider: {
+        name: config.providerName,
+        sessionId: created.sessionId,
+        cdpEndpoint: created.cdpEndpoint,
+        liveViewUrl: created.liveViewUrl,
+        recordingUrl: created.recordingUrl,
+      },
+      providerSession: {
+        provider,
+        name: config.providerName,
+        sessionId: created.sessionId,
+        recordingUrl: created.recordingUrl,
+      },
+      beforeReady: () => {
+        // Daemon owns the provider session now — drop failure-path cleanup.
+        cleanup.move();
+        startupCleanup.dispose();
+      },
+    });
+
+    daemon.logger.info("child-provider-connected", {
+      provider: config.providerName,
+      sessionId: created.sessionId,
+      url: config.initialUrl,
+      startUrl,
+      startUrlPreloaded: created.startUrlPreloaded === true,
+      gpu: config.gpu,
+      viewport: config.viewport,
+      pid: process.pid,
+      session,
+    });
+
+    return daemon;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -93,6 +93,7 @@ import { WorkflowController } from "../workflow-runner/runner.js";
 import { errorToMessage } from "../workflow-runner/workflow-error.js";
 import { validateWorkflowInput } from "../../../shared/workflow/workflow.js";
 import { captureAuthProfileStorageState } from "../../../shared/workflow/auth-profile-state.js";
+import * as errore from "errore";
 import { applyWindowPosition } from "../../../shared/run/window-position.js";
 
 function isOperationalPage(page: Page): boolean {
@@ -121,26 +122,32 @@ function firstLine(error: unknown): string {
   return message.split("\n", 1)[0] ?? message;
 }
 
-function failedToConnectCdp(cdpEndpoint: string, error: unknown): Error {
-  return new Error(
-    [
-      `Failed to connect to CDP endpoint ${cdpEndpoint}: ${firstLine(error)}.`,
-      "Confirm the target is listening and that this process can reach it",
-      "(sandbox, firewall, or network policy may block the connection).",
-    ].join(" "),
-    { cause: error },
-  );
-}
+class CdpConnectError extends errore.createTaggedError({
+  name: "CdpConnectError",
+  message:
+    "Failed to connect to CDP endpoint $cdpEndpoint: $detail. Confirm the target is listening and that this process can reach it (sandbox, firewall, or network policy may block the connection).",
+}) {}
+
+class ChromiumLaunchError extends errore.createTaggedError({
+  name: "ChromiumLaunchError",
+  message: "Failed to launch Chromium: $detail",
+}) {}
+
+class ConnectPageNotFoundError extends errore.createTaggedError({
+  name: "ConnectPageNotFoundError",
+  message:
+    'Page "$pageId" was not found while connecting to $cdpEndpoint. Discovered $pageCount page(s) (use page-0 .. page-$lastPageIndex). List pages on an interactive session with: libretto connect $cdpEndpoint && libretto pages',
+}) {}
 
 function resolveAuthProfileStorageStatePath(args: {
   authProfileName?: string;
   session: string;
-}): string | undefined {
+}): Error | string | undefined {
   if (!args.authProfileName) return undefined;
   const profileName = normalizeProfileName(args.authProfileName);
   const profilePath = getProfilePath(profileName);
   if (!hasProfile(profileName)) {
-    throw new Error(
+    return new Error(
       formatMissingLocalAuthProfileMessage({
         profileName,
         profilePath,
@@ -376,7 +383,7 @@ class BrowserDaemon {
     experiments: Experiments;
     browser: DaemonBrowserLaunchConfig;
     workflow?: DaemonWorkflowConfig;
-  }): Promise<BrowserDaemon> {
+  }) {
     const { session, browser: config } = args;
     const storageStatePath =
       config.storageStatePath ??
@@ -384,13 +391,14 @@ class BrowserDaemon {
         authProfileName: args.workflow?.authProfileName,
         session,
       });
+    if (storageStatePath instanceof Error) return storageStatePath;
+
     const windowPositionArg = config.windowPosition
       ? `--window-position=${config.windowPosition.x},${config.windowPosition.y}`
       : undefined;
 
-    let browser: Browser;
-    try {
-      browser = await chromium.launch({
+    const browser = await chromium
+      .launch({
         headless: !config.headed,
         args: [
           "--disable-blink-features=AutomationControlled",
@@ -401,12 +409,12 @@ class BrowserDaemon {
           "--no-focus-on-check",
           ...(windowPositionArg ? [windowPositionArg] : []),
         ],
-      });
-    } catch (error) {
-      throw new Error(`Failed to launch Chromium: ${firstLine(error)}`, {
-        cause: error,
-      });
-    }
+      })
+      .catch(
+        (cause: unknown) =>
+          new ChromiumLaunchError({ detail: firstLine(cause), cause }),
+      );
+    if (browser instanceof Error) return browser;
 
     const context = await browser.newContext({
       ...(storageStatePath ? { storageState: storageStatePath } : {}),
@@ -449,43 +457,48 @@ class BrowserDaemon {
     session: string;
     experiments: Experiments;
     browser: DaemonBrowserConnectConfig;
-  }): Promise<BrowserDaemon> {
+  }) {
     const { session, browser: config } = args;
-    let browser: Browser;
-    try {
-      browser = await chromium.connectOverCDP(config.cdpEndpoint);
-    } catch (error) {
-      throw failedToConnectCdp(config.cdpEndpoint, error);
-    }
+    const browser = await chromium
+      .connectOverCDP(config.cdpEndpoint)
+      .catch(
+        (cause: unknown) =>
+          new CdpConnectError({
+            cdpEndpoint: config.cdpEndpoint,
+            detail: firstLine(cause),
+            cause,
+          }),
+      );
+    if (browser instanceof Error) return browser;
 
     // Discover existing contexts and pages.
     const contexts = browser.contexts();
     const context =
       contexts.length > 0 ? contexts[0] : await browser.newContext();
     const operationalPages = context.pages().filter(isOperationalPage);
-    let page: Page;
-    if (config.pageId) {
+
+    const page = await (async (): Promise<ConnectPageNotFoundError | Page> => {
+      if (!config.pageId) {
+        return operationalPages.length > 0
+          ? operationalPages[operationalPages.length - 1]
+          : await context.newPage();
+      }
       const pageIndex = parseConnectPageIndex(config.pageId);
       if (
         pageIndex === undefined ||
         pageIndex < 0 ||
         pageIndex >= operationalPages.length
       ) {
-        throw new Error(
-          [
-            `Page "${config.pageId}" was not found while connecting to ${config.cdpEndpoint}.`,
-            `Discovered ${operationalPages.length} page(s) (use page-0 .. page-${Math.max(operationalPages.length - 1, 0)}).`,
-            `List pages on an interactive session with: libretto connect ${config.cdpEndpoint} && libretto pages`,
-          ].join(" "),
-        );
+        return new ConnectPageNotFoundError({
+          pageId: config.pageId,
+          cdpEndpoint: config.cdpEndpoint,
+          pageCount: String(operationalPages.length),
+          lastPageIndex: String(Math.max(operationalPages.length - 1, 0)),
+        });
       }
-      page = operationalPages[pageIndex];
-    } else {
-      page =
-        operationalPages.length > 0
-          ? operationalPages[operationalPages.length - 1]
-          : await context.newPage();
-    }
+      return operationalPages[pageIndex];
+    })();
+    if (page instanceof Error) return page;
 
     const daemon = await BrowserDaemon.initialize({
       session,
@@ -512,7 +525,7 @@ class BrowserDaemon {
     session: string;
     experiments: Experiments;
     browser: DaemonBrowserProviderConfig;
-  }): Promise<BrowserDaemon> {
+  }) {
     const { session, browser: config } = args;
     const provider = getCloudProviderApi(config.providerName);
     let providerSession: ProviderSession | undefined;
@@ -520,22 +533,39 @@ class BrowserDaemon {
       provider,
       getProviderSession: () => providerSession,
     });
-    try {
+
+    const result = await (async () => {
       const startUrl = config.startUrl ?? config.initialUrl;
-      providerSession = await provider.createSession({
-        authProfileName: config.authProfileName,
-        authProfilePersist: config.authProfilePersist,
-        headless: config.headless,
-        startUrl,
-        gpu: config.gpu,
-        viewport: config.viewport,
-      });
-      let browser: Browser;
-      try {
-        browser = await chromium.connectOverCDP(providerSession.cdpEndpoint);
-      } catch (error) {
-        throw failedToConnectCdp(providerSession.cdpEndpoint, error);
-      }
+      const created = await provider
+        .createSession({
+          authProfileName: config.authProfileName,
+          authProfilePersist: config.authProfilePersist,
+          headless: config.headless,
+          startUrl,
+          gpu: config.gpu,
+          viewport: config.viewport,
+        })
+        .catch(
+          (cause: unknown) =>
+            new Error(
+              `Failed to create ${config.providerName} session: ${firstLine(cause)}`,
+              { cause },
+            ),
+        );
+      if (created instanceof Error) return created;
+      providerSession = created;
+
+      const browser = await chromium
+        .connectOverCDP(created.cdpEndpoint)
+        .catch(
+          (cause: unknown) =>
+            new CdpConnectError({
+              cdpEndpoint: created.cdpEndpoint,
+              detail: firstLine(cause),
+              cause,
+            }),
+        );
+      if (browser instanceof Error) return browser;
 
       const contexts = browser.contexts();
       const context =
@@ -558,29 +588,29 @@ class BrowserDaemon {
         // second page.goto — that re-triggers bot detection on some sites.
         // Providers without create-time start_url still navigate here so
         // workflow startUrl works without a first-handler page.goto.
-        navigateUrl: providerSession.startUrlPreloaded ? undefined : startUrl,
+        navigateUrl: created.startUrlPreloaded ? undefined : startUrl,
         readyProvider: {
           name: config.providerName,
-          sessionId: providerSession.sessionId,
-          cdpEndpoint: providerSession.cdpEndpoint,
-          liveViewUrl: providerSession.liveViewUrl,
-          recordingUrl: providerSession.recordingUrl,
+          sessionId: created.sessionId,
+          cdpEndpoint: created.cdpEndpoint,
+          liveViewUrl: created.liveViewUrl,
+          recordingUrl: created.recordingUrl,
         },
         providerSession: {
           provider,
           name: config.providerName,
-          sessionId: providerSession.sessionId,
-          recordingUrl: providerSession.recordingUrl,
+          sessionId: created.sessionId,
+          recordingUrl: created.recordingUrl,
         },
         beforeReady: startupCleanup.dispose,
       });
 
       daemon.logger.info("child-provider-connected", {
         provider: config.providerName,
-        sessionId: providerSession.sessionId,
+        sessionId: created.sessionId,
         url: config.initialUrl,
         startUrl,
-        startUrlPreloaded: providerSession.startUrlPreloaded === true,
+        startUrlPreloaded: created.startUrlPreloaded === true,
         gpu: config.gpu,
         viewport: config.viewport,
         pid: process.pid,
@@ -588,13 +618,18 @@ class BrowserDaemon {
       });
 
       return daemon;
-    } catch (error) {
+    })().catch((cause: unknown) =>
+      cause instanceof Error ? cause : new Error(String(cause), { cause }),
+    );
+
+    if (result instanceof Error) {
       startupCleanup.dispose();
       if (providerSession) {
         await provider.closeSession(providerSession.sessionId);
       }
-      throw error;
+      return result;
     }
+    return result;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────
@@ -986,7 +1021,7 @@ function createProviderStartupCleanup(args: {
 
 // ── Main ───────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+async function main(): Promise<Error | void> {
   const config = JSON.parse(process.argv[2]) as DaemonConfig;
   const headed =
     config.browser.kind === "launch" ? config.browser.headed : false;
@@ -995,37 +1030,45 @@ async function main(): Promise<void> {
   let workflowConfig = config.workflow;
   let browserConfig = config.browser;
   if (config.workflow) {
-    try {
-      loadedWorkflow = await loadDefaultWorkflow(
-        getAbsoluteIntegrationPath(config.workflow.integrationPath),
-      );
-      validateWorkflowInput(loadedWorkflow, config.workflow.params ?? {});
-      const authProfileName = loadedWorkflow.authProfileName;
-      const authProfilePersist =
-        loadedWorkflow.authProfileRefresh === true;
-      workflowConfig = {
-        ...config.workflow,
+    const workflow = config.workflow;
+    const loaded = await loadDefaultWorkflow(
+      getAbsoluteIntegrationPath(workflow.integrationPath),
+    ).catch(
+      (cause: unknown) => new Error(firstLine(cause), { cause }),
+    );
+    if (loaded instanceof Error) return loaded;
+
+    const validated = errore.try({
+      try: () => {
+        validateWorkflowInput(loaded, workflow.params ?? {});
+      },
+      catch: (cause) => new Error(firstLine(cause), { cause }),
+    });
+    if (validated instanceof Error) return validated;
+    loadedWorkflow = loaded;
+
+    const authProfileName = loadedWorkflow.authProfileName;
+    const authProfilePersist = loadedWorkflow.authProfileRefresh === true;
+    workflowConfig = {
+      ...workflow,
+      authProfileName,
+      authProfilePersist,
+    };
+    if (config.browser.kind === "provider") {
+      browserConfig = {
+        ...config.browser,
         authProfileName,
         authProfilePersist,
+        startUrl: loadedWorkflow.startUrl ?? config.browser.startUrl,
+        gpu: loadedWorkflow.gpu ?? config.browser.gpu,
+        // Explicit daemon/CLI viewport wins over workflow viewport.
+        viewport: config.browser.viewport ?? loadedWorkflow.viewport,
       };
-      if (config.browser.kind === "provider") {
-        browserConfig = {
-          ...config.browser,
-          authProfileName,
-          authProfilePersist,
-          startUrl: loadedWorkflow.startUrl ?? config.browser.startUrl,
-          gpu: loadedWorkflow.gpu ?? config.browser.gpu,
-          // Explicit daemon/CLI viewport wins over workflow viewport.
-          viewport: config.browser.viewport ?? loadedWorkflow.viewport,
-        };
-      } else {
-        browserConfig = applyWorkflowStartUrlToBrowserConfig(
-          config.browser,
-          loadedWorkflow.startUrl,
-        );
-      }
-    } catch (error) {
-      throw new Error(firstLine(error), { cause: error });
+    } else {
+      browserConfig = applyWorkflowStartUrlToBrowserConfig(
+        config.browser,
+        loadedWorkflow.startUrl,
+      );
     }
   }
 
@@ -1048,6 +1091,7 @@ async function main(): Promise<void> {
             browser: browserConfig,
             workflow: workflowConfig,
           });
+  if (daemon instanceof Error) return daemon;
 
   if (workflowConfig) {
     void waitForSessionState(config.session)
@@ -1103,12 +1147,11 @@ async function main(): Promise<void> {
   // letting the process exit naturally.
 }
 
-async function reportStartupError(error: unknown): Promise<never> {
+async function reportStartupError(error: Error): Promise<never> {
   const message = firstLine(error);
   // Prefer the original failure (via cause) for the session log; IPC gets the
   // wrapped message so the parent shows operation + endpoint context.
-  const logged =
-    error instanceof Error && error.cause !== undefined ? error.cause : error;
+  const logged = error.cause !== undefined ? error.cause : error;
   console.error(
     logged instanceof Error ? (logged.stack ?? String(logged)) : String(logged),
   );
@@ -1126,8 +1169,7 @@ async function reportStartupError(error: unknown): Promise<never> {
   throw new Error("unreachable");
 }
 
-try {
-  await main();
-} catch (error) {
-  await reportStartupError(error);
-}
+const startup = await main().catch((cause: unknown) =>
+  cause instanceof Error ? cause : new Error(String(cause), { cause }),
+);
+if (startup instanceof Error) await reportStartupError(startup);

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -477,12 +477,8 @@ class BrowserDaemon {
       contexts.length > 0 ? contexts[0] : await browser.newContext();
     const operationalPages = context.pages().filter(isOperationalPage);
 
-    const page = await (async (): Promise<ConnectPageNotFoundError | Page> => {
-      if (!config.pageId) {
-        return operationalPages.length > 0
-          ? operationalPages[operationalPages.length - 1]
-          : await context.newPage();
-      }
+    let page: Page;
+    if (config.pageId) {
       const pageIndex = parseConnectPageIndex(config.pageId);
       if (
         pageIndex === undefined ||
@@ -496,9 +492,13 @@ class BrowserDaemon {
           lastPageIndex: String(Math.max(operationalPages.length - 1, 0)),
         });
       }
-      return operationalPages[pageIndex];
-    })();
-    if (page instanceof Error) return page;
+      page = operationalPages[pageIndex];
+    } else {
+      page =
+        operationalPages.length > 0
+          ? operationalPages[operationalPages.length - 1]
+          : await context.newPage();
+    }
 
     const daemon = await BrowserDaemon.initialize({
       session,
@@ -627,7 +627,20 @@ class BrowserDaemon {
     if (result instanceof Error) {
       startupCleanup.dispose();
       if (providerSession) {
-        await provider.closeSession(providerSession.sessionId);
+        const closed = await provider
+          .closeSession(providerSession.sessionId)
+          .catch((cause: unknown) =>
+            cause instanceof Error
+              ? cause
+              : new Error(String(cause), { cause }),
+          );
+        if (closed instanceof Error) {
+          // Keep the original startup failure as the returned error; only log
+          // cleanup trouble so it cannot replace the real cause over IPC.
+          console.error(
+            `Also failed to close ${config.providerName} session ${providerSession.sessionId} during startup cleanup: ${closed.message}`,
+          );
+        }
       }
       return result;
     }

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -758,8 +758,8 @@ export default workflow("main", async (ctx) => {
     const result = await librettoCli("open https://example.com", {
       PLAYWRIGHT_BROWSERS_PATH: "/definitely-not-real",
     });
-    expect(result.stderr).toContain("Daemon exited before startup");
-    expect(result.stderr).toContain("Check logs:");
+    expect(result.stderr).toContain("Failed to launch Chromium");
+    expect(result.stderr).not.toContain("Daemon exited before startup");
   });
 
   test("warns on open when the installed skill version is out of date", async ({
@@ -781,7 +781,23 @@ export default workflow("main", async (ctx) => {
     expect(result.stderr).toContain("agent skill:   0.0.0");
     expectNoPackageUpdateCommand(result.stderr);
     expectSkillSetupCommand(result.stderr);
-    expect(result.stderr).toContain("Daemon exited before startup");
+    expect(result.stderr).toContain("Failed to launch Chromium");
+  });
+
+  test("surfaces CDP connect failures instead of a generic daemon exit", async ({
+    librettoCli,
+  }) => {
+    const endpoint = "ws://127.0.0.1:1/devtools/browser/fake";
+    const result = await librettoCli(
+      `connect ${endpoint} --session connect-startup-error`,
+    );
+
+    expect(result.stderr).toContain(`Failed to connect to CDP endpoint ${endpoint}`);
+    expect(result.stderr).toContain("ECONNREFUSED");
+    expect(result.stderr).toContain(
+      "sandbox, firewall, or network policy may block the connection",
+    );
+    expect(result.stderr).not.toContain("Daemon exited before startup");
   });
 
   test("does not warn when only the current command differs from the local package", async ({

--- a/packages/libretto/test/run-cdp.spec.ts
+++ b/packages/libretto/test/run-cdp.spec.ts
@@ -322,4 +322,64 @@ export default workflow("main", async ({ page }) => {
     expect(result.stderr).toContain("integration-run-cdp-wait-stack.ts");
     expect(result.stderr).toContain("at extractExampleData (");
   }, 90_000);
+
+  test("run --cdp surfaces unreachable endpoint instead of a generic daemon exit", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const endpoint = "ws://127.0.0.1:1/devtools/browser/fake";
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp-unreachable.mjs",
+      `
+export default workflow("main", async () => "should-not-run");
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp ${endpoint} --session run-cdp-unreachable`,
+    );
+
+    expect(result.stderr).toContain(`Failed to connect to CDP endpoint ${endpoint}`);
+    expect(result.stderr).toContain("ECONNREFUSED");
+    expect(result.stderr).not.toContain("Daemon exited before startup");
+    expect(result.stdout).not.toContain("should-not-run");
+    expect(result.stdout).not.toContain("Integration completed.");
+  });
+
+  test("run --cdp --page reports missing page ids with recovery guidance", async ({
+    librettoCli,
+    writeWorkflow,
+    workspacePath,
+  }) => {
+    const sourceSession = "run-cdp-missing-page-source";
+    const runSession = "run-cdp-missing-page-run";
+
+    await librettoCli(
+      `open about:blank --headless --session ${sourceSession}`,
+    );
+    const sourceState = JSON.parse(
+      await readFile(
+        workspacePath(".libretto", "sessions", sourceSession, "state.json"),
+        "utf8",
+      ),
+    ) as { port: number };
+    const endpoint = `http://127.0.0.1:${sourceState.port}`;
+
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-cdp-missing-page.mjs",
+      `
+export default workflow("main", async () => "should-not-run");
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --cdp ${endpoint} --page page-99 --session ${runSession}`,
+    );
+
+    expect(result.stderr).toContain('Page "page-99" was not found');
+    expect(result.stderr).toContain(endpoint);
+    expect(result.stderr).toContain("libretto pages");
+    expect(result.stderr).not.toContain("Daemon exited before startup");
+    expect(result.stdout).not.toContain("should-not-run");
+  }, 90_000);
 });

--- a/packages/libretto/tsconfig.json
+++ b/packages/libretto/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "outDir": "./dist",
     "rootDir": "."
   },

--- a/packages/libretto/tsconfig.json
+++ b/packages/libretto/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "outDir": "./dist",
     "rootDir": "."
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       ai:
         specifier: ^6.0.116
         version: 6.0.140(zod@4.3.6)
+      errore:
+        specifier: ^0.14.1
+        version: 0.14.1
       esbuild:
         specifier: ^0.27.0
         version: 0.27.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Daemon startup used to discard ordinary exceptions from `chromium.connectOverCDP()` / `chromium.launch()` and only send `startup-error` for a special error class. Parents then reported the opaque `Daemon exited before startup (status: 1)`, which hid real causes such as sandbox `connect EPERM` on a CDP endpoint.

## Changes

- Always serialize startup failures to the parent over IPC
- Opt the daemon startup path into [errore](https://errore.org/): tagged `CdpConnectError` / `ChromiumLaunchError` / `ConnectPageNotFoundError`, `.catch` at Playwright boundaries, return `Error | T`
- Provider connect uses `errore.tryAsync`; cleanup failures no longer replace the original startup error
- Keep full multi-line startup messages (auth profile / `--tsconfig` guidance)
- Tests for connect failures, `run --cdp` unreachable endpoints, and missing `--page` ids
- Document the opt-in in `AGENTS.md`

## Test plan

- [x] `libretto connect ws://127.0.0.1:1/...` prints CDP connect failure
- [x] Broken `PLAYWRIGHT_BROWSERS_PATH` prints `Failed to launch Chromium`
- [x] Missing auth profile keeps multi-line recovery guidance
- [x] Compile failures keep `--tsconfig` guidance
- [x] `run --cdp` unreachable endpoint surfaces real error
- [x] `run --cdp --page page-99` reports missing page with recovery guidance
- [x] Related vitest suites green locally
- [x] `pnpm --filter libretto type-check`
- [x] OpenCode review: cleanup cannot mask startup error; page selection IIFE removed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60d9a19e-6f73-4812-bcd3-4ee93a7e65d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60d9a19e-6f73-4812-bcd3-4ee93a7e65d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

