### PR TITLE
Continue ChatGPT OAuth through Libretto onboarding

### DIFF
--- a/apps/website/src/OAuthContinuePage.tsx
+++ b/apps/website/src/OAuthContinuePage.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { withReturnTo } from "./authRedirect";
+import { authPost, getAuthStatus } from "./cloudApi";
+import { Navbar } from "./components/Navbar";
+
+type AuthResponse = {
+  url?: string;
+  uri?: string;
+};
+
+export function OAuthContinuePage() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function continueOAuth() {
+      const oauthQuery = window.location.search.replace(/^\?/, "");
+      const params = new URLSearchParams(oauthQuery);
+      if (!params.has("client_id") || !params.has("sig")) {
+        setError("The ChatGPT authorization request is missing or invalid. Start again in ChatGPT.");
+        return;
+      }
+
+      const returnTo = `/oauth/continue?${oauthQuery}`;
+      const status = await getAuthStatus();
+      if (!status.emailVerified) {
+        window.location.assign(withReturnTo("/verify-email", returnTo));
+        return;
+      }
+      if (!status.hasTenant) {
+        window.location.assign(withReturnTo("/onboarding", returnTo));
+        return;
+      }
+
+      const result = await authPost<AuthResponse>("/api/auth/oauth2/continue", {
+        postLogin: true,
+        oauth_query: oauthQuery,
+      });
+      const destination = result.uri ?? result.url;
+      if (!destination) {
+        throw new Error("Libretto did not return a ChatGPT authorization destination.");
+      }
+      window.location.assign(destination);
+    }
+
+    continueOAuth().catch((reason: unknown) => {
+      setError(reason instanceof Error ? reason.message : "Could not continue ChatGPT authorization.");
+    });
+  }, []);
+
+  return (
+    <div className="crt-page min-h-screen bg-bg text-ink">
+      <Navbar />
+      <main className="mx-auto flex min-h-[calc(100vh-96px)] w-full max-w-[760px] items-center px-6 py-10">
+        <section className="w-full rounded-lg border border-rule bg-panel/85 p-6 text-center shadow-2xl shadow-black/25">
+          <p className="mb-3 font-mono text-xs uppercase text-accent">Libretto Cloud</p>
+          <h1 className="font-serif text-4xl font-light">Continue to ChatGPT</h1>
+          {error ? (
+            <p className="mt-5 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-3 text-sm leading-5 text-red-200">
+              {error}
+            </p>
+          ) : (
+            <p className="mt-4 text-sm leading-6 text-muted">
+              Checking your account and workspace before showing the access request.
+            </p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/website/src/SignInPage.tsx
+++ b/apps/website/src/SignInPage.tsx
@@ -9,6 +9,7 @@ import {
 import { Navbar } from "./components/Navbar";
 import {
   authPost,
+  cloudApiUrl,
   getAuthStatus,
   getCloudSession,
   orpcCall,
@@ -19,6 +20,7 @@ import { GitHubIcon } from "./icons";
 type AuthResponse = {
   redirect?: boolean;
   url?: string;
+  uri?: string;
 };
 
 type AuthMode = "signin" | "signup";
@@ -64,6 +66,27 @@ function currentSigninCallbackUrl(): string {
     url.searchParams.set("cliLoginSecret", cliLogin.secret);
   }
   return url.toString();
+}
+
+function currentOAuthQuery(): string | null {
+  if (typeof window === "undefined") return null;
+  const query = window.location.search.replace(/^\?/, "");
+  const params = new URLSearchParams(query);
+  return params.has("client_id") && params.has("sig") ? query : null;
+}
+
+function oauthAuthorizeUrl(query: string): string {
+  const params = new URLSearchParams(query);
+  params.delete("exp");
+  params.delete("sig");
+  return `${cloudApiUrl}/api/auth/oauth2/authorize?${params}`;
+}
+
+function followAuthResponse(result: AuthResponse): boolean {
+  const destination = result.url ?? result.uri;
+  if (!destination) return false;
+  window.location.assign(destination);
+  return true;
 }
 
 async function resolvePostAuthRedirect(
@@ -169,6 +192,11 @@ export function SignInPage() {
     getCloudSession()
       .then((session) => {
         if (!session) return;
+        const oauthQuery = currentOAuthQuery();
+        if (oauthQuery) {
+          window.location.assign(oauthAuthorizeUrl(oauthQuery));
+          return;
+        }
         if (getCliLoginParams()) {
           approveCliLogin().catch((err) => {
             setError(err instanceof Error ? err.message : "CLI login approval failed.");
@@ -194,9 +222,11 @@ export function SignInPage() {
     setError(null);
     setNotice(null);
     try {
+      const oauthQuery = currentOAuthQuery();
       const result = await authPost<AuthResponse>("/api/auth/sign-in/email", {
         email,
         password,
+        ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
         callbackURL: getCliLoginParams()
           ? currentSigninCallbackUrl()
           : `${window.location.origin}${withReturnTo(
@@ -204,10 +234,7 @@ export function SignInPage() {
               sanitizeReturnToForAuthState(getSafeReturnTo(), true),
             )}`,
       });
-      if (result.url) {
-        window.location.assign(result.url);
-        return;
-      }
+      if (followAuthResponse(result)) return;
       if (await approveCliLogin()) return;
       window.location.assign(
         await resolvePostAuthRedirect(await getAuthStatus(), getSafeReturnTo()),
@@ -226,14 +253,17 @@ export function SignInPage() {
     try {
       const returnTo = getSafeReturnTo();
       const callbackReturnTo = sanitizeReturnToForAuthState(returnTo, false);
-      await authPost<AuthResponse>("/api/auth/sign-up/email", {
+      const oauthQuery = currentOAuthQuery();
+      const result = await authPost<AuthResponse>("/api/auth/sign-up/email", {
         name,
         email,
         password,
+        ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
         callbackURL: getCliLoginParams()
           ? currentSigninCallbackUrl()
           : `${window.location.origin}${withReturnTo("/verify-email", callbackReturnTo)}`,
       });
+      if (followAuthResponse(result)) return;
       if (await approveCliLogin()) return;
       window.location.assign(withReturnTo("/verify-email", callbackReturnTo));
     } catch (err) {
@@ -252,8 +282,10 @@ export function SignInPage() {
         returnTo,
         mode === "signin",
       );
+      const oauthQuery = currentOAuthQuery();
       const result = await authPost<AuthResponse>("/api/auth/sign-in/social", {
         provider,
+        ...(oauthQuery ? { oauth_query: oauthQuery } : {}),
         callbackURL: getCliLoginParams()
           ? currentSigninCallbackUrl()
           : `${window.location.origin}${withReturnTo(
@@ -261,10 +293,7 @@ export function SignInPage() {
               callbackReturnTo,
             )}`,
       });
-      if (result.url) {
-        window.location.assign(result.url);
-        return;
-      }
+      if (followAuthResponse(result)) return;
       if (await approveCliLogin()) return;
       window.location.assign(
         await resolvePostAuthRedirect(await getAuthStatus(), callbackReturnTo),

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as VsStagehandRouteImport } from './routes/vs/stagehand'
 import { Route as VsPlaywrightCodegenRouteImport } from './routes/vs/playwright-codegen'
 import { Route as VsBrowserUseRouteImport } from './routes/vs/browser-use'
+import { Route as OauthContinueRouteImport } from './routes/oauth.continue'
 import { Route as GithubSetupRouteImport } from './routes/github.setup'
 import { Route as DashboardPrAgentRouteImport } from './routes/dashboard_.pr-agent'
 import { Route as DashboardCloudBrowsersRouteImport } from './routes/dashboard_.cloud-browsers'
@@ -112,6 +113,11 @@ const VsBrowserUseRoute = VsBrowserUseRouteImport.update({
   path: '/vs/browser-use',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OauthContinueRoute = OauthContinueRouteImport.update({
+  id: '/oauth/continue',
+  path: '/oauth/continue',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GithubSetupRoute = GithubSetupRouteImport.update({
   id: '/github/setup',
   path: '/github/setup',
@@ -163,6 +169,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/cloud-browsers': typeof DashboardCloudBrowsersRoute
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -186,6 +193,7 @@ export interface FileRoutesByTo {
   '/dashboard/cloud-browsers': typeof DashboardCloudBrowsersRoute
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -211,6 +219,7 @@ export interface FileRoutesById {
   '/dashboard_/cloud-browsers': typeof DashboardCloudBrowsersRoute
   '/dashboard_/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -237,6 +246,7 @@ export interface FileRouteTypes {
     | '/dashboard/cloud-browsers'
     | '/dashboard/pr-agent'
     | '/github/setup'
+    | '/oauth/continue'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -260,6 +270,7 @@ export interface FileRouteTypes {
     | '/dashboard/cloud-browsers'
     | '/dashboard/pr-agent'
     | '/github/setup'
+    | '/oauth/continue'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -284,6 +295,7 @@ export interface FileRouteTypes {
     | '/dashboard_/cloud-browsers'
     | '/dashboard_/pr-agent'
     | '/github/setup'
+    | '/oauth/continue'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -308,6 +320,7 @@ export interface RootRouteChildren {
   DashboardCloudBrowsersRoute: typeof DashboardCloudBrowsersRoute
   DashboardPrAgentRoute: typeof DashboardPrAgentRoute
   GithubSetupRoute: typeof GithubSetupRoute
+  OauthContinueRoute: typeof OauthContinueRoute
   VsBrowserUseRoute: typeof VsBrowserUseRoute
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
   VsStagehandRoute: typeof VsStagehandRoute
@@ -427,6 +440,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof VsBrowserUseRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/oauth/continue': {
+      id: '/oauth/continue'
+      path: '/oauth/continue'
+      fullPath: '/oauth/continue'
+      preLoaderRoute: typeof OauthContinueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/github/setup': {
       id: '/github/setup'
       path: '/github/setup'
@@ -504,6 +524,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardCloudBrowsersRoute: DashboardCloudBrowsersRoute,
   DashboardPrAgentRoute: DashboardPrAgentRoute,
   GithubSetupRoute: GithubSetupRoute,
+  OauthContinueRoute: OauthContinueRoute,
   VsBrowserUseRoute: VsBrowserUseRoute,
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,
   VsStagehandRoute: VsStagehandRoute,

--- a/apps/website/src/routes/oauth.continue.tsx
+++ b/apps/website/src/routes/oauth.continue.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { OAuthContinuePage } from "../OAuthContinuePage";
+
+export const Route = createFileRoute("/oauth/continue")({
+  component: OAuthContinuePage,
+});


### PR DESCRIPTION
Routes ChatGPT OAuth through the same Libretto sign-in and sign-up experience used by the Chrome extension. The page now preserves Better Auth OAuth requests through email, Google, and GitHub authentication, and a continuation page resumes OAuth after email verification and workspace onboarding.

Depends on saffron-health/libretto-cloud#231.

Validation:
- pnpm --dir apps/website build
- pnpm lint
- Live Chrome check of sign-in/sign-up, Google, GitHub, and email controls through the ChatGPT connector flow
