### PR TITLE
Rerun host harnesses with local Chrome for Browser Tools MCP

### DIFF
--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # Browser harness benchmark results
 
-Results from three full Browser Use Cloud runs completed July 17–20, 2026, plus a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in.
+Results from three full Browser Use Cloud runs completed July 17–20, 2026; a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in; and a Hermes/OpenClaw stock vs Browser Tools MCP host-harness run on August 4–5, 2026.
 
 ## Methodology
 
@@ -9,7 +9,8 @@ Results from three full Browser Use Cloud runs completed July 17–20, 2026, plu
 - GPT-5.6 Sol ran through the Pi agent with concurrency 5.
 - July 17–20 runs used Browser Use Cloud with a US proxy. Every full run scheduled 104 attempts: 26 tasks per harness.
 - The July 29 re-run used Kernel and only the `browser-tools` harness (26 attempts), with opt-in `diffSnapshot` on `browser_exec`.
-- A separate judge scored raw Pi events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
+- The August 4–5 host-harness run used Hermes and OpenClaw with either each host's stock browser or Libretto Browser Tools MCP (104 attempts, concurrency 1). See that section for browser infra details — stock and MCP lanes did not share the same browser backend.
+- A separate judge scored raw agent events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
 - Cost, token, duration, and tool-call metrics below cover the task agent, not the judge.
 
 Browser Use Cloud suite command:
@@ -29,6 +30,15 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
+Host harness stock vs Browser Tools MCP command:
+
+```bash
+pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
+  --harnesses hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools \
+  --provider kernel \
+  --concurrency 1
+```
+
 ## Latest `browser-tools` run (Kernel, opt-in diffs)
 
 July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: true`.
@@ -46,6 +56,42 @@ July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: tr
 Failures were all anti-bot: Reddit, Walmart, and Yelp. Agents set `diffSnapshot: true` on 15 of 137 `browser_exec` calls (7 of 26 cases).
 
 Compared with the best prior Browser Use `browser-tools` row (24/26, 1.45M tokens, $2.53, 85.9s avg), this run was one pass lower and about 10% higher on tokens and cost. Excluding the long Walmart bot-check failure (170k tokens, $0.23, 239s), the remaining tasks were 1.42M tokens, $2.54, and 82.6s avg — on par with that earlier best. Provider differs (Kernel vs Browser Use), so the comparison is not causal for the opt-in change.
+
+## Host harnesses (Hermes / OpenClaw stock vs Browser Tools MCP)
+
+August 4–5, 2026. Same 26 tasks and GPT-5.6 Sol. Concurrency 1. Overall 57/104 passed (104 completed). Summed agent duration was 2.9h; wall clock was 24h 18m because one OpenClaw Yelp attempt stalled for about 21h before finishing.
+
+Browser infra was asymmetric across lanes:
+
+| Lane | Browser backend |
+|---|---|
+| `hermes-stock` | Hermes built-in browser (local Chromium; no Kernel) |
+| `openclaw-stock` | Local headless Chrome (`/usr/bin/google-chrome-stable`, `noSandbox`) |
+| `hermes-browser-tools`, `openclaw-browser-tools` | Libretto Browser Tools MCP → Kernel (`headless: false`, `stealth: true`, 600s timeout) |
+
+`--provider kernel` only affects the MCP lanes. Stock lanes ignore it.
+
+| Harness | Passed | Avg duration | Agent tokens | Agent cost | Tool calls |
+|---|---:|---:|---:|---:|---:|
+| `hermes-stock` | 14/26 | 82.0s | 9.70M | $8.34 | 26 |
+| `hermes-browser-tools` | 16/26 | 113.8s | 3.28M | $4.27 | 26 |
+| `openclaw-stock` | 13/26 | 113.9s | 10.83M | $13.96 | 277 |
+| `openclaw-browser-tools` | 14/26 | 96.4s | 5.57M | $8.93 | 178 |
+
+Pairwise stock vs Browser Tools MCP:
+
+| Host | Stock pass | MCP pass | Judgment agreement | Both-pass mean MCP/stock tokens | Both-pass mean MCP/stock cost |
+|---|---:|---:|---:|---:|---:|
+| Hermes | 14/26 | 16/26 | 24/26 (92%) | 1.34x (n=14) | 1.01x (n=14) |
+| OpenClaw | 13/26 | 14/26 | 21/26 (81%) | 0.85x (n=11) | 0.75x (n=11) |
+
+Hermes MCP beat stock on pass rate and roughly halved total tokens and cost, even though both-pass cases averaged 1.34x stock tokens. Stock spent heavily on a few hard sites (for example Airbnb 521k tokens, Hacker News 490k) while MCP failed or finished cheaper there.
+
+OpenClaw MCP was slightly ahead on pass rate and cheaper on both-pass tokens and cost. Stock used many more tool calls (277 vs 178).
+
+Ten cases failed all four harnesses: Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm. Ten cases passed all four: Apple, Best Buy, books to scrape, Craigslist, GitHub, Hacker News, LinkedIn, MDN, Wikipedia, and YouTube.
+
+Compared with the Pi Kernel `browser-tools` re-run (23/26), host lanes trailed by about 7–10 passes. That gap is agent stack and prompts plus the stock-vs-Kernel infra split, not a clean stock-vs-MCP tool comparison.
 
 ## Full runs (Browser Use Cloud, all harnesses)
 
@@ -82,6 +128,8 @@ The best-result composite is 93/104 passed at $20.56 and 10.73M agent tokens.
 - `browser-tools` and `dev-browser` tied at 24/26 in the Browser Use suite. `browser-tools` used 59% fewer tokens and cost 59% less.
 - `agent-browser` was the most stable harness at 23/26 in all three Browser Use runs.
 - `playwright-cli` used the most tokens and had the highest cost per successful task.
-- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp.
+- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp. The host-harness run failed all four hosts on Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm.
 - The Kernel opt-in-diff re-run (23/26) stayed in the prior `browser-tools` pass-rate band (20–24/26). The modest token and cost increase versus the Browser Use best row was driven mainly by one long Walmart challenge, not by frequent use of snapshot diffs.
+- On the August host-harness run, Hermes with Browser Tools MCP (16/26, $4.27) beat Hermes stock (14/26, $8.34) on pass rate and total spend. OpenClaw MCP (14/26, $8.93) edged OpenClaw stock (13/26, $13.96) and used fewer tokens on both-pass cases (0.85x).
+- Host stock lanes used local Chrome; MCP lanes used Kernel. Treat stock-vs-MCP gaps as mixed tool-API and browser-infra effects, not a pure tool comparison. Host lanes also trailed the Pi Kernel `browser-tools` baseline (23/26) by several passes.
 - Results are exploratory, not causal harness rankings. Live content, provider, proxy reputation, anti-bot state, and agent behavior varied between runs.

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # Browser harness benchmark results
 
-Results from three full Browser Use Cloud runs completed July 17–20, 2026; a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in; and a Hermes/OpenClaw stock vs Browser Tools MCP host-harness run on August 4–5, 2026.
+Results from three full Browser Use Cloud runs completed July 17–20, 2026; a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in; a Hermes/OpenClaw stock vs Browser Tools MCP host-harness run on August 4–5, 2026 (MCP on Kernel); and a local-Chrome host-harness rerun on August 9, 2026.
 
 ## Methodology
 
@@ -9,7 +9,8 @@ Results from three full Browser Use Cloud runs completed July 17–20, 2026; a l
 - GPT-5.6 Sol ran through the Pi agent with concurrency 5.
 - July 17–20 runs used Browser Use Cloud with a US proxy. Every full run scheduled 104 attempts: 26 tasks per harness.
 - The July 29 re-run used Kernel and only the `browser-tools` harness (26 attempts), with opt-in `diffSnapshot` on `browser_exec`.
-- The August 4–5 host-harness run used Hermes and OpenClaw with either each host's stock browser or Libretto Browser Tools MCP (104 attempts, concurrency 1). See that section for browser infra details — stock and MCP lanes did not share the same browser backend.
+- The August 4–5 host-harness run used Hermes and OpenClaw with either each host's stock browser or Libretto Browser Tools MCP (104 attempts, concurrency 1). MCP lanes used Kernel; stock lanes used local Chrome.
+- The August 9 host-harness rerun used the same four host harnesses with `--provider local`, so MCP lanes launched Playwright Chromium on the host instead of Kernel.
 - A separate judge scored raw agent events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
 - Cost, token, duration, and tool-call metrics below cover the task agent, not the judge.
 
@@ -30,12 +31,21 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
-Host harness stock vs Browser Tools MCP command:
+Host harness stock vs Browser Tools MCP (Kernel MCP):
 
 ```bash
 pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --harnesses hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools \
   --provider kernel \
+  --concurrency 1
+```
+
+Host harness stock vs Browser Tools MCP (local Chrome MCP):
+
+```bash
+pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
+  --harnesses hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools \
+  --provider local \
   --concurrency 1
 ```
 
@@ -93,6 +103,42 @@ Ten cases failed all four harnesses: Google, Reddit, Walmart, Expedia, DoorDash,
 
 Compared with the Pi Kernel `browser-tools` re-run (23/26), host lanes trailed by about 7–10 passes. That gap is agent stack and prompts plus the stock-vs-Kernel infra split, not a clean stock-vs-MCP tool comparison.
 
+## Host harnesses (local Chrome MCP)
+
+August 9, 2026. Same 26 tasks and GPT-5.6 Sol. Concurrency 1. Overall 56/104 passed (104 completed). Summed agent duration was 2.4h; wall clock was 2h 44m.
+
+Browser infra for this rerun:
+
+| Lane | Browser backend |
+|---|---|
+| `hermes-stock` | Hermes built-in browser (local Chromium) |
+| `openclaw-stock` | Local headless Chrome (`/usr/bin/google-chrome-stable`, `noSandbox`) |
+| `hermes-browser-tools`, `openclaw-browser-tools` | Libretto Browser Tools MCP → local Playwright Chromium (`--provider local`, headless) |
+
+`--provider local` only affects the MCP lanes. Stock lanes ignore it. Host harnesses set `PLAYWRIGHT_BROWSERS_PATH` on the MCP server env so isolated `HOME` does not force a per-attempt Chromium install.
+
+| Harness | Passed | Avg duration | Agent tokens | Agent cost | Tool calls |
+|---|---:|---:|---:|---:|---:|
+| `hermes-stock` | 15/26 | 72.1s | 7.92M | $7.26 | 26 |
+| `hermes-browser-tools` | 14/26 | 69.8s | 3.61M | $4.50 | 26 |
+| `openclaw-stock` | 13/26 | 113.6s | 19.06M | $19.43 | 301 |
+| `openclaw-browser-tools` | 14/26 | 77.7s | 5.69M | $7.63 | 174 |
+
+Pairwise stock vs Browser Tools MCP:
+
+| Host | Stock pass | MCP pass | Judgment agreement | Both-pass mean MCP/stock tokens | Both-pass mean MCP/stock cost |
+|---|---:|---:|---:|---:|---:|
+| Hermes | 15/26 | 14/26 | 23/26 (88%) | 1.27x (n=13) | 1.00x (n=13) |
+| OpenClaw | 13/26 | 14/26 | 25/26 (96%) | 0.59x (n=13) | 0.54x (n=13) |
+
+With local Chrome on both sides, Hermes stock edged MCP on pass rate (15 vs 14) while MCP still used about half the total tokens and cost. Both-pass MCP/stock tokens stayed above 1x (1.27x), so Hermes MCP paid a multi-step session tax on easy wins and won mainly by spending less on failures.
+
+OpenClaw MCP matched the Kernel-run pass rate (14/26), beat stock by one pass, and cut both-pass tokens and cost roughly in half (0.59x / 0.54x). Stock again used many more tool calls (301 vs 174). OpenClaw stock blew out on Booking.com (~10.3M tokens, $7.05); MCP failed that case cheaper (~1.08M tokens, $1.06).
+
+Ten cases failed all four harnesses: Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm. Eleven cases passed all four: Airbnb, Apple, Best Buy, books to scrape, Craigslist, GitHub, Hacker News, LinkedIn, MDN, Wikipedia, and YouTube.
+
+Versus the August 4–5 Kernel MCP run (57/104), local Chrome MCP finished one pass lower overall (56/104) and finished in 2h 44m wall time instead of ~24h (no multi-hour OpenClaw stall). Hermes MCP dropped from 16/26 to 14/26; OpenClaw MCP stayed at 14/26. Treat Kernel vs local as provider reputation and anti-bot differences, not only tool-API differences.
+
 ## Full runs (Browser Use Cloud, all harnesses)
 
 | Run | Passed | Completed | Pass rate | Agent tokens | Agent cost | Tool calls | Wall time |
@@ -128,8 +174,9 @@ The best-result composite is 93/104 passed at $20.56 and 10.73M agent tokens.
 - `browser-tools` and `dev-browser` tied at 24/26 in the Browser Use suite. `browser-tools` used 59% fewer tokens and cost 59% less.
 - `agent-browser` was the most stable harness at 23/26 in all three Browser Use runs.
 - `playwright-cli` used the most tokens and had the highest cost per successful task.
-- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp. The host-harness run failed all four hosts on Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm.
+- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp. Both host-harness runs failed all four hosts on Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm.
 - The Kernel opt-in-diff re-run (23/26) stayed in the prior `browser-tools` pass-rate band (20–24/26). The modest token and cost increase versus the Browser Use best row was driven mainly by one long Walmart challenge, not by frequent use of snapshot diffs.
-- On the August host-harness run, Hermes with Browser Tools MCP (16/26, $4.27) beat Hermes stock (14/26, $8.34) on pass rate and total spend. OpenClaw MCP (14/26, $8.93) edged OpenClaw stock (13/26, $13.96) and used fewer tokens on both-pass cases (0.85x).
-- Host stock lanes used local Chrome; MCP lanes used Kernel. Treat stock-vs-MCP gaps as mixed tool-API and browser-infra effects, not a pure tool comparison. Host lanes also trailed the Pi Kernel `browser-tools` baseline (23/26) by several passes.
+- On the August Kernel host-harness run, Hermes with Browser Tools MCP (16/26, $4.27) beat Hermes stock (14/26, $8.34) on pass rate and total spend. OpenClaw MCP (14/26, $8.93) edged OpenClaw stock (13/26, $13.96) and used fewer tokens on both-pass cases (0.85x). Stock used local Chrome; MCP used Kernel.
+- On the August 9 local-Chrome host-harness rerun (56/104), MCP and stock shared local browsers. Hermes stock led MCP by one pass (15 vs 14) while MCP still spent less overall ($4.50 vs $7.26). OpenClaw MCP beat stock by one pass (14 vs 13) and cut both-pass tokens/cost to about 0.59x / 0.54x. Wall time dropped to 2h 44m versus ~24h on the Kernel run.
+- Host lanes still trailed the Pi Kernel `browser-tools` baseline (23/26) by several passes. That gap is agent stack and prompts as much as provider choice.
 - Results are exploratory, not causal harness rankings. Live content, provider, proxy reputation, anti-bot state, and agent behavior varied between runs.

--- a/packages/browser-tools/benchmarks/RESULTS.md
+++ b/packages/browser-tools/benchmarks/RESULTS.md
@@ -1,20 +1,10 @@
 # Browser harness benchmark results
 
-Results from three full Browser Use Cloud runs completed July 17–20, 2026; a later `browser-tools`-only Kernel re-run on July 29, 2026 after snapshot diffs became opt-in; a Hermes/OpenClaw stock vs Browser Tools MCP host-harness run on August 4–5, 2026 (MCP on Kernel); and a local-Chrome host-harness rerun on August 9, 2026.
+Latest full-suite scores for each benchmark configuration on the 26 live-site public cases. GPT-5.6 Sol. A separate judge scores agent events; CAPTCHA, access denial, timeout, and tool failure count as incomplete. Cost, token, duration, and tool-call metrics cover the task agent, not the judge.
 
-## Methodology
+## How to run
 
-- 26 live-site tasks across search, commerce, travel, delivery, real estate, and documentation sites.
-- Four harnesses in the July 17–20 suite: `browser-tools`, `agent-browser`, `playwright-cli`, and `dev-browser`.
-- GPT-5.6 Sol ran through the Pi agent with concurrency 5.
-- July 17–20 runs used Browser Use Cloud with a US proxy. Every full run scheduled 104 attempts: 26 tasks per harness.
-- The July 29 re-run used Kernel and only the `browser-tools` harness (26 attempts), with opt-in `diffSnapshot` on `browser_exec`.
-- The August 4–5 host-harness run used Hermes and OpenClaw with either each host's stock browser or Libretto Browser Tools MCP (104 attempts, concurrency 1). MCP lanes used Kernel; stock lanes used local Chrome.
-- The August 9 host-harness rerun used the same four host harnesses with `--provider local`, so MCP lanes launched Playwright Chromium on the host instead of Kernel.
-- A separate judge scored raw agent events. Reporting a CAPTCHA, access denial, timeout, or tool failure counted as incomplete.
-- Cost, token, duration, and tool-call metrics below cover the task agent, not the judge.
-
-Browser Use Cloud suite command:
+Pi harnesses (Browser Use Cloud):
 
 ```bash
 pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
@@ -22,7 +12,7 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
-Kernel `browser-tools` re-run command:
+Pi `browser-tools` only (Kernel):
 
 ```bash
 pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
@@ -31,16 +21,7 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 5
 ```
 
-Host harness stock vs Browser Tools MCP (Kernel MCP):
-
-```bash
-pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
-  --harnesses hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools \
-  --provider kernel \
-  --concurrency 1
-```
-
-Host harness stock vs Browser Tools MCP (local Chrome MCP):
+Host harnesses (Hermes / OpenClaw stock vs Browser Tools MCP):
 
 ```bash
 pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
@@ -49,9 +30,29 @@ pnpm --dir packages/browser-tools exec tsx benchmarks/index.ts run \
   --concurrency 1
 ```
 
-## Latest `browser-tools` run (Kernel, opt-in diffs)
+## Pi harnesses (Browser Use Cloud)
 
-July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: true`.
+July 17–20, 2026. Harnesses: `browser-tools`, `agent-browser`, `playwright-cli`, `dev-browser`. Provider: Browser Use Cloud (US proxy). Concurrency 5.
+
+| Metric | Value |
+|---|---:|
+| Passed | 84/104 |
+| Completed | 100/104 |
+| Agent tokens | 10.79M |
+| Agent cost | $19.68 |
+| Tool calls | 880 |
+| Wall time | 53m 43s |
+
+| Harness | Passed |
+|---|---:|
+| `browser-tools` | 20/26 |
+| `agent-browser` | 23/26 |
+| `playwright-cli` | 22/26 |
+| `dev-browser` | 19/26 |
+
+## Pi `browser-tools` (Kernel)
+
+July 29, 2026. Snapshot diffs off unless the agent passed `diffSnapshot: true`.
 
 | Metric | Value |
 |---|---:|
@@ -63,51 +64,11 @@ July 29, 2026. Snapshot diffs were off unless the agent passed `diffSnapshot: tr
 | Tool calls | 239 |
 | Wall time | 9m 28s |
 
-Failures were all anti-bot: Reddit, Walmart, and Yelp. Agents set `diffSnapshot: true` on 15 of 137 `browser_exec` calls (7 of 26 cases).
+Failures: Reddit, Walmart, and Yelp (anti-bot). Agents set `diffSnapshot: true` on 15 of 137 `browser_exec` calls (7 of 26 cases).
 
-Compared with the best prior Browser Use `browser-tools` row (24/26, 1.45M tokens, $2.53, 85.9s avg), this run was one pass lower and about 10% higher on tokens and cost. Excluding the long Walmart bot-check failure (170k tokens, $0.23, 239s), the remaining tasks were 1.42M tokens, $2.54, and 82.6s avg — on par with that earlier best. Provider differs (Kernel vs Browser Use), so the comparison is not causal for the opt-in change.
+## Host harnesses (local Chrome)
 
-## Host harnesses (Hermes / OpenClaw stock vs Browser Tools MCP)
-
-August 4–5, 2026. Same 26 tasks and GPT-5.6 Sol. Concurrency 1. Overall 57/104 passed (104 completed). Summed agent duration was 2.9h; wall clock was 24h 18m because one OpenClaw Yelp attempt stalled for about 21h before finishing.
-
-Browser infra was asymmetric across lanes:
-
-| Lane | Browser backend |
-|---|---|
-| `hermes-stock` | Hermes built-in browser (local Chromium; no Kernel) |
-| `openclaw-stock` | Local headless Chrome (`/usr/bin/google-chrome-stable`, `noSandbox`) |
-| `hermes-browser-tools`, `openclaw-browser-tools` | Libretto Browser Tools MCP → Kernel (`headless: false`, `stealth: true`, 600s timeout) |
-
-`--provider kernel` only affects the MCP lanes. Stock lanes ignore it.
-
-| Harness | Passed | Avg duration | Agent tokens | Agent cost | Tool calls |
-|---|---:|---:|---:|---:|---:|
-| `hermes-stock` | 14/26 | 82.0s | 9.70M | $8.34 | 26 |
-| `hermes-browser-tools` | 16/26 | 113.8s | 3.28M | $4.27 | 26 |
-| `openclaw-stock` | 13/26 | 113.9s | 10.83M | $13.96 | 277 |
-| `openclaw-browser-tools` | 14/26 | 96.4s | 5.57M | $8.93 | 178 |
-
-Pairwise stock vs Browser Tools MCP:
-
-| Host | Stock pass | MCP pass | Judgment agreement | Both-pass mean MCP/stock tokens | Both-pass mean MCP/stock cost |
-|---|---:|---:|---:|---:|---:|
-| Hermes | 14/26 | 16/26 | 24/26 (92%) | 1.34x (n=14) | 1.01x (n=14) |
-| OpenClaw | 13/26 | 14/26 | 21/26 (81%) | 0.85x (n=11) | 0.75x (n=11) |
-
-Hermes MCP beat stock on pass rate and roughly halved total tokens and cost, even though both-pass cases averaged 1.34x stock tokens. Stock spent heavily on a few hard sites (for example Airbnb 521k tokens, Hacker News 490k) while MCP failed or finished cheaper there.
-
-OpenClaw MCP was slightly ahead on pass rate and cheaper on both-pass tokens and cost. Stock used many more tool calls (277 vs 178).
-
-Ten cases failed all four harnesses: Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm. Ten cases passed all four: Apple, Best Buy, books to scrape, Craigslist, GitHub, Hacker News, LinkedIn, MDN, Wikipedia, and YouTube.
-
-Compared with the Pi Kernel `browser-tools` re-run (23/26), host lanes trailed by about 7–10 passes. That gap is agent stack and prompts plus the stock-vs-Kernel infra split, not a clean stock-vs-MCP tool comparison.
-
-## Host harnesses (local Chrome MCP)
-
-August 9, 2026. Same 26 tasks and GPT-5.6 Sol. Concurrency 1. Overall 56/104 passed (104 completed). Summed agent duration was 2.4h; wall clock was 2h 44m.
-
-Browser infra for this rerun:
+August 9, 2026. Hermes and OpenClaw, each with stock browser tools or Libretto Browser Tools MCP. Concurrency 1. Overall 56/104 passed. Agent duration 2.4h; wall time 2h 44m.
 
 | Lane | Browser backend |
 |---|---|
@@ -115,7 +76,7 @@ Browser infra for this rerun:
 | `openclaw-stock` | Local headless Chrome (`/usr/bin/google-chrome-stable`, `noSandbox`) |
 | `hermes-browser-tools`, `openclaw-browser-tools` | Libretto Browser Tools MCP → local Playwright Chromium (`--provider local`, headless) |
 
-`--provider local` only affects the MCP lanes. Stock lanes ignore it. Host harnesses set `PLAYWRIGHT_BROWSERS_PATH` on the MCP server env so isolated `HOME` does not force a per-attempt Chromium install.
+`--provider local` affects MCP lanes only. Host harnesses set `PLAYWRIGHT_BROWSERS_PATH` on the MCP server env so isolated `HOME` does not reinstall Chromium per attempt.
 
 | Harness | Passed | Avg duration | Agent tokens | Agent cost | Tool calls |
 |---|---:|---:|---:|---:|---:|
@@ -131,52 +92,12 @@ Pairwise stock vs Browser Tools MCP:
 | Hermes | 15/26 | 14/26 | 23/26 (88%) | 1.27x (n=13) | 1.00x (n=13) |
 | OpenClaw | 13/26 | 14/26 | 25/26 (96%) | 0.59x (n=13) | 0.54x (n=13) |
 
-With local Chrome on both sides, Hermes stock edged MCP on pass rate (15 vs 14) while MCP still used about half the total tokens and cost. Both-pass MCP/stock tokens stayed above 1x (1.27x), so Hermes MCP paid a multi-step session tax on easy wins and won mainly by spending less on failures.
+Hermes stock led MCP by one pass; MCP still spent less overall. OpenClaw MCP beat stock by one pass and cut both-pass tokens and cost roughly in half. OpenClaw stock used many more tool calls (301 vs 174).
 
-OpenClaw MCP matched the Kernel-run pass rate (14/26), beat stock by one pass, and cut both-pass tokens and cost roughly in half (0.59x / 0.54x). Stock again used many more tool calls (301 vs 174). OpenClaw stock blew out on Booking.com (~10.3M tokens, $7.05); MCP failed that case cheaper (~1.08M tokens, $1.06).
+All four failed: Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, npm. All four passed: Airbnb, Apple, Best Buy, books to scrape, Craigslist, GitHub, Hacker News, LinkedIn, MDN, Wikipedia, YouTube.
 
-Ten cases failed all four harnesses: Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm. Eleven cases passed all four: Airbnb, Apple, Best Buy, books to scrape, Craigslist, GitHub, Hacker News, LinkedIn, MDN, Wikipedia, and YouTube.
+## Notes
 
-Versus the August 4–5 Kernel MCP run (57/104), local Chrome MCP finished one pass lower overall (56/104) and finished in 2h 44m wall time instead of ~24h (no multi-hour OpenClaw stall). Hermes MCP dropped from 16/26 to 14/26; OpenClaw MCP stayed at 14/26. Treat Kernel vs local as provider reputation and anti-bot differences, not only tool-API differences.
-
-## Full runs (Browser Use Cloud, all harnesses)
-
-| Run | Passed | Completed | Pass rate | Agent tokens | Agent cost | Tool calls | Wall time |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 86/104 | 101/104 | 82.7% | 11.62M | $21.05 | 789 | 46m 13s |
-| 2 | 93/104 | 104/104 | 89.4% | 11.70M | $21.39 | 844 | 36m 16s |
-| 3 | 84/104 | 100/104 | 80.8% | 10.79M | $19.68 | 880 | 53m 43s |
-
-Harness scores by run:
-
-| Harness | Run 1 | Run 2 | Run 3 |
-|---|---:|---:|---:|
-| `browser-tools` | 21/26 | 24/26 | 20/26 |
-| `agent-browser` | 23/26 | 23/26 | 23/26 |
-| `playwright-cli` | 21/26 | 22/26 | 22/26 |
-| `dev-browser` | 21/26 | 24/26 | 19/26 |
-
-## Best result per harness (Browser Use Cloud)
-
-The selection uses highest pass count, then completion count, then lower cost. These rows come from different runs and do not represent one simultaneous run.
-
-| Harness | Selected run | Passed | Anti-bot | Other failures | Avg duration | Agent tokens | Agent cost | Cost/pass |
-|---|---|---:|---:|---:|---:|---:|---:|---:|
-| `browser-tools` | 2 | 24/26 | 2 | 0 | 85.9s | 1.45M | $2.53 | $0.106 |
-| `agent-browser` | 1 | 23/26 | 3 | 0 | 110.1s | 2.29M | $5.41 | $0.235 |
-| `playwright-cli` | 2 | 22/26 | 4 | 0 | 70.6s | 3.48M | $6.44 | $0.293 |
-| `dev-browser` | 2 | 24/26 | 2 | 0 | 79.6s | 3.51M | $6.18 | $0.257 |
-
-The best-result composite is 93/104 passed at $20.56 and 10.73M agent tokens.
-
-## Findings
-
-- `browser-tools` and `dev-browser` tied at 24/26 in the Browser Use suite. `browser-tools` used 59% fewer tokens and cost 59% less.
-- `agent-browser` was the most stable harness at 23/26 in all three Browser Use runs.
-- `playwright-cli` used the most tokens and had the highest cost per successful task.
-- Anti-bot behavior dominated selected failures. In the Browser Use suite, Reddit blocked all four harnesses; Expedia blocked three; Yelp blocked three; Google blocked one. The Kernel re-run failed Reddit, Walmart, and Yelp. Both host-harness runs failed all four hosts on Google, Reddit, Walmart, Expedia, DoorDash, Uber Eats, Zillow, Realtor, Yelp, and npm.
-- The Kernel opt-in-diff re-run (23/26) stayed in the prior `browser-tools` pass-rate band (20–24/26). The modest token and cost increase versus the Browser Use best row was driven mainly by one long Walmart challenge, not by frequent use of snapshot diffs.
-- On the August Kernel host-harness run, Hermes with Browser Tools MCP (16/26, $4.27) beat Hermes stock (14/26, $8.34) on pass rate and total spend. OpenClaw MCP (14/26, $8.93) edged OpenClaw stock (13/26, $13.96) and used fewer tokens on both-pass cases (0.85x). Stock used local Chrome; MCP used Kernel.
-- On the August 9 local-Chrome host-harness rerun (56/104), MCP and stock shared local browsers. Hermes stock led MCP by one pass (15 vs 14) while MCP still spent less overall ($4.50 vs $7.26). OpenClaw MCP beat stock by one pass (14 vs 13) and cut both-pass tokens/cost to about 0.59x / 0.54x. Wall time dropped to 2h 44m versus ~24h on the Kernel run.
-- Host lanes still trailed the Pi Kernel `browser-tools` baseline (23/26) by several passes. That gap is agent stack and prompts as much as provider choice.
-- Results are exploratory, not causal harness rankings. Live content, provider, proxy reputation, anti-bot state, and agent behavior varied between runs.
+- Anti-bot blocks drive most shared failures across suites.
+- Host lanes trail the Pi Kernel `browser-tools` baseline (23/26). That gap mixes agent stack, prompts, and provider effects.
+- These scores are exploratory. Live content, provider reputation, and anti-bot state change between runs.

--- a/packages/browser-tools/benchmarks/agent.ts
+++ b/packages/browser-tools/benchmarks/agent.ts
@@ -16,47 +16,63 @@ import { dirname, join } from "node:path";
 const MODEL_PROVIDER = "openai";
 const MODEL_ID = "gpt-5.6-sol";
 const BENCHMARK_SYSTEM_PROMPT =
-  "You are an AI agent in a controlled benchmark. Follow the user's instructions, use the available tools, and report only evidence you actually observed.";
-const COMMON_BROWSER_TASK_INSTRUCTIONS = [
-  "Complete the task on the requested live website and ground the final answer in observed page evidence.",
-  "Use only the browser tools provided by the benchmark harness. Do not launch or connect to a browser outside those tools.",
-  "If the intended site shows a CAPTCHA, reCAPTCHA, Cloudflare challenge, or similar test, wait up to 2 minutes for the browser's automatic solver. Do not try to solve it yourself or click a Cloudflare checkbox. If Cloudflare shows Ready, continue with the task; report blocked only if the challenge remains after waiting.",
-  "If the browser tools cannot complete the task because of anti-bot protection, a connection failure, or another blocker, stop and end with a concise explanation of why the task could not be completed.",
-  "Do not use another site, an API, a cached copy, or prior knowledge as a fallback.",
-  "Return a concise final answer after completing the task.",
+	"You are an AI agent in a controlled benchmark. Follow the user's instructions, use the available tools, and report only evidence you actually observed.";
+const SHARED_BROWSER_TASK_RULES = [
+	"Complete the task on the requested live website and ground the final answer in observed page evidence.",
+	"If the intended site shows a CAPTCHA, reCAPTCHA, Cloudflare challenge, or similar test, wait up to 2 minutes for the browser's automatic solver. Do not try to solve it yourself or click a Cloudflare checkbox. If Cloudflare shows Ready, continue with the task; report blocked only if the challenge remains after waiting.",
+	"If the browser tools cannot complete the task because of anti-bot protection, a connection failure, or another blocker, stop and end with a concise explanation of why the task could not be completed.",
+	"Do not use another site, an API, a cached copy, or prior knowledge as a fallback.",
+	"Return a concise final answer after completing the task.",
 ].join(" ");
+
+export type BrowserToolGuidance =
+	| "harness-provided"
+	| "stock"
+	| "mcp";
+
+function browserToolGuidanceText(guidance: BrowserToolGuidance): string {
+	switch (guidance) {
+		case "harness-provided":
+			return "Use only the browser tools provided by the benchmark harness. Do not launch or connect to a browser outside those tools.";
+		case "stock":
+			return "Use the built-in browser tools.";
+		case "mcp":
+			return "Use the mcp browser tools.";
+	}
+}
 
 export const MODEL_SELECTOR = `${MODEL_PROVIDER}/${MODEL_ID}`;
 export const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 
+/** Metrics the harness observed. Omit fields the host did not report. */
 export type UsageMetrics = {
-  durationMs: number;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheWriteTokens: number;
-  totalTokens: number;
-  maxRequestContextTokens: number;
-  costUsd: number;
-  turns: number;
-  toolCalls: Record<string, number>;
-  totalToolCalls: number;
+	durationMs?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+	totalTokens?: number;
+	maxRequestContextTokens?: number;
+	costUsd?: number;
+	turns?: number;
+	toolCalls?: Record<string, number>;
+	totalToolCalls?: number;
 };
 
 export type SessionRun = {
-  session: AgentSession;
-  events: AgentSessionEvent[];
-  durationMs: number;
+	session: AgentSession;
+	events: AgentSessionEvent[];
+	durationMs: number;
 };
 
 export class SessionRunError extends Error {
-  readonly run: SessionRun;
+	readonly run: SessionRun;
 
-  constructor(error: unknown, run: SessionRun) {
-    super(error instanceof Error ? error.message : String(error));
-    this.name = "SessionRunError";
-    this.run = run;
-  }
+	constructor(error: unknown, run: SessionRun) {
+		super(error instanceof Error ? error.message : String(error));
+		this.name = "SessionRunError";
+		this.run = run;
+	}
 }
 
 export async function createPiSession(options: {
@@ -130,10 +146,15 @@ export async function createPiSession(options: {
   return session;
 }
 
-export function browserTaskPrompt(options: { task: string }): string {
-  return [COMMON_BROWSER_TASK_INSTRUCTIONS, `TASK:\n${options.task}`]
-    .filter((part): part is string => Boolean(part))
-    .join("\n\n");
+export function browserTaskPrompt(options: {
+	task: string;
+	guidance?: BrowserToolGuidance;
+}): string {
+	const guidance = options.guidance ?? "harness-provided";
+	return [
+		[browserToolGuidanceText(guidance), SHARED_BROWSER_TASK_RULES].join(" "),
+		`TASK:\n${options.task}`,
+	].join("\n\n");
 }
 
 export async function runPrompt(
@@ -189,68 +210,59 @@ function toolCallCounts(events: AgentSessionEvent[]): Record<string, number> {
 }
 
 export function usageMetrics(run: SessionRun): UsageMetrics {
-  const stats = run.session.getSessionStats();
-  const toolCalls = toolCallCounts(run.events);
-  return {
-    durationMs: run.durationMs,
-    inputTokens: stats.tokens.input,
-    outputTokens: stats.tokens.output,
-    cacheReadTokens: stats.tokens.cacheRead,
-    cacheWriteTokens: stats.tokens.cacheWrite,
-    totalTokens: stats.tokens.total,
-    maxRequestContextTokens: maxRequestContextTokens(run.events),
-    costUsd: stats.cost,
-    turns: stats.assistantMessages,
-    toolCalls,
-    totalToolCalls: Object.values(toolCalls).reduce(
-      (total, count) => total + count,
-      0,
-    ),
-  };
+	const stats = run.session.getSessionStats();
+	const toolCalls = toolCallCounts(run.events);
+	const totalToolCalls = Object.values(toolCalls).reduce(
+		(total, count) => total + count,
+		0,
+	);
+	const maxTokens = maxRequestContextTokens(run.events);
+	return {
+		durationMs: run.durationMs,
+		inputTokens: stats.tokens.input,
+		outputTokens: stats.tokens.output,
+		cacheReadTokens: stats.tokens.cacheRead,
+		cacheWriteTokens: stats.tokens.cacheWrite,
+		totalTokens: stats.tokens.total,
+		...(maxTokens !== undefined
+			? { maxRequestContextTokens: maxTokens }
+			: {}),
+		costUsd: stats.cost,
+		turns: stats.assistantMessages,
+		toolCalls,
+		totalToolCalls,
+	};
 }
 
-export function emptyMetrics(): UsageMetrics {
-  return {
-    durationMs: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    totalTokens: 0,
-    maxRequestContextTokens: 0,
-    costUsd: 0,
-    turns: 0,
-    toolCalls: {},
-    totalToolCalls: 0,
-  };
-}
-
-function maxRequestContextTokens(events: AgentSessionEvent[]): number {
-  let maxTokens = 0;
-  for (const event of events) {
-    if (event.type !== "message_end") continue;
-    const message = event.message as {
-      role?: unknown;
-      usage?: {
-        input?: unknown;
-        cacheRead?: unknown;
-        cacheWrite?: unknown;
-      };
-    };
-    if (message.role !== "assistant") continue;
-    const input =
-      typeof message.usage?.input === "number" ? message.usage.input : 0;
-    const cacheRead =
-      typeof message.usage?.cacheRead === "number"
-        ? message.usage.cacheRead
-        : 0;
-    const cacheWrite =
-      typeof message.usage?.cacheWrite === "number"
-        ? message.usage.cacheWrite
-        : 0;
-    maxTokens = Math.max(maxTokens, input + cacheRead + cacheWrite);
-  }
-  return maxTokens;
+function maxRequestContextTokens(
+	events: AgentSessionEvent[],
+): number | undefined {
+	let maxTokens: number | undefined;
+	for (const event of events) {
+		if (event.type !== "message_end") continue;
+		const message = event.message as {
+			role?: unknown;
+			usage?: {
+				input?: unknown;
+				cacheRead?: unknown;
+				cacheWrite?: unknown;
+			};
+		};
+		if (message.role !== "assistant") continue;
+		const input =
+			typeof message.usage?.input === "number" ? message.usage.input : 0;
+		const cacheRead =
+			typeof message.usage?.cacheRead === "number"
+				? message.usage.cacheRead
+				: 0;
+		const cacheWrite =
+			typeof message.usage?.cacheWrite === "number"
+				? message.usage.cacheWrite
+				: 0;
+		const total = input + cacheRead + cacheWrite;
+		maxTokens = maxTokens === undefined ? total : Math.max(maxTokens, total);
+	}
+	return maxTokens;
 }
 
 function eventReplacer(key: string, value: unknown): unknown {

--- a/packages/browser-tools/benchmarks/harness-run.ts
+++ b/packages/browser-tools/benchmarks/harness-run.ts
@@ -1,0 +1,192 @@
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { SessionRun, UsageMetrics } from "./agent.js";
+
+/**
+ * Normalized benchmark event log. Pi harnesses convert AgentSessionEvent into
+ * this shape; host CLIs (Hermes/OpenClaw) emit it directly.
+ */
+export type HarnessMessageEvent = {
+	type: "message";
+	role: "user" | "assistant" | "system";
+	text: string;
+};
+
+export type HarnessToolStartEvent = {
+	type: "tool_execution_start";
+	toolName: string;
+	args?: unknown;
+};
+
+export type HarnessToolEndEvent = {
+	type: "tool_execution_end";
+	toolName: string;
+	isError?: boolean;
+	result?: unknown;
+};
+
+export type HarnessLogEvent = {
+	type: "log";
+	stream: "stdout" | "stderr";
+	text: string;
+};
+
+export type HarnessErrorEvent = {
+	type: "error";
+	message: string;
+};
+
+export type HarnessEvent =
+	| HarnessMessageEvent
+	| HarnessToolStartEvent
+	| HarnessToolEndEvent
+	| HarnessLogEvent
+	| HarnessErrorEvent;
+
+export type HarnessRun = {
+	answer: string;
+	events: HarnessEvent[];
+	/** Present fields only; omit unknowns instead of inventing zeros. */
+	metrics: UsageMetrics;
+	browserBackend: "benchmark-provider" | "host-stock";
+	dispose(): Promise<void>;
+};
+
+export class HarnessRunError extends Error {
+	readonly run: HarnessRun;
+
+	constructor(error: unknown, run: HarnessRun) {
+		super(error instanceof Error ? error.message : String(error));
+		this.name = "HarnessRunError";
+		this.run = run;
+	}
+}
+
+function eventReplacer(key: string, value: unknown): unknown {
+	if (typeof value === "bigint") return value.toString();
+	if (key === "data" && typeof value === "string" && value.length > 10_000) {
+		return `[omitted ${value.length} characters]`;
+	}
+	return value;
+}
+
+export function harnessEventsJsonl(events: readonly HarnessEvent[]): string {
+	return `${events
+		.map((event) => JSON.stringify(event, eventReplacer))
+		.join("\n")}\n`;
+}
+
+export function transcriptFromHarnessEvents(
+	events: readonly HarnessEvent[],
+): string {
+	const sections: string[] = [];
+	for (const event of events) {
+		switch (event.type) {
+			case "message":
+				sections.push(`## ${event.role}\n\n${event.text}`);
+				break;
+			case "tool_execution_start":
+				sections.push(`### tool start: ${event.toolName}`);
+				break;
+			case "tool_execution_end":
+				sections.push(
+					`### tool end: ${event.toolName}${event.isError ? " (error)" : ""}`,
+				);
+				break;
+			case "log":
+				sections.push(`### ${event.stream}\n\n${event.text}`);
+				break;
+			case "error":
+				sections.push(`### error\n\n${event.message}`);
+				break;
+		}
+	}
+	return sections.join("\n\n").trim();
+}
+
+function messageText(message: {
+	role?: unknown;
+	content?: unknown;
+}): string | null {
+	if (typeof message.content === "string") return message.content;
+	if (!Array.isArray(message.content)) return null;
+	const parts: string[] = [];
+	for (const part of message.content) {
+		if (
+			part &&
+			typeof part === "object" &&
+			"type" in part &&
+			(part as { type: unknown }).type === "text" &&
+			"text" in part &&
+			typeof (part as { text: unknown }).text === "string"
+		) {
+			parts.push((part as { text: string }).text);
+		}
+	}
+	return parts.length > 0 ? parts.join("\n") : null;
+}
+
+/**
+ * Map Pi session events into the shared HarnessEvent log so the judge sees one
+ * schema across Pi and host CLI harnesses.
+ */
+export function harnessEventsFromPi(
+	events: readonly AgentSessionEvent[],
+): HarnessEvent[] {
+	const out: HarnessEvent[] = [];
+	for (const event of events) {
+		if (event.type === "tool_execution_start") {
+			out.push({
+				type: "tool_execution_start",
+				toolName: event.toolName,
+				args: "args" in event ? (event as { args?: unknown }).args : undefined,
+			});
+			continue;
+		}
+		if (event.type === "tool_execution_end") {
+			out.push({
+				type: "tool_execution_end",
+				toolName: event.toolName,
+				isError:
+					"isError" in event
+						? Boolean((event as { isError?: unknown }).isError)
+						: undefined,
+				result:
+					"result" in event ? (event as { result?: unknown }).result : undefined,
+			});
+			continue;
+		}
+		if (event.type === "message_end") {
+			const message = event.message as {
+				role?: unknown;
+				content?: unknown;
+			};
+			const role =
+				message.role === "user" ||
+				message.role === "assistant" ||
+				message.role === "system"
+					? message.role
+					: null;
+			const text = messageText(message);
+			if (role && text !== null) {
+				out.push({ type: "message", role, text });
+			}
+		}
+	}
+	return out;
+}
+
+export function harnessRunFromPiSession(
+	run: SessionRun,
+	metrics: UsageMetrics,
+): HarnessRun {
+	const answer = run.session.getLastAssistantText()?.trim() ?? "";
+	return {
+		answer,
+		events: harnessEventsFromPi(run.events),
+		metrics,
+		browserBackend: "benchmark-provider",
+		async dispose() {
+			run.session.dispose();
+		},
+	};
+}

--- a/packages/browser-tools/benchmarks/harness/agent-browser.ts
+++ b/packages/browser-tools/benchmarks/harness/agent-browser.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
-import type { SessionRun } from "../agent.js";
+import type { HarnessRun } from "../harness-run.js";
 import {
 	closeCloudBrowserConnection,
 	createCloudBrowserConnection,
@@ -20,7 +20,7 @@ export async function runAgentBrowserHarness(
 	task: string,
 	workspace: string,
 	provider: BrowserProviderName,
-): Promise<SessionRun> {
+): Promise<HarnessRun> {
 	const browser = await createCloudBrowserConnection(provider);
 	try {
 		const command = [

--- a/packages/browser-tools/benchmarks/harness/browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/browser-tools.ts
@@ -1,5 +1,5 @@
 import { createPiBrowserTools } from "libretto-browser-tools/pi";
-import { SessionRunError, type SessionRun } from "../agent.js";
+import { HarnessRunError, type HarnessRun } from "../harness-run.js";
 import {
 	createBenchmarkBrowserProvider,
 	type BrowserProviderName,
@@ -10,9 +10,9 @@ export async function runBrowserToolsHarness(
 	task: string,
 	workspace: string,
 	provider: BrowserProviderName,
-): Promise<SessionRun> {
+): Promise<HarnessRun> {
 	const toolkit = createPiBrowserTools(createBenchmarkBrowserProvider(provider));
-	let run: SessionRun;
+	let run: HarnessRun;
 	try {
 		run = await runBrowserTask({
 			task,
@@ -37,7 +37,7 @@ export async function runBrowserToolsHarness(
 	try {
 		await toolkit.dispose();
 	} catch (error) {
-		throw new SessionRunError(
+		throw new HarnessRunError(
 			new Error(
 				`Browser cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
 			),

--- a/packages/browser-tools/benchmarks/harness/dev-browser.ts
+++ b/packages/browser-tools/benchmarks/harness/dev-browser.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import type { SessionRun } from "../agent.js";
+import type { HarnessRun } from "../harness-run.js";
 import {
 	closeCloudBrowserConnection,
 	createCloudBrowserConnection,
@@ -19,7 +19,7 @@ export async function runDevBrowserHarness(
 	task: string,
 	workspace: string,
 	provider: BrowserProviderName,
-): Promise<SessionRun> {
+): Promise<HarnessRun> {
 	const browser = await createCloudBrowserConnection(provider);
 	try {
 		const command = [

--- a/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
@@ -37,14 +37,23 @@ export async function runHermesBrowserToolsHarness(
 		.join("\n");
 
 	const envLines = [`OPENAI_API_KEY=${openAiKey}`];
+	const mcpEnvEntries: string[] = [];
 	if (provider === "kernel" && providerKey) {
 		envLines.push(`KERNEL_API_KEY=${providerKey}`);
+		mcpEnvEntries.push(`      KERNEL_API_KEY: ${JSON.stringify(providerKey)}`);
 	} else if (provider === "browserbase" && providerKey) {
 		envLines.push(`BROWSERBASE_API_KEY=${providerKey}`);
+		mcpEnvEntries.push(
+			`      BROWSERBASE_API_KEY: ${JSON.stringify(providerKey)}`,
+		);
 	} else if (provider === "browser-use" && providerKey) {
 		envLines.push(`BROWSER_USE_API_KEY=${providerKey}`);
+		mcpEnvEntries.push(
+			`      BROWSER_USE_API_KEY: ${JSON.stringify(providerKey)}`,
+		);
 	} else if (provider === "steel" && providerKey) {
 		envLines.push(`STEEL_API_KEY=${providerKey}`);
+		mcpEnvEntries.push(`      STEEL_API_KEY: ${JSON.stringify(providerKey)}`);
 	}
 
 	await writeTextFile(
@@ -65,6 +74,9 @@ export async function runHermesBrowserToolsHarness(
 			"    args:",
 			`      - ${JSON.stringify(mcpBinary)}`,
 			providerArgs,
+			...(mcpEnvEntries.length > 0
+				? ["    env:", ...mcpEnvEntries]
+				: []),
 			"",
 		].join("\n"),
 	);

--- a/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
@@ -1,0 +1,122 @@
+import { join } from "node:path";
+import {
+	HarnessRunError,
+	type HarnessRun,
+} from "../harness-run.js";
+import type { BrowserProviderName } from "./cloud-browser.js";
+import {
+	extractHostAnswer,
+	hostEventsFromProcess,
+	hostMetrics,
+	hostTaskPrompt,
+	mcpProviderArgs,
+	requireBrowserToolsMcpBinary,
+	requireCommandOnPath,
+	requireOpenAiApiKey,
+	requireProviderApiKey,
+	runHostProcess,
+	writeTextFile,
+} from "./host-agent.js";
+
+/**
+ * Hermes with Libretto Browser Tools MCP; stock Hermes browser toolset disabled.
+ */
+export async function runHermesBrowserToolsHarness(
+	task: string,
+	workspace: string,
+	provider: BrowserProviderName,
+): Promise<HarnessRun> {
+	const hermesBin = requireCommandOnPath("hermes");
+	const openAiKey = requireOpenAiApiKey();
+	const providerKey = requireProviderApiKey(provider);
+	const mcpBinary = requireBrowserToolsMcpBinary();
+	const hermesHome = join(workspace, "hermes-home");
+	const prompt = hostTaskPrompt(task, "mcp");
+	const providerArgs = mcpProviderArgs(provider)
+		.map((arg) => `      - ${JSON.stringify(arg)}`)
+		.join("\n");
+
+	const envLines = [`OPENAI_API_KEY=${openAiKey}`];
+	if (provider === "kernel" && providerKey) {
+		envLines.push(`KERNEL_API_KEY=${providerKey}`);
+	} else if (provider === "browserbase" && providerKey) {
+		envLines.push(`BROWSERBASE_API_KEY=${providerKey}`);
+	} else if (provider === "browser-use" && providerKey) {
+		envLines.push(`BROWSER_USE_API_KEY=${providerKey}`);
+	} else if (provider === "steel" && providerKey) {
+		envLines.push(`STEEL_API_KEY=${providerKey}`);
+	}
+
+	await writeTextFile(
+		join(hermesHome, "config.yaml"),
+		[
+			"model:",
+			"  provider: openai-api",
+			"  default: gpt-5.6-sol",
+			"  base_url: https://api.openai.com/v1",
+			"agent:",
+			"  reasoning_effort: none",
+			"  supports_parallel_tool_calls: false",
+			"  disabled_toolsets:",
+			"    - browser",
+			"mcp_servers:",
+			"  libretto:",
+			"    command: node",
+			"    args:",
+			`      - ${JSON.stringify(mcpBinary)}`,
+			providerArgs,
+			"",
+		].join("\n"),
+	);
+	await writeTextFile(join(hermesHome, ".env"), `${envLines.join("\n")}\n`);
+
+	const childEnv: NodeJS.ProcessEnv = {
+		...process.env,
+		HOME: hermesHome,
+		HERMES_HOME: hermesHome,
+		OPENAI_API_KEY: openAiKey,
+	};
+	if (providerKey) {
+		const keyName =
+			provider === "kernel"
+				? "KERNEL_API_KEY"
+				: provider === "browserbase"
+					? "BROWSERBASE_API_KEY"
+					: provider === "browser-use"
+						? "BROWSER_USE_API_KEY"
+						: provider === "steel"
+							? "STEEL_API_KEY"
+							: null;
+		if (keyName) childEnv[keyName] = providerKey;
+	}
+
+	const result = await runHostProcess({
+		command: hermesBin,
+		args: ["chat", "-q", prompt],
+		cwd: workspace,
+		env: childEnv,
+	});
+	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const run: HarnessRun = {
+		answer,
+		events: hostEventsFromProcess({ prompt, result, answer }),
+		metrics: hostMetrics(result.durationMs),
+		browserBackend: "benchmark-provider",
+		async dispose() {},
+	};
+	if (result.timedOut) {
+		throw new HarnessRunError(
+			new Error(
+				`Hermes Browser Tools harness timed out after ${result.durationMs}ms.`,
+			),
+			run,
+		);
+	}
+	if (!answer) {
+		throw new HarnessRunError(
+			new Error("Hermes Browser Tools harness returned no final answer."),
+			run,
+		);
+	}
+	return run;
+}

--- a/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
@@ -15,6 +15,7 @@ import {
 	requireOpenAiApiKey,
 	requireProviderApiKey,
 	runHostProcess,
+	usageFromHermesHome,
 	writeTextFile,
 } from "./host-agent.js";
 
@@ -109,10 +110,14 @@ export async function runHermesBrowserToolsHarness(
 		env: childEnv,
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const events = hostEventsFromProcess({ prompt, result, answer });
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromProcess({ prompt, result, answer }),
-		metrics: hostMetrics(result.durationMs),
+		events,
+		metrics: hostMetrics(result.durationMs, {
+			events,
+			usage: usageFromHermesHome(hermesHome),
+		}),
 		browserBackend: "benchmark-provider",
 		async dispose() {},
 	};

--- a/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
@@ -11,6 +11,8 @@ import {
 	hostMetrics,
 	hostTaskPrompt,
 	mcpProviderArgs,
+	playwrightBrowsersPath,
+	playwrightBrowsersPathEnv,
 	requireBrowserToolsMcpBinary,
 	requireCommandOnPath,
 	requireOpenAiApiKey,
@@ -37,9 +39,12 @@ export async function runHermesBrowserToolsHarness(
 	const providerArgs = mcpProviderArgs(provider)
 		.map((arg) => `      - ${JSON.stringify(arg)}`)
 		.join("\n");
+	const playwrightBrowsersPathValue = playwrightBrowsersPath();
 
 	const envLines = [`OPENAI_API_KEY=${openAiKey}`];
-	const mcpEnvEntries: string[] = [];
+	const mcpEnvEntries: string[] = [
+		`      PLAYWRIGHT_BROWSERS_PATH: ${JSON.stringify(playwrightBrowsersPathValue)}`,
+	];
 	if (provider === "kernel" && providerKey) {
 		envLines.push(`KERNEL_API_KEY=${providerKey}`);
 		mcpEnvEntries.push(`      KERNEL_API_KEY: ${JSON.stringify(providerKey)}`);
@@ -76,9 +81,8 @@ export async function runHermesBrowserToolsHarness(
 			"    args:",
 			`      - ${JSON.stringify(mcpBinary)}`,
 			providerArgs,
-			...(mcpEnvEntries.length > 0
-				? ["    env:", ...mcpEnvEntries]
-				: []),
+			"    env:",
+			...mcpEnvEntries,
 			"",
 		].join("\n"),
 	);
@@ -86,6 +90,7 @@ export async function runHermesBrowserToolsHarness(
 
 	const providerEnv: NodeJS.ProcessEnv = {
 		OPENAI_API_KEY: openAiKey,
+		PLAYWRIGHT_BROWSERS_PATH: playwrightBrowsersPathValue,
 	};
 	if (providerKey) {
 		const keyName =

--- a/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-browser-tools.ts
@@ -6,6 +6,7 @@ import {
 import type { BrowserProviderName } from "./cloud-browser.js";
 import {
 	extractHostAnswer,
+	hermesIsolatedEnv,
 	hostEventsFromProcess,
 	hostMetrics,
 	hostTaskPrompt,
@@ -83,10 +84,7 @@ export async function runHermesBrowserToolsHarness(
 	);
 	await writeTextFile(join(hermesHome, ".env"), `${envLines.join("\n")}\n`);
 
-	const childEnv: NodeJS.ProcessEnv = {
-		...process.env,
-		HOME: hermesHome,
-		HERMES_HOME: hermesHome,
+	const providerEnv: NodeJS.ProcessEnv = {
 		OPENAI_API_KEY: openAiKey,
 	};
 	if (providerKey) {
@@ -100,14 +98,14 @@ export async function runHermesBrowserToolsHarness(
 						: provider === "steel"
 							? "STEEL_API_KEY"
 							: null;
-		if (keyName) childEnv[keyName] = providerKey;
+		if (keyName) providerEnv[keyName] = providerKey;
 	}
 
 	const result = await runHostProcess({
 		command: hermesBin,
 		args: ["chat", "-q", prompt],
 		cwd: workspace,
-		env: childEnv,
+		env: hermesIsolatedEnv(hermesHome, providerEnv),
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
 	const events = hostEventsFromProcess({ prompt, result, answer });

--- a/packages/browser-tools/benchmarks/harness/hermes-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-stock.ts
@@ -1,0 +1,83 @@
+import { join } from "node:path";
+import {
+	HarnessRunError,
+	type HarnessRun,
+} from "../harness-run.js";
+import type { BrowserProviderName } from "./cloud-browser.js";
+import {
+	extractHostAnswer,
+	hostEventsFromProcess,
+	hostMetrics,
+	hostTaskPrompt,
+	requireCommandOnPath,
+	requireOpenAiApiKey,
+	runHostProcess,
+	writeTextFile,
+} from "./host-agent.js";
+
+/**
+ * Hermes with its stock built-in browser toolset (no Libretto MCP).
+ */
+export async function runHermesStockHarness(
+	task: string,
+	workspace: string,
+	_provider: BrowserProviderName,
+): Promise<HarnessRun> {
+	const hermesBin = requireCommandOnPath("hermes");
+	const openAiKey = requireOpenAiApiKey();
+	const hermesHome = join(workspace, "hermes-home");
+	const prompt = hostTaskPrompt(task, "stock");
+
+	await writeTextFile(
+		join(hermesHome, "config.yaml"),
+		[
+			"model:",
+			"  provider: openai-api",
+			"  default: gpt-5.6-sol",
+			"  base_url: https://api.openai.com/v1",
+			"agent:",
+			"  reasoning_effort: none",
+			"  supports_parallel_tool_calls: false",
+			"",
+		].join("\n"),
+	);
+	await writeTextFile(
+		join(hermesHome, ".env"),
+		`OPENAI_API_KEY=${openAiKey}\n`,
+	);
+
+	const result = await runHostProcess({
+		command: hermesBin,
+		args: ["chat", "-q", prompt],
+		cwd: workspace,
+		env: {
+			...process.env,
+			HOME: hermesHome,
+			HERMES_HOME: hermesHome,
+			OPENAI_API_KEY: openAiKey,
+		},
+	});
+	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const run: HarnessRun = {
+		answer,
+		events: hostEventsFromProcess({ prompt, result, answer }),
+		metrics: hostMetrics(result.durationMs),
+		browserBackend: "host-stock",
+		async dispose() {},
+	};
+	if (result.timedOut) {
+		throw new HarnessRunError(
+			new Error(
+				`Hermes stock harness timed out after ${result.durationMs}ms.`,
+			),
+			run,
+		);
+	}
+	if (!answer) {
+		throw new HarnessRunError(
+			new Error("Hermes stock harness returned no final answer."),
+			run,
+		);
+	}
+	return run;
+}

--- a/packages/browser-tools/benchmarks/harness/hermes-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-stock.ts
@@ -12,6 +12,7 @@ import {
 	requireCommandOnPath,
 	requireOpenAiApiKey,
 	runHostProcess,
+	usageFromHermesHome,
 	writeTextFile,
 } from "./host-agent.js";
 
@@ -58,10 +59,14 @@ export async function runHermesStockHarness(
 		},
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const events = hostEventsFromProcess({ prompt, result, answer });
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromProcess({ prompt, result, answer }),
-		metrics: hostMetrics(result.durationMs),
+		events,
+		metrics: hostMetrics(result.durationMs, {
+			events,
+			usage: usageFromHermesHome(hermesHome),
+		}),
 		browserBackend: "host-stock",
 		async dispose() {},
 	};

--- a/packages/browser-tools/benchmarks/harness/hermes-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/hermes-stock.ts
@@ -9,6 +9,7 @@ import {
 	hostEventsFromProcess,
 	hostMetrics,
 	hostTaskPrompt,
+	hermesIsolatedEnv,
 	requireCommandOnPath,
 	requireOpenAiApiKey,
 	runHostProcess,
@@ -51,12 +52,9 @@ export async function runHermesStockHarness(
 		command: hermesBin,
 		args: ["chat", "-q", prompt],
 		cwd: workspace,
-		env: {
-			...process.env,
-			HOME: hermesHome,
-			HERMES_HOME: hermesHome,
+		env: hermesIsolatedEnv(hermesHome, {
 			OPENAI_API_KEY: openAiKey,
-		},
+		}),
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
 	const events = hostEventsFromProcess({ prompt, result, answer });

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -1,5 +1,12 @@
-import { spawn } from "node:child_process";
-import { accessSync, constants, readdirSync, readFileSync, readlinkSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import {
+	accessSync,
+	constants,
+	existsSync,
+	readdirSync,
+	readFileSync,
+	readlinkSync,
+} from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -329,8 +336,285 @@ export function hostEventsFromProcess(options: {
 	return events;
 }
 
-export function hostMetrics(durationMs: number): UsageMetrics {
-	return { durationMs };
+function toolCallCountsFromEvents(
+	events: HarnessEvent[],
+): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const event of events) {
+		if (event.type !== "tool_execution_start") continue;
+		counts[event.toolName] = (counts[event.toolName] ?? 0) + 1;
+	}
+	return counts;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
+}
+
+function sumDefined(...values: Array<number | undefined>): number | undefined {
+	const present = values.filter((value): value is number => value !== undefined);
+	if (present.length === 0) return undefined;
+	return present.reduce((total, value) => total + value, 0);
+}
+
+/**
+ * Build host UsageMetrics. Token/cost fields stay undefined when unknown —
+ * never invent zeros for missing host telemetry.
+ */
+export function hostMetrics(
+	durationMs: number,
+	options?: {
+		events?: HarnessEvent[];
+		usage?: Partial<UsageMetrics>;
+	},
+): UsageMetrics {
+	const usage = options?.usage ?? {};
+	const toolCalls =
+		options?.events !== undefined
+			? toolCallCountsFromEvents(options.events)
+			: usage.toolCalls;
+	const totalToolCalls =
+		toolCalls !== undefined
+			? Object.values(toolCalls).reduce((total, count) => total + count, 0)
+			: usage.totalToolCalls;
+	const inputTokens = numberOrUndefined(usage.inputTokens);
+	const outputTokens = numberOrUndefined(usage.outputTokens);
+	const cacheReadTokens = numberOrUndefined(usage.cacheReadTokens);
+	const cacheWriteTokens = numberOrUndefined(usage.cacheWriteTokens);
+	const totalTokens =
+		numberOrUndefined(usage.totalTokens) ??
+		sumDefined(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens);
+	return {
+		durationMs,
+		...(inputTokens !== undefined ? { inputTokens } : {}),
+		...(outputTokens !== undefined ? { outputTokens } : {}),
+		...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+		...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+		...(totalTokens !== undefined ? { totalTokens } : {}),
+		...(numberOrUndefined(usage.maxRequestContextTokens) !== undefined
+			? { maxRequestContextTokens: usage.maxRequestContextTokens }
+			: {}),
+		...(numberOrUndefined(usage.costUsd) !== undefined
+			? { costUsd: usage.costUsd }
+			: {}),
+		...(numberOrUndefined(usage.turns) !== undefined
+			? { turns: usage.turns }
+			: {}),
+		...(toolCalls !== undefined ? { toolCalls } : {}),
+		...(totalToolCalls !== undefined ? { totalToolCalls } : {}),
+	};
+}
+
+/**
+ * Read token/cost totals for the latest Hermes session from HERMES_HOME/state.db.
+ * Missing fields stay omitted (undefined), including when the DB is absent.
+ */
+export function usageFromHermesHome(hermesHome: string): Partial<UsageMetrics> {
+	const dbPath = join(hermesHome, "state.db");
+	if (!existsSync(dbPath)) return {};
+	const query = [
+		"SELECT input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,",
+		"api_call_count, COALESCE(actual_cost_usd, estimated_cost_usd) AS cost_usd",
+		"FROM sessions ORDER BY started_at DESC LIMIT 1;",
+	].join(" ");
+	const result = spawnSync(
+		"python3",
+		[
+			"-c",
+			[
+				"import json, sqlite3, sys",
+				"db = sqlite3.connect(sys.argv[1])",
+				"row = db.execute(sys.argv[2]).fetchone()",
+				"print(json.dumps(row))",
+			].join("; "),
+			dbPath,
+			query,
+		],
+		{ encoding: "utf8" },
+	);
+	if (result.status !== 0 || !result.stdout.trim()) return {};
+	let row: unknown;
+	try {
+		row = JSON.parse(result.stdout.trim());
+	} catch {
+		return {};
+	}
+	if (!Array.isArray(row) || row.length < 6) return {};
+	const inputTokens = numberOrUndefined(row[0]);
+	const outputTokens = numberOrUndefined(row[1]);
+	const cacheReadTokens = numberOrUndefined(row[2]);
+	const cacheWriteTokens = numberOrUndefined(row[3]);
+	const turns = numberOrUndefined(row[4]);
+	const costUsd = numberOrUndefined(row[5]);
+	const totalTokens = sumDefined(
+		inputTokens,
+		outputTokens,
+		cacheReadTokens,
+		cacheWriteTokens,
+	);
+	// Hermes defaults missing counters to 0 in SQLite; treat an all-zero row
+	// with no API calls as "unknown" rather than a real zero-token run.
+	const hasSignal =
+		(turns !== undefined && turns > 0) ||
+		(totalTokens !== undefined && totalTokens > 0) ||
+		(costUsd !== undefined && costUsd > 0);
+	if (!hasSignal) return {};
+	return {
+		...(inputTokens !== undefined ? { inputTokens } : {}),
+		...(outputTokens !== undefined ? { outputTokens } : {}),
+		...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+		...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+		...(totalTokens !== undefined ? { totalTokens } : {}),
+		...(costUsd !== undefined ? { costUsd } : {}),
+		...(turns !== undefined ? { turns } : {}),
+	};
+}
+
+type OpenClawUsageBuckets = {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	total: number;
+	cost: number;
+	assistantTurns: number;
+	maxRequestContextTokens: number;
+};
+
+function emptyOpenClawUsageBuckets(): OpenClawUsageBuckets {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		total: 0,
+		cost: 0,
+		assistantTurns: 0,
+		maxRequestContextTokens: 0,
+	};
+}
+
+function addOpenClawMessageUsage(
+	buckets: OpenClawUsageBuckets,
+	message: {
+		role?: unknown;
+		usage?: {
+			input?: unknown;
+			output?: unknown;
+			cacheRead?: unknown;
+			cacheWrite?: unknown;
+			total?: unknown;
+			cost?: unknown | { total?: unknown };
+		};
+	},
+): void {
+	if (message.role !== "assistant") return;
+	const usage = message.usage;
+	if (!usage || typeof usage !== "object") return;
+	const input = numberOrUndefined(usage.input) ?? 0;
+	const output = numberOrUndefined(usage.output) ?? 0;
+	const cacheRead = numberOrUndefined(usage.cacheRead) ?? 0;
+	const cacheWrite = numberOrUndefined(usage.cacheWrite) ?? 0;
+	const componentTotal = input + output + cacheRead + cacheWrite;
+	const total = numberOrUndefined(usage.total) ?? componentTotal;
+	const cost =
+		numberOrUndefined(usage.cost) ??
+		(usage.cost && typeof usage.cost === "object"
+			? numberOrUndefined((usage.cost as { total?: unknown }).total)
+			: undefined) ??
+		0;
+	buckets.input += input;
+	buckets.output += output;
+	buckets.cacheRead += cacheRead;
+	buckets.cacheWrite += cacheWrite;
+	buckets.total += total;
+	buckets.cost += cost;
+	buckets.assistantTurns += 1;
+	const requestContext = input + cacheRead + cacheWrite;
+	buckets.maxRequestContextTokens = Math.max(
+		buckets.maxRequestContextTokens,
+		requestContext,
+	);
+}
+
+/**
+ * Sum token/cost usage from OpenClaw session JSONL under OPENCLAW_STATE_DIR.
+ */
+export function usageFromOpenClawHome(
+	openclawHome: string,
+): Partial<UsageMetrics> {
+	const sessionsDir = join(
+		openclawHome,
+		".openclaw",
+		"agents",
+		"main",
+		"sessions",
+	);
+	let sessionFiles: string[] = [];
+	try {
+		sessionFiles = readdirSync(sessionsDir)
+			.filter(
+				(name) =>
+					name.endsWith(".jsonl") &&
+					!name.endsWith(".trajectory.jsonl") &&
+					name !== "sessions.json",
+			)
+			.map((name) => join(sessionsDir, name));
+	} catch {
+		return {};
+	}
+
+	const buckets = emptyOpenClawUsageBuckets();
+	for (const sessionFile of sessionFiles) {
+		let lines: string[] = [];
+		try {
+			lines = readFileSync(sessionFile, "utf8").split(/\r?\n/);
+		} catch {
+			continue;
+		}
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			let record: unknown;
+			try {
+				record = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (!record || typeof record !== "object") continue;
+			const entry = record as {
+				type?: unknown;
+				message?: {
+					role?: unknown;
+					usage?: {
+						input?: unknown;
+						output?: unknown;
+						cacheRead?: unknown;
+						cacheWrite?: unknown;
+						total?: unknown;
+						cost?: unknown | { total?: unknown };
+					};
+				};
+			};
+			if (entry.type !== "message" || !entry.message) continue;
+			addOpenClawMessageUsage(buckets, entry.message);
+		}
+	}
+
+	if (buckets.assistantTurns === 0 && buckets.total === 0) return {};
+	return {
+		inputTokens: buckets.input,
+		outputTokens: buckets.output,
+		cacheReadTokens: buckets.cacheRead,
+		cacheWriteTokens: buckets.cacheWrite,
+		totalTokens: buckets.total,
+		...(buckets.maxRequestContextTokens > 0
+			? { maxRequestContextTokens: buckets.maxRequestContextTokens }
+			: {}),
+		...(buckets.cost > 0 ? { costUsd: buckets.cost } : {}),
+		turns: buckets.assistantTurns,
+	};
 }
 
 function textFromOpenClawContent(content: unknown): string | null {

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -129,6 +129,7 @@ export async function runHostProcess(options: {
 		const stderrChunks: Buffer[] = [];
 		let timedOut = false;
 		let settled = false;
+		let earlyExitScheduled = false;
 		const killByCwdHint = (): void => {
 			const hint = options.alsoKillCwdContains;
 			if (!hint) return;
@@ -197,11 +198,12 @@ export async function runHostProcess(options: {
 		}, timeoutMs);
 		const maybeExitEarly = (): void => {
 			if (!options.exitOnStdoutMatch) return;
-			if (settled) return;
+			if (settled || earlyExitScheduled) return;
 			const text =
 				Buffer.concat(stdoutChunks).toString("utf8") +
 				Buffer.concat(stderrChunks).toString("utf8");
 			if (!options.exitOnStdoutMatch.test(text)) return;
+			earlyExitScheduled = true;
 			setTimeout(() => {
 				if (settled) return;
 				killTree("SIGTERM");
@@ -447,7 +449,9 @@ export function usageFromHermesHome(hermesHome: string): Partial<UsageMetrics> {
 	const outputTokens = numberOrUndefined(row[1]);
 	const cacheReadTokens = numberOrUndefined(row[2]);
 	const cacheWriteTokens = numberOrUndefined(row[3]);
-	const turns = numberOrUndefined(row[4]);
+	// api_call_count is not assistant-message turns (Pi/OpenClaw measure those).
+	// Keep it only as a presence signal for an all-zero telemetry row.
+	const apiCallCount = numberOrUndefined(row[4]);
 	const costUsd = numberOrUndefined(row[5]);
 	const totalTokens = sumDefined(
 		inputTokens,
@@ -458,7 +462,7 @@ export function usageFromHermesHome(hermesHome: string): Partial<UsageMetrics> {
 	// Hermes defaults missing counters to 0 in SQLite; treat an all-zero row
 	// with no API calls as "unknown" rather than a real zero-token run.
 	const hasSignal =
-		(turns !== undefined && turns > 0) ||
+		(apiCallCount !== undefined && apiCallCount > 0) ||
 		(totalTokens !== undefined && totalTokens > 0) ||
 		(costUsd !== undefined && costUsd > 0);
 	if (!hasSignal) return {};
@@ -469,7 +473,6 @@ export function usageFromHermesHome(hermesHome: string): Partial<UsageMetrics> {
 		...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
 		...(totalTokens !== undefined ? { totalTokens } : {}),
 		...(costUsd !== undefined ? { costUsd } : {}),
-		...(turns !== undefined ? { turns } : {}),
 	};
 }
 

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -1,0 +1,233 @@
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	browserTaskPrompt,
+	DEFAULT_TIMEOUT_MS,
+	MODEL_SELECTOR,
+	type BrowserToolGuidance,
+	type UsageMetrics,
+} from "../agent.js";
+import type { HarnessEvent, HarnessRun } from "../harness-run.js";
+import type { BrowserProviderName } from "./cloud-browser.js";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export function browserToolsMcpBinaryPath(): string {
+	return join(packageRoot, "dist", "cli", "index.js");
+}
+
+export function requireBrowserToolsMcpBinary(): string {
+	const path = browserToolsMcpBinaryPath();
+	try {
+		accessSync(path, constants.R_OK);
+	} catch {
+		throw new Error(
+			`Missing Browser Tools MCP binary at ${path}. Run \`pnpm --filter libretto-browser-tools build\`, then rerun the benchmark.`,
+		);
+	}
+	return path;
+}
+
+export function requireCommandOnPath(command: string): string {
+	const pathDirs = (process.env.PATH ?? "").split(":");
+	for (const dir of pathDirs) {
+		if (!dir) continue;
+		const candidate = join(dir, command);
+		try {
+			accessSync(candidate, constants.X_OK);
+			return candidate;
+		} catch {
+			// try next
+		}
+	}
+	throw new Error(
+		`\`${command}\` was not found on PATH. Install it, ensure PATH includes its bin directory, then rerun with the host harness selected.`,
+	);
+}
+
+export function requireOpenAiApiKey(): string {
+	const value = process.env.OPENAI_API_KEY?.trim();
+	if (!value) {
+		throw new Error(
+			"OPENAI_API_KEY is required for Hermes/OpenClaw host harnesses. Set it in the environment or repo .env, then rerun.",
+		);
+	}
+	return value;
+}
+
+export function providerApiKeyEnvName(
+	provider: BrowserProviderName,
+): string | null {
+	switch (provider) {
+		case "kernel":
+			return "KERNEL_API_KEY";
+		case "browserbase":
+			return "BROWSERBASE_API_KEY";
+		case "browser-use":
+			return "BROWSER_USE_API_KEY";
+		case "steel":
+			return "STEEL_API_KEY";
+		case "local":
+			return null;
+	}
+}
+
+export function requireProviderApiKey(
+	provider: BrowserProviderName,
+): string | undefined {
+	const envName = providerApiKeyEnvName(provider);
+	if (!envName) return undefined;
+	const value = process.env[envName]?.trim();
+	if (!value) {
+		throw new Error(
+			`${envName} is required for --provider ${provider} with Browser Tools MCP. Set it, then rerun.`,
+		);
+	}
+	return value;
+}
+
+export type HostProcessResult = {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+	durationMs: number;
+	timedOut: boolean;
+};
+
+export async function runHostProcess(options: {
+	command: string;
+	args: string[];
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+	timeoutMs?: number;
+}): Promise<HostProcessResult> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const startedMs = Date.now();
+	return await new Promise<HostProcessResult>((resolvePromise, reject) => {
+		const child = spawn(options.command, options.args, {
+			cwd: options.cwd,
+			env: options.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const stdoutChunks: Buffer[] = [];
+		const stderrChunks: Buffer[] = [];
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGKILL");
+		}, timeoutMs);
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdoutChunks.push(chunk);
+			process.stdout.write(chunk);
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderrChunks.push(chunk);
+			process.stderr.write(chunk);
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.once("close", (exitCode) => {
+			clearTimeout(timer);
+			resolvePromise({
+				exitCode,
+				stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+				stderr: Buffer.concat(stderrChunks).toString("utf8"),
+				durationMs: Date.now() - startedMs,
+				timedOut,
+			});
+		});
+	});
+}
+
+/**
+ * Pull a final answer from host CLI output. Prefer the last non-empty line that
+ * looks like content rather than progress chrome.
+ */
+export function extractHostAnswer(stdout: string, stderr: string): string {
+	const combined = `${stdout}\n${stderr}`;
+	const lines = combined
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	const ignored = /^(Query:|Initializing|Testing |Transport:|Auth:|✓|✗|┊|──|╭|╰|\[diagnostic\]|\[plugins\]|\[provider-|\[agent\/|\[agents\/|Resume this session|Session:|Duration:|Messages:|MCP doctor|Saved MCP|Removed MCP|Goodbye)/;
+	for (let i = lines.length - 1; i >= 0; i -= 1) {
+		const line = lines[i];
+		if (!line || ignored.test(line)) continue;
+		if (line.startsWith("http://") || line.startsWith("https://")) continue;
+		return line;
+	}
+	return lines.at(-1) ?? "";
+}
+
+export function hostEventsFromProcess(options: {
+	prompt: string;
+	result: HostProcessResult;
+	answer: string;
+}): HarnessEvent[] {
+	const events: HarnessEvent[] = [
+		{ type: "message", role: "user", text: options.prompt },
+	];
+	if (options.result.stdout.trim()) {
+		events.push({
+			type: "log",
+			stream: "stdout",
+			text: options.result.stdout,
+		});
+	}
+	if (options.result.stderr.trim()) {
+		events.push({
+			type: "log",
+			stream: "stderr",
+			text: options.result.stderr,
+		});
+	}
+	if (options.result.timedOut) {
+		events.push({
+			type: "error",
+			message: `Host process timed out after ${options.result.durationMs}ms.`,
+		});
+	} else if (options.result.exitCode !== 0 && options.result.exitCode !== null) {
+		events.push({
+			type: "error",
+			message: `Host process exited with code ${options.result.exitCode}.`,
+		});
+	}
+	if (options.answer) {
+		events.push({
+			type: "message",
+			role: "assistant",
+			text: options.answer,
+		});
+	}
+	return events;
+}
+
+export function hostMetrics(durationMs: number): UsageMetrics {
+	return { durationMs };
+}
+
+export function hostTaskPrompt(
+	task: string,
+	guidance: Exclude<BrowserToolGuidance, "harness-provided">,
+): string {
+	return browserTaskPrompt({ task, guidance });
+}
+
+export async function writeTextFile(
+	path: string,
+	contents: string,
+): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, contents, "utf8");
+}
+
+export function mcpProviderArgs(provider: BrowserProviderName): string[] {
+	return ["--provider", provider];
+}
+
+export { MODEL_SELECTOR, packageRoot };

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -793,6 +793,18 @@ export function mcpProviderArgs(provider: BrowserProviderName): string[] {
 }
 
 /**
+ * Playwright browsers live under the real user cache. Isolated HOME for Hermes
+ * and OpenClaw would otherwise force a fresh `playwright install` per attempt.
+ */
+export function playwrightBrowsersPathEnv(): NodeJS.ProcessEnv {
+	const existing = process.env.PLAYWRIGHT_BROWSERS_PATH?.trim();
+	return {
+		PLAYWRIGHT_BROWSERS_PATH:
+			existing || join(homedir(), ".cache", "ms-playwright"),
+	};
+}
+
+/**
  * Env for a Hermes child with an isolated HOME/HERMES_HOME.
  * Keep PYTHONUSERBASE on the real user base so a pip --user install of
  * hermes-agent remains importable after HOME is redirected.
@@ -808,6 +820,7 @@ export function hermesIsolatedEnv(
 		HOME: hermesHome,
 		HERMES_HOME: hermesHome,
 		PYTHONUSERBASE: realUserBase,
+		...playwrightBrowsersPathEnv(),
 		...extra,
 	};
 }

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -796,11 +796,16 @@ export function mcpProviderArgs(provider: BrowserProviderName): string[] {
  * Playwright browsers live under the real user cache. Isolated HOME for Hermes
  * and OpenClaw would otherwise force a fresh `playwright install` per attempt.
  */
-export function playwrightBrowsersPathEnv(): NodeJS.ProcessEnv {
-	const existing = process.env.PLAYWRIGHT_BROWSERS_PATH?.trim();
+export function playwrightBrowsersPath(): string {
+	return (
+		process.env.PLAYWRIGHT_BROWSERS_PATH?.trim() ||
+		join(homedir(), ".cache", "ms-playwright")
+	);
+}
+
+export function playwrightBrowsersPathEnv(): Record<string, string> {
 	return {
-		PLAYWRIGHT_BROWSERS_PATH:
-			existing || join(homedir(), ".cache", "ms-playwright"),
+		PLAYWRIGHT_BROWSERS_PATH: playwrightBrowsersPath(),
 	};
 }
 

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -8,6 +8,7 @@ import {
 	readlinkSync,
 } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -789,6 +790,26 @@ export async function writeTextFile(
 
 export function mcpProviderArgs(provider: BrowserProviderName): string[] {
 	return ["--provider", provider];
+}
+
+/**
+ * Env for a Hermes child with an isolated HOME/HERMES_HOME.
+ * Keep PYTHONUSERBASE on the real user base so a pip --user install of
+ * hermes-agent remains importable after HOME is redirected.
+ */
+export function hermesIsolatedEnv(
+	hermesHome: string,
+	extra: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+	const realUserBase =
+		process.env.PYTHONUSERBASE?.trim() || join(homedir(), ".local");
+	return {
+		...process.env,
+		HOME: hermesHome,
+		HERMES_HOME: hermesHome,
+		PYTHONUSERBASE: realUserBase,
+		...extra,
+	};
 }
 
 export { MODEL_SELECTOR, packageRoot };

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -812,4 +812,26 @@ export function hermesIsolatedEnv(
 	};
 }
 
+/**
+ * Hermes Browser Tools MCP needs the optional `mcp` extra (`hermes-agent[mcp]`).
+ */
+export function requireHermesMcpSdk(): void {
+	const result = spawnSync(
+		"python3",
+		["-c", "import mcp"],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				PYTHONUSERBASE:
+					process.env.PYTHONUSERBASE?.trim() || join(homedir(), ".local"),
+			},
+		},
+	);
+	if (result.status === 0) return;
+	throw new Error(
+		"Hermes MCP support is not installed (missing Python package `mcp`). Install with `pip install 'hermes-agent[mcp]'`, then rerun with hermes-browser-tools.",
+	);
+}
+
 export { MODEL_SELECTOR, packageRoot };

--- a/packages/browser-tools/benchmarks/harness/host-agent.ts
+++ b/packages/browser-tools/benchmarks/harness/host-agent.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, readdirSync, readFileSync, readlinkSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -103,6 +103,10 @@ export async function runHostProcess(options: {
 	cwd: string;
 	env: NodeJS.ProcessEnv;
 	timeoutMs?: number;
+	/** When stdout matches, stop waiting and kill the process tree. */
+	exitOnStdoutMatch?: RegExp;
+	/** Also SIGKILL processes whose cwd contains this path (orphaned helpers). */
+	alsoKillCwdContains?: string;
 }): Promise<HostProcessResult> {
 	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const startedMs = Date.now();
@@ -111,28 +115,65 @@ export async function runHostProcess(options: {
 			cwd: options.cwd,
 			env: options.env,
 			stdio: ["ignore", "pipe", "pipe"],
+			detached: true,
 		});
 		const stdoutChunks: Buffer[] = [];
 		const stderrChunks: Buffer[] = [];
 		let timedOut = false;
-		const timer = setTimeout(() => {
-			timedOut = true;
-			child.kill("SIGKILL");
-		}, timeoutMs);
-		child.stdout.on("data", (chunk: Buffer) => {
-			stdoutChunks.push(chunk);
-			process.stdout.write(chunk);
-		});
-		child.stderr.on("data", (chunk: Buffer) => {
-			stderrChunks.push(chunk);
-			process.stderr.write(chunk);
-		});
-		child.once("error", (error) => {
+		let settled = false;
+		const killByCwdHint = (): void => {
+			const hint = options.alsoKillCwdContains;
+			if (!hint) return;
+			try {
+				const pids = readdirSync("/proc").filter((name) => /^\d+$/.test(name));
+				for (const pid of pids) {
+					try {
+						const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+						if (
+							!cmdline.includes("openclaw-agent") &&
+							!cmdline.includes("google-chrome")
+						) {
+							continue;
+						}
+						const cwd = readlinkSync(`/proc/${pid}/cwd`);
+						if (!cwd.includes(hint)) continue;
+						process.kill(Number(pid), "SIGKILL");
+					} catch {
+						// ignore vanishing procs / permission
+					}
+				}
+			} catch {
+				// ignore
+			}
+		};
+		const killTree = (signal: NodeJS.Signals): void => {
+			if (child.pid != null) {
+				try {
+					process.kill(-child.pid, signal);
+				} catch {
+					try {
+						child.kill(signal);
+					} catch {
+						// already gone
+					}
+				}
+			}
+			if (signal === "SIGKILL") killByCwdHint();
+		};
+		const finish = (exitCode: number | null): void => {
+			if (settled) return;
+			settled = true;
 			clearTimeout(timer);
-			reject(error);
-		});
-		child.once("close", (exitCode) => {
-			clearTimeout(timer);
+			try {
+				child.stdout.destroy();
+			} catch {
+				// ignore
+			}
+			try {
+				child.stderr.destroy();
+			} catch {
+				// ignore
+			}
 			resolvePromise({
 				exitCode,
 				stdout: Buffer.concat(stdoutChunks).toString("utf8"),
@@ -140,24 +181,85 @@ export async function runHostProcess(options: {
 				durationMs: Date.now() - startedMs,
 				timedOut,
 			});
+		};
+		const timer = setTimeout(() => {
+			timedOut = true;
+			killTree("SIGKILL");
+			finish(null);
+		}, timeoutMs);
+		const maybeExitEarly = (): void => {
+			if (!options.exitOnStdoutMatch) return;
+			if (settled) return;
+			const text =
+				Buffer.concat(stdoutChunks).toString("utf8") +
+				Buffer.concat(stderrChunks).toString("utf8");
+			if (!options.exitOnStdoutMatch.test(text)) return;
+			setTimeout(() => {
+				if (settled) return;
+				killTree("SIGTERM");
+				setTimeout(() => {
+					if (settled) return;
+					killTree("SIGKILL");
+					finish(child.exitCode);
+				}, 1_500);
+			}, 300);
+		};
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdoutChunks.push(chunk);
+			process.stdout.write(chunk);
+			maybeExitEarly();
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderrChunks.push(chunk);
+			process.stderr.write(chunk);
+			maybeExitEarly();
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			if (settled) return;
+			settled = true;
+			reject(error);
+		});
+		child.once("exit", (exitCode) => {
+			// OpenClaw's CLI wrapper can exit while openclaw-agent keeps stdio
+			// open. When exitOnStdoutMatch is set, wait for that (or timeout).
+			if (options.exitOnStdoutMatch) return;
+			finish(exitCode);
+		});
+		child.once("close", (exitCode) => {
+			finish(exitCode);
 		});
 	});
 }
 
+export const OPENCLAW_AGENT_DONE =
+	/\[agents\/agent-command\] \[agent\] run \S+ ended with stopReason=/;
+
+const HOST_OUTPUT_NOISE =
+	/^(Query:|Initializing|Testing |Transport:|Auth:|✓|✗|┊|──|╭|╰|│|\[diagnostic\]|\[plugins\]|\[provider-|\[agent\/|\[agents\/|\[tools\]|\[browser\/|Resume this session|Session:|Duration:|Messages:|MCP doctor|Saved MCP|Removed MCP|Goodbye|hermes --resume\b)/;
+
 /**
- * Pull a final answer from host CLI output. Prefer the last non-empty line that
- * looks like content rather than progress chrome.
+ * Prefer the Hermes chat reply box when present; otherwise the last non-noise
+ * content line from host stdout/stderr.
  */
 export function extractHostAnswer(stdout: string, stderr: string): string {
 	const combined = `${stdout}\n${stderr}`;
+	const hermesBox = combined.match(/╭─[^\n]*\n([\s\S]*?)\n╰─/);
+	if (hermesBox?.[1]) {
+		const boxed = hermesBox[1]
+			.split(/\r?\n/)
+			.map((line) => line.replace(/^\s*│\s?/, "").trimEnd())
+			.join("\n")
+			.trim();
+		if (boxed) return boxed;
+	}
 	const lines = combined
 		.split(/\r?\n/)
 		.map((line) => line.trim())
 		.filter((line) => line.length > 0);
-	const ignored = /^(Query:|Initializing|Testing |Transport:|Auth:|✓|✗|┊|──|╭|╰|\[diagnostic\]|\[plugins\]|\[provider-|\[agent\/|\[agents\/|Resume this session|Session:|Duration:|Messages:|MCP doctor|Saved MCP|Removed MCP|Goodbye)/;
 	for (let i = lines.length - 1; i >= 0; i -= 1) {
 		const line = lines[i];
-		if (!line || ignored.test(line)) continue;
+		if (!line || HOST_OUTPUT_NOISE.test(line)) continue;
 		if (line.startsWith("http://") || line.startsWith("https://")) continue;
 		return line;
 	}
@@ -172,19 +274,39 @@ export function hostEventsFromProcess(options: {
 	const events: HarnessEvent[] = [
 		{ type: "message", role: "user", text: options.prompt },
 	];
-	if (options.result.stdout.trim()) {
+	const hostLog = [options.result.stdout, options.result.stderr]
+		.filter((part) => part.trim().length > 0)
+		.join("\n");
+	if (hostLog) {
+		// Emit a synthetic tool span so the shared judge can treat host CLI
+		// stdout/stderr as observed browser evidence (hosts do not emit Pi tool events).
 		events.push({
-			type: "log",
-			stream: "stdout",
-			text: options.result.stdout,
+			type: "tool_execution_start",
+			toolName: "host_browser",
+			args: { source: "host-cli" },
 		});
-	}
-	if (options.result.stderr.trim()) {
 		events.push({
-			type: "log",
-			stream: "stderr",
-			text: options.result.stderr,
+			type: "tool_execution_end",
+			toolName: "host_browser",
+			isError:
+				options.result.timedOut ||
+				(options.result.exitCode !== 0 && options.result.exitCode !== null),
+			result: hostLog,
 		});
+		if (options.result.stdout.trim()) {
+			events.push({
+				type: "log",
+				stream: "stdout",
+				text: options.result.stdout,
+			});
+		}
+		if (options.result.stderr.trim()) {
+			events.push({
+				type: "log",
+				stream: "stderr",
+				text: options.result.stderr,
+			});
+		}
 	}
 	if (options.result.timedOut) {
 		events.push({
@@ -209,6 +331,161 @@ export function hostEventsFromProcess(options: {
 
 export function hostMetrics(durationMs: number): UsageMetrics {
 	return { durationMs };
+}
+
+function textFromOpenClawContent(content: unknown): string | null {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return null;
+	const parts: string[] = [];
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue;
+		const record = part as { type?: unknown; text?: unknown };
+		if (record.type === "text" && typeof record.text === "string") {
+			parts.push(record.text);
+		}
+	}
+	return parts.length > 0 ? parts.join("\n") : null;
+}
+
+/**
+ * Convert OpenClaw session JSONL (under OPENCLAW_STATE_DIR) into HarnessEvents
+ * so the shared judge sees real tool calls instead of only process stdout.
+ */
+export function hostEventsFromOpenClawHome(options: {
+	openclawHome: string;
+	prompt: string;
+	result: HostProcessResult;
+	answer: string;
+}): HarnessEvent[] {
+	const sessionsDir = join(
+		options.openclawHome,
+		".openclaw",
+		"agents",
+		"main",
+		"sessions",
+	);
+	let sessionFiles: string[] = [];
+	try {
+		sessionFiles = readdirSync(sessionsDir)
+			.filter(
+				(name) =>
+					name.endsWith(".jsonl") &&
+					!name.endsWith(".trajectory.jsonl") &&
+					name !== "sessions.json",
+			)
+			.map((name) => join(sessionsDir, name));
+	} catch {
+		sessionFiles = [];
+	}
+
+	const events: HarnessEvent[] = [];
+	for (const sessionFile of sessionFiles) {
+		let lines: string[] = [];
+		try {
+			lines = readFileSync(sessionFile, "utf8").split(/\r?\n/);
+		} catch {
+			continue;
+		}
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			let record: unknown;
+			try {
+				record = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (!record || typeof record !== "object") continue;
+			const entry = record as {
+				type?: unknown;
+				message?: {
+					role?: unknown;
+					content?: unknown;
+					toolName?: unknown;
+					isError?: unknown;
+				};
+			};
+			if (entry.type !== "message" || !entry.message) continue;
+			const message = entry.message;
+			if (message.role === "user" || message.role === "assistant") {
+				const text = textFromOpenClawContent(message.content);
+				if (text) {
+					events.push({
+						type: "message",
+						role: message.role,
+						text,
+					});
+				}
+				if (message.role === "assistant" && Array.isArray(message.content)) {
+					for (const part of message.content) {
+						if (!part || typeof part !== "object") continue;
+						const toolCall = part as {
+							type?: unknown;
+							name?: unknown;
+							arguments?: unknown;
+						};
+						if (toolCall.type !== "toolCall") continue;
+						if (typeof toolCall.name !== "string") continue;
+						events.push({
+							type: "tool_execution_start",
+							toolName: toolCall.name,
+							args: toolCall.arguments,
+						});
+					}
+				}
+				continue;
+			}
+			if (message.role === "toolResult") {
+				const toolName =
+					typeof message.toolName === "string"
+						? message.toolName
+						: "tool";
+				events.push({
+					type: "tool_execution_end",
+					toolName,
+					isError: Boolean(message.isError),
+					result: message.content,
+				});
+			}
+		}
+	}
+
+	if (events.length === 0) {
+		return hostEventsFromProcess({
+			prompt: options.prompt,
+			result: options.result,
+			answer: options.answer,
+		});
+	}
+
+	if (options.result.timedOut) {
+		events.push({
+			type: "error",
+			message: `Host process timed out after ${options.result.durationMs}ms.`,
+		});
+	} else if (
+		options.result.exitCode !== 0 &&
+		options.result.exitCode !== null
+	) {
+		events.push({
+			type: "error",
+			message: `Host process exited with code ${options.result.exitCode}.`,
+		});
+	}
+
+	const hasAssistantAnswer = events.some(
+		(event) =>
+			event.type === "message" &&
+			event.role === "assistant" &&
+			event.text.trim() === options.answer.trim(),
+	);
+	if (options.answer && !hasAssistantAnswer) {
+		events.push({
+			type: "message",
+			role: "assistant",
+			text: options.answer,
+		});
+	}
+	return events;
 }
 
 export function hostTaskPrompt(

--- a/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
@@ -11,6 +11,7 @@ import {
 	hostTaskPrompt,
 	mcpProviderArgs,
 	OPENCLAW_AGENT_DONE,
+	playwrightBrowsersPathEnv,
 	requireBrowserToolsMcpBinary,
 	requireCommandOnPath,
 	requireOpenAiApiKey,
@@ -94,6 +95,7 @@ export async function runOpenclawBrowserToolsHarness(
 		OPENCLAW_HOME: openclawHome,
 		OPENCLAW_STATE_DIR: configDir,
 		OPENCLAW_BROWSER_HEADLESS: "1",
+		...playwrightBrowsersPathEnv(),
 		...mcpEnv,
 	};
 

--- a/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
@@ -6,10 +6,11 @@ import {
 import type { BrowserProviderName } from "./cloud-browser.js";
 import {
 	extractHostAnswer,
-	hostEventsFromProcess,
+	hostEventsFromOpenClawHome,
 	hostMetrics,
 	hostTaskPrompt,
 	mcpProviderArgs,
+	OPENCLAW_AGENT_DONE,
 	requireBrowserToolsMcpBinary,
 	requireCommandOnPath,
 	requireOpenAiApiKey,
@@ -50,6 +51,11 @@ export async function runOpenclawBrowserToolsHarness(
 		join(configDir, "openclaw.json"),
 		`${JSON.stringify(
 			{
+				browser: {
+					enabled: false,
+					headless: true,
+					noSandbox: true,
+				},
 				plugins: {
 					entries: {
 						browser: { enabled: false },
@@ -86,6 +92,7 @@ export async function runOpenclawBrowserToolsHarness(
 		OPENAI_API_KEY: openAiKey,
 		OPENCLAW_HOME: openclawHome,
 		OPENCLAW_STATE_DIR: configDir,
+		OPENCLAW_BROWSER_HEADLESS: "1",
 		...mcpEnv,
 	};
 
@@ -105,11 +112,18 @@ export async function runOpenclawBrowserToolsHarness(
 		],
 		cwd: workspace,
 		env: childEnv,
+		exitOnStdoutMatch: OPENCLAW_AGENT_DONE,
+		alsoKillCwdContains: openclawHome,
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromProcess({ prompt, result, answer }),
+		events: hostEventsFromOpenClawHome({
+			openclawHome,
+			prompt,
+			result,
+			answer,
+		}),
 		metrics: hostMetrics(result.durationMs),
 		browserBackend: "benchmark-provider",
 		async dispose() {},

--- a/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
@@ -38,7 +38,9 @@ export async function runOpenclawBrowserToolsHarness(
 	const prompt = hostTaskPrompt(task, "mcp");
 	const model = "openai/gpt-5.6-sol";
 
-	const mcpEnv: Record<string, string> = {};
+	const mcpEnv: Record<string, string> = {
+		...playwrightBrowsersPathEnv(),
+	};
 	if (provider === "kernel" && providerKey) {
 		mcpEnv.KERNEL_API_KEY = providerKey;
 	} else if (provider === "browserbase" && providerKey) {
@@ -78,7 +80,7 @@ export async function runOpenclawBrowserToolsHarness(
 						libretto: {
 							command: "node",
 							args: [mcpBinary, ...mcpProviderArgs(provider)],
-							...(Object.keys(mcpEnv).length > 0 ? { env: mcpEnv } : {}),
+							env: mcpEnv,
 						},
 					},
 				},

--- a/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
@@ -1,0 +1,132 @@
+import { join } from "node:path";
+import {
+	HarnessRunError,
+	type HarnessRun,
+} from "../harness-run.js";
+import type { BrowserProviderName } from "./cloud-browser.js";
+import {
+	extractHostAnswer,
+	hostEventsFromProcess,
+	hostMetrics,
+	hostTaskPrompt,
+	mcpProviderArgs,
+	requireBrowserToolsMcpBinary,
+	requireCommandOnPath,
+	requireOpenAiApiKey,
+	requireProviderApiKey,
+	runHostProcess,
+	writeTextFile,
+} from "./host-agent.js";
+
+/**
+ * OpenClaw with Libretto Browser Tools MCP; bundled browser plugin disabled.
+ */
+export async function runOpenclawBrowserToolsHarness(
+	task: string,
+	workspace: string,
+	provider: BrowserProviderName,
+): Promise<HarnessRun> {
+	const openclawBin = requireCommandOnPath("openclaw");
+	const openAiKey = requireOpenAiApiKey();
+	const providerKey = requireProviderApiKey(provider);
+	const mcpBinary = requireBrowserToolsMcpBinary();
+	const openclawHome = join(workspace, "openclaw-home");
+	const configDir = join(openclawHome, ".openclaw");
+	const prompt = hostTaskPrompt(task, "mcp");
+	const model = "openai/gpt-5.6-sol";
+
+	const mcpEnv: Record<string, string> = {};
+	if (provider === "kernel" && providerKey) {
+		mcpEnv.KERNEL_API_KEY = providerKey;
+	} else if (provider === "browserbase" && providerKey) {
+		mcpEnv.BROWSERBASE_API_KEY = providerKey;
+	} else if (provider === "browser-use" && providerKey) {
+		mcpEnv.BROWSER_USE_API_KEY = providerKey;
+	} else if (provider === "steel" && providerKey) {
+		mcpEnv.STEEL_API_KEY = providerKey;
+	}
+
+	await writeTextFile(
+		join(configDir, "openclaw.json"),
+		`${JSON.stringify(
+			{
+				plugins: {
+					entries: {
+						browser: { enabled: false },
+					},
+				},
+				agents: {
+					defaults: {
+						model,
+						models: {
+							[model]: {
+								agentRuntime: { id: "openclaw" },
+							},
+						},
+					},
+				},
+				mcp: {
+					servers: {
+						libretto: {
+							command: "node",
+							args: [mcpBinary, ...mcpProviderArgs(provider)],
+							...(Object.keys(mcpEnv).length > 0 ? { env: mcpEnv } : {}),
+						},
+					},
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+
+	const childEnv: NodeJS.ProcessEnv = {
+		...process.env,
+		HOME: openclawHome,
+		OPENAI_API_KEY: openAiKey,
+		OPENCLAW_HOME: openclawHome,
+		OPENCLAW_STATE_DIR: configDir,
+		...mcpEnv,
+	};
+
+	const result = await runHostProcess({
+		command: openclawBin,
+		args: [
+			"agent",
+			"--local",
+			"--agent",
+			"main",
+			"--model",
+			model,
+			"--thinking",
+			"off",
+			"--message",
+			prompt,
+		],
+		cwd: workspace,
+		env: childEnv,
+	});
+	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const run: HarnessRun = {
+		answer,
+		events: hostEventsFromProcess({ prompt, result, answer }),
+		metrics: hostMetrics(result.durationMs),
+		browserBackend: "benchmark-provider",
+		async dispose() {},
+	};
+	if (result.timedOut) {
+		throw new HarnessRunError(
+			new Error(
+				`OpenClaw Browser Tools harness timed out after ${result.durationMs}ms.`,
+			),
+			run,
+		);
+	}
+	if (!answer) {
+		throw new HarnessRunError(
+			new Error("OpenClaw Browser Tools harness returned no final answer."),
+			run,
+		);
+	}
+	return run;
+}

--- a/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-browser-tools.ts
@@ -16,6 +16,7 @@ import {
 	requireOpenAiApiKey,
 	requireProviderApiKey,
 	runHostProcess,
+	usageFromOpenClawHome,
 	writeTextFile,
 } from "./host-agent.js";
 
@@ -116,15 +117,19 @@ export async function runOpenclawBrowserToolsHarness(
 		alsoKillCwdContains: openclawHome,
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const events = hostEventsFromOpenClawHome({
+		openclawHome,
+		prompt,
+		result,
+		answer,
+	});
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromOpenClawHome({
-			openclawHome,
-			prompt,
-			result,
-			answer,
+		events,
+		metrics: hostMetrics(result.durationMs, {
+			events,
+			usage: usageFromOpenClawHome(openclawHome),
 		}),
-		metrics: hostMetrics(result.durationMs),
 		browserBackend: "benchmark-provider",
 		async dispose() {},
 	};

--- a/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
@@ -6,9 +6,10 @@ import {
 import type { BrowserProviderName } from "./cloud-browser.js";
 import {
 	extractHostAnswer,
-	hostEventsFromProcess,
+	hostEventsFromOpenClawHome,
 	hostMetrics,
 	hostTaskPrompt,
+	OPENCLAW_AGENT_DONE,
 	requireCommandOnPath,
 	requireOpenAiApiKey,
 	runHostProcess,
@@ -34,6 +35,12 @@ export async function runOpenclawStockHarness(
 		join(configDir, "openclaw.json"),
 		`${JSON.stringify(
 			{
+				browser: {
+					enabled: true,
+					headless: true,
+					noSandbox: true,
+					executablePath: "/usr/bin/google-chrome-stable",
+				},
 				plugins: {
 					entries: {
 						browser: { enabled: true },
@@ -71,12 +78,22 @@ export async function runOpenclawStockHarness(
 			OPENAI_API_KEY: openAiKey,
 			OPENCLAW_HOME: openclawHome,
 			OPENCLAW_STATE_DIR: configDir,
+			OPENCLAW_BROWSER_HEADLESS: "1",
+			DISPLAY: "",
+			WAYLAND_DISPLAY: "",
 		},
+		exitOnStdoutMatch: OPENCLAW_AGENT_DONE,
+		alsoKillCwdContains: openclawHome,
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromProcess({ prompt, result, answer }),
+		events: hostEventsFromOpenClawHome({
+			openclawHome,
+			prompt,
+			result,
+			answer,
+		}),
 		metrics: hostMetrics(result.durationMs),
 		browserBackend: "host-stock",
 		async dispose() {},

--- a/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
@@ -1,0 +1,99 @@
+import { join } from "node:path";
+import {
+	HarnessRunError,
+	type HarnessRun,
+} from "../harness-run.js";
+import type { BrowserProviderName } from "./cloud-browser.js";
+import {
+	extractHostAnswer,
+	hostEventsFromProcess,
+	hostMetrics,
+	hostTaskPrompt,
+	requireCommandOnPath,
+	requireOpenAiApiKey,
+	runHostProcess,
+	writeTextFile,
+} from "./host-agent.js";
+
+/**
+ * OpenClaw with its stock bundled browser plugin (no Libretto MCP).
+ */
+export async function runOpenclawStockHarness(
+	task: string,
+	workspace: string,
+	_provider: BrowserProviderName,
+): Promise<HarnessRun> {
+	const openclawBin = requireCommandOnPath("openclaw");
+	const openAiKey = requireOpenAiApiKey();
+	const openclawHome = join(workspace, "openclaw-home");
+	const configDir = join(openclawHome, ".openclaw");
+	const prompt = hostTaskPrompt(task, "stock");
+	const model = "openai/gpt-5.6-sol";
+
+	await writeTextFile(
+		join(configDir, "openclaw.json"),
+		`${JSON.stringify(
+			{
+				plugins: {
+					entries: {
+						browser: { enabled: true },
+					},
+				},
+				agents: {
+					defaults: {
+						model,
+					},
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+
+	const result = await runHostProcess({
+		command: openclawBin,
+		args: [
+			"agent",
+			"--local",
+			"--agent",
+			"main",
+			"--model",
+			model,
+			"--thinking",
+			"off",
+			"--message",
+			prompt,
+		],
+		cwd: workspace,
+		env: {
+			...process.env,
+			HOME: openclawHome,
+			OPENAI_API_KEY: openAiKey,
+			OPENCLAW_HOME: openclawHome,
+			OPENCLAW_STATE_DIR: configDir,
+		},
+	});
+	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const run: HarnessRun = {
+		answer,
+		events: hostEventsFromProcess({ prompt, result, answer }),
+		metrics: hostMetrics(result.durationMs),
+		browserBackend: "host-stock",
+		async dispose() {},
+	};
+	if (result.timedOut) {
+		throw new HarnessRunError(
+			new Error(
+				`OpenClaw stock harness timed out after ${result.durationMs}ms.`,
+			),
+			run,
+		);
+	}
+	if (!answer) {
+		throw new HarnessRunError(
+			new Error("OpenClaw stock harness returned no final answer."),
+			run,
+		);
+	}
+	return run;
+}

--- a/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
+++ b/packages/browser-tools/benchmarks/harness/openclaw-stock.ts
@@ -13,6 +13,7 @@ import {
 	requireCommandOnPath,
 	requireOpenAiApiKey,
 	runHostProcess,
+	usageFromOpenClawHome,
 	writeTextFile,
 } from "./host-agent.js";
 
@@ -86,15 +87,19 @@ export async function runOpenclawStockHarness(
 		alsoKillCwdContains: openclawHome,
 	});
 	const answer = extractHostAnswer(result.stdout, result.stderr);
+	const events = hostEventsFromOpenClawHome({
+		openclawHome,
+		prompt,
+		result,
+		answer,
+	});
 	const run: HarnessRun = {
 		answer,
-		events: hostEventsFromOpenClawHome({
-			openclawHome,
-			prompt,
-			result,
-			answer,
+		events,
+		metrics: hostMetrics(result.durationMs, {
+			events,
+			usage: usageFromOpenClawHome(openclawHome),
 		}),
-		metrics: hostMetrics(result.durationMs),
 		browserBackend: "host-stock",
 		async dispose() {},
 	};

--- a/packages/browser-tools/benchmarks/harness/playwright-cli.ts
+++ b/packages/browser-tools/benchmarks/harness/playwright-cli.ts
@@ -1,4 +1,4 @@
-import type { SessionRun } from "../agent.js";
+import type { HarnessRun } from "../harness-run.js";
 import {
 	closeCloudBrowserConnection,
 	createCloudBrowserConnection,
@@ -12,7 +12,7 @@ export async function runPlaywrightCliHarness(
 	task: string,
 	workspace: string,
 	provider: BrowserProviderName,
-): Promise<SessionRun> {
+): Promise<HarnessRun> {
 	const browser = await createCloudBrowserConnection(provider);
 	try {
 		const session = shellQuote(browser.sessionName);

--- a/packages/browser-tools/benchmarks/harness/run-browser-task.ts
+++ b/packages/browser-tools/benchmarks/harness/run-browser-task.ts
@@ -4,8 +4,14 @@ import {
 	browserTaskPrompt,
 	createPiSession,
 	runPrompt,
-	type SessionRun,
+	SessionRunError,
+	usageMetrics,
 } from "../agent.js";
+import {
+	HarnessRunError,
+	harnessRunFromPiSession,
+	type HarnessRun,
+} from "../harness-run.js";
 
 export async function runBrowserTask(options: {
 	task: string;
@@ -13,7 +19,7 @@ export async function runBrowserTask(options: {
 	customTools?: ToolDefinition[];
 	skillPaths?: string[];
 	appendSystemPrompt?: string[];
-}): Promise<SessionRun> {
+}): Promise<HarnessRun> {
 	const session = await createPiSession({
 		workspace: options.workspace,
 		sessionFile: join(options.workspace, "session.jsonl"),
@@ -21,5 +27,20 @@ export async function runBrowserTask(options: {
 		skillPaths: options.skillPaths,
 		appendSystemPrompt: options.appendSystemPrompt,
 	});
-	return await runPrompt(session, browserTaskPrompt({ task: options.task }));
+	try {
+		const run = await runPrompt(
+			session,
+			browserTaskPrompt({ task: options.task }),
+		);
+		return harnessRunFromPiSession(run, usageMetrics(run));
+	} catch (error) {
+		if (error instanceof SessionRunError) {
+			throw new HarnessRunError(
+				error,
+				harnessRunFromPiSession(error.run, usageMetrics(error.run)),
+			);
+		}
+		session.dispose();
+		throw error;
+	}
 }

--- a/packages/browser-tools/benchmarks/index.ts
+++ b/packages/browser-tools/benchmarks/index.ts
@@ -27,6 +27,7 @@ import { runPlaywrightCliHarness } from "./harness/playwright-cli.js";
 import {
 	requireBrowserToolsMcpBinary,
 	requireCommandOnPath,
+	requireHermesMcpSdk,
 } from "./harness/host-agent.js";
 import {
 	HarnessRunError,
@@ -270,6 +271,9 @@ function requireHostHarnesses(harnesses: HarnessName[]): void {
 	if (selected.length === 0) return;
 	if (selected.some((name) => name.startsWith("hermes-"))) {
 		requireCommandOnPath("hermes");
+	}
+	if (selected.includes("hermes-browser-tools")) {
+		requireHermesMcpSdk();
 	}
 	if (selected.some((name) => name.startsWith("openclaw-"))) {
 		requireCommandOnPath("openclaw");

--- a/packages/browser-tools/benchmarks/index.ts
+++ b/packages/browser-tools/benchmarks/index.ts
@@ -5,11 +5,8 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { z } from "zod";
 import {
-	emptyMetrics,
-	eventsJsonl,
 	MODEL_SELECTOR,
 	SessionRunError,
-	transcriptFor,
 	usageMetrics,
 	type SessionRun,
 	type UsageMetrics,
@@ -22,15 +19,36 @@ import {
 	type BrowserProviderName,
 } from "./harness/cloud-browser.js";
 import { runDevBrowserHarness } from "./harness/dev-browser.js";
+import { runHermesBrowserToolsHarness } from "./harness/hermes-browser-tools.js";
+import { runHermesStockHarness } from "./harness/hermes-stock.js";
+import { runOpenclawBrowserToolsHarness } from "./harness/openclaw-browser-tools.js";
+import { runOpenclawStockHarness } from "./harness/openclaw-stock.js";
 import { runPlaywrightCliHarness } from "./harness/playwright-cli.js";
+import {
+	requireBrowserToolsMcpBinary,
+	requireCommandOnPath,
+} from "./harness/host-agent.js";
+import {
+	HarnessRunError,
+	harnessEventsJsonl,
+	transcriptFromHarnessEvents,
+	type HarnessRun,
+} from "./harness-run.js";
 import { judgeBrowserRun, type Judgment } from "./judge.js";
 
 const DEFAULT_CONCURRENCY = 5;
-const HARNESS_NAMES = [
+const DEFAULT_HARNESS_NAMES = [
 	"browser-tools",
 	"agent-browser",
 	"playwright-cli",
 	"dev-browser",
+] as const;
+const HARNESS_NAMES = [
+	...DEFAULT_HARNESS_NAMES,
+	"hermes-stock",
+	"hermes-browser-tools",
+	"openclaw-stock",
+	"openclaw-browser-tools",
 ] as const;
 type HarnessName = (typeof HARNESS_NAMES)[number];
 const HarnessNameSchema = z.enum(HARNESS_NAMES);
@@ -41,13 +59,23 @@ const HARNESS_RUNNERS: Record<
 		task: string,
 		workspace: string,
 		provider: BrowserProviderName,
-	) => Promise<SessionRun>
+	) => Promise<HarnessRun>
 > = {
 	"browser-tools": runBrowserToolsHarness,
 	"agent-browser": runAgentBrowserHarness,
 	"playwright-cli": runPlaywrightCliHarness,
 	"dev-browser": runDevBrowserHarness,
+	"hermes-stock": runHermesStockHarness,
+	"hermes-browser-tools": runHermesBrowserToolsHarness,
+	"openclaw-stock": runOpenclawStockHarness,
+	"openclaw-browser-tools": runOpenclawBrowserToolsHarness,
 };
+const HOST_HARNESS_NAMES = new Set<HarnessName>([
+	"hermes-stock",
+	"hermes-browser-tools",
+	"openclaw-stock",
+	"openclaw-browser-tools",
+]);
 const packageRoot = resolve(import.meta.dirname, "..");
 const repoRoot = resolve(packageRoot, "../..");
 
@@ -146,9 +174,9 @@ const benchmarkInput = SimpleCLI.input({
 			},
 		),
 		harnesses: SimpleCLI.option(
-			forAffordance(z.string().default(HARNESS_NAMES.join(","))),
+			forAffordance(z.string().default(DEFAULT_HARNESS_NAMES.join(","))),
 			{
-				help: `Comma-separated harnesses (default: ${HARNESS_NAMES.join(",")})`,
+				help: `Comma-separated harnesses (default: ${DEFAULT_HARNESS_NAMES.join(",")}; also: hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools)`,
 			},
 		),
 		provider: SimpleCLI.option(
@@ -187,8 +215,18 @@ function requireEnvironment(name: string): string {
 	return value;
 }
 
-function requireProviderEnvironment(provider: BrowserProviderName): void {
+function harnessNeedsBenchmarkProvider(harness: HarnessName): boolean {
+	return (
+		!HOST_HARNESS_NAMES.has(harness) || harness.endsWith("-browser-tools")
+	);
+}
+
+function requireProviderEnvironment(
+	provider: BrowserProviderName,
+	harnesses: HarnessName[],
+): void {
 	requireEnvironment("OPENAI_API_KEY");
+	if (!harnesses.some(harnessNeedsBenchmarkProvider)) return;
 	switch (provider) {
 		case "kernel":
 			requireEnvironment("KERNEL_API_KEY");
@@ -227,14 +265,44 @@ function jsonReplacer(key: string, value: unknown): unknown {
 	return value;
 }
 
+function requireHostHarnesses(harnesses: HarnessName[]): void {
+	const selected = harnesses.filter((name) => HOST_HARNESS_NAMES.has(name));
+	if (selected.length === 0) return;
+	if (selected.some((name) => name.startsWith("hermes-"))) {
+		requireCommandOnPath("hermes");
+	}
+	if (selected.some((name) => name.startsWith("openclaw-"))) {
+		requireCommandOnPath("openclaw");
+	}
+	if (selected.some((name) => name.endsWith("-browser-tools"))) {
+		requireBrowserToolsMcpBinary();
+	}
+}
+
+function formatMetric(value: number | undefined, digits?: number): string {
+	if (value === undefined) return "—";
+	if (digits === undefined) return String(value);
+	return value.toFixed(digits);
+}
+
 async function writeAgentArtifacts(
-	run: SessionRun,
+	run: HarnessRun,
 	transcriptPath: string,
 	eventsPath: string,
+	sessionPath: string,
 ): Promise<void> {
-	const transcript = transcriptFor(run.session);
-	await writeFile(transcriptPath, `${transcript}\n`, "utf8");
-	await writeFile(eventsPath, eventsJsonl(run.events), "utf8");
+	await writeFile(
+		transcriptPath,
+		`${transcriptFromHarnessEvents(run.events)}\n`,
+		"utf8",
+	);
+	await writeFile(eventsPath, harnessEventsJsonl(run.events), "utf8");
+	const { dispose: _dispose, ...serializable } = run;
+	await writeFile(
+		sessionPath,
+		`${JSON.stringify(serializable, jsonReplacer, 2)}\n`,
+		"utf8",
+	);
 }
 
 async function runAttempt(options: {
@@ -248,12 +316,12 @@ async function runAttempt(options: {
 	const caseDir = join(options.runDir, "cases", id);
 	const transcriptPath = join(caseDir, "transcript.md");
 	const eventsPath = join(caseDir, "events.jsonl");
-	const sessionPath = join(caseDir, "session.jsonl");
+	const sessionPath = join(caseDir, "session.json");
 	const resultPath = join(caseDir, "result.json");
 	await mkdir(caseDir, { recursive: true });
 
 	const startedAt = new Date().toISOString();
-	let agentRun: SessionRun | null = null;
+	let agentRun: HarnessRun | null = null;
 	let judgeRun: SessionRun | null = null;
 	let answer: string | null = null;
 	let judgment: Judgment | null = null;
@@ -268,15 +336,16 @@ async function runAttempt(options: {
 				options.provider,
 			);
 		} catch (error) {
-			if (error instanceof SessionRunError) agentRun = error.run;
+			if (error instanceof HarnessRunError) agentRun = error.run;
 			throw error;
 		}
 		await writeAgentArtifacts(
 			agentRun,
 			transcriptPath,
 			eventsPath,
+			sessionPath,
 		);
-		answer = agentRun.session.getLastAssistantText()?.trim() || null;
+		answer = agentRun.answer.trim() || null;
 		if (!answer) throw new Error("Browser agent returned no final answer.");
 		try {
 			const judged = await judgeBrowserRun({
@@ -295,11 +364,26 @@ async function runAttempt(options: {
 			agentRun &&
 			(!existsSync(transcriptPath) || !existsSync(eventsPath))
 		) {
-			await writeAgentArtifacts(agentRun, transcriptPath, eventsPath);
+			await writeAgentArtifacts(
+				agentRun,
+				transcriptPath,
+				eventsPath,
+				sessionPath,
+			);
 		}
 		errorMessage = error instanceof Error ? error.message : String(error);
 	} finally {
-		agentRun?.session.dispose();
+		if (agentRun) {
+			try {
+				await agentRun.dispose();
+			} catch (cleanupError) {
+				const message =
+					cleanupError instanceof Error
+						? cleanupError.message
+						: String(cleanupError);
+				process.stderr.write(`[${id}] dispose failed: ${message}\n`);
+			}
+		}
 		judgeRun?.session.dispose();
 	}
 
@@ -312,8 +396,8 @@ async function runAttempt(options: {
 		status: errorMessage ? "error" : "completed",
 		answer,
 		judgment,
-		agentMetrics: agentRun ? usageMetrics(agentRun) : emptyMetrics(),
-		judgeMetrics: judgeRun ? usageMetrics(judgeRun) : emptyMetrics(),
+		agentMetrics: agentRun?.metrics ?? {},
+		judgeMetrics: judgeRun ? usageMetrics(judgeRun) : {},
 		startedAt,
 		finishedAt: new Date().toISOString(),
 		error: errorMessage,
@@ -358,15 +442,32 @@ async function mapWithConcurrency<Input, Output>(
 function totalMetric(
 	results: AttemptResult[],
 	key: "durationMs" | "totalTokens" | "costUsd" | "totalToolCalls",
-): number {
-	return results.reduce((total, result) => total + result.agentMetrics[key], 0);
+): number | undefined {
+	let total = 0;
+	let sawValue = false;
+	for (const result of results) {
+		const value = result.agentMetrics[key];
+		if (typeof value !== "number") continue;
+		total += value;
+		sawValue = true;
+	}
+	return sawValue ? total : undefined;
 }
 
-function maxContextTokens(results: AttemptResult[]): number {
-	return results.reduce(
-		(max, result) => Math.max(max, result.agentMetrics.maxRequestContextTokens),
-		0,
-	);
+function maxContextTokens(results: AttemptResult[]): number | undefined {
+	let max: number | undefined;
+	for (const result of results) {
+		const value = result.agentMetrics.maxRequestContextTokens;
+		if (typeof value !== "number") continue;
+		max = max === undefined ? value : Math.max(max, value);
+	}
+	return max;
+}
+
+function averageDurationSeconds(results: AttemptResult[]): string {
+	const total = totalMetric(results, "durationMs");
+	if (total === undefined || results.length === 0) return "—";
+	return `${(total / results.length / 1000).toFixed(1)}s`;
 }
 
 function summaryMarkdown(options: {
@@ -382,6 +483,8 @@ function summaryMarkdown(options: {
 	const passed = options.results.filter(
 		(result) => result.judgment?.completed === true,
 	).length;
+	const agentDurationMs = totalMetric(options.results, "durationMs");
+	const agentCostUsd = totalMetric(options.results, "costUsd");
 	const lines = [
 		"# Browser Harness Benchmark",
 		"",
@@ -393,11 +496,11 @@ function summaryMarkdown(options: {
 		`- Attempts: \`${options.results.length}\``,
 		`- Completed: \`${completed}\``,
 		`- Passed: \`${passed}\``,
-		`- Agent duration: \`${(totalMetric(options.results, "durationMs") / 1000).toFixed(1)}s\``,
-		`- Maximum request context: \`${maxContextTokens(options.results)}\``,
-		`- Agent tokens: \`${totalMetric(options.results, "totalTokens")}\``,
-		`- Agent cost: \`$${totalMetric(options.results, "costUsd").toFixed(4)}\``,
-		`- Browser tool calls: \`${totalMetric(options.results, "totalToolCalls")}\``,
+		`- Agent duration: \`${agentDurationMs === undefined ? "—" : `${(agentDurationMs / 1000).toFixed(1)}s`}\``,
+		`- Maximum request context: \`${formatMetric(maxContextTokens(options.results))}\``,
+		`- Agent tokens: \`${formatMetric(totalMetric(options.results, "totalTokens"))}\``,
+		`- Agent cost: \`${agentCostUsd === undefined ? "—" : `$${agentCostUsd.toFixed(4)}`}\``,
+		`- Browser tool calls: \`${formatMetric(totalMetric(options.results, "totalToolCalls"))}\``,
 		"",
 		"## Harnesses",
 		"",
@@ -409,8 +512,9 @@ function summaryMarkdown(options: {
 			(result) => result.harness === harness,
 		);
 		if (harnessResults.length === 0) continue;
+		const harnessCost = totalMetric(harnessResults, "costUsd");
 		lines.push(
-			`| ${harness} | ${harnessResults.length} | ${harnessResults.filter((result) => result.status === "completed").length} | ${harnessResults.filter((result) => result.judgment?.completed === true).length} | ${(totalMetric(harnessResults, "durationMs") / harnessResults.length / 1000).toFixed(1)}s | ${maxContextTokens(harnessResults)} | ${totalMetric(harnessResults, "totalTokens")} | $${totalMetric(harnessResults, "costUsd").toFixed(4)} | ${totalMetric(harnessResults, "totalToolCalls")} |`,
+			`| ${harness} | ${harnessResults.length} | ${harnessResults.filter((result) => result.status === "completed").length} | ${harnessResults.filter((result) => result.judgment?.completed === true).length} | ${averageDurationSeconds(harnessResults)} | ${formatMetric(maxContextTokens(harnessResults))} | ${formatMetric(totalMetric(harnessResults, "totalTokens"))} | ${harnessCost === undefined ? "—" : `$${harnessCost.toFixed(4)}`} | ${formatMetric(totalMetric(harnessResults, "totalToolCalls"))} |`,
 		);
 	}
 	lines.push(
@@ -421,8 +525,10 @@ function summaryMarkdown(options: {
 		"|---|---|---:|---|---|---:|---:|---:|---:|",
 	);
 	for (const result of options.results) {
+		const durationMs = result.agentMetrics.durationMs;
+		const costUsd = result.agentMetrics.costUsd;
 		lines.push(
-			`| ${result.caseName} | ${result.harness} | ${result.repeat} | ${result.status} | ${result.judgment?.completed === true ? "pass" : "fail"} | ${(result.agentMetrics.durationMs / 1000).toFixed(1)}s | ${result.agentMetrics.maxRequestContextTokens} | ${result.agentMetrics.totalTokens} | $${result.agentMetrics.costUsd.toFixed(4)} |`,
+			`| ${result.caseName} | ${result.harness} | ${result.repeat} | ${result.status} | ${result.judgment?.completed === true ? "pass" : "fail"} | ${durationMs === undefined ? "—" : `${(durationMs / 1000).toFixed(1)}s`} | ${formatMetric(result.agentMetrics.maxRequestContextTokens)} | ${formatMetric(result.agentMetrics.totalTokens)} | ${costUsd === undefined ? "—" : `$${costUsd.toFixed(4)}`} |`,
 		);
 	}
 	return `${lines.join("\n")}\n`;
@@ -430,7 +536,8 @@ function summaryMarkdown(options: {
 
 async function runBenchmarks(options: CliOptions): Promise<void> {
 	loadRepoEnv();
-	requireProviderEnvironment(options.provider);
+	requireProviderEnvironment(options.provider, options.harnesses);
+	requireHostHarnesses(options.harnesses);
 
 	const matchingCases = options.casePattern
 		? WEBSITE_CASES.filter((websiteCase) =>
@@ -554,6 +661,7 @@ const app = SimpleCLI.define(
 			"For --provider browserbase: BROWSERBASE_API_KEY.",
 			"For --provider browser-use: BROWSER_USE_API_KEY.",
 			"For --provider steel: STEEL_API_KEY.",
+			"Host harnesses (hermes-*/openclaw-*) need hermes or openclaw on PATH; *-browser-tools also needs a built packages/browser-tools/dist/cli/index.js.",
 		].join(" "),
 	},
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reruns Hermes/OpenClaw stock vs Libretto Browser Tools MCP with `--provider local` so MCP lanes use local Playwright Chromium instead of Kernel, then documents the suite in `RESULTS.md`.

## Fixes for local MCP

- Pin `PLAYWRIGHT_BROWSERS_PATH` outside isolated `HOME`
- Pass that path into Hermes/OpenClaw MCP server env (children do not inherit it otherwise)

## Bugbot follow-ups

- Debounce OpenClaw `exitOnStdoutMatch` so matching output schedules one SIGTERM/SIGKILL chain
- Stop mapping Hermes `api_call_count` into `UsageMetrics.turns` (omit turns when Hermes has no assistant-message count)

## Full suite (26 × 4, local Chrome)

Overall **56/104** passed. Wall time 2h 44m (agent duration 2.4h).

| Harness | Pass | Tokens | Cost |
|---|---:|---:|---:|
| hermes-stock | 15/26 | 7.92M | $7.26 |
| hermes-browser-tools | 14/26 | 3.61M | $4.50 |
| openclaw-stock | 13/26 | 19.06M | $19.43 |
| openclaw-browser-tools | 14/26 | 5.69M | $7.63 |

## RESULTS.md

Reorganized to store one latest run per suite (Pi Browser Use, Pi Kernel `browser-tools`, host harnesses local Chrome). Dropped stacked historical Kernel host and multi-run Browser Use tables.

```bash
pnpm --filter libretto-browser-tools exec tsx benchmarks/index.ts run \
  --harnesses hermes-stock,hermes-browser-tools,openclaw-stock,openclaw-browser-tools \
  --provider local \
  --concurrency 1
```

Related: #531.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1370f197-e7cc-4493-80f2-bb87ce8f47f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

