### PR TITLE
Use waitUntil commit for daemon startup navigation

### DIFF
--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -324,10 +324,14 @@ class BrowserDaemon {
     });
 
     // Navigate after telemetry is installed (so we capture the initial
-    // page load) but before starting the IPC server (so callers polling
-    // for IPC readiness see a page that has already loaded).
+    // document) but before starting the IPC server (so callers polling
+    // for IPC readiness see a committed navigation). Wait only for
+    // "commit": some apps (e.g. eCW) paint a usable shell without ever
+    // finishing DOMContentLoaded/load, and Playwright's default "load"
+    // would block daemon ready until the 45s navigation timeout / 60s
+    // startup guard. Workflows should wait for site-specific readiness.
     if (navigateUrl) {
-      await page.goto(navigateUrl);
+      await page.goto(navigateUrl, { waitUntil: "commit" });
     }
 
     const ipcServer = createIpcSocketServer((transport) => {

--- a/packages/libretto/src/cli/core/daemon/daemon.ts
+++ b/packages/libretto/src/cli/core/daemon/daemon.ts
@@ -324,12 +324,11 @@ class BrowserDaemon {
     });
 
     // Navigate after telemetry is installed (so we capture the initial
-    // document) but before starting the IPC server (so callers polling
-    // for IPC readiness see a committed navigation). Wait only for
-    // "commit": some apps (e.g. eCW) paint a usable shell without ever
-    // finishing DOMContentLoaded/load, and Playwright's default "load"
-    // would block daemon ready until the 45s navigation timeout / 60s
-    // startup guard. Workflows should wait for site-specific readiness.
+    // document) but before starting the IPC server. Use waitUntil:
+    // "commit" — not Playwright's default "load" — because some apps
+    // paint a usable shell without finishing DOMContentLoaded/load;
+    // waiting for load would block daemon ready until navigation/startup
+    // timeouts. Workflows should wait for site-specific readiness.
     if (navigateUrl) {
       await page.goto(navigateUrl, { waitUntil: "commit" });
     }

--- a/packages/libretto/test/daemon-startup-commit-nav.spec.ts
+++ b/packages/libretto/test/daemon-startup-commit-nav.spec.ts
@@ -1,0 +1,181 @@
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect } from "vitest";
+import { test as base } from "./fixtures.js";
+
+/**
+ * Serves HTML that commits immediately, paints a usable shell, then
+ * blocks forever on a script so DOMContentLoaded/load never complete.
+ */
+type HangAfterCommitServer = {
+  url: string;
+  close: () => Promise<void>;
+};
+
+const test = base.extend<{ hangAfterCommitServer: HangAfterCommitServer }>({
+  hangAfterCommitServer: async ({}, use) => {
+    const pending: ServerResponse[] = [];
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      if (request.url === "/hang.js") {
+        // Never finish — keeps document parsing blocked after the shell.
+        pending.push(response);
+        request.on("close", () => {
+          const index = pending.indexOf(response);
+          if (index >= 0) pending.splice(index, 1);
+        });
+        return;
+      }
+
+      response.writeHead(200, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-store",
+      });
+      response.end(`<!doctype html>
+<html>
+  <head><title>Hang After Commit</title></head>
+  <body>
+    <h1 id="shell">Committed shell</h1>
+    <button id="go" type="button">Go</button>
+    <script>
+      document.getElementById("go").addEventListener("click", () => {
+        document.getElementById("shell").textContent = "Clicked";
+      });
+    </script>
+    <script src="/hang.js"></script>
+  </body>
+</html>`);
+    });
+
+    await listen(server);
+    const address = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${address.port}/`;
+
+    await use({
+      url,
+      close: async () => {
+        for (const response of pending) {
+          response.destroy();
+        }
+        pending.length = 0;
+        await closeServer(server);
+      },
+    });
+
+    for (const response of pending) {
+      response.destroy();
+    }
+    pending.length = 0;
+    await closeServer(server);
+  },
+});
+
+describe("daemon startup commit navigation", () => {
+  test("run startUrl becomes ready before DOMContentLoaded and can interact with the shell", async ({
+    librettoCli,
+    writeWorkflow,
+    hangAfterCommitServer,
+  }) => {
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-commit-nav.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: ${JSON.stringify(hangAfterCommitServer.url)} },
+  async ({ page }) => {
+    console.log("COMMIT_NAV_STARTED");
+    await page.locator("#shell").waitFor({ state: "visible", timeout: 10_000 });
+    console.log("COMMIT_NAV_SHELL", await page.locator("#shell").textContent());
+    await page.locator("#go").click();
+    await page.locator("#shell").filter({ hasText: "Clicked" }).waitFor({
+      state: "visible",
+      timeout: 10_000,
+    });
+    console.log("COMMIT_NAV_CLICKED", await page.locator("#shell").textContent());
+  },
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session run-commit-nav --headless`,
+    );
+
+    expect(result.stderr).not.toContain("Daemon exited before startup");
+    expect(result.stdout).toContain("COMMIT_NAV_STARTED");
+    expect(result.stdout).toContain("COMMIT_NAV_SHELL Committed shell");
+    expect(result.stdout).toContain("COMMIT_NAV_CLICKED Clicked");
+    expect(result.stdout).toContain("Integration completed.");
+  }, 90_000);
+
+  test("open startUrl reports ready before DOMContentLoaded and allows interaction", async ({
+    librettoCli,
+    hangAfterCommitServer,
+  }) => {
+    const session = "open-commit-nav";
+    const opened = await librettoCli(
+      `open "${hangAfterCommitServer.url}" --headless --session ${session}`,
+    );
+    expect(opened.stderr).toBe("");
+    expect(opened.stdout).toContain(
+      `Browser open (headless): ${hangAfterCommitServer.url}`,
+    );
+
+    const clicked = await librettoCli(
+      `exec "await page.locator('#shell').waitFor({ state: 'visible', timeout: 10_000 }); await page.locator('#go').click(); await page.locator('#shell').filter({ hasText: 'Clicked' }).waitFor({ state: 'visible', timeout: 10_000 }); await page.locator('#shell').textContent()" --session ${session}`,
+    );
+    expect(clicked.stderr).toBe("");
+    expect(clicked.stdout).toContain("Clicked");
+  }, 90_000);
+
+  test("unreachable startUrl still surfaces an actionable startup error", async ({
+    librettoCli,
+    writeWorkflow,
+  }) => {
+    const unreachable = "http://127.0.0.1:1/";
+    const integrationFilePath = await writeWorkflow(
+      "integration-run-unreachable-starturl.mjs",
+      `
+export default workflow(
+  "main",
+  { startUrl: ${JSON.stringify(unreachable)} },
+  async () => "should-not-run",
+);
+`,
+    );
+
+    const result = await librettoCli(
+      `run "${integrationFilePath}" --session run-unreachable-starturl --headless`,
+    );
+
+    expect(result.stderr).toMatch(/page\.goto|ERR_CONNECTION_REFUSED|ECONNREFUSED/);
+    expect(result.stderr).not.toContain("Daemon exited before startup");
+    expect(result.stdout).not.toContain("should-not-run");
+    expect(result.stdout).not.toContain("Integration completed.");
+  }, 90_000);
+
+  test("unreachable open URL still surfaces an actionable startup error", async ({
+    librettoCli,
+  }) => {
+    const unreachable = "http://127.0.0.1:1/";
+    const result = await librettoCli(
+      `open "${unreachable}" --headless --session open-unreachable-starturl`,
+    );
+
+    expect(result.stderr).toMatch(/page\.goto|ERR_CONNECTION_REFUSED|ECONNREFUSED/);
+    expect(result.stderr).not.toContain("Daemon exited before startup");
+    expect(result.stdout).not.toContain(`Browser open (headless): ${unreachable}`);
+  }, 90_000);
+});
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Daemon startup `page.goto` for Libretto-managed `startUrl` / `initialUrl` navigation now uses `waitUntil: "commit"` instead of Playwright’s default `"load"`.

Apps that paint a usable shell without finishing `DOMContentLoaded`/`load` (e.g. eCW) no longer block daemon ready until the 45s navigation timeout or the CLI’s 60s startup guard. Workflows should wait for site-specific readiness after commit.

## Scope

- Applies when Libretto launches a local browser and navigates itself
- Applies when Libretto must navigate a provider browser (`startUrlPreloaded` remains skipped)
- Unchanged: provider-preloaded startUrl, `run --cdp` existing page, explicit `page.goto` inside workflows
- Telemetry/action logging still installs before navigation
- Failures before commit still go through the startup-error IPC path

## Tests

- Local HTTP fixture that commits HTML then hangs on `/hang.js` so load never completes
- `run` with `startUrl` becomes ready and can interact with the shell
- `open` becomes ready and `exec` can interact
- Unreachable `startUrl` / `open` URL still surfaces an actionable startup error (not a generic daemon exit)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3a0b02d-3e29-4018-8af7-d7a2ce2712df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3a0b02d-3e29-4018-8af7-d7a2ce2712df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

