### PR TITLE
Stop OpenCode review process narration on PR comments

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -89,6 +89,11 @@ jobs:
 
             Your only job is to inspect the pull request and produce the review markdown requested below.
 
+            Output rules (strict):
+            - Do not narrate your process, plans, tool choices, or progress.
+            - Do not print status updates like "I'll verify…", "Next I'll…", or "GitHub API access is available…".
+            - Between tool calls, stay silent. The only text you print for the final answer is the review markdown, starting with `# OpenCode Review`.
+
             You are an expert code reviewer specializing in evaluating implementations for simplicity and correctness. Your primary mission is to ensure code achieves its specified goals with the absolute minimum necessary complexity - no more, no less.
 
             Your review process follows these strict steps:
@@ -294,12 +299,16 @@ jobs:
             }
 
             const sourceBodyRaw = fs.readFileSync("opencode-review.md", "utf8").trim();
-            if (!sourceBodyRaw.includes("# OpenCode Review")) {
+            const reviewHeading = "# OpenCode Review";
+            const reviewHeadingIndex = sourceBodyRaw.lastIndexOf(reviewHeading);
+            if (reviewHeadingIndex === -1) {
               core.setFailed("OpenCode review output did not contain the expected review heading");
               return;
             }
 
-            const sourceBody = `${sourceBodyRaw}\n\n[github run](${runPath})`;
+            // opencode run prints intermediate assistant narration before the final
+            // review. Keep only the review markdown for the sticky PR comment.
+            const sourceBody = `${sourceBodyRaw.slice(reviewHeadingIndex).trim()}\n\n[github run](${runPath})`;
             const stickyBody = `${marker}\n${sourceBody}`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -299,8 +299,13 @@ jobs:
             }
 
             const sourceBodyRaw = fs.readFileSync("opencode-review.md", "utf8").trim();
-            const reviewHeading = "# OpenCode Review";
-            const reviewHeadingIndex = sourceBodyRaw.lastIndexOf(reviewHeading);
+            // Match a full markdown heading line only. Do not use indexOf/lastIndexOf on
+            // the bare string — reviews often mention `# OpenCode Review` in prose/code.
+            const reviewHeadingPattern = /^# OpenCode Review\s*$/gm;
+            let reviewHeadingIndex = -1;
+            for (const match of sourceBodyRaw.matchAll(reviewHeadingPattern)) {
+              reviewHeadingIndex = match.index ?? -1;
+            }
             if (reviewHeadingIndex === -1) {
               core.setFailed("OpenCode review output did not contain the expected review heading");
               return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenCode review sticky comments were including the model's intermediate process narration ("I'll verify GitHub API access…", "Next I'll fetch…") before the actual `# OpenCode Review` markdown.

`opencode run` streams every assistant turn to stdout, and the workflow posted the whole file. This change:

- Keeps only the content from the last markdown heading line `# OpenCode Review` when upserting the sticky comment (line-anchored, so inline mentions of that text do not truncate the comment)
- Adds prompt rules telling the model not to narrate between tool calls

## Test plan

- [x] Triggered automatically on this PR; first revision truncated because `lastIndexOf` matched an inline mention — fixed with a line-anchored heading match
- [ ] Confirm the updated sticky comment starts with `# OpenCode Review` and includes the full Summary / Required Actions / Suggestions sections
- [ ] Confirm no process narration appears above the review heading
- [ ] Confirm the github run link still appears at the bottom
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd3577da-3341-41af-9f95-82d3ae1c58b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd3577da-3341-41af-9f95-82d3ae1c58b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

