### PR TITLE
Move YC P26 link to header; footer says Backed by YC

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -17,8 +17,6 @@ import { Footer } from "./components/Footer";
 import { VersionBadge } from "./components/VersionBadge";
 import { ProductListing } from "./components/ProductListing";
 import { SectionDivider } from "./components/SectionDivider.js";
-import { BackedByYC } from "./components/BackedByYC";
-
 function Hero({
   paneUnlocked,
   onClosePane,
@@ -101,10 +99,6 @@ function Hero({
               TALK TO A DEV
             </a>
           </div>
-          <BackedByYC
-            className="mt-3 text-xs text-muted/60 hover:text-muted"
-            fathomEvent="Hero YC click"
-          />
         </div>
       </div>
     </section>

--- a/apps/website/src/components/BackedByYC.tsx
+++ b/apps/website/src/components/BackedByYC.tsx
@@ -23,9 +23,11 @@ function ExternalArrowIcon({ className }: { className?: string }) {
 export function BackedByYC({
   className = "",
   fathomEvent,
+  label,
 }: {
   className?: string;
   fathomEvent: string;
+  label: string;
 }) {
   return (
     <a
@@ -36,7 +38,7 @@ export function BackedByYC({
       data-fathom-event={fathomEvent}
     >
       <YCLogo className="size-3.5 shrink-0" />
-      YC P26
+      {label}
       <ExternalArrowIcon className="size-3 shrink-0 opacity-70" />
     </a>
   );

--- a/apps/website/src/components/BackedByYC.tsx
+++ b/apps/website/src/components/BackedByYC.tsx
@@ -23,11 +23,9 @@ function ExternalArrowIcon({ className }: { className?: string }) {
 export function BackedByYC({
   className = "",
   fathomEvent,
-  label,
 }: {
   className?: string;
   fathomEvent: string;
-  label: string;
 }) {
   return (
     <a
@@ -38,7 +36,7 @@ export function BackedByYC({
       data-fathom-event={fathomEvent}
     >
       <YCLogo className="size-3.5 shrink-0" />
-      {label}
+      Backed by YC
       <ExternalArrowIcon className="size-3 shrink-0 opacity-70" />
     </a>
   );

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -51,6 +51,7 @@ export function Footer() {
             <BackedByYC
               className="text-xs text-muted/50 hover:text-muted"
               fathomEvent="Footer YC click"
+              label="Backed by YC"
             />
           </div>
           <div className="flex flex-wrap justify-end gap-x-6 gap-y-2">

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -51,7 +51,6 @@ export function Footer() {
             <BackedByYC
               className="text-xs text-muted/50 hover:text-muted"
               fathomEvent="Footer YC click"
-              label="Backed by YC"
             />
           </div>
           <div className="flex flex-wrap justify-end gap-x-6 gap-y-2">

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -9,13 +9,12 @@ import {
 } from "react-aria-components";
 import { Text } from "./Text";
 import { Button } from "./Button";
-import { GitHubStarIcon } from "../icons";
+import { GitHubStarIcon, YCLogo } from "../icons";
 import { AnimationTarget } from "./AnimationOrchestration";
-import { RELEASES_URL, REPO_URL } from "../site";
+import { RELEASES_URL, REPO_URL, YC_URL } from "../site";
 import { MobileMenu } from "./MobileMenu";
 import { LibrettoLogoAndName } from "../brand.js";
 import { getCloudSession, type CloudSession } from "../cloudApi";
-import { BackedByYC } from "./BackedByYC";
 
 const GLITCH_CHARS = "@#$%&*+=<>{}[]|/\\~^!?";
 
@@ -132,6 +131,38 @@ function GlitchNavLink({
           {display}
         </Text>
         {trailingIcon && <ExternalIcon />}
+      </span>
+    </a>
+  );
+}
+
+function YCNavLink() {
+  const { display, isScrambling, hovered, onEnter, onLeave } = useGlitchText("P26");
+
+  return (
+    <a
+      href={YC_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hidden h-[1.9375rem] items-center no-underline lg:flex"
+      data-fathom-event="Nav YC click"
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
+      <span
+        className={`inline-flex items-center gap-1.5 transition-colors duration-75 ${
+          isScrambling ? "text-amber" : hovered ? "text-accent-bright" : "text-ink"
+        }`}
+      >
+        <YCLogo className="size-3.5 shrink-0" />
+        <Text
+          size="sm"
+          className={`font-medium leading-none ${
+            isScrambling ? "font-mono" : ""
+          }`}
+        >
+          {display}
+        </Text>
       </span>
     </a>
   );
@@ -408,11 +439,7 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
           </div>
         </div>
         <div className="flex items-center gap-3 md:gap-4">
-          <BackedByYC
-            className="hidden h-[1.9375rem] text-xs text-muted/70 hover:text-muted lg:inline-flex"
-            fathomEvent="Nav YC click"
-            label="YC P26"
-          />
+          <YCNavLink />
           <a
             href={REPO_URL}
             target="_blank"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -15,6 +15,7 @@ import { RELEASES_URL, REPO_URL } from "../site";
 import { MobileMenu } from "./MobileMenu";
 import { LibrettoLogoAndName } from "../brand.js";
 import { getCloudSession, type CloudSession } from "../cloudApi";
+import { BackedByYC } from "./BackedByYC";
 
 const GLITCH_CHARS = "@#$%&*+=<>{}[]|/\\~^!?";
 
@@ -388,6 +389,11 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
           >
             <LibrettoLogoAndName />
           </a>
+          <BackedByYC
+            className="h-[1.9375rem] text-xs text-muted/70 hover:text-muted"
+            fathomEvent="Nav YC click"
+            label="YC P26"
+          />
           <div className="hidden items-center gap-6 lg:flex">
             <OpenSourceNavMenu />
             <GlitchNavLink

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -389,11 +389,6 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
           >
             <LibrettoLogoAndName />
           </a>
-          <BackedByYC
-            className="h-[1.9375rem] text-xs text-muted/70 hover:text-muted"
-            fathomEvent="Nav YC click"
-            label="YC P26"
-          />
           <div className="hidden items-center gap-6 lg:flex">
             <OpenSourceNavMenu />
             <GlitchNavLink
@@ -413,6 +408,11 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
           </div>
         </div>
         <div className="flex items-center gap-3 md:gap-4">
+          <BackedByYC
+            className="hidden h-[1.9375rem] text-xs text-muted/70 hover:text-muted lg:inline-flex"
+            fathomEvent="Nav YC click"
+            label="YC P26"
+          />
           <a
             href={REPO_URL}
             target="_blank"

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -137,33 +137,16 @@ function GlitchNavLink({
 }
 
 function YCNavLink() {
-  const { display, isScrambling, hovered, onEnter, onLeave } = useGlitchText("P26");
-
   return (
     <a
       href={YC_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="hidden h-[1.9375rem] items-center no-underline lg:flex"
+      className="hidden h-[1.9375rem] items-center gap-1.5 text-ink/70 no-underline transition-colors hover:text-ink lg:flex"
       data-fathom-event="Nav YC click"
-      onMouseEnter={onEnter}
-      onMouseLeave={onLeave}
     >
-      <span
-        className={`inline-flex items-center gap-1.5 transition-colors duration-75 ${
-          isScrambling ? "text-amber" : hovered ? "text-accent-bright" : "text-ink"
-        }`}
-      >
-        <YCLogo className="size-3.5 shrink-0" />
-        <Text
-          size="sm"
-          className={`font-medium leading-none ${
-            isScrambling ? "font-mono" : ""
-          }`}
-        >
-          {display}
-        </Text>
-      </span>
+      <YCLogo className="size-3.5 shrink-0" />
+      <span className="text-sm font-medium">P26</span>
     </a>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the YC badge from the homepage hero into the site header, left of the GitHub stars
- Header shows the Y logo + "P26" in the same muted color as the GitHub stars link
- Change the footer YC link label to "Backed by YC"

## Test plan
- [ ] Homepage hero no longer shows the YC badge under the install snippet
- [ ] Navbar shows Y logo + "P26" immediately left of the GitHub stars, matching stars text color, and links to the YC company page
- [ ] Footer shows YC logo + "Backed by YC" and still links to the YC company page
- [ ] Check desktop header spacing with the badge beside GitHub stars

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38cb6a4c-901a-481c-a9f9-f0bf125c1be8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38cb6a4c-901a-481c-a9f9-f0bf125c1be8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

