### PR TITLE
Rename Marketplace → Open workflows (website, docs, CLI)

### DIFF
--- a/.agents/skills/libretto/references/workflow-sharing.md
+++ b/.agents/skills/libretto/references/workflow-sharing.md
@@ -1,9 +1,11 @@
-# Public Workflow Sharing
+# Public Workflow Sharing (Open workflows)
 
 Before running `libretto cloud share <workflow>`, review the complete local workflow source and every local module it imports for information that must not become public. Check `package.json` as well.
 
 Look for hardcoded secrets, authentication material, private keys, payment-card data, personal information, private URLs, account identifiers, addresses, email addresses, and phone numbers. Make sure this reviewed source is the version deployed for that workflow; if it has changed since deployment, deploy the reviewed version before sharing.
 
 Values read from workflow parameters or declared Libretto credentials are not part of the published source values and do not need to be removed. Hardcoded sensitive values do. If you find any, refuse to share the workflow, identify each file and line without repeating the sensitive value, and offer to replace it with a workflow parameter or named Libretto credential. Run `libretto cloud share` only after the local review is clean.
+
+`libretto cloud share` publishes **Open workflows** — public source-sharing listings at `/open-workflows/...` (plus a plain-text `/code` URL). That is different from **hosted workflows**, which expose an opaque run API without sharing source.
 
 The CLI publishes directly after this local review; Libretto Cloud does not repeat it. Chrome extension shares explicitly request a cloud privacy review before publication because extension users cannot inspect the generated source directly.

--- a/.claude/skills/libretto/references/workflow-sharing.md
+++ b/.claude/skills/libretto/references/workflow-sharing.md
@@ -1,9 +1,11 @@
-# Public Workflow Sharing
+# Public Workflow Sharing (Open workflows)
 
 Before running `libretto cloud share <workflow>`, review the complete local workflow source and every local module it imports for information that must not become public. Check `package.json` as well.
 
 Look for hardcoded secrets, authentication material, private keys, payment-card data, personal information, private URLs, account identifiers, addresses, email addresses, and phone numbers. Make sure this reviewed source is the version deployed for that workflow; if it has changed since deployment, deploy the reviewed version before sharing.
 
 Values read from workflow parameters or declared Libretto credentials are not part of the published source values and do not need to be removed. Hardcoded sensitive values do. If you find any, refuse to share the workflow, identify each file and line without repeating the sensitive value, and offer to replace it with a workflow parameter or named Libretto credential. Run `libretto cloud share` only after the local review is clean.
+
+`libretto cloud share` publishes **Open workflows** — public source-sharing listings at `/open-workflows/...` (plus a plain-text `/code` URL). That is different from **hosted workflows**, which expose an opaque run API without sharing source.
 
 The CLI publishes directly after this local review; Libretto Cloud does not repeat it. Chrome extension shares explicitly request a cloud privacy review before publication because extension users cannot inspect the generated source directly.

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -1933,7 +1933,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
     if (
       !enabled &&
       !window.confirm(
-        "Disable public workflow sharing? Every workflow from this workspace will be removed from the marketplace. Re-enabling sharing will not republish them automatically.",
+        "Disable public workflow sharing? Every workflow from this workspace will be removed from Open workflows. Re-enabling sharing will not republish them automatically.",
       )
     ) {
       return;
@@ -1951,7 +1951,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       setNotice(
         enabled
           ? "Workflow sharing is enabled. Workflows remain private until someone explicitly shares them."
-          : "Workflow sharing is disabled and existing marketplace listings were unpublished.",
+          : "Workflow sharing is disabled and existing Open workflows listings were unpublished.",
       );
     } catch (err) {
       setError(
@@ -1994,8 +1994,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
               className="mt-2 max-w-2xl text-sm leading-6 text-muted"
             >
               Allow people in this workspace to publish workflow source code
-              to the Libretto Marketplace. Credentials, run history, and
-              per-run parameters are never included.
+              to Open workflows. Credentials, run history, and per-run
+              parameters are never included.
             </p>
           </div>
           <button

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -428,15 +428,19 @@ function ProfileMenu({
   );
 }
 
-function DashboardShell({
+export function DashboardShell({
   section,
   session,
   action,
+  title,
+  description,
   children,
 }: {
   section: DashboardSection;
   session: CloudSession;
   action?: ReactNode;
+  title?: string;
+  description?: string;
   children: ReactNode;
 }) {
   const meta = sectionMeta[section];
@@ -507,10 +511,10 @@ function DashboardShell({
           <div className="mb-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <h1 className="font-serif text-[36px] font-[300] tracking-[-0.025em] md:text-[44px]">
-                {meta.title}
+                {title ?? meta.title}
               </h1>
               <p className="mt-2 text-sm leading-6 text-muted">
-                {meta.description}
+                {description ?? meta.description}
               </p>
             </div>
             {action}
@@ -545,11 +549,14 @@ function WorkflowsTable() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     orpcCall<{
-      deployed_workflows: WorkflowRow[];
-      in_progress_builds: WorkflowBuildRow[];
+      deployed_workflows?: WorkflowRow[];
+      in_progress_builds?: WorkflowBuildRow[];
     }>("/v1/workflows/list")
       .then((result) =>
-        setRows([...result.in_progress_builds, ...result.deployed_workflows]),
+        setRows([
+          ...(result.in_progress_builds ?? []),
+          ...(result.deployed_workflows ?? []),
+        ]),
       )
       .catch((err) =>
         setError(
@@ -578,7 +585,16 @@ function WorkflowsTable() {
                 className="hover:bg-panel-hi/35"
               >
                 <td className={`${tdClass} font-medium text-ink`}>
-                  {build ? row.workflow_name || "New workflow" : row.name}
+                  {build ? (
+                    row.workflow_name || "New workflow"
+                  ) : (
+                    <a
+                      href={`/dashboard/workflows/${encodeURIComponent(row.name)}`}
+                      className="text-ink underline decoration-rule underline-offset-4 hover:decoration-accent"
+                    >
+                      {row.name}
+                    </a>
+                  )}
                 </td>
                 <td className={tdClass}>
                   <StatusBadge
@@ -1933,7 +1949,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
     if (
       !enabled &&
       !window.confirm(
-        "Disable public workflow sharing? Every workflow from this workspace will be removed from Open workflows. Re-enabling sharing will not republish them automatically.",
+        "Disable public workflow sharing? Every Open and Hosted workflow from this workspace will be removed. Re-enabling sharing will not republish them automatically.",
       )
     ) {
       return;
@@ -1951,7 +1967,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       setNotice(
         enabled
           ? "Workflow sharing is enabled. Workflows remain private until someone explicitly shares them."
-          : "Workflow sharing is disabled and existing Open workflows listings were unpublished.",
+          : "Workflow sharing is disabled and existing Open and Hosted workflows were unpublished.",
       );
     } catch (err) {
       setError(
@@ -1993,9 +2009,9 @@ function SettingsPanel({ session }: { session: CloudSession }) {
               id="workflow-sharing-description"
               className="mt-2 max-w-2xl text-sm leading-6 text-muted"
             >
-              Allow people in this workspace to publish workflow source code
-              to Open workflows. Credentials, run history, and per-run
-              parameters are never included.
+              Allow people in this workspace to publish open source workflows with
+              source or Hosted workflows with an opaque run API. Credentials,
+              inputs, and outputs are never included in publisher telemetry.
             </p>
           </div>
           <button

--- a/apps/website/src/OpenWorkflowsPage.tsx
+++ b/apps/website/src/OpenWorkflowsPage.tsx
@@ -135,7 +135,7 @@ export function OpenWorkflowsPage() {
           size="xs"
           className="mb-4 uppercase tracking-[0.18em] text-accent"
         >
-          Open workflows
+          Open source workflows
         </Text>
         <Text
           as="h1"
@@ -461,7 +461,7 @@ export function OpenWorkflowPage({ shareId }: { shareId: string }) {
         href="/open-workflows"
         className="inline-flex pt-4 font-mono text-xs text-muted no-underline transition hover:text-ink"
       >
-        ← Open workflows
+        ← Open source workflows
       </a>
 
       <header className="mt-8">

--- a/apps/website/src/OpenWorkflowsPage.tsx
+++ b/apps/website/src/OpenWorkflowsPage.tsx
@@ -15,7 +15,7 @@ import {
 import { withReturnTo } from "./authRedirect";
 import { Prism } from "./prism";
 
-export type MarketplaceWorkflowSummary = {
+export type OpenWorkflowSummary = {
   id: string;
   workflow_name: string;
   description: string | null;
@@ -27,7 +27,7 @@ export type MarketplaceWorkflowSummary = {
   updated_at: string;
 };
 
-type MarketplaceWorkflowDetail = MarketplaceWorkflowSummary & {
+type OpenWorkflowDetail = OpenWorkflowSummary & {
   files: Array<{ file_name: string; code: string }>;
 };
 
@@ -59,7 +59,7 @@ function pageShell(children: React.ReactNode) {
 }
 
 function matchesQuery(
-  workflow: MarketplaceWorkflowSummary,
+  workflow: OpenWorkflowSummary,
   query: string,
 ): boolean {
   const needle = query.trim().toLowerCase();
@@ -103,15 +103,15 @@ function buildCliSetupPrompt(args: {
   ].join("\n");
 }
 
-export function MarketplacePage() {
+export function OpenWorkflowsPage() {
   const [workflows, setWorkflows] = useState<
-    MarketplaceWorkflowSummary[] | null
+    OpenWorkflowSummary[] | null
   >(null);
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    publicCloudGet<{ workflows: MarketplaceWorkflowSummary[] }>("/marketplace")
+    publicCloudGet<{ workflows: OpenWorkflowSummary[] }>("/open-workflows")
       .then((result) => setWorkflows(result.workflows))
       .catch((reason) =>
         setError(
@@ -135,7 +135,7 @@ export function MarketplacePage() {
           size="xs"
           className="mb-4 uppercase tracking-[0.18em] text-accent"
         >
-          Libretto Marketplace
+          Open workflows
         </Text>
         <Text
           as="h1"
@@ -200,7 +200,7 @@ export function MarketplacePage() {
         {filtered.map((workflow) => (
           <a
             key={workflow.id}
-            href={`/marketplace/${encodeURIComponent(workflow.id)}`}
+            href={`/open-workflows/${encodeURIComponent(workflow.id)}`}
             className="group flex flex-col rounded-lg border border-rule bg-panel p-5 text-ink no-underline transition hover:border-accent/35 hover:bg-panel-hi"
           >
             <div className="flex items-start justify-between gap-4">
@@ -298,8 +298,8 @@ function SourceBrowser({
   );
 }
 
-export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
-  const [workflow, setWorkflow] = useState<MarketplaceWorkflowDetail | null>(
+export function OpenWorkflowPage({ shareId }: { shareId: string }) {
+  const [workflow, setWorkflow] = useState<OpenWorkflowDetail | null>(
     null,
   );
   const [session, setSession] = useState<CloudSession | null>(null);
@@ -314,8 +314,8 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
   const [build, setBuild] = useState<WorkflowBuildStatus | null>(null);
 
   useEffect(() => {
-    publicCloudGet<MarketplaceWorkflowDetail>(
-      `/marketplace/${encodeURIComponent(shareId)}/data`,
+    publicCloudGet<OpenWorkflowDetail>(
+      `/open-workflows/${encodeURIComponent(shareId)}/data`,
     )
       .then(setWorkflow)
       .catch((reason) =>
@@ -394,7 +394,7 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
         build_id: string;
         status: "deploying";
         workflow_name: string;
-      }>("/v1/marketplace/import", {
+      }>("/v1/openWorkflows/import", {
         share_id: workflow.id,
         credential_ids: credentialIds,
         auto_repair: options.autoRepair,
@@ -418,7 +418,7 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
   }
 
   function startUsingWorkflow() {
-    const returnTo = `/marketplace/${encodeURIComponent(shareId)}`;
+    const returnTo = `/open-workflows/${encodeURIComponent(shareId)}`;
     if (!session) {
       window.location.assign(withReturnTo("/signin", returnTo));
       return;
@@ -438,7 +438,7 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
   const cliPrompt = workflow
     ? buildCliSetupPrompt({
         workflowName: workflow.workflow_name,
-        codeUrl: `${cloudApiUrl}/marketplace/${encodeURIComponent(workflow.id)}/code`,
+        codeUrl: `${cloudApiUrl}/open-workflows/${encodeURIComponent(workflow.id)}/code`,
       })
     : "";
 
@@ -458,10 +458,10 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
   return pageShell(
     <>
       <a
-        href="/marketplace"
+        href="/open-workflows"
         className="inline-flex pt-4 font-mono text-xs text-muted no-underline transition hover:text-ink"
       >
-        ← Marketplace
+        ← Open workflows
       </a>
 
       <header className="mt-8">
@@ -624,7 +624,7 @@ export function MarketplaceWorkflowPage({ shareId }: { shareId: string }) {
                 <button
                   type="button"
                   className="mt-3 inline-flex h-9 w-full shrink-0 cursor-pointer items-center justify-center rounded-lg border border-rule bg-transparent font-mono text-xs font-medium tracking-[0.06em] text-muted uppercase transition hover:border-accent/40 hover:bg-white/[0.04] hover:text-accent-bright focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_rgba(18,206,65,0.25)]"
-                  data-fathom-event="Marketplace copy CLI prompt"
+                  data-fathom-event="Open workflows copy CLI prompt"
                   onClick={() => {
                     void navigator.clipboard
                       .writeText(cliPrompt)

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -1,0 +1,594 @@
+import { useEffect, useState } from "react";
+import {
+  getAuthStatus,
+  getCloudSession,
+  orpcCall,
+  type CloudSession,
+} from "./cloudApi";
+import { DashboardShell } from "./AuthenticatedDashboardPage";
+
+type Publication = {
+  description: string | null;
+  stale: boolean;
+};
+
+type WorkflowDetail = {
+  workflow: string;
+  deployment_status: "building" | "ready" | "failed";
+  updated_at: string;
+  sharing_enabled: boolean;
+  open_workflow: (Publication & { open_workflow_url: string }) | null;
+  hosted_workflow: (Publication & { page_url: string }) | null;
+};
+
+type HostedRunSummary = {
+  has_publication_history: boolean;
+  metrics: {
+    runs_last_30_days: number;
+    succeeded_last_30_days: number;
+    failed_last_30_days: number;
+  };
+  runs: Array<{
+    ran_at: string;
+    outcome: "succeeded" | "failed" | "in_progress" | "cancelled";
+  }>;
+};
+
+type WorkflowRun = {
+  job_id: string;
+  status: "queued" | "starting_browser" | "running" | "completed" | "failed" | "cancelled";
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  failure_class: string | null;
+};
+
+type PrivacyFinding = {
+  file: string;
+  line: number | null;
+  explanation: string;
+};
+
+type ShareResponse =
+  | { status: "created" | "existing" | "refreshed" }
+  | {
+      status: "needs_review" | "blocked";
+      review_id: string;
+      findings: PrivacyFinding[];
+    }
+  | { status: "review_expired" };
+
+const panelClass =
+  "overflow-hidden rounded-xl border border-rule bg-panel/55 shadow-[0_12px_40px_rgba(0,0,0,0.14)]";
+const primaryButtonClass =
+  "inline-flex h-8 items-center justify-center rounded-md border border-accent/45 bg-green-9/55 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-ink transition-colors hover:bg-green-9/80 disabled:cursor-not-allowed disabled:opacity-40";
+const secondaryButtonClass =
+  "inline-flex h-8 items-center justify-center rounded-md border border-rule bg-bg/35 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted no-underline transition-colors hover:border-accent/35 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40";
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatDuration(startedAt: string | null, completedAt: string | null) {
+  if (!startedAt || !completedAt) return "—";
+  const seconds = Math.max(
+    0,
+    Math.round(
+      (new Date(completedAt).getTime() - new Date(startedAt).getTime()) / 1000,
+    ),
+  );
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function StatusPill({ value }: { value: string }) {
+  const success = value === "completed" || value === "succeeded";
+  const failed = value === "failed";
+  return (
+    <span
+      className={`inline-flex rounded-full border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.06em] ${
+        success
+          ? "border-accent/25 bg-green-9/10 text-accent-bright"
+          : failed
+            ? "border-red-400/25 bg-red-500/10 text-red-200"
+            : "border-rule bg-bg/40 text-muted"
+      }`}
+    >
+      {value.replaceAll("_", " ")}
+    </span>
+  );
+}
+
+function EmptyRuns({ hosted }: { hosted?: boolean }) {
+  return (
+    <div className="px-5 py-12 text-center">
+      <p className="text-sm text-ink">
+        {hosted ? "No external Hosted runs yet." : "No workflow runs yet."}
+      </p>
+      <p className="mt-1 text-xs text-muted">
+        Runs will appear here after this workflow is invoked.
+      </p>
+    </div>
+  );
+}
+
+function WorkflowRunsTable({ runs }: { runs: WorkflowRun[] }) {
+  if (runs.length === 0) return <EmptyRuns />;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[700px] border-collapse">
+        <thead>
+          <tr className="border-b border-rule bg-panel-hi/30">
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Started
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Status
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Runtime
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Result
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.job_id} className="border-b border-rule last:border-0">
+              <td className="px-5 py-4 text-sm text-muted">
+                {formatDate(run.started_at ?? run.created_at)}
+              </td>
+              <td className="px-5 py-4">
+                <StatusPill value={run.status} />
+              </td>
+              <td className="px-5 py-4 font-mono text-xs text-muted">
+                {formatDuration(run.started_at, run.completed_at)}
+              </td>
+              <td className="px-5 py-4 text-sm text-muted">
+                {run.failure_class ?? (run.status === "completed" ? "Completed" : "—")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HostedRunsTable({ summary }: { summary: HostedRunSummary }) {
+  return (
+    <>
+      <div className="grid gap-px border-b border-rule bg-rule sm:grid-cols-3">
+        {[
+          ["Runs in 30 days", summary.metrics.runs_last_30_days],
+          ["Succeeded", summary.metrics.succeeded_last_30_days],
+          ["Failed", summary.metrics.failed_last_30_days],
+        ].map(([label, value]) => (
+          <div key={label} className="bg-panel px-5 py-4">
+            <p className="font-mono text-2xl text-ink">{value}</p>
+            <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
+              {label}
+            </p>
+          </div>
+        ))}
+      </div>
+      {summary.runs.length === 0 ? (
+        <EmptyRuns hosted />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse">
+            <thead>
+              <tr className="border-b border-rule bg-panel-hi/30">
+                <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+                  Ran at
+                </th>
+                <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+                  Outcome
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.runs.map((run, index) => (
+                <tr
+                  key={`${run.ran_at}-${index}`}
+                  className="border-b border-rule last:border-0"
+                >
+                  <td className="px-5 py-4 text-sm text-muted">
+                    {formatDate(run.ran_at)}
+                  </td>
+                  <td className="px-5 py-4">
+                    <StatusPill value={run.outcome} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function WorkflowDetailPage({ workflow }: { workflow: string }) {
+  const [session, setSession] = useState<CloudSession | null>(null);
+  const [detail, setDetail] = useState<WorkflowDetail | null>(null);
+  const [hostedRuns, setHostedRuns] = useState<HostedRunSummary | null>(null);
+  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
+  const [publishingOpen, setPublishingOpen] = useState(false);
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function refresh() {
+    const [nextDetail, nextHostedRuns, nextWorkflowRuns] = await Promise.all([
+      orpcCall<WorkflowDetail>("/v1/workflows/get", { workflow }),
+      orpcCall<HostedRunSummary>("/v1/workflows/hostedRuns", {
+        workflow,
+        limit: 100,
+      }),
+      orpcCall<{ jobs: WorkflowRun[] }>("/v1/dashboard/jobs", {
+        workflow,
+        limit: 100,
+      }),
+    ]);
+    setDetail(nextDetail);
+    setHostedRuns(nextHostedRuns);
+    setWorkflowRuns(nextWorkflowRuns.jobs);
+    setDescription(nextDetail.hosted_workflow?.description ?? "");
+  }
+
+  useEffect(() => {
+    getCloudSession()
+      .then(async (nextSession) => {
+        if (!nextSession) {
+          window.location.assign("/signin");
+          return;
+        }
+        const status = await getAuthStatus();
+        if (!status.hasTenant) {
+          window.location.assign("/onboarding?product=chrome-extension");
+          return;
+        }
+        setSession(nextSession);
+        await refresh();
+      })
+      .catch((cause) =>
+        setError(
+          cause instanceof Error ? cause.message : "Could not load workflow.",
+        ),
+      );
+  }, [workflow]);
+
+  async function runAction(name: string, action: () => Promise<void>) {
+    setBusy(name);
+    setError(null);
+    setNotice(null);
+    try {
+      await action();
+      await refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Action failed.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function shareOpen(acknowledgement?: {
+    reviewId: string;
+    acknowledgeWarnings: boolean;
+  }): Promise<void> {
+    const response = await orpcCall<ShareResponse>("/v1/workflows/share", {
+      workflow,
+      refresh: Boolean(detail?.open_workflow),
+      privacyReview: {
+        capability: "workflow_privacy_review_v1",
+        ...(acknowledgement
+          ? {
+              reviewId: acknowledgement.reviewId,
+              acknowledgeWarnings: acknowledgement.acknowledgeWarnings,
+            }
+          : {}),
+      },
+    });
+    if (!("findings" in response) && response.status !== "review_expired") {
+      setNotice("Open source workflow published.");
+      return;
+    }
+    if (response.status === "review_expired") {
+      throw new Error("The privacy review expired. Publish again to rerun it.");
+    }
+    if (!("findings" in response)) return;
+    const findings = response.findings
+      .map(
+        (finding) =>
+          `${finding.file}${finding.line ? `:${finding.line}` : ""}: ${finding.explanation}`,
+      )
+      .join("\n");
+    if (response.status === "blocked") {
+      throw new Error(`Publishing is blocked by the privacy review:\n${findings}`);
+    }
+    if (
+      window.confirm(
+        `The privacy review found warnings:\n\n${findings}\n\nPublish anyway?`,
+      )
+    ) {
+      await shareOpen({
+        reviewId: response.review_id,
+        acknowledgeWarnings: true,
+      });
+    }
+  }
+
+  if (!session || !detail || !hostedRuns) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-bg px-6 text-sm text-muted">
+        {error ?? "Loading workflow…"}
+      </div>
+    );
+  }
+
+  const canPublish =
+    detail.sharing_enabled && detail.deployment_status === "ready";
+  const hasPublicWorkflow =
+    Boolean(detail.open_workflow) || Boolean(detail.hosted_workflow);
+
+  return (
+    <DashboardShell
+      section="workflows"
+      session={session}
+      title={detail.workflow}
+      description={`Updated ${formatDate(detail.updated_at)}`}
+      action={
+        <a href="/dashboard/workflows" className={secondaryButtonClass}>
+          ← Workflows
+        </a>
+      }
+    >
+      <div className="space-y-6">
+        {error && (
+          <p className="whitespace-pre-wrap rounded-md border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </p>
+        )}
+        {notice && (
+          <p className="rounded-md border border-accent/30 bg-green-9/10 px-4 py-3 text-sm text-accent-bright">
+            {notice}
+          </p>
+        )}
+
+        <section className={panelClass}>
+          <div className="border-b border-rule px-5 py-4">
+            <h2 className="text-base font-medium text-ink">Runs</h2>
+          </div>
+          <WorkflowRunsTable runs={workflowRuns} />
+        </section>
+
+        {detail.open_workflow && (
+          <section className={panelClass}>
+            <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                <div>
+                  <h2 className="text-base font-medium text-ink">
+                    Open source workflow
+                  </h2>
+                </div>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
+                    detail.open_workflow.stale
+                      ? "border-rule text-muted"
+                      : "border-accent/30 bg-green-9/10 text-accent-bright"
+                  }`}
+                >
+                  {detail.open_workflow.stale ? "Older version" : "Live"}
+                </span>
+              </div>
+              <div className="flex items-center gap-4">
+                {detail.open_workflow.stale && (
+                  <button
+                    type="button"
+                    disabled={!canPublish || busy !== null}
+                    onClick={() =>
+                      void runAction("open", async () => shareOpen())
+                    }
+                    className={primaryButtonClass}
+                  >
+                    {busy === "open" ? "Publishing…" : "Publish latest"}
+                  </button>
+                )}
+                <a
+                  href={detail.open_workflow.open_workflow_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-muted no-underline hover:text-ink"
+                >
+                  Public page ↗
+                </a>
+                <button
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() => {
+                    if (!window.confirm("Stop sharing this workflow's source?")) return;
+                    void runAction("unshare", async () => {
+                      await orpcCall("/v1/workflows/unshare", { workflow });
+                      setNotice("Source sharing stopped.");
+                    });
+                  }}
+                  className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
+                >
+                  Stop sharing
+                </button>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {detail.hosted_workflow && (
+          <section className={panelClass}>
+            <div className="flex items-center justify-between gap-4 px-5 pb-2 pt-4">
+              <div className="flex items-center gap-3">
+                <div>
+                  <h2 className="text-base font-medium text-ink">Hosted workflow</h2>
+                </div>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
+                    detail.hosted_workflow.stale
+                      ? "border-rule text-muted"
+                      : "border-accent/30 bg-green-9/10 text-accent-bright"
+                  }`}
+                >
+                  {detail.hosted_workflow.stale ? "Older version" : "Live"}
+                </span>
+              </div>
+              <a
+                href={detail.hosted_workflow.page_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-muted no-underline hover:text-ink"
+              >
+                Hosted page ↗
+              </a>
+            </div>
+            <div className="flex flex-col gap-3 border-b border-rule px-5 py-3 sm:flex-row sm:items-end">
+              <label className="block min-w-0 flex-1 text-[10px] uppercase tracking-[0.08em] text-muted sm:max-w-xl">
+                Description
+                <input
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  maxLength={2000}
+                  className="mt-1 h-8 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                />
+              </label>
+              <button
+                type="button"
+                disabled={!canPublish || busy !== null}
+                onClick={() =>
+                  void runAction("host", async () => {
+                    await orpcCall("/v1/workflows/host", {
+                      workflow,
+                      description: description.trim() || undefined,
+                    });
+                    setNotice("Hosted workflow deployed.");
+                  })
+                }
+                className={
+                  detail.hosted_workflow.stale
+                    ? primaryButtonClass
+                    : "inline-flex h-8 items-center justify-center rounded-md border border-accent/35 bg-green-9/10 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-accent-bright transition-colors hover:bg-green-9/25 disabled:cursor-not-allowed disabled:opacity-40"
+                }
+              >
+                {busy === "host"
+                  ? "Deploying…"
+                  : detail.hosted_workflow.stale
+                    ? "Deploy latest"
+                    : "Redeploy"}
+              </button>
+            </div>
+            <HostedRunsTable summary={hostedRuns} />
+            <div className="flex justify-end border-t border-rule px-5 py-3">
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() => {
+                  if (!window.confirm("Stop hosting this workflow?")) return;
+                  void runAction("unhost", async () => {
+                    await orpcCall("/v1/workflows/unhost", { workflow });
+                    setNotice("Hosted workflow removed.");
+                  });
+                }}
+                className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
+              >
+                Stop hosting
+              </button>
+            </div>
+          </section>
+        )}
+
+        {!hasPublicWorkflow && (
+          <section className={panelClass}>
+            <button
+              type="button"
+              aria-expanded={publishingOpen}
+              onClick={() => setPublishingOpen((open) => !open)}
+              className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-panel-hi/25"
+            >
+              <span>
+                <span className="block text-sm font-medium text-ink">
+                  Make workflow publicly available
+                </span>
+                <span className="mt-1 block text-xs text-muted">
+                  Choose how others can use it.
+                </span>
+              </span>
+              <span className="text-xs text-muted" aria-hidden>
+                {publishingOpen ? "↑" : "↓"}
+              </span>
+            </button>
+            {publishingOpen && (
+              <div className="border-t border-rule">
+                {!detail.sharing_enabled && (
+                  <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
+                    Publishing is disabled. Enable it in{" "}
+                    <a href="/dashboard/settings" className="underline">
+                      Settings
+                    </a>
+                    .
+                  </div>
+                )}
+                <div className="grid gap-3 p-4 sm:grid-cols-2">
+                  {!detail.open_workflow && (
+                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
+                      <h3 className="text-sm font-medium text-ink">
+                        Open source workflow
+                      </h3>
+                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
+                        Publish a version others can inspect and import.
+                      </p>
+                      <button
+                        type="button"
+                        disabled={!canPublish || busy !== null}
+                        onClick={() =>
+                          void runAction("open", async () => shareOpen())
+                        }
+                        className={`${primaryButtonClass} mt-4 w-full`}
+                      >
+                        {busy === "open"
+                          ? "Publishing…"
+                          : "Publish open source workflow"}
+                      </button>
+                    </div>
+                  )}
+                  {!detail.hosted_workflow && (
+                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
+                      <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
+                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
+                        Publish a hosted version others can run.
+                      </p>
+                      <button
+                        type="button"
+                        disabled={!canPublish || busy !== null}
+                        onClick={() =>
+                          void runAction("host", async () => {
+                            await orpcCall("/v1/workflows/host", { workflow });
+                            setNotice("Hosted workflow published.");
+                          })
+                        }
+                        className={`${primaryButtonClass} mt-4 w-full`}
+                      >
+                        {busy === "host" ? "Publishing…" : "Publish Hosted workflow"}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </DashboardShell>
+  );
+}

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as SigninRouteImport } from './routes/signin'
 import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as OpenWorkflowsRouteImport } from './routes/open-workflows'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as MarketplaceRouteImport } from './routes/marketplace'
 import { Route as InviteRouteImport } from './routes/invite'
@@ -26,6 +27,7 @@ import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as VsStagehandRouteImport } from './routes/vs/stagehand'
 import { Route as VsPlaywrightCodegenRouteImport } from './routes/vs/playwright-codegen'
 import { Route as VsBrowserUseRouteImport } from './routes/vs/browser-use'
+import { Route as OpenWorkflowsIdRouteImport } from './routes/open-workflows_.$id'
 import { Route as MarketplaceIdRouteImport } from './routes/marketplace_.$id'
 import { Route as GithubSetupRouteImport } from './routes/github.setup'
 import { Route as DashboardPrAgentRouteImport } from './routes/dashboard_.pr-agent'
@@ -47,6 +49,11 @@ const SigninRoute = SigninRouteImport.update({
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpenWorkflowsRoute = OpenWorkflowsRouteImport.update({
+  id: '/open-workflows',
+  path: '/open-workflows',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnboardingRoute = OnboardingRouteImport.update({
@@ -119,6 +126,11 @@ const VsBrowserUseRoute = VsBrowserUseRouteImport.update({
   path: '/vs/browser-use',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OpenWorkflowsIdRoute = OpenWorkflowsIdRouteImport.update({
+  id: '/open-workflows_/$id',
+  path: '/open-workflows/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarketplaceIdRoute = MarketplaceIdRouteImport.update({
   id: '/marketplace_/$id',
   path: '/marketplace/$id',
@@ -167,6 +179,7 @@ export interface FileRoutesByFullPath {
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
+  '/open-workflows': typeof OpenWorkflowsRoute
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -177,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace/$id': typeof MarketplaceIdRoute
+  '/open-workflows/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -192,6 +206,7 @@ export interface FileRoutesByTo {
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
+  '/open-workflows': typeof OpenWorkflowsRoute
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -202,6 +217,7 @@ export interface FileRoutesByTo {
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace/$id': typeof MarketplaceIdRoute
+  '/open-workflows/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -219,6 +235,7 @@ export interface FileRoutesById {
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
+  '/open-workflows': typeof OpenWorkflowsRoute
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -229,6 +246,7 @@ export interface FileRoutesById {
   '/dashboard_/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace_/$id': typeof MarketplaceIdRoute
+  '/open-workflows_/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
@@ -247,6 +265,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/marketplace'
     | '/onboarding'
+    | '/open-workflows'
     | '/privacy'
     | '/signin'
     | '/verify-email'
@@ -257,6 +276,7 @@ export interface FileRouteTypes {
     | '/dashboard/pr-agent'
     | '/github/setup'
     | '/marketplace/$id'
+    | '/open-workflows/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -272,6 +292,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/marketplace'
     | '/onboarding'
+    | '/open-workflows'
     | '/privacy'
     | '/signin'
     | '/verify-email'
@@ -282,6 +303,7 @@ export interface FileRouteTypes {
     | '/dashboard/pr-agent'
     | '/github/setup'
     | '/marketplace/$id'
+    | '/open-workflows/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -298,6 +320,7 @@ export interface FileRouteTypes {
     | '/invite'
     | '/marketplace'
     | '/onboarding'
+    | '/open-workflows'
     | '/privacy'
     | '/signin'
     | '/verify-email'
@@ -308,6 +331,7 @@ export interface FileRouteTypes {
     | '/dashboard_/pr-agent'
     | '/github/setup'
     | '/marketplace_/$id'
+    | '/open-workflows_/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
@@ -325,6 +349,7 @@ export interface RootRouteChildren {
   InviteRoute: typeof InviteRoute
   MarketplaceRoute: typeof MarketplaceRoute
   OnboardingRoute: typeof OnboardingRoute
+  OpenWorkflowsRoute: typeof OpenWorkflowsRoute
   PrivacyRoute: typeof PrivacyRoute
   SigninRoute: typeof SigninRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
@@ -334,6 +359,7 @@ export interface RootRouteChildren {
   DashboardPrAgentRoute: typeof DashboardPrAgentRoute
   GithubSetupRoute: typeof GithubSetupRoute
   MarketplaceIdRoute: typeof MarketplaceIdRoute
+  OpenWorkflowsIdRoute: typeof OpenWorkflowsIdRoute
   VsBrowserUseRoute: typeof VsBrowserUseRoute
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
   VsStagehandRoute: typeof VsStagehandRoute
@@ -360,6 +386,13 @@ declare module '@tanstack/react-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/open-workflows': {
+      id: '/open-workflows'
+      path: '/open-workflows'
+      fullPath: '/open-workflows'
+      preLoaderRoute: typeof OpenWorkflowsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/onboarding': {
@@ -460,6 +493,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof VsBrowserUseRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/open-workflows_/$id': {
+      id: '/open-workflows_/$id'
+      path: '/open-workflows/$id'
+      fullPath: '/open-workflows/$id'
+      preLoaderRoute: typeof OpenWorkflowsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/marketplace_/$id': {
       id: '/marketplace_/$id'
       path: '/marketplace/$id'
@@ -537,6 +577,7 @@ const rootRouteChildren: RootRouteChildren = {
   InviteRoute: InviteRoute,
   MarketplaceRoute: MarketplaceRoute,
   OnboardingRoute: OnboardingRoute,
+  OpenWorkflowsRoute: OpenWorkflowsRoute,
   PrivacyRoute: PrivacyRoute,
   SigninRoute: SigninRoute,
   VerifyEmailRoute: VerifyEmailRoute,
@@ -546,6 +587,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardPrAgentRoute: DashboardPrAgentRoute,
   GithubSetupRoute: GithubSetupRoute,
   MarketplaceIdRoute: MarketplaceIdRoute,
+  OpenWorkflowsIdRoute: OpenWorkflowsIdRoute,
   VsBrowserUseRoute: VsBrowserUseRoute,
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,
   VsStagehandRoute: VsStagehandRoute,
@@ -553,12 +595,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as DashboardCloudBrowsersRouteImport } from './routes/dashboard_.
 import { Route as DashboardChromeExtensionRouteImport } from './routes/dashboard_.chrome-extension'
 import { Route as DashboardSectionRouteImport } from './routes/dashboard_.$section'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as DashboardWorkflowsWorkflowRouteImport } from './routes/dashboard_.workflows_.$workflow'
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
   id: '/verify-email',
@@ -167,6 +168,12 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
   path: '/$slug',
   getParentRoute: () => BlogRouteRoute,
 } as any)
+const DashboardWorkflowsWorkflowRoute =
+  DashboardWorkflowsWorkflowRouteImport.update({
+    id: '/dashboard_/workflows_/$workflow',
+    path: '/dashboard/workflows/$workflow',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByFullPath {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
+  '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -222,6 +230,7 @@ export interface FileRoutesByTo {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog': typeof BlogIndexRoute
+  '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -251,6 +260,7 @@ export interface FileRoutesById {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
+  '/dashboard_/workflows_/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -281,6 +291,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog/'
+    | '/dashboard/workflows/$workflow'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -308,6 +319,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog'
+    | '/dashboard/workflows/$workflow'
   id:
     | '__root__'
     | '/'
@@ -336,6 +348,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog/'
+    | '/dashboard_/workflows_/$workflow'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -363,6 +376,7 @@ export interface RootRouteChildren {
   VsBrowserUseRoute: typeof VsBrowserUseRoute
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
   VsStagehandRoute: typeof VsStagehandRoute
+  DashboardWorkflowsWorkflowRoute: typeof DashboardWorkflowsWorkflowRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -549,6 +563,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof BlogRouteRoute
     }
+    '/dashboard_/workflows_/$workflow': {
+      id: '/dashboard_/workflows_/$workflow'
+      path: '/dashboard/workflows/$workflow'
+      fullPath: '/dashboard/workflows/$workflow'
+      preLoaderRoute: typeof DashboardWorkflowsWorkflowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -591,7 +612,17 @@ const rootRouteChildren: RootRouteChildren = {
   VsBrowserUseRoute: VsBrowserUseRoute,
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,
   VsStagehandRoute: VsStagehandRoute,
+  DashboardWorkflowsWorkflowRoute: DashboardWorkflowsWorkflowRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/apps/website/src/routes/dashboard_.workflows_.$workflow.tsx
+++ b/apps/website/src/routes/dashboard_.workflows_.$workflow.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { WorkflowDetailPage } from "../WorkflowDetailPage";
+
+export const Route = createFileRoute("/dashboard_/workflows_/$workflow")({
+  head: ({ params }) => ({
+    meta: [
+      { title: `${params.workflow} | Libretto` },
+      { name: "robots", content: "noindex, nofollow" },
+    ],
+  }),
+  component: WorkflowPage,
+});
+
+function WorkflowPage() {
+  const { workflow } = Route.useParams();
+  return <WorkflowDetailPage workflow={workflow} />;
+}

--- a/apps/website/src/routes/marketplace.tsx
+++ b/apps/website/src/routes/marketplace.tsx
@@ -1,15 +1,9 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { MarketplacePage } from "../MarketplacePage";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/marketplace")({
-  head: () => ({
-    meta: [
-      { title: "Workflow Marketplace | Libretto" },
-      {
-        name: "description",
-        content: "Add reusable browser workflows to your Libretto account.",
-      },
-    ],
-  }),
-  component: MarketplacePage,
+  beforeLoad: () => {
+    throw redirect({
+      to: "/open-workflows",
+    });
+  },
 });

--- a/apps/website/src/routes/marketplace_.$id.tsx
+++ b/apps/website/src/routes/marketplace_.$id.tsx
@@ -1,14 +1,10 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { MarketplaceWorkflowPage } from "../MarketplacePage";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/marketplace_/$id")({
-  head: () => ({
-    meta: [{ title: "Marketplace Workflow | Libretto" }],
-  }),
-  component: MarketplaceWorkflowRoute,
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: "/open-workflows/$id",
+      params: { id: params.id },
+    });
+  },
 });
-
-function MarketplaceWorkflowRoute() {
-  const { id } = Route.useParams();
-  return <MarketplaceWorkflowPage shareId={id} />;
-}

--- a/apps/website/src/routes/open-workflows.tsx
+++ b/apps/website/src/routes/open-workflows.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { OpenWorkflowsPage } from "../OpenWorkflowsPage";
+
+export const Route = createFileRoute("/open-workflows")({
+  head: () => ({
+    meta: [
+      { title: "Open workflows | Libretto" },
+      {
+        name: "description",
+        content: "Add reusable browser workflows to your Libretto account.",
+      },
+    ],
+  }),
+  component: OpenWorkflowsPage,
+});

--- a/apps/website/src/routes/open-workflows.tsx
+++ b/apps/website/src/routes/open-workflows.tsx
@@ -4,7 +4,7 @@ import { OpenWorkflowsPage } from "../OpenWorkflowsPage";
 export const Route = createFileRoute("/open-workflows")({
   head: () => ({
     meta: [
-      { title: "Open workflows | Libretto" },
+      { title: "Open source workflows | Libretto" },
       {
         name: "description",
         content: "Add reusable browser workflows to your Libretto account.",

--- a/apps/website/src/routes/open-workflows_.$id.tsx
+++ b/apps/website/src/routes/open-workflows_.$id.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { OpenWorkflowPage } from "../OpenWorkflowsPage";
+
+export const Route = createFileRoute("/open-workflows_/$id")({
+  head: () => ({
+    meta: [{ title: "Open workflow | Libretto" }],
+  }),
+  component: OpenWorkflowRoute,
+});
+
+function OpenWorkflowRoute() {
+  const { id } = Route.useParams();
+  return <OpenWorkflowPage shareId={id} />;
+}

--- a/apps/website/src/routes/open-workflows_.$id.tsx
+++ b/apps/website/src/routes/open-workflows_.$id.tsx
@@ -3,7 +3,7 @@ import { OpenWorkflowPage } from "../OpenWorkflowsPage";
 
 export const Route = createFileRoute("/open-workflows_/$id")({
   head: () => ({
-    meta: [{ title: "Open workflow | Libretto" }],
+    meta: [{ title: "Open source workflow | Libretto" }],
   }),
   component: OpenWorkflowRoute,
 });

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "outputDirectory": "dist/client",
+  "redirects": [
+    {
+      "source": "/marketplace",
+      "destination": "/open-workflows",
+      "permanent": true
+    },
+    {
+      "source": "/marketplace/:id",
+      "destination": "/open-workflows/:id",
+      "permanent": true
+    }
+  ],
   "headers": [
     {
       "source": "/((?!docs(?:/|$)).*)",

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
         enabled: true,
         crawlLinks: false,
       },
-      pages: [...blogPostPaths, ...dashboardPaths, "/marketplace"].map((path) => ({
+      pages: [...blogPostPaths, ...dashboardPaths, "/open-workflows"].map((path) => ({
         path,
         prerender: { enabled: true },
       })),

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -194,6 +194,8 @@
               "libretto-cloud-api/sessions",
               "libretto-cloud-api/recordings",
               "libretto-cloud-api/deployments-and-workflows",
+              "libretto-cloud-api/open-workflows",
+              "libretto-cloud-api/hosted-workflows",
               "libretto-cloud-api/jobs-and-logs",
               "libretto-cloud-api/credentials",
               "libretto-cloud-api/webhooks",

--- a/docs/libretto-cloud-api/hosted-workflows.mdx
+++ b/docs/libretto-cloud-api/hosted-workflows.mdx
@@ -1,0 +1,106 @@
+---
+title: Hosted workflows
+"og:image": "https://libretto.sh/docs/og/libretto-cloud-api/hosted-workflows.png"
+---
+
+> Publish an opaque run API for a deployed workflow. Consumers call it with their own API key and credentials; source stays with the publisher.
+
+Hosted workflows are consumer-run, source-hidden APIs. Jobs and credentials belong to the **consumer** tenant. Publishers pin a ready deployment with `POST /v1/workflows/host`; consumers discover and run it under `/v1/hosted-workflows…`.
+
+This is different from [open workflows](/libretto-cloud-api/open-workflows), which publish source for forking/import. It is also different from private `POST /v1/jobs/create` against workflows you own.
+
+### Publisher: host and unhost
+
+These routes require `x-api-key`. The tenant must have an organization slug.
+
+#### POST `/v1/workflows/host`
+
+Host a ready workflow in the public catalog. Re-hosting replaces the live publication (bumps deployment version).
+
+Request fields:
+
+- `workflow`: deployed workflow name
+- `description`: optional public description
+- `credential_requirements`: optional array of `{ name, description }`. When omitted, Libretto derives requirements from the workflow's declared credential names.
+
+Response fields:
+
+- `id`
+- `hosted_workflow`: public key `tenantSlug/workflowName`
+- `page_url`: public HTML docs page on the API host
+- `deployment_version`
+
+Workflows that use auth profiles cannot be hosted in v1.
+
+#### POST `/v1/workflows/unhost`
+
+Tombstone a live publication. Catalog and run endpoints return 404 afterward. In-flight consumer jobs are left alone. Known consumers may receive a best-effort email.
+
+Request fields:
+
+- `workflow`: deployed workflow name
+
+Response fields:
+
+- `success`
+- `hosted_workflow`
+- `notified_consumers`
+
+### Consumer catalog and run
+
+Authenticated routes require `x-api-key` (session auth is also accepted where applicable). Former `/v1/published-workflows` paths permanently redirect to `/v1/hosted-workflows`.
+
+#### GET `/v1/hosted-workflows`
+
+List hosted workflows. Optional query `q` filters the catalog.
+
+#### GET `/v1/hosted-workflows/:tenantSlug/:workflowName`
+
+Return metadata for one hosted workflow, including:
+
+- `input_schema` / `output_schema`
+- `credential_requirements`
+- `deployment_version`
+- `published_at`
+- `page_url`
+
+#### POST `/v1/hosted-workflows/run/:tenantSlug/:workflowName`
+
+Start a consumer-owned job against the publisher's pinned deployment.
+
+Request body fields (JSON, not ORPC `{ "json": ... }` wrapping):
+
+- `params`: workflow input object
+- `credential_id`: optional single credential id
+- `nonce`: optional idempotency-style nonce
+- `timeout_seconds`: optional timeout
+- `headless`, `start_url`, `gpu`, `viewport`, `residential_proxy`: optional launch overrides
+- `callback_url` / `callback_secret`: delivery target for results
+- `skip_callbacks`: optional boolean
+
+Callback rules:
+
+- Provide both `callback_url` and `callback_secret`, **or** set `skip_callbacks: true` and poll `POST /v1/jobs/get` with the returned `job_id`.
+- Hosted runs do not fall back to the consumer's stored tenant webhooks unless you opt into callbacks that way through normal job delivery after a callback is set.
+
+Credentials:
+
+- Create credentials in **your** tenant with the exact names listed in `credential_requirements` before running.
+- The publisher cannot list your jobs or read your credential values.
+
+Response fields:
+
+- `success`
+- `job_id`
+- `status`
+- `hosted_workflow`
+- `message`
+
+### Public HTML pages
+
+These routes do not require auth:
+
+- `GET /hosted-workflows` — catalog index
+- `GET /hosted-workflows/:tenantSlug/:workflowName` — docs page with credential requirements and example curl
+
+Former `/published-workflows` paths permanently redirect here.

--- a/docs/libretto-cloud-api/hosted-workflows.mdx
+++ b/docs/libretto-cloud-api/hosted-workflows.mdx
@@ -11,7 +11,18 @@ This is different from [open workflows](/libretto-cloud-api/open-workflows), whi
 
 ### Publisher: host and unhost
 
-These routes require `x-api-key`. The tenant must have an organization slug.
+These routes require `x-api-key`. The tenant must have an organization slug and workflow sharing must be enabled:
+
+```bash
+libretto cloud sharing enable
+```
+
+Publish and remove a Hosted workflow from the CLI:
+
+```bash
+libretto cloud host dailyReport --description "Generate the daily report"
+libretto cloud unhost dailyReport
+```
 
 #### POST `/v1/workflows/host`
 
@@ -71,7 +82,7 @@ Start a consumer-owned job against the publisher's pinned deployment.
 Request body fields (JSON, not ORPC `{ "json": ... }` wrapping):
 
 - `params`: workflow input object
-- `credential_id`: optional single credential id
+- `credentials`: optional map from each required credential name to a credential id or secret name in the consumer tenant
 - `nonce`: optional idempotency-style nonce
 - `timeout_seconds`: optional timeout
 - `headless`, `start_url`, `gpu`, `viewport`, `residential_proxy`: optional launch overrides
@@ -86,7 +97,8 @@ Callback rules:
 Credentials:
 
 - Create credentials in **your** tenant with the exact names listed in `credential_requirements` before running.
-- The publisher cannot list your jobs or read your credential values.
+- The publisher can see only when an external run started and whether it succeeded, failed, was cancelled, or is still in progress.
+- The publisher cannot see your identity, inputs, credentials, outputs, errors, or job details.
 
 Response fields:
 

--- a/docs/libretto-cloud-api/open-workflows.mdx
+++ b/docs/libretto-cloud-api/open-workflows.mdx
@@ -1,0 +1,113 @@
+---
+title: Open workflows
+"og:image": "https://libretto.sh/docs/og/libretto-cloud-api/open-workflows.png"
+---
+
+> Browse and import public workflow source. Open workflows are a source-sharing catalog, not an opaque run API.
+
+Open workflows let publishers share automation source so others can fork it locally or import a private Cloud copy. Credentials, run history, and per-run parameters are never included.
+
+This is different from [hosted workflows](/libretto-cloud-api/hosted-workflows), which expose a consumer-run API without publishing source. Private runs of your own deployments still use [jobs/create](/libretto-cloud-api/jobs-and-logs#jobs).
+
+Public catalog and source routes live on the API host (`https://api.libretto.sh`). The website SPA at `https://libretto.sh/open-workflows` consumes the same JSON.
+
+### Public catalog and source
+
+These routes do not require `x-api-key`.
+
+#### GET `/open-workflows`
+
+List published open workflows.
+
+Optional query:
+
+- `q`: search string matched against name, description, and publisher
+
+Response:
+
+```json
+{
+  "workflows": [
+    {
+      "id": "<share-id>",
+      "workflow_name": "check-eligibility",
+      "description": "...",
+      "publisher_name": "Acme",
+      "publisher_slug": "acme",
+      "credential_names": ["payer-portal"],
+      "import_available": true,
+      "import_count": 12,
+      "updated_at": "2026-08-10T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+#### GET `/open-workflows/:id`
+
+HTML detail page for a share (API-hosted fallback UI).
+
+#### GET `/open-workflows/:id/data`
+
+JSON detail including source files for the website SPA.
+
+Response fields match the list entry, plus:
+
+- `files`: array of `{ file_name, code }`
+
+#### GET `/open-workflows/:id/code`
+
+Plain-text source bundle. Multi-file shares are concatenated with `// File: <name>` section headers.
+
+Former `/marketplace` paths permanently redirect to `/open-workflows`.
+
+### Import into your account
+
+#### POST `/v1/openWorkflows/import`
+
+Requires session auth or `x-api-key`. Creates a private Cloud deployment from a published share.
+
+Request fields:
+
+- `share_id`: open workflow share id
+- `credential_ids`: optional array of your credential UUIDs that cover required names
+- `auto_repair`: optional boolean, default `true`
+
+Response fields:
+
+- `build_id`
+- `status`: always `deploying`
+- `workflow_name`
+
+Missing required credentials must be created in your tenant (matching names) before or during import. The website SPA can create secrets and then call this route.
+
+### Publisher share / unshare
+
+These routes require `x-api-key`. Tenant code sharing must be enabled (`POST /v1/tenant/updateCodeSharing` or `npx libretto cloud sharing enable`).
+
+#### POST `/v1/workflows/share`
+
+Publish the current deployment's source as an open workflow.
+
+Request fields:
+
+- `workflow`: deployed workflow name
+- `refresh`: optional boolean to refresh an existing share from the current deployment
+
+Response fields:
+
+- `id`
+- `status`: `created` | `existing` | `refreshed`
+- `workflow`
+- `open_workflow_url`: website URL such as `https://libretto.sh/open-workflows/<id>`
+- `code_url`: API plain-text URL such as `https://api.libretto.sh/open-workflows/<id>/code`
+
+#### POST `/v1/workflows/unshare`
+
+Remove a workflow from the open-workflows catalog.
+
+Request fields:
+
+- `workflow`: deployed workflow name
+
+See also the CLI: [share](/reference/cli/share).

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -56,6 +56,14 @@ This section documents the public `/v1/*` routes exposed by Libretto Cloud in th
     Upload bundles, build workflows, and inspect workflow state.
   </Card>
 
+  <Card title="Open workflows" icon="share-2" href="/libretto-cloud-api/open-workflows">
+    Publish and import public workflow source.
+  </Card>
+
+  <Card title="Hosted workflows" icon="globe" href="/libretto-cloud-api/hosted-workflows">
+    Publish opaque consumer-run APIs without sharing source.
+  </Card>
+
   <Card title="Jobs and Logs" icon="terminal" href="/libretto-cloud-api/jobs-and-logs">
     Start jobs, poll results, inspect debug reports, and fetch logs.
   </Card>

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -56,7 +56,7 @@ This section documents the public `/v1/*` routes exposed by Libretto Cloud in th
     Upload bundles, build workflows, and inspect workflow state.
   </Card>
 
-  <Card title="Open workflows" icon="share-2" href="/libretto-cloud-api/open-workflows">
+  <Card title="Open workflows" icon="share" href="/libretto-cloud-api/open-workflows">
     Publish and import public workflow source.
   </Card>
 

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -154,6 +154,8 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
 - [Overview](/libretto-cloud-api/overview)
 - [Sessions](/libretto-cloud-api/sessions)
 - [Deployments and Workflows](/libretto-cloud-api/deployments-and-workflows)
+- [Open workflows](/libretto-cloud-api/open-workflows)
+- [Hosted workflows](/libretto-cloud-api/hosted-workflows)
 - [Jobs and Logs](/libretto-cloud-api/jobs-and-logs)
 - [Credentials](/libretto-cloud-api/credentials)
 - [Webhooks](/libretto-cloud-api/webhooks)

--- a/docs/reference/cli/share.mdx
+++ b/docs/reference/cli/share.mdx
@@ -3,9 +3,11 @@ title: share
 "og:image": "https://libretto.sh/docs/og/reference/cli/share.png"
 ---
 
-> Make hosted workflow source code public through Libretto Cloud.
+> Make workflow source code public as an Open workflow through Libretto Cloud.
 
-The `cloud share` command creates a public code share for a workflow that is already deployed to Libretto Cloud. Use it when you want anyone with the generated URL to fork your automation code and use it as the starting point for their own automation.
+The `cloud share` command creates a public Open workflows listing for a workflow that is already deployed to Libretto Cloud. Use it when you want anyone with the generated URL to fork your automation code and use it as the starting point for their own automation.
+
+Open workflows share source. They are not the same as [hosted workflows](/libretto-cloud-api/hosted-workflows), which expose an opaque run API without publishing source.
 
 <Info>
   Workflow sharing requires a Libretto Cloud account, API key, and tenant-level
@@ -27,12 +29,12 @@ npx libretto cloud share <workflow> [flags]
 ```
 
 <ParamField path="workflow" type="string" required>
-  The hosted workflow name to share. This is the workflow name declared in code
-  and deployed with `npx libretto cloud deploy`.
+  The deployed workflow name to publish as an open workflow. This is the
+  workflow name declared in code and deployed with `npx libretto cloud deploy`.
 </ParamField>
 
 <ParamField path="--refresh" type="boolean">
-  Refresh an existing share from the workflow's current deployment.
+  Refresh an existing open workflow from the workflow's current deployment.
 </ParamField>
 
 #### Prerequisites
@@ -68,7 +70,7 @@ npx libretto cloud share <workflow> [flags]
   </Step>
 
   <Step title="Deploy the workflow">
-    Share works on hosted workflows. Deploy the package that contains the
+    Share works on deployed workflows. Deploy the package that contains the
     workflow before sharing it:
 
     ```bash theme={null}
@@ -79,12 +81,12 @@ npx libretto cloud share <workflow> [flags]
 
 #### Output
 
-When sharing succeeds, Libretto prints the public marketplace URL and code URL:
+When sharing succeeds, Libretto prints the public Open workflow URL and code URL:
 
 ```bash theme={null}
 Shared workflow: check-eligibility
-Marketplace URL: https://libretto.sh/...
-Code URL: https://libretto.sh/...
+Open workflow URL: https://libretto.sh/open-workflows/...
+Code URL: https://api.libretto.sh/open-workflows/.../code
 ```
 
 If the workflow is already shared, rerun the command with `--refresh` to update the shared code from the current deployment:

--- a/packages/libretto/skills/libretto/references/workflow-sharing.md
+++ b/packages/libretto/skills/libretto/references/workflow-sharing.md
@@ -1,9 +1,11 @@
-# Public Workflow Sharing
+# Public Workflow Sharing (Open workflows)
 
 Before running `libretto cloud share <workflow>`, review the complete local workflow source and every local module it imports for information that must not become public. Check `package.json` as well.
 
 Look for hardcoded secrets, authentication material, private keys, payment-card data, personal information, private URLs, account identifiers, addresses, email addresses, and phone numbers. Make sure this reviewed source is the version deployed for that workflow; if it has changed since deployment, deploy the reviewed version before sharing.
 
 Values read from workflow parameters or declared Libretto credentials are not part of the published source values and do not need to be removed. Hardcoded sensitive values do. If you find any, refuse to share the workflow, identify each file and line without repeating the sensitive value, and offer to replace it with a workflow parameter or named Libretto credential. Run `libretto cloud share` only after the local review is clean.
+
+`libretto cloud share` publishes **Open workflows** — public source-sharing listings at `/open-workflows/...` (plus a plain-text `/code` URL). That is different from **hosted workflows**, which expose an opaque run API without sharing source.
 
 The CLI publishes directly after this local review; Libretto Cloud does not repeat it. Chrome extension shares explicitly request a cloud privacy review before publication because extension users cannot inspect the generated source directly.

--- a/packages/libretto/src/cli/commands/cloud-settings.ts
+++ b/packages/libretto/src/cli/commands/cloud-settings.ts
@@ -10,7 +10,6 @@ type TenantSettingsResponse = {
 };
 
 type TenantSettingsInput = {
-  code_sharing_enabled?: boolean;
   disable_job_failure_notifications?: boolean;
 };
 
@@ -25,7 +24,7 @@ function printTenantSettings(
 ): TenantSettingsResponse {
   const notificationsEnabled = !settings.disable_job_failure_notifications;
   console.log(
-    `Code sharing: ${settings.code_sharing_enabled ? "enabled" : "disabled"}`,
+    `Workflow sharing: ${settings.code_sharing_enabled ? "enabled" : "disabled"}`,
   );
   console.log(
     `Job failure notifications: ${notificationsEnabled ? "enabled" : "disabled"}`,
@@ -62,9 +61,6 @@ export const setSettingsCommand = SimpleCLI.command({
     SimpleCLI.input({
       positionals: [],
       named: {
-        codeSharing: SimpleCLI.option(settingState.optional(), {
-          help: "Set tenant code sharing: enabled or disabled",
-        }),
         jobFailureNotifications: SimpleCLI.option(settingState.optional(), {
           help: "Set hosted job failure notification emails: enabled or disabled",
         }),
@@ -74,9 +70,6 @@ export const setSettingsCommand = SimpleCLI.command({
   .use(withCloudApiKey("manage Libretto Cloud settings"))
   .handle(async ({ input, ctx }) => {
     const updates: TenantSettingsInput = {};
-    if (input.codeSharing !== undefined) {
-      updates.code_sharing_enabled = toBoolean(input.codeSharing);
-    }
     if (input.jobFailureNotifications !== undefined) {
       updates.disable_job_failure_notifications = !toBoolean(
         input.jobFailureNotifications,
@@ -85,7 +78,7 @@ export const setSettingsCommand = SimpleCLI.command({
 
     if (Object.keys(updates).length === 0) {
       throw new Error(
-        "No settings provided. Use one or more flags, for example `libretto cloud settings set --code-sharing enabled --job-failure-notifications disabled`.",
+        "No settings provided. For example, use `libretto cloud settings set --job-failure-notifications disabled`. Use `libretto cloud sharing enable` or `disable` to change workflow sharing.",
       );
     }
 

--- a/packages/libretto/src/cli/commands/cloud-sharing.ts
+++ b/packages/libretto/src/cli/commands/cloud-sharing.ts
@@ -15,6 +15,18 @@ type ShareWorkflowResponse = {
   code_url: string;
 };
 
+type HostWorkflowResponse = {
+  hosted_workflow: string;
+  page_url: string;
+  deployment_version: number;
+  status: "created" | "updated";
+};
+
+type UnhostWorkflowResponse = {
+  hosted_workflow: string;
+  notified_consumers: number;
+};
+
 export const shareWorkflowCommand = SimpleCLI.command({
   description: "Share one workflow's source as a public open workflow",
 })
@@ -55,8 +67,66 @@ export const shareWorkflowCommand = SimpleCLI.command({
     return response.open_workflow_url;
   });
 
+export const hostWorkflowCommand = SimpleCLI.command({
+  description: "Publish a deployed workflow as a public hosted workflow",
+})
+  .input(SimpleCLI.input({
+    positionals: [
+      SimpleCLI.positional("workflow", z.string().min(1), {
+        help: "Deployed workflow name to publish as a hosted workflow",
+      }),
+    ],
+    named: {
+      description: SimpleCLI.option(z.string().optional(), {
+        help: "Public description for the hosted workflow",
+      }),
+    },
+  }))
+  .use(withCloudApiKey("publish a Libretto Cloud hosted workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await orpcCall<HostWorkflowResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/workflows/host",
+      input: {
+        workflow: input.workflow,
+        description: input.description,
+      },
+      credential: ctx.credential,
+    });
+    console.log(
+      `${response.status === "created" ? "Published" : "Updated"} hosted workflow: ${response.hosted_workflow}`,
+    );
+    console.log(`Page URL: ${response.page_url}`);
+    console.log(`Deployment version: ${response.deployment_version}`);
+    return response.page_url;
+  });
+
+export const unhostWorkflowCommand = SimpleCLI.command({
+  description: "Remove a workflow from public hosted workflows",
+})
+  .input(SimpleCLI.input({
+    positionals: [
+      SimpleCLI.positional("workflow", z.string().min(1), {
+        help: "Deployed workflow name to unhost",
+      }),
+    ],
+    named: {},
+  }))
+  .use(withCloudApiKey("unhost a Libretto Cloud hosted workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await orpcCall<UnhostWorkflowResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/workflows/unhost",
+      input: { workflow: input.workflow },
+      credential: ctx.credential,
+    });
+    console.log(`Unhosted workflow: ${response.hosted_workflow}`);
+    console.log(`Notified consumers: ${response.notified_consumers}`);
+    return response.hosted_workflow;
+  });
+
 export const codeSharingStatusCommand = SimpleCLI.command({
-  description: "Show whether tenant code sharing is enabled",
+  description: "Show whether tenant workflow sharing is enabled",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
@@ -67,7 +137,7 @@ export const codeSharingStatusCommand = SimpleCLI.command({
       input: {},
       credential: ctx.credential,
     });
-    console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+    console.log(`Workflow sharing: ${response.enabled ? "enabled" : "disabled"}`);
     return response.enabled;
   });
 
@@ -81,26 +151,26 @@ async function updateCodeSharing(
     input: { enabled },
     credential: ctx.credential,
   });
-  console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+  console.log(`Workflow sharing: ${response.enabled ? "enabled" : "disabled"}`);
   return response.enabled;
 }
 
 export const enableCodeSharingCommand = SimpleCLI.command({
-  description: "Enable public workflow code sharing for this tenant",
+  description: "Enable public workflow sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
   .handle(async ({ ctx }) => updateCodeSharing(true, ctx));
 
 export const disableCodeSharingCommand = SimpleCLI.command({
-  description: "Disable public workflow code sharing for this tenant",
+  description: "Disable public workflow sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
   .handle(async ({ ctx }) => updateCodeSharing(false, ctx));
 
 export const codeSharingCommands = SimpleCLI.group({
-  description: "Manage tenant workflow code sharing",
+  description: "Manage tenant workflow sharing",
   routes: {
     status: codeSharingStatusCommand,
     enable: enableCodeSharingCommand,

--- a/packages/libretto/src/cli/commands/cloud-sharing.ts
+++ b/packages/libretto/src/cli/commands/cloud-sharing.ts
@@ -11,22 +11,22 @@ type ShareWorkflowResponse = {
   id: string;
   status: "created" | "existing" | "refreshed";
   workflow: string;
-  marketplace_url: string;
+  open_workflow_url: string;
   code_url: string;
 };
 
 export const shareWorkflowCommand = SimpleCLI.command({
-  description: "Share one hosted workflow's code publicly",
+  description: "Share one workflow's source as a public open workflow",
 })
   .input(SimpleCLI.input({
     positionals: [
       SimpleCLI.positional("workflow", z.string().min(1), {
-        help: "Hosted workflow name to share",
+        help: "Deployed workflow name to publish as an open workflow",
       }),
     ],
     named: {
       refresh: SimpleCLI.flag({
-        help: "Refresh an existing share from the workflow's current deployment",
+        help: "Refresh an existing open workflow from the workflow's current deployment",
       }),
     },
   }))
@@ -50,9 +50,9 @@ export const shareWorkflowCommand = SimpleCLI.command({
     } else {
       console.log(`Shared workflow: ${response.workflow}`);
     }
-    console.log(`Marketplace URL: ${response.marketplace_url}`);
+    console.log(`Open workflow URL: ${response.open_workflow_url}`);
     console.log(`Code URL: ${response.code_url}`);
-    return response.marketplace_url;
+    return response.open_workflow_url;
   });
 
 export const codeSharingStatusCommand = SimpleCLI.command({

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -5,7 +5,12 @@ import { cloudCredentialCommands } from "./commands/cloud-credentials.js";
 import { cloudJobCommands } from "./commands/cloud-jobs.js";
 import { cloudScheduleCommands } from "./commands/cloud-schedules.js";
 import { settingsCommands } from "./commands/cloud-settings.js";
-import { codeSharingCommands, shareWorkflowCommand } from "./commands/cloud-sharing.js";
+import {
+  codeSharingCommands,
+  hostWorkflowCommand,
+  shareWorkflowCommand,
+  unhostWorkflowCommand,
+} from "./commands/cloud-sharing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
 import { experimentsCommand } from "./commands/experiments.js";
@@ -33,6 +38,8 @@ export const cliRoutes = {
       schedules: cloudScheduleCommands,
       settings: settingsCommands,
       share: shareWorkflowCommand,
+      host: hostWorkflowCommand,
+      unhost: unhostWorkflowCommand,
       sharing: codeSharingCommands,
     },
   }),

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -443,6 +443,36 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toContain("libretto cloud auth api-key issue");
   });
 
+  test("prints cloud host help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud host");
+    expect(result.stdout).toContain(
+      "Publish a deployed workflow as a public hosted workflow",
+    );
+    expect(result.stdout).toContain("libretto cloud host <workflow>");
+    expect(result.stdout).toContain("--description");
+    expect(result.stderr).toBe("");
+  });
+
+  test("cloud host requires an API key", async ({ librettoCli }) => {
+    const result = await librettoCli("cloud host testWorkflow", {
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to publish a Libretto Cloud hosted workflow.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
+  });
+
+  test("prints cloud unhost help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud unhost");
+    expect(result.stdout).toContain(
+      "Remove a workflow from public hosted workflows",
+    );
+    expect(result.stdout).toContain("libretto cloud unhost <workflow>");
+    expect(result.stderr).toBe("");
+  });
+
   test("prints deploy help with auto repair flag", async ({ librettoCli }) => {
     const result = await librettoCli("help cloud deploy", {
       npm_command: undefined,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -425,7 +425,7 @@ describe("basic CLI subprocess behavior", () => {
   test("prints cloud share help", async ({ librettoCli }) => {
     const result = await librettoCli("help cloud share");
     expect(result.stdout).toContain(
-      "Share one hosted workflow's code publicly",
+      "Share one workflow's source as a public open workflow",
     );
     expect(result.stdout).toContain("libretto cloud share <workflow>");
     expect(result.stdout).toContain("--refresh");


### PR DESCRIPTION
## Summary
- Rename the website Marketplace SPA to **Open workflows** (`/open-workflows`), including API fetches (`/open-workflows`, `/v1/openWorkflows/import`), copy, and Fathom event naming
- Keep `/marketplace` (+ `/$id`) as client redirects and add Vercel permanent redirects
- Update CLI share output to `open_workflow_url` / `Open workflow URL:`, plus the workflow-sharing skill note distinguishing open vs hosted workflows
- Document Open workflows and Hosted workflows under Libretto Cloud API, and link them from the API/hosting overviews

Companion cloud API rename: https://github.com/saffron-health/libretto-cloud/pull/246

## Test plan
- [x] `pnpm --filter @libretto/website type-check`
- [x] Grep leftovers: only intentional `/marketplace` redirects + docs mention of redirects (ignore generic English in `start.md`/blog)
- [ ] Spot-check `/open-workflows` and `/marketplace` → redirect in website preview
- [ ] Confirm `npx libretto help cloud share` shows open-workflow wording after package build

Made with [Cursor](https://cursor.com)