### PR TITLE
Add subtle Backed by Y Combinator badge to homepage hero

### DIFF
--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -17,6 +17,8 @@ import { Footer } from "./components/Footer";
 import { VersionBadge } from "./components/VersionBadge";
 import { ProductListing } from "./components/ProductListing";
 import { SectionDivider } from "./components/SectionDivider.js";
+import { BackedByYC } from "./components/BackedByYC";
+
 function Hero({
   paneUnlocked,
   onClosePane,
@@ -46,8 +48,12 @@ function Hero({
         />
       </div>
       <div className="relative mx-auto max-w-[1200px]">
-        <div data-animate={AnimationTarget.Navbar} style={{ opacity: 0 }}>
-          <VersionBadge />
+        <div
+          data-animate={AnimationTarget.Navbar}
+          style={{ opacity: 0 }}
+          className="mb-8 flex justify-center"
+        >
+          <BackedByYC variant="badge" fathomEvent="Hero YC click" />
         </div>
         <div
           data-animate={AnimationTarget.AsciiLogo}
@@ -98,6 +104,9 @@ function Hero({
             >
               TALK TO A DEV
             </a>
+          </div>
+          <div className="mt-2">
+            <VersionBadge />
           </div>
         </div>
       </div>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -53,7 +53,7 @@ function Hero({
           style={{ opacity: 0 }}
           className="mb-8 flex justify-center"
         >
-          <BackedByYC variant="badge" fathomEvent="Hero YC click" />
+          <VersionBadge />
         </div>
         <div
           data-animate={AnimationTarget.AsciiLogo}
@@ -105,8 +105,8 @@ function Hero({
               TALK TO A DEV
             </a>
           </div>
-          <div className="mt-2">
-            <VersionBadge />
+          <div className="mt-10">
+            <BackedByYC variant="badge" fathomEvent="Hero YC click" />
           </div>
         </div>
       </div>

--- a/apps/website/src/components/BackedByYC.tsx
+++ b/apps/website/src/components/BackedByYC.tsx
@@ -20,13 +20,37 @@ function ExternalArrowIcon({ className }: { className?: string }) {
   );
 }
 
+/** `badge` is the prominent hero lockup; `credit` is the compact footer mark. */
 export function BackedByYC({
   className = "",
   fathomEvent,
+  variant = "credit",
 }: {
   className?: string;
   fathomEvent: string;
+  variant?: "badge" | "credit";
 }) {
+  if (variant === "badge") {
+    return (
+      <a
+        href={YC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`inline-flex items-center gap-3.5 border border-ink/15 bg-panel/80 px-5 py-3 font-mono text-sm tracking-[0.02em] text-muted no-underline backdrop-blur-sm transition-colors hover:border-ink/30 hover:text-ink sm:gap-4 sm:px-6 sm:py-3.5 sm:text-base ${className}`}
+        data-fathom-event={fathomEvent}
+      >
+        <YCLogo
+          className="size-7 shrink-0 sm:size-8"
+          width={32}
+          height={32}
+        />
+        <span className="leading-none">
+          Backed by <span className="text-ink">Y Combinator</span>
+        </span>
+      </a>
+    );
+  }
+
   return (
     <a
       href={YC_URL}

--- a/apps/website/src/components/BackedByYC.tsx
+++ b/apps/website/src/components/BackedByYC.tsx
@@ -36,16 +36,12 @@ export function BackedByYC({
         href={YC_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className={`inline-flex items-center gap-3.5 border border-ink/15 bg-panel/80 px-5 py-3 font-mono text-sm tracking-[0.02em] text-muted no-underline backdrop-blur-sm transition-colors hover:border-ink/30 hover:text-ink sm:gap-4 sm:px-6 sm:py-3.5 sm:text-base ${className}`}
+        className={`inline-flex items-center gap-2 font-mono text-xs text-muted/60 no-underline transition-colors hover:text-muted sm:text-[13px] ${className}`}
         data-fathom-event={fathomEvent}
       >
-        <YCLogo
-          className="size-7 shrink-0 sm:size-8"
-          width={32}
-          height={32}
-        />
+        <YCLogo className="size-4 shrink-0 sm:size-[18px]" width={18} height={18} />
         <span className="leading-none">
-          Backed by <span className="text-ink">Y Combinator</span>
+          Backed by Y Combinator
         </span>
       </a>
     );

--- a/apps/website/src/components/Navbar.tsx
+++ b/apps/website/src/components/Navbar.tsx
@@ -9,9 +9,9 @@ import {
 } from "react-aria-components";
 import { Text } from "./Text";
 import { Button } from "./Button";
-import { GitHubStarIcon, YCLogo } from "../icons";
+import { GitHubStarIcon } from "../icons";
 import { AnimationTarget } from "./AnimationOrchestration";
-import { RELEASES_URL, REPO_URL, YC_URL } from "../site";
+import { RELEASES_URL, REPO_URL } from "../site";
 import { MobileMenu } from "./MobileMenu";
 import { LibrettoLogoAndName } from "../brand.js";
 import { getCloudSession, type CloudSession } from "../cloudApi";
@@ -132,21 +132,6 @@ function GlitchNavLink({
         </Text>
         {trailingIcon && <ExternalIcon />}
       </span>
-    </a>
-  );
-}
-
-function YCNavLink() {
-  return (
-    <a
-      href={YC_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="hidden h-[1.9375rem] items-center gap-1.5 text-ink/70 no-underline transition-colors hover:text-ink lg:flex"
-      data-fathom-event="Nav YC click"
-    >
-      <YCLogo className="size-3.5 shrink-0" />
-      <span className="text-sm font-medium">P26</span>
     </a>
   );
 }
@@ -422,7 +407,6 @@ export function Navbar({ animate = false }: { animate?: boolean }) {
           </div>
         </div>
         <div className="flex items-center gap-3 md:gap-4">
-          <YCNavLink />
           <a
             href={REPO_URL}
             target="_blank"

--- a/apps/website/src/components/VersionBadge.tsx
+++ b/apps/website/src/components/VersionBadge.tsx
@@ -74,11 +74,11 @@ export function VersionBadge() {
   const release = useLatestRelease("saffron-health/libretto");
 
   if (release === null) {
-    return <div className="mb-8 h-[26px]" />;
+    return <div className="h-[26px]" />;
   }
 
   return (
-    <div className="mb-8 flex items-center justify-center">
+    <div className="flex items-center justify-center">
       <a
         href={release.url}
         target="_blank"


### PR DESCRIPTION
## Summary
- Keep the package release pill at the top of the homepage hero
- Add a subtle **Backed by Y Combinator** lockup below Talk to a Dev
- Remove the navbar P26 link (footer Backed by YC credit remains)

## Test plan
- [x] Local website preview at `/` shows version pill above logo
- [x] YC lockup appears below Talk to a Dev with muted styling
- [x] Navbar no longer shows P26