### PR TITLE
Add hosted workflow publishing commands

### DIFF
--- a/docs/libretto-cloud-api/hosted-workflows.mdx
+++ b/docs/libretto-cloud-api/hosted-workflows.mdx
@@ -11,7 +11,18 @@ This is different from [open workflows](/libretto-cloud-api/open-workflows), whi
 
 ### Publisher: host and unhost
 
-These routes require `x-api-key`. The tenant must have an organization slug.
+These routes require `x-api-key`. The tenant must have an organization slug and workflow sharing must be enabled:
+
+```bash
+libretto cloud sharing enable
+```
+
+Publish and remove a Hosted workflow from the CLI:
+
+```bash
+libretto cloud host dailyReport --description "Generate the daily report"
+libretto cloud unhost dailyReport
+```
 
 #### POST `/v1/workflows/host`
 
@@ -71,7 +82,7 @@ Start a consumer-owned job against the publisher's pinned deployment.
 Request body fields (JSON, not ORPC `{ "json": ... }` wrapping):
 
 - `params`: workflow input object
-- `credential_id`: optional single credential id
+- `credentials`: optional map from each required credential name to a credential id or secret name in the consumer tenant
 - `nonce`: optional idempotency-style nonce
 - `timeout_seconds`: optional timeout
 - `headless`, `start_url`, `gpu`, `viewport`, `residential_proxy`: optional launch overrides
@@ -86,7 +97,8 @@ Callback rules:
 Credentials:
 
 - Create credentials in **your** tenant with the exact names listed in `credential_requirements` before running.
-- The publisher cannot list your jobs or read your credential values.
+- The publisher can see only when an external run started and whether it succeeded, failed, was cancelled, or is still in progress.
+- The publisher cannot see your identity, inputs, credentials, outputs, errors, or job details.
 
 Response fields:
 

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -56,7 +56,7 @@ This section documents the public `/v1/*` routes exposed by Libretto Cloud in th
     Upload bundles, build workflows, and inspect workflow state.
   </Card>
 
-  <Card title="Open workflows" icon="share-2" href="/libretto-cloud-api/open-workflows">
+  <Card title="Open workflows" icon="share" href="/libretto-cloud-api/open-workflows">
     Publish and import public workflow source.
   </Card>
 

--- a/packages/libretto/src/cli/commands/cloud-settings.ts
+++ b/packages/libretto/src/cli/commands/cloud-settings.ts
@@ -10,7 +10,6 @@ type TenantSettingsResponse = {
 };
 
 type TenantSettingsInput = {
-  code_sharing_enabled?: boolean;
   disable_job_failure_notifications?: boolean;
 };
 
@@ -25,7 +24,7 @@ function printTenantSettings(
 ): TenantSettingsResponse {
   const notificationsEnabled = !settings.disable_job_failure_notifications;
   console.log(
-    `Code sharing: ${settings.code_sharing_enabled ? "enabled" : "disabled"}`,
+    `Workflow sharing: ${settings.code_sharing_enabled ? "enabled" : "disabled"}`,
   );
   console.log(
     `Job failure notifications: ${notificationsEnabled ? "enabled" : "disabled"}`,
@@ -62,9 +61,6 @@ export const setSettingsCommand = SimpleCLI.command({
     SimpleCLI.input({
       positionals: [],
       named: {
-        codeSharing: SimpleCLI.option(settingState.optional(), {
-          help: "Set tenant code sharing: enabled or disabled",
-        }),
         jobFailureNotifications: SimpleCLI.option(settingState.optional(), {
           help: "Set hosted job failure notification emails: enabled or disabled",
         }),
@@ -74,9 +70,6 @@ export const setSettingsCommand = SimpleCLI.command({
   .use(withCloudApiKey("manage Libretto Cloud settings"))
   .handle(async ({ input, ctx }) => {
     const updates: TenantSettingsInput = {};
-    if (input.codeSharing !== undefined) {
-      updates.code_sharing_enabled = toBoolean(input.codeSharing);
-    }
     if (input.jobFailureNotifications !== undefined) {
       updates.disable_job_failure_notifications = !toBoolean(
         input.jobFailureNotifications,
@@ -85,7 +78,7 @@ export const setSettingsCommand = SimpleCLI.command({
 
     if (Object.keys(updates).length === 0) {
       throw new Error(
-        "No settings provided. Use one or more flags, for example `libretto cloud settings set --code-sharing enabled --job-failure-notifications disabled`.",
+        "No settings provided. For example, use `libretto cloud settings set --job-failure-notifications disabled`. Use `libretto cloud sharing enable` or `disable` to change workflow sharing.",
       );
     }
 

--- a/packages/libretto/src/cli/commands/cloud-sharing.ts
+++ b/packages/libretto/src/cli/commands/cloud-sharing.ts
@@ -15,6 +15,18 @@ type ShareWorkflowResponse = {
   code_url: string;
 };
 
+type HostWorkflowResponse = {
+  hosted_workflow: string;
+  page_url: string;
+  deployment_version: number;
+  status: "created" | "updated";
+};
+
+type UnhostWorkflowResponse = {
+  hosted_workflow: string;
+  notified_consumers: number;
+};
+
 export const shareWorkflowCommand = SimpleCLI.command({
   description: "Share one workflow's source as a public open workflow",
 })
@@ -55,8 +67,66 @@ export const shareWorkflowCommand = SimpleCLI.command({
     return response.open_workflow_url;
   });
 
+export const hostWorkflowCommand = SimpleCLI.command({
+  description: "Publish a deployed workflow as a public hosted workflow",
+})
+  .input(SimpleCLI.input({
+    positionals: [
+      SimpleCLI.positional("workflow", z.string().min(1), {
+        help: "Deployed workflow name to publish as a hosted workflow",
+      }),
+    ],
+    named: {
+      description: SimpleCLI.option(z.string().optional(), {
+        help: "Public description for the hosted workflow",
+      }),
+    },
+  }))
+  .use(withCloudApiKey("publish a Libretto Cloud hosted workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await orpcCall<HostWorkflowResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/workflows/host",
+      input: {
+        workflow: input.workflow,
+        description: input.description,
+      },
+      credential: ctx.credential,
+    });
+    console.log(
+      `${response.status === "created" ? "Published" : "Updated"} hosted workflow: ${response.hosted_workflow}`,
+    );
+    console.log(`Page URL: ${response.page_url}`);
+    console.log(`Deployment version: ${response.deployment_version}`);
+    return response.page_url;
+  });
+
+export const unhostWorkflowCommand = SimpleCLI.command({
+  description: "Remove a workflow from public hosted workflows",
+})
+  .input(SimpleCLI.input({
+    positionals: [
+      SimpleCLI.positional("workflow", z.string().min(1), {
+        help: "Deployed workflow name to unhost",
+      }),
+    ],
+    named: {},
+  }))
+  .use(withCloudApiKey("unhost a Libretto Cloud hosted workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await orpcCall<UnhostWorkflowResponse>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/workflows/unhost",
+      input: { workflow: input.workflow },
+      credential: ctx.credential,
+    });
+    console.log(`Unhosted workflow: ${response.hosted_workflow}`);
+    console.log(`Notified consumers: ${response.notified_consumers}`);
+    return response.hosted_workflow;
+  });
+
 export const codeSharingStatusCommand = SimpleCLI.command({
-  description: "Show whether tenant code sharing is enabled",
+  description: "Show whether tenant workflow sharing is enabled",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
@@ -67,7 +137,7 @@ export const codeSharingStatusCommand = SimpleCLI.command({
       input: {},
       credential: ctx.credential,
     });
-    console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+    console.log(`Workflow sharing: ${response.enabled ? "enabled" : "disabled"}`);
     return response.enabled;
   });
 
@@ -81,26 +151,26 @@ async function updateCodeSharing(
     input: { enabled },
     credential: ctx.credential,
   });
-  console.log(`Code sharing: ${response.enabled ? "enabled" : "disabled"}`);
+  console.log(`Workflow sharing: ${response.enabled ? "enabled" : "disabled"}`);
   return response.enabled;
 }
 
 export const enableCodeSharingCommand = SimpleCLI.command({
-  description: "Enable public workflow code sharing for this tenant",
+  description: "Enable public workflow sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
   .handle(async ({ ctx }) => updateCodeSharing(true, ctx));
 
 export const disableCodeSharingCommand = SimpleCLI.command({
-  description: "Disable public workflow code sharing for this tenant",
+  description: "Disable public workflow sharing for this tenant",
 })
   .input(SimpleCLI.input({ positionals: [], named: {} }))
   .use(withCloudApiKey("manage tenant workflow code sharing"))
   .handle(async ({ ctx }) => updateCodeSharing(false, ctx));
 
 export const codeSharingCommands = SimpleCLI.group({
-  description: "Manage tenant workflow code sharing",
+  description: "Manage tenant workflow sharing",
   routes: {
     status: codeSharingStatusCommand,
     enable: enableCodeSharingCommand,

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -5,7 +5,12 @@ import { cloudCredentialCommands } from "./commands/cloud-credentials.js";
 import { cloudJobCommands } from "./commands/cloud-jobs.js";
 import { cloudScheduleCommands } from "./commands/cloud-schedules.js";
 import { settingsCommands } from "./commands/cloud-settings.js";
-import { codeSharingCommands, shareWorkflowCommand } from "./commands/cloud-sharing.js";
+import {
+  codeSharingCommands,
+  hostWorkflowCommand,
+  shareWorkflowCommand,
+  unhostWorkflowCommand,
+} from "./commands/cloud-sharing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
 import { experimentsCommand } from "./commands/experiments.js";
@@ -33,6 +38,8 @@ export const cliRoutes = {
       schedules: cloudScheduleCommands,
       settings: settingsCommands,
       share: shareWorkflowCommand,
+      host: hostWorkflowCommand,
+      unhost: unhostWorkflowCommand,
       sharing: codeSharingCommands,
     },
   }),

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -443,6 +443,36 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stderr).toContain("libretto cloud auth api-key issue");
   });
 
+  test("prints cloud host help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud host");
+    expect(result.stdout).toContain(
+      "Publish a deployed workflow as a public hosted workflow",
+    );
+    expect(result.stdout).toContain("libretto cloud host <workflow>");
+    expect(result.stdout).toContain("--description");
+    expect(result.stderr).toBe("");
+  });
+
+  test("cloud host requires an API key", async ({ librettoCli }) => {
+    const result = await librettoCli("cloud host testWorkflow", {
+      LIBRETTO_API_KEY: undefined,
+    });
+
+    expect(result.stderr).toContain(
+      "LIBRETTO_API_KEY is required to publish a Libretto Cloud hosted workflow.",
+    );
+    expect(result.stderr).toContain("libretto cloud auth api-key issue");
+  });
+
+  test("prints cloud unhost help", async ({ librettoCli }) => {
+    const result = await librettoCli("help cloud unhost");
+    expect(result.stdout).toContain(
+      "Remove a workflow from public hosted workflows",
+    );
+    expect(result.stdout).toContain("libretto cloud unhost <workflow>");
+    expect(result.stderr).toBe("");
+  });
+
   test("prints deploy help with auto repair flag", async ({ librettoCli }) => {
     const result = await librettoCli("help cloud deploy", {
       npm_command: undefined,


### PR DESCRIPTION
## Summary
- add libretto cloud host and cloud unhost commands
- make workflow sharing labels cover both Open and Hosted workflows
- keep workflow-sharing mutation on the dedicated owner-checked command path
- document the sharing prerequisite and publisher-visible run telemetry
- fix PR #547 docs icon resolution

## Tests
- Libretto type-check and build
- focused CLI help and API-key tests

Stacked on PR #547. Cloud API support is in saffron-health/libretto-cloud#250 and #251.