### PR TITLE
Add workflow publishing dashboard

### DIFF
--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -428,15 +428,19 @@ function ProfileMenu({
   );
 }
 
-function DashboardShell({
+export function DashboardShell({
   section,
   session,
   action,
+  title,
+  description,
   children,
 }: {
   section: DashboardSection;
   session: CloudSession;
   action?: ReactNode;
+  title?: string;
+  description?: string;
   children: ReactNode;
 }) {
   const meta = sectionMeta[section];
@@ -507,10 +511,10 @@ function DashboardShell({
           <div className="mb-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <h1 className="font-serif text-[36px] font-[300] tracking-[-0.025em] md:text-[44px]">
-                {meta.title}
+                {title ?? meta.title}
               </h1>
               <p className="mt-2 text-sm leading-6 text-muted">
-                {meta.description}
+                {description ?? meta.description}
               </p>
             </div>
             {action}
@@ -578,7 +582,16 @@ function WorkflowsTable() {
                 className="hover:bg-panel-hi/35"
               >
                 <td className={`${tdClass} font-medium text-ink`}>
-                  {build ? row.workflow_name || "New workflow" : row.name}
+                  {build ? (
+                    row.workflow_name || "New workflow"
+                  ) : (
+                    <a
+                      href={`/dashboard/workflows/${encodeURIComponent(row.name)}`}
+                      className="text-ink underline decoration-rule underline-offset-4 hover:decoration-accent"
+                    >
+                      {row.name}
+                    </a>
+                  )}
                 </td>
                 <td className={tdClass}>
                   <StatusBadge
@@ -1933,7 +1946,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
     if (
       !enabled &&
       !window.confirm(
-        "Disable public workflow sharing? Every workflow from this workspace will be removed from Open workflows. Re-enabling sharing will not republish them automatically.",
+        "Disable public workflow sharing? Every Open and Hosted workflow from this workspace will be removed. Re-enabling sharing will not republish them automatically.",
       )
     ) {
       return;
@@ -1951,7 +1964,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       setNotice(
         enabled
           ? "Workflow sharing is enabled. Workflows remain private until someone explicitly shares them."
-          : "Workflow sharing is disabled and existing Open workflows listings were unpublished.",
+          : "Workflow sharing is disabled and existing Open and Hosted workflows were unpublished.",
       );
     } catch (err) {
       setError(
@@ -1993,9 +2006,9 @@ function SettingsPanel({ session }: { session: CloudSession }) {
               id="workflow-sharing-description"
               className="mt-2 max-w-2xl text-sm leading-6 text-muted"
             >
-              Allow people in this workspace to publish workflow source code
-              to Open workflows. Credentials, run history, and per-run
-              parameters are never included.
+              Allow people in this workspace to publish Open workflows with
+              source or Hosted workflows with an opaque run API. Credentials,
+              inputs, and outputs are never included in publisher telemetry.
             </p>
           </div>
           <button

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -2009,7 +2009,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
               id="workflow-sharing-description"
               className="mt-2 max-w-2xl text-sm leading-6 text-muted"
             >
-              Allow people in this workspace to publish Open workflows with
+              Allow people in this workspace to publish open source workflows with
               source or Hosted workflows with an opaque run API. Credentials,
               inputs, and outputs are never included in publisher telemetry.
             </p>

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -549,11 +549,14 @@ function WorkflowsTable() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     orpcCall<{
-      deployed_workflows: WorkflowRow[];
-      in_progress_builds: WorkflowBuildRow[];
+      deployed_workflows?: WorkflowRow[];
+      in_progress_builds?: WorkflowBuildRow[];
     }>("/v1/workflows/list")
       .then((result) =>
-        setRows([...result.in_progress_builds, ...result.deployed_workflows]),
+        setRows([
+          ...(result.in_progress_builds ?? []),
+          ...(result.deployed_workflows ?? []),
+        ]),
       )
       .catch((err) =>
         setError(

--- a/apps/website/src/OpenWorkflowsPage.tsx
+++ b/apps/website/src/OpenWorkflowsPage.tsx
@@ -135,7 +135,7 @@ export function OpenWorkflowsPage() {
           size="xs"
           className="mb-4 uppercase tracking-[0.18em] text-accent"
         >
-          Open workflows
+          Open source workflows
         </Text>
         <Text
           as="h1"
@@ -461,7 +461,7 @@ export function OpenWorkflowPage({ shareId }: { shareId: string }) {
         href="/open-workflows"
         className="inline-flex pt-4 font-mono text-xs text-muted no-underline transition hover:text-ink"
       >
-        ← Open workflows
+        ← Open source workflows
       </a>
 
       <header className="mt-8">

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useState } from "react";
+import {
+  getAuthStatus,
+  getCloudSession,
+  orpcCall,
+  type CloudSession,
+} from "./cloudApi";
+import { DashboardShell } from "./AuthenticatedDashboardPage";
+
+type Publication = {
+  description: string | null;
+  stale: boolean;
+};
+
+type WorkflowDetail = {
+  workflow: string;
+  deployment_status: "building" | "ready" | "failed";
+  updated_at: string;
+  sharing_enabled: boolean;
+  open_workflow: (Publication & {
+    open_workflow_url: string;
+  }) | null;
+  hosted_workflow: (Publication & {
+    page_url: string;
+  }) | null;
+};
+
+type RunSummary = {
+  has_publication_history: boolean;
+  metrics: {
+    runs_last_30_days: number;
+    succeeded_last_30_days: number;
+    failed_last_30_days: number;
+  };
+  runs: Array<{
+    ran_at: string;
+    outcome: "succeeded" | "failed" | "in_progress" | "cancelled";
+  }>;
+};
+
+type PrivacyFinding = {
+  file: string;
+  line: number | null;
+  explanation: string;
+};
+
+type ShareResponse =
+  | { status: "created" | "existing" | "refreshed" }
+  | {
+      status: "needs_review" | "blocked";
+      review_id: string;
+      findings: PrivacyFinding[];
+    }
+  | { status: "review_expired" };
+
+const cardClass =
+  "rounded-xl border border-rule bg-panel/65 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.16)] sm:p-6";
+const buttonClass =
+  "libretto-button libretto-button--default inline-flex h-10 items-center justify-center disabled:cursor-not-allowed disabled:opacity-50";
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export function WorkflowDetailPage({ workflow }: { workflow: string }) {
+  const [session, setSession] = useState<CloudSession | null>(null);
+  const [detail, setDetail] = useState<WorkflowDetail | null>(null);
+  const [runs, setRuns] = useState<RunSummary | null>(null);
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function refresh() {
+    const [nextDetail, nextRuns] = await Promise.all([
+      orpcCall<WorkflowDetail>("/v1/workflows/get", { workflow }),
+      orpcCall<RunSummary>("/v1/workflows/hostedRuns", {
+        workflow,
+        limit: 100,
+      }),
+    ]);
+    setDetail(nextDetail);
+    setRuns(nextRuns);
+    setDescription(nextDetail.hosted_workflow?.description ?? "");
+  }
+
+  useEffect(() => {
+    getCloudSession()
+      .then(async (nextSession) => {
+        if (!nextSession) {
+          window.location.assign("/signin");
+          return;
+        }
+        const status = await getAuthStatus();
+        if (!status.hasTenant) {
+          window.location.assign("/onboarding?product=chrome-extension");
+          return;
+        }
+        setSession(nextSession);
+        await refresh();
+      })
+      .catch((cause) =>
+        setError(
+          cause instanceof Error ? cause.message : "Could not load workflow.",
+        ),
+      );
+  }, [workflow]);
+
+  async function runAction(name: string, action: () => Promise<void>) {
+    setBusy(name);
+    setError(null);
+    setNotice(null);
+    try {
+      await action();
+      await refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Action failed.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function shareOpen(acknowledgement?: {
+    reviewId: string;
+    acknowledgeWarnings: boolean;
+  }): Promise<void> {
+    const response = await orpcCall<ShareResponse>("/v1/workflows/share", {
+      workflow,
+      refresh: Boolean(detail?.open_workflow),
+      privacyReview: {
+        capability: "workflow_privacy_review_v1",
+        ...(acknowledgement
+          ? {
+              reviewId: acknowledgement.reviewId,
+              acknowledgeWarnings: acknowledgement.acknowledgeWarnings,
+            }
+          : {}),
+      },
+    });
+    if (!("findings" in response) && response.status !== "review_expired") {
+      setNotice("Open workflow published.");
+      return;
+    }
+    if (response.status === "review_expired") {
+      throw new Error("The privacy review expired. Publish again to rerun it.");
+    }
+    if (!("findings" in response)) return;
+    const findings = response.findings
+      .map(
+        (finding) =>
+          `${finding.file}${finding.line ? `:${finding.line}` : ""}: ${finding.explanation}`,
+      )
+      .join("\n");
+    if (response.status === "blocked") {
+      throw new Error(`Publishing is blocked by the privacy review:\n${findings}`);
+    }
+    if (
+      window.confirm(
+        `The privacy review found warnings:\n\n${findings}\n\nPublish anyway?`,
+      )
+    ) {
+      await shareOpen({
+        reviewId: response.review_id,
+        acknowledgeWarnings: true,
+      });
+    }
+  }
+
+  if (!session || !detail) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-bg px-6 text-sm text-muted">
+        {error ?? "Loading workflow…"}
+      </div>
+    );
+  }
+
+  const canPublish =
+    detail.sharing_enabled && detail.deployment_status === "ready";
+  return (
+    <DashboardShell
+      section="workflows"
+      session={session}
+      title={detail.workflow}
+      description={`Updated ${formatDate(detail.updated_at)}`}
+      action={
+        <a
+          href="/dashboard/workflows"
+          className="libretto-button inline-flex h-10 items-center no-underline"
+        >
+          Back to workflows
+        </a>
+      }
+    >
+      <div className="space-y-6">
+        {error && (
+          <p className="whitespace-pre-wrap rounded-md border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </p>
+        )}
+        {notice && (
+          <p className="rounded-md border border-accent/30 bg-green-9/10 px-4 py-3 text-sm text-accent-bright">
+            {notice}
+          </p>
+        )}
+        {!detail.sharing_enabled && (
+          <p className="rounded-md border border-amber-300/30 bg-amber-300/10 px-4 py-3 text-sm text-amber-100">
+            Workflow sharing is disabled. A workspace owner can enable it in{" "}
+            <a href="/dashboard/settings" className="underline">
+              Settings
+            </a>
+            .
+          </p>
+        )}
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <section className={cardClass}>
+            <h2 className="text-lg font-medium text-ink">Open workflow</h2>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Publish source that other users can inspect and import.
+            </p>
+            {detail.open_workflow && (
+              <p className="mt-3 text-xs text-muted">
+                {detail.open_workflow.stale
+                  ? "A newer deployment is available."
+                  : "Published from the current workflow."}
+              </p>
+            )}
+            <div className="mt-5 flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={!canPublish || busy !== null}
+                onClick={() =>
+                  void runAction("open", async () => shareOpen())
+                }
+                className={buttonClass}
+              >
+                {busy === "open"
+                  ? "Publishing…"
+                  : detail.open_workflow
+                    ? "Refresh"
+                    : "Publish"}
+              </button>
+              {detail.open_workflow && (
+                <>
+                  <a
+                    href={detail.open_workflow.open_workflow_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="libretto-button inline-flex h-10 items-center no-underline"
+                  >
+                    View
+                  </a>
+                  <button
+                    type="button"
+                    disabled={busy !== null}
+                    onClick={() => {
+                      if (!window.confirm("Remove this Open workflow?")) return;
+                      void runAction("unshare", async () => {
+                        await orpcCall("/v1/workflows/unshare", { workflow });
+                        setNotice("Open workflow removed.");
+                      });
+                    }}
+                    className="libretto-button h-10"
+                  >
+                    Remove
+                  </button>
+                </>
+              )}
+            </div>
+          </section>
+
+          <section className={cardClass}>
+            <h2 className="text-lg font-medium text-ink">Hosted workflow</h2>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Publish an opaque API that external users run with their own
+              credentials.
+            </p>
+            <label className="mt-4 block text-xs text-muted">
+              Public description
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={2000}
+                rows={3}
+                className="mt-2 w-full rounded-md border border-rule bg-bg px-3 py-2 text-sm text-ink outline-none focus:border-accent/50"
+              />
+            </label>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={!canPublish || busy !== null}
+                onClick={() =>
+                  void runAction("host", async () => {
+                    await orpcCall("/v1/workflows/host", {
+                      workflow,
+                      description: description.trim() || undefined,
+                    });
+                    setNotice("Hosted workflow published.");
+                  })
+                }
+                className={buttonClass}
+              >
+                {busy === "host"
+                  ? "Publishing…"
+                  : detail.hosted_workflow
+                    ? "Update"
+                    : "Publish"}
+              </button>
+              {detail.hosted_workflow && (
+                <>
+                  <a
+                    href={detail.hosted_workflow.page_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="libretto-button inline-flex h-10 items-center no-underline"
+                  >
+                    View
+                  </a>
+                  <button
+                    type="button"
+                    disabled={busy !== null}
+                    onClick={() => {
+                      if (!window.confirm("Unhost this workflow?")) return;
+                      void runAction("unhost", async () => {
+                        await orpcCall("/v1/workflows/unhost", { workflow });
+                        setNotice("Hosted workflow removed.");
+                      });
+                    }}
+                    className="libretto-button h-10"
+                  >
+                    Unhost
+                  </button>
+                </>
+              )}
+            </div>
+          </section>
+        </div>
+
+        {runs?.has_publication_history && (
+          <section className={cardClass}>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-lg font-medium text-ink">
+                  External Hosted runs
+                </h2>
+                <p className="mt-1 text-sm text-muted">
+                  Times and outcomes only. Consumer identity and run data stay
+                  private.
+                </p>
+              </div>
+              <div className="grid grid-cols-3 gap-3 text-center">
+                {[
+                  ["30-day runs", runs.metrics.runs_last_30_days],
+                  ["Succeeded", runs.metrics.succeeded_last_30_days],
+                  ["Failed", runs.metrics.failed_last_30_days],
+                ].map(([label, value]) => (
+                  <div key={label} className="rounded-md border border-rule px-3 py-2">
+                    <p className="text-lg text-ink">{value}</p>
+                    <p className="text-[10px] uppercase tracking-wide text-muted">
+                      {label}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="mt-5 overflow-x-auto">
+              <table className="w-full min-w-[520px] border-collapse">
+                <thead>
+                  <tr>
+                    <th className="border-b border-rule px-3 py-2 text-left text-xs text-muted">
+                      Ran at
+                    </th>
+                    <th className="border-b border-rule px-3 py-2 text-left text-xs text-muted">
+                      Outcome
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {runs.runs.map((run, index) => (
+                    <tr key={`${run.ran_at}-${index}`}>
+                      <td className="border-b border-rule px-3 py-3 text-sm text-muted">
+                        {formatDate(run.ran_at)}
+                      </td>
+                      <td className="border-b border-rule px-3 py-3 text-sm text-ink">
+                        {run.outcome.replace("_", " ")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {runs.runs.length === 0 && (
+                <p className="py-6 text-center text-sm text-muted">
+                  No external runs yet.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </DashboardShell>
+  );
+}

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -374,9 +374,6 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
               <div className="flex items-center gap-3">
                 <div>
                   <h2 className="text-base font-medium text-ink">Open workflow</h2>
-                  <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
-                    Source code
-                  </p>
                 </div>
                 <span
                   className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
@@ -434,9 +431,6 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
               <div className="flex items-center gap-3">
                 <div>
                   <h2 className="text-base font-medium text-ink">Hosted workflow</h2>
-                  <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
-                    Runnable API
-                  </p>
                 </div>
                 <span
                   className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
@@ -528,7 +522,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   Make workflow publicly available
                 </span>
                 <span className="mt-1 block text-xs text-muted">
-                  Share its source or publish a runnable API.
+                  Choose how others can use it.
                 </span>
               </span>
               <span className="text-xs text-muted" aria-hidden>
@@ -551,7 +545,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     <div className="rounded-lg border border-rule bg-bg/25 p-4">
                       <h3 className="text-sm font-medium text-ink">Open workflow</h3>
                       <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
-                        Publish source code others can inspect and import.
+                        Publish a version others can inspect and import.
                       </p>
                       <button
                         type="button"
@@ -569,7 +563,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     <div className="rounded-lg border border-rule bg-bg/25 p-4">
                       <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
                       <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
-                        Publish an API others can run without seeing the source.
+                        Publish a hosted version others can run.
                       </p>
                       <button
                         type="button"

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -488,9 +488,6 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     : "Redeploy"}
               </button>
             </div>
-            <div className="px-5 py-4">
-              <h3 className="text-sm font-medium text-ink">External runs</h3>
-            </div>
             <HostedRunsTable summary={hostedRuns} />
             <div className="flex justify-end border-t border-rule px-5 py-3">
               <button

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -59,6 +59,7 @@ type ShareResponse =
   | { status: "review_expired" };
 
 type RunTab = "workflow" | "hosted";
+type PublishingMode = "open" | "hosted" | null;
 
 const panelClass =
   "overflow-hidden rounded-xl border border-rule bg-panel/55 shadow-[0_12px_40px_rgba(0,0,0,0.14)]";
@@ -66,8 +67,6 @@ const primaryButtonClass =
   "inline-flex h-8 items-center justify-center rounded-md border border-accent/45 bg-green-9/55 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-ink transition-colors hover:bg-green-9/80 disabled:cursor-not-allowed disabled:opacity-40";
 const secondaryButtonClass =
   "inline-flex h-8 items-center justify-center rounded-md border border-rule bg-bg/35 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted no-underline transition-colors hover:border-accent/35 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40";
-const dangerButtonClass =
-  "inline-flex h-8 items-center justify-center rounded-md border border-red-400/20 bg-transparent px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-red-200 transition-colors hover:border-red-400/40 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-40";
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
@@ -224,6 +223,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
   const [activeTab, setActiveTab] = useState<RunTab>("workflow");
   const [publishingOpen, setPublishingOpen] = useState(false);
+  const [publishingMode, setPublishingMode] = useState<PublishingMode>(null);
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -435,152 +435,187 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           </button>
           {publishingOpen && (
             <div className="border-t border-rule">
-          {!detail.sharing_enabled && (
-            <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
-              Workflow sharing is disabled. A workspace owner can enable it in{" "}
-              <a href="/dashboard/settings" className="underline">
-                Settings
-              </a>
-              .
-            </div>
-          )}
-
-          <div className="divide-y divide-rule">
-            <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <div className="flex items-center gap-2">
-                  <h3 className="text-sm font-medium text-ink">Share source</h3>
-                  {detail.open_workflow && (
-                    <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                      {detail.open_workflow.stale ? "Older version live" : "Live"}
-                    </span>
-                  )}
+              {!detail.sharing_enabled && (
+                <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
+                  Publishing is disabled. Enable it in{" "}
+                  <a href="/dashboard/settings" className="underline">
+                    Settings
+                  </a>
+                  .
                 </div>
-                <p className="mt-1 text-xs text-muted">
-                  Let others inspect and import this workflow.
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {(!detail.open_workflow || detail.open_workflow.stale) && (
+              )}
+
+              <div className="grid gap-3 p-4 sm:grid-cols-2">
+                {([
+                  {
+                    mode: "open" as const,
+                    title: "Open workflow",
+                    kind: "Source code",
+                    publication: detail.open_workflow,
+                  },
+                  {
+                    mode: "hosted" as const,
+                    title: "Hosted workflow",
+                    kind: "Runnable API",
+                    publication: detail.hosted_workflow,
+                  },
+                ]).map((option) => (
                   <button
+                    key={option.mode}
                     type="button"
-                    disabled={!canPublish || busy !== null}
+                    aria-pressed={publishingMode === option.mode}
                     onClick={() =>
-                      void runAction("open", async () => shareOpen())
+                      setPublishingMode((current) =>
+                        current === option.mode ? null : option.mode,
+                      )
                     }
-                    className={primaryButtonClass}
+                    className={`flex items-center justify-between rounded-lg border px-4 py-4 text-left transition-colors ${
+                      publishingMode === option.mode
+                        ? "border-accent/45 bg-green-9/10"
+                        : "border-rule bg-bg/25 hover:border-accent/25 hover:bg-panel-hi/25"
+                    }`}
                   >
-                    {busy === "open"
-                      ? "Publishing…"
-                      : detail.open_workflow
-                        ? "Publish latest version"
-                        : "Share source"}
-                  </button>
-                )}
-                {detail.open_workflow && (
-                  <>
-                    <a
-                      href={detail.open_workflow.open_workflow_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className={secondaryButtonClass}
-                    >
-                      Open public page
-                    </a>
-                    <button
-                      type="button"
-                      disabled={busy !== null}
-                      onClick={() => {
-                        if (!window.confirm("Stop sharing this workflow's source?")) return;
-                        void runAction("unshare", async () => {
-                          await orpcCall("/v1/workflows/unshare", { workflow });
-                          setNotice("Source sharing stopped.");
-                        });
-                      }}
-                      className={dangerButtonClass}
-                    >
-                      Stop sharing
-                    </button>
-                  </>
-                )}
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-end lg:justify-between">
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <h3 className="text-sm font-medium text-ink">Host workflow</h3>
-                  {detail.hosted_workflow && (
-                    <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                      {detail.hosted_workflow.stale ? "Older version live" : "Live"}
+                    <span>
+                      <span className="block text-sm font-medium text-ink">
+                        {option.title}
+                      </span>
+                      <span className="mt-1 block text-[10px] uppercase tracking-[0.08em] text-muted">
+                        {option.kind}
+                      </span>
                     </span>
+                    <span className="flex items-center gap-3">
+                      <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                        {option.publication
+                          ? option.publication.stale
+                            ? "Older"
+                            : "Live"
+                          : "Off"}
+                      </span>
+                      <span aria-hidden className="text-muted">›</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              {publishingMode === "open" && (
+                <div className="border-t border-rule bg-bg/15">
+                  <div className="px-5 py-5">
+                    <h3 className="text-base font-medium text-ink">Open workflow</h3>
+                    {detail.open_workflow?.stale && (
+                      <p className="mt-1 text-xs text-muted">
+                        The public copy uses an older deployment.
+                      </p>
+                    )}
+                    {(!detail.open_workflow || detail.open_workflow.stale) && (
+                      <button
+                        type="button"
+                        disabled={!canPublish || busy !== null}
+                        onClick={() =>
+                          void runAction("open", async () => shareOpen())
+                        }
+                        className={`${primaryButtonClass} mt-5 min-w-44`}
+                      >
+                        {busy === "open"
+                          ? "Publishing…"
+                          : detail.open_workflow
+                            ? "Publish latest"
+                            : "Publish source"}
+                      </button>
+                    )}
+                  </div>
+                  {detail.open_workflow && (
+                    <div className="flex items-center justify-between border-t border-rule px-5 py-3 text-xs">
+                      <a
+                        href={detail.open_workflow.open_workflow_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-muted no-underline hover:text-ink"
+                      >
+                        Public page ↗
+                      </a>
+                      <button
+                        type="button"
+                        disabled={busy !== null}
+                        onClick={() => {
+                          if (!window.confirm("Stop sharing this workflow's source?")) return;
+                          void runAction("unshare", async () => {
+                            await orpcCall("/v1/workflows/unshare", { workflow });
+                            setNotice("Source sharing stopped.");
+                          });
+                        }}
+                        className="text-red-200/75 hover:text-red-200 disabled:opacity-40"
+                      >
+                        Stop sharing
+                      </button>
+                    </div>
                   )}
                 </div>
-                <p className="mt-1 text-xs text-muted">
-                  Let others run it without seeing the source.
-                </p>
-                <label className="mt-3 block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
-                  Public description
-                  <input
-                    value={description}
-                    onChange={(event) => setDescription(event.target.value)}
-                    maxLength={2000}
-                    className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
-                  />
-                </label>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  disabled={!canPublish || busy !== null}
-                  onClick={() =>
-                    void runAction("host", async () => {
-                      await orpcCall("/v1/workflows/host", {
-                        workflow,
-                        description: description.trim() || undefined,
-                      });
-                      setNotice("Hosted workflow published.");
-                    })
-                  }
-                  className={primaryButtonClass}
-                >
-                  {busy === "host"
-                    ? "Publishing…"
-                    : detail.hosted_workflow
-                      ? detail.hosted_workflow.stale
-                        ? "Publish latest version"
-                        : "Save changes"
-                      : "Host workflow"}
-                </button>
-                {detail.hosted_workflow && (
-                  <>
-                    <a
-                      href={detail.hosted_workflow.page_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className={secondaryButtonClass}
-                    >
-                      Open hosted page
-                    </a>
+              )}
+
+              {publishingMode === "hosted" && (
+                <div className="border-t border-rule bg-bg/15">
+                  <div className="px-5 py-5">
+                    <h3 className="text-base font-medium text-ink">Hosted workflow</h3>
+                    <label className="mt-4 block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
+                      Description
+                      <input
+                        value={description}
+                        onChange={(event) => setDescription(event.target.value)}
+                        maxLength={2000}
+                        className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                      />
+                    </label>
                     <button
                       type="button"
-                      disabled={busy !== null}
-                      onClick={() => {
-                        if (!window.confirm("Stop hosting this workflow?")) return;
-                        void runAction("unhost", async () => {
-                          await orpcCall("/v1/workflows/unhost", { workflow });
-                          setNotice("Hosted workflow removed.");
-                        });
-                      }}
-                      className={dangerButtonClass}
+                      disabled={!canPublish || busy !== null}
+                      onClick={() =>
+                        void runAction("host", async () => {
+                          await orpcCall("/v1/workflows/host", {
+                            workflow,
+                            description: description.trim() || undefined,
+                          });
+                          setNotice("Hosted workflow published.");
+                        })
+                      }
+                      className={`${primaryButtonClass} mt-4 min-w-44`}
                     >
-                      Stop hosting
+                      {busy === "host"
+                        ? "Publishing…"
+                        : detail.hosted_workflow?.stale
+                          ? "Publish latest"
+                          : detail.hosted_workflow
+                            ? "Save"
+                            : "Publish hosted"}
                     </button>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
+                  </div>
+                  {detail.hosted_workflow && (
+                    <div className="flex items-center justify-between border-t border-rule px-5 py-3 text-xs">
+                      <a
+                        href={detail.hosted_workflow.page_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-muted no-underline hover:text-ink"
+                      >
+                        Hosted page ↗
+                      </a>
+                      <button
+                        type="button"
+                        disabled={busy !== null}
+                        onClick={() => {
+                          if (!window.confirm("Stop hosting this workflow?")) return;
+                          void runAction("unhost", async () => {
+                            await orpcCall("/v1/workflows/unhost", { workflow });
+                            setNotice("Hosted workflow removed.");
+                          });
+                        }}
+                        className="text-red-200/75 hover:text-red-200 disabled:opacity-40"
+                      >
+                        Stop hosting
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </section>

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -499,7 +499,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           </section>
         )}
 
-        {(!detail.open_workflow || !detail.hosted_workflow) && (
+        {!hasPublicWorkflow && (
           <section className={panelClass}>
             <button
               type="button"
@@ -509,15 +509,11 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             >
               <span>
                 <span className="block text-sm font-medium text-ink">
-                  {hasPublicWorkflow
-                    ? "Add another public version"
-                    : "Make workflow publicly available"}
+                  Make workflow publicly available
                 </span>
-                {!hasPublicWorkflow && (
-                  <span className="mt-1 block text-xs text-muted">
-                    Share its source or publish a runnable API.
-                  </span>
-                )}
+                <span className="mt-1 block text-xs text-muted">
+                  Share its source or publish a runnable API.
+                </span>
               </span>
               <span className="text-xs text-muted" aria-hidden>
                 {publishingOpen ? "↑" : "↓"}

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -378,7 +378,13 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     Source code
                   </p>
                 </div>
-                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
+                    detail.open_workflow.stale
+                      ? "border-rule text-muted"
+                      : "border-accent/30 bg-green-9/10 text-accent-bright"
+                  }`}
+                >
                   {detail.open_workflow.stale ? "Older version" : "Live"}
                 </span>
               </div>
@@ -424,7 +430,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
 
         {detail.hosted_workflow && (
           <section className={panelClass}>
-            <div className="flex items-center justify-between gap-4 border-b border-rule px-5 py-4">
+            <div className="flex items-center justify-between gap-4 px-5 pb-2 pt-4">
               <div className="flex items-center gap-3">
                 <div>
                   <h2 className="text-base font-medium text-ink">Hosted workflow</h2>
@@ -432,7 +438,13 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     Runnable API
                   </p>
                 </div>
-                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
+                    detail.hosted_workflow.stale
+                      ? "border-rule text-muted"
+                      : "border-accent/30 bg-green-9/10 text-accent-bright"
+                  }`}
+                >
                   {detail.hosted_workflow.stale ? "Older version" : "Live"}
                 </span>
               </div>
@@ -470,7 +482,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 className={
                   detail.hosted_workflow.stale
                     ? primaryButtonClass
-                    : secondaryButtonClass
+                    : "inline-flex h-8 items-center justify-center rounded-md border border-accent/35 bg-green-9/10 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-accent-bright transition-colors hover:bg-green-9/25 disabled:cursor-not-allowed disabled:opacity-40"
                 }
               >
                 {busy === "host"
@@ -480,7 +492,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     : "Redeploy"}
               </button>
             </div>
-            <div className="border-t border-rule px-5 py-4">
+            <div className="px-5 py-4">
               <h3 className="text-sm font-medium text-ink">External runs</h3>
             </div>
             <HostedRunsTable summary={hostedRuns} />

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -296,7 +296,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       },
     });
     if (!("findings" in response) && response.status !== "review_expired") {
-      setNotice("Open workflow published.");
+      setNotice("Open source workflow published.");
       return;
     }
     if (response.status === "review_expired") {
@@ -373,7 +373,9 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
                 <div>
-                  <h2 className="text-base font-medium text-ink">Open workflow</h2>
+                  <h2 className="text-base font-medium text-ink">
+                    Open source workflow
+                  </h2>
                 </div>
                 <span
                   className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
@@ -543,7 +545,9 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 <div className="grid gap-3 p-4 sm:grid-cols-2">
                   {!detail.open_workflow && (
                     <div className="rounded-lg border border-rule bg-bg/25 p-4">
-                      <h3 className="text-sm font-medium text-ink">Open workflow</h3>
+                      <h3 className="text-sm font-medium text-ink">
+                        Open source workflow
+                      </h3>
                       <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
                         Publish a version others can inspect and import.
                       </p>
@@ -555,7 +559,9 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                         }
                         className={`${primaryButtonClass} mt-4 w-full`}
                       >
-                        {busy === "open" ? "Publishing…" : "Publish Open workflow"}
+                        {busy === "open"
+                          ? "Publishing…"
+                          : "Publish open source workflow"}
                       </button>
                     </div>
                   )}

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -370,7 +370,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
 
         {detail.open_workflow && (
           <section className={panelClass}>
-            <div className="flex items-center justify-between gap-4 border-b border-rule px-5 py-4">
+            <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
                 <div>
                   <h2 className="text-base font-medium text-ink">Open workflow</h2>
@@ -382,42 +382,42 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   {detail.open_workflow.stale ? "Older version" : "Live"}
                 </span>
               </div>
-              <a
-                href={detail.open_workflow.open_workflow_url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs text-muted no-underline hover:text-ink"
-              >
-                Public page ↗
-              </a>
-            </div>
-            {detail.open_workflow.stale && (
-              <div className="px-5 py-4">
+              <div className="flex items-center gap-4">
+                {detail.open_workflow.stale && (
+                  <button
+                    type="button"
+                    disabled={!canPublish || busy !== null}
+                    onClick={() =>
+                      void runAction("open", async () => shareOpen())
+                    }
+                    className={primaryButtonClass}
+                  >
+                    {busy === "open" ? "Publishing…" : "Publish latest"}
+                  </button>
+                )}
+                <a
+                  href={detail.open_workflow.open_workflow_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-muted no-underline hover:text-ink"
+                >
+                  Public page ↗
+                </a>
                 <button
                   type="button"
-                  disabled={!canPublish || busy !== null}
-                  onClick={() => void runAction("open", async () => shareOpen())}
-                  className={`${primaryButtonClass} min-w-40`}
+                  disabled={busy !== null}
+                  onClick={() => {
+                    if (!window.confirm("Stop sharing this workflow's source?")) return;
+                    void runAction("unshare", async () => {
+                      await orpcCall("/v1/workflows/unshare", { workflow });
+                      setNotice("Source sharing stopped.");
+                    });
+                  }}
+                  className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
                 >
-                  {busy === "open" ? "Publishing…" : "Publish latest"}
+                  Stop sharing
                 </button>
               </div>
-            )}
-            <div className="flex justify-end border-t border-rule px-5 py-3">
-              <button
-                type="button"
-                disabled={busy !== null}
-                onClick={() => {
-                  if (!window.confirm("Stop sharing this workflow's source?")) return;
-                  void runAction("unshare", async () => {
-                    await orpcCall("/v1/workflows/unshare", { workflow });
-                    setNotice("Source sharing stopped.");
-                  });
-                }}
-                className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
-              >
-                Stop sharing
-              </button>
             </div>
           </section>
         )}
@@ -445,14 +445,14 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 Hosted page ↗
               </a>
             </div>
-            <div className="px-5 py-5">
-              <label className="block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
+            <div className="flex flex-col gap-3 border-b border-rule px-5 py-3 sm:flex-row sm:items-end">
+              <label className="block min-w-0 flex-1 text-[10px] uppercase tracking-[0.08em] text-muted sm:max-w-xl">
                 Description
                 <input
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
                   maxLength={2000}
-                  className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                  className="mt-1 h-8 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
                 />
               </label>
               <button
@@ -467,7 +467,11 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     setNotice("Hosted workflow deployed.");
                   })
                 }
-                className={`${primaryButtonClass} mt-4 min-w-40`}
+                className={
+                  detail.hosted_workflow.stale
+                    ? primaryButtonClass
+                    : secondaryButtonClass
+                }
               >
                 {busy === "host"
                   ? "Deploying…"

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -17,15 +17,11 @@ type WorkflowDetail = {
   deployment_status: "building" | "ready" | "failed";
   updated_at: string;
   sharing_enabled: boolean;
-  open_workflow: (Publication & {
-    open_workflow_url: string;
-  }) | null;
-  hosted_workflow: (Publication & {
-    page_url: string;
-  }) | null;
+  open_workflow: (Publication & { open_workflow_url: string }) | null;
+  hosted_workflow: (Publication & { page_url: string }) | null;
 };
 
-type RunSummary = {
+type HostedRunSummary = {
   has_publication_history: boolean;
   metrics: {
     runs_last_30_days: number;
@@ -36,6 +32,15 @@ type RunSummary = {
     ran_at: string;
     outcome: "succeeded" | "failed" | "in_progress" | "cancelled";
   }>;
+};
+
+type WorkflowRun = {
+  job_id: string;
+  status: "queued" | "starting_browser" | "running" | "completed" | "failed" | "cancelled";
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  failure_class: string | null;
 };
 
 type PrivacyFinding = {
@@ -53,10 +58,16 @@ type ShareResponse =
     }
   | { status: "review_expired" };
 
-const cardClass =
-  "rounded-xl border border-rule bg-panel/65 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.16)] sm:p-6";
-const buttonClass =
-  "libretto-button libretto-button--default inline-flex h-10 items-center justify-center disabled:cursor-not-allowed disabled:opacity-50";
+type RunTab = "workflow" | "hosted";
+
+const panelClass =
+  "overflow-hidden rounded-xl border border-rule bg-panel/55 shadow-[0_12px_40px_rgba(0,0,0,0.14)]";
+const primaryButtonClass =
+  "inline-flex h-8 items-center justify-center rounded-md border border-accent/45 bg-green-9/55 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-ink transition-colors hover:bg-green-9/80 disabled:cursor-not-allowed disabled:opacity-40";
+const secondaryButtonClass =
+  "inline-flex h-8 items-center justify-center rounded-md border border-rule bg-bg/35 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted no-underline transition-colors hover:border-accent/35 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40";
+const dangerButtonClass =
+  "inline-flex h-8 items-center justify-center rounded-md border border-red-400/20 bg-transparent px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-red-200 transition-colors hover:border-red-400/40 hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-40";
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
@@ -65,25 +76,173 @@ function formatDate(value: string) {
   }).format(new Date(value));
 }
 
+function formatDuration(startedAt: string | null, completedAt: string | null) {
+  if (!startedAt || !completedAt) return "—";
+  const seconds = Math.max(
+    0,
+    Math.round(
+      (new Date(completedAt).getTime() - new Date(startedAt).getTime()) / 1000,
+    ),
+  );
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function StatusPill({ value }: { value: string }) {
+  const success = value === "completed" || value === "succeeded";
+  const failed = value === "failed";
+  return (
+    <span
+      className={`inline-flex rounded-full border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.06em] ${
+        success
+          ? "border-accent/25 bg-green-9/10 text-accent-bright"
+          : failed
+            ? "border-red-400/25 bg-red-500/10 text-red-200"
+            : "border-rule bg-bg/40 text-muted"
+      }`}
+    >
+      {value.replaceAll("_", " ")}
+    </span>
+  );
+}
+
+function EmptyRuns({ hosted }: { hosted?: boolean }) {
+  return (
+    <div className="px-5 py-12 text-center">
+      <p className="text-sm text-ink">
+        {hosted ? "No external Hosted runs yet." : "No workflow runs yet."}
+      </p>
+      <p className="mt-1 text-xs text-muted">
+        Runs will appear here after this workflow is invoked.
+      </p>
+    </div>
+  );
+}
+
+function WorkflowRunsTable({ runs }: { runs: WorkflowRun[] }) {
+  if (runs.length === 0) return <EmptyRuns />;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[700px] border-collapse">
+        <thead>
+          <tr className="border-b border-rule bg-panel-hi/30">
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Started
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Status
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Runtime
+            </th>
+            <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+              Result
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.job_id} className="border-b border-rule last:border-0">
+              <td className="px-5 py-4 text-sm text-muted">
+                {formatDate(run.started_at ?? run.created_at)}
+              </td>
+              <td className="px-5 py-4">
+                <StatusPill value={run.status} />
+              </td>
+              <td className="px-5 py-4 font-mono text-xs text-muted">
+                {formatDuration(run.started_at, run.completed_at)}
+              </td>
+              <td className="px-5 py-4 text-sm text-muted">
+                {run.failure_class ?? (run.status === "completed" ? "Completed" : "—")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HostedRunsTable({ summary }: { summary: HostedRunSummary }) {
+  return (
+    <>
+      <div className="grid gap-px border-b border-rule bg-rule sm:grid-cols-3">
+        {[
+          ["Runs in 30 days", summary.metrics.runs_last_30_days],
+          ["Succeeded", summary.metrics.succeeded_last_30_days],
+          ["Failed", summary.metrics.failed_last_30_days],
+        ].map(([label, value]) => (
+          <div key={label} className="bg-panel px-5 py-4">
+            <p className="font-mono text-2xl text-ink">{value}</p>
+            <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
+              {label}
+            </p>
+          </div>
+        ))}
+      </div>
+      {summary.runs.length === 0 ? (
+        <EmptyRuns hosted />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse">
+            <thead>
+              <tr className="border-b border-rule bg-panel-hi/30">
+                <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+                  Ran at
+                </th>
+                <th className="px-5 py-3 text-left text-[10px] font-medium uppercase tracking-[0.08em] text-muted">
+                  Outcome
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.runs.map((run, index) => (
+                <tr
+                  key={`${run.ran_at}-${index}`}
+                  className="border-b border-rule last:border-0"
+                >
+                  <td className="px-5 py-4 text-sm text-muted">
+                    {formatDate(run.ran_at)}
+                  </td>
+                  <td className="px-5 py-4">
+                    <StatusPill value={run.outcome} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
 export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [session, setSession] = useState<CloudSession | null>(null);
   const [detail, setDetail] = useState<WorkflowDetail | null>(null);
-  const [runs, setRuns] = useState<RunSummary | null>(null);
+  const [hostedRuns, setHostedRuns] = useState<HostedRunSummary | null>(null);
+  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
+  const [activeTab, setActiveTab] = useState<RunTab>("workflow");
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
   async function refresh() {
-    const [nextDetail, nextRuns] = await Promise.all([
+    const [nextDetail, nextHostedRuns, nextWorkflowRuns] = await Promise.all([
       orpcCall<WorkflowDetail>("/v1/workflows/get", { workflow }),
-      orpcCall<RunSummary>("/v1/workflows/hostedRuns", {
+      orpcCall<HostedRunSummary>("/v1/workflows/hostedRuns", {
+        workflow,
+        limit: 100,
+      }),
+      orpcCall<{ jobs: WorkflowRun[] }>("/v1/dashboard/jobs", {
         workflow,
         limit: 100,
       }),
     ]);
     setDetail(nextDetail);
-    setRuns(nextRuns);
+    setHostedRuns(nextHostedRuns);
+    setWorkflowRuns(nextWorkflowRuns.jobs);
     setDescription(nextDetail.hosted_workflow?.description ?? "");
   }
 
@@ -169,7 +328,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
     }
   }
 
-  if (!session || !detail) {
+  if (!session || !detail || !hostedRuns) {
     return (
       <div className="grid min-h-screen place-items-center bg-bg px-6 text-sm text-muted">
         {error ?? "Loading workflow…"}
@@ -179,6 +338,9 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
 
   const canPublish =
     detail.sharing_enabled && detail.deployment_status === "ready";
+  const hasHostedTab =
+    Boolean(detail.hosted_workflow) || hostedRuns.has_publication_history;
+
   return (
     <DashboardShell
       section="workflows"
@@ -186,11 +348,8 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       title={detail.workflow}
       description={`Updated ${formatDate(detail.updated_at)}`}
       action={
-        <a
-          href="/dashboard/workflows"
-          className="libretto-button inline-flex h-10 items-center no-underline"
-        >
-          Back to workflows
+        <a href="/dashboard/workflows" className={secondaryButtonClass}>
+          ← Workflows
         </a>
       }
     >
@@ -205,200 +364,203 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             {notice}
           </p>
         )}
-        {!detail.sharing_enabled && (
-          <p className="rounded-md border border-amber-300/30 bg-amber-300/10 px-4 py-3 text-sm text-amber-100">
-            Workflow sharing is disabled. A workspace owner can enable it in{" "}
-            <a href="/dashboard/settings" className="underline">
-              Settings
-            </a>
-            .
-          </p>
-        )}
 
-        <div className="grid gap-6 lg:grid-cols-2">
-          <section className={cardClass}>
-            <h2 className="text-lg font-medium text-ink">Open workflow</h2>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              Publish source that other users can inspect and import.
-            </p>
-            {detail.open_workflow && (
-              <p className="mt-3 text-xs text-muted">
-                {detail.open_workflow.stale
-                  ? "A newer deployment is available."
-                  : "Published from the current workflow."}
+        <section className={panelClass}>
+          <div className="flex items-end justify-between border-b border-rule px-5 pt-5">
+            <div>
+              <h2 className="text-base font-medium text-ink">Runs</h2>
+              <p className="mt-1 pb-4 text-xs text-muted">
+                Execution history for this workflow.
               </p>
-            )}
-            <div className="mt-5 flex flex-wrap gap-2">
+            </div>
+            <div className="flex gap-5" role="tablist" aria-label="Workflow run type">
               <button
                 type="button"
-                disabled={!canPublish || busy !== null}
-                onClick={() =>
-                  void runAction("open", async () => shareOpen())
-                }
-                className={buttonClass}
+                role="tab"
+                aria-selected={activeTab === "workflow"}
+                onClick={() => setActiveTab("workflow")}
+                className={`border-b-2 pb-4 text-xs transition-colors ${
+                  activeTab === "workflow"
+                    ? "border-accent text-ink"
+                    : "border-transparent text-muted hover:text-ink"
+                }`}
               >
-                {busy === "open"
-                  ? "Publishing…"
-                  : detail.open_workflow
-                    ? "Refresh"
-                    : "Publish"}
+                Workflow runs
               </button>
-              {detail.open_workflow && (
-                <>
-                  <a
-                    href={detail.open_workflow.open_workflow_url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="libretto-button inline-flex h-10 items-center no-underline"
-                  >
-                    View
-                  </a>
-                  <button
-                    type="button"
-                    disabled={busy !== null}
-                    onClick={() => {
-                      if (!window.confirm("Remove this Open workflow?")) return;
-                      void runAction("unshare", async () => {
-                        await orpcCall("/v1/workflows/unshare", { workflow });
-                        setNotice("Open workflow removed.");
-                      });
-                    }}
-                    className="libretto-button h-10"
-                  >
-                    Remove
-                  </button>
-                </>
+              {hasHostedTab && (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "hosted"}
+                  onClick={() => setActiveTab("hosted")}
+                  className={`border-b-2 pb-4 text-xs transition-colors ${
+                    activeTab === "hosted"
+                      ? "border-accent text-ink"
+                      : "border-transparent text-muted hover:text-ink"
+                  }`}
+                >
+                  Hosted runs
+                </button>
               )}
             </div>
-          </section>
+          </div>
+          {activeTab === "hosted" && hasHostedTab ? (
+            <HostedRunsTable summary={hostedRuns} />
+          ) : (
+            <WorkflowRunsTable runs={workflowRuns} />
+          )}
+        </section>
 
-          <section className={cardClass}>
-            <h2 className="text-lg font-medium text-ink">Hosted workflow</h2>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              Publish an opaque API that external users run with their own
-              credentials.
+        <section className={panelClass}>
+          <div className="border-b border-rule px-5 py-4">
+            <h2 className="text-sm font-medium text-ink">Publishing</h2>
+            <p className="mt-1 text-xs text-muted">
+              Optional public versions of this workflow.
             </p>
-            <label className="mt-4 block text-xs text-muted">
-              Public description
-              <textarea
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                maxLength={2000}
-                rows={3}
-                className="mt-2 w-full rounded-md border border-rule bg-bg px-3 py-2 text-sm text-ink outline-none focus:border-accent/50"
-              />
-            </label>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                type="button"
-                disabled={!canPublish || busy !== null}
-                onClick={() =>
-                  void runAction("host", async () => {
-                    await orpcCall("/v1/workflows/host", {
-                      workflow,
-                      description: description.trim() || undefined,
-                    });
-                    setNotice("Hosted workflow published.");
-                  })
-                }
-                className={buttonClass}
-              >
-                {busy === "host"
-                  ? "Publishing…"
-                  : detail.hosted_workflow
-                    ? "Update"
-                    : "Publish"}
-              </button>
-              {detail.hosted_workflow && (
-                <>
-                  <a
-                    href={detail.hosted_workflow.page_url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="libretto-button inline-flex h-10 items-center no-underline"
-                  >
-                    View
-                  </a>
-                  <button
-                    type="button"
-                    disabled={busy !== null}
-                    onClick={() => {
-                      if (!window.confirm("Unhost this workflow?")) return;
-                      void runAction("unhost", async () => {
-                        await orpcCall("/v1/workflows/unhost", { workflow });
-                        setNotice("Hosted workflow removed.");
-                      });
-                    }}
-                    className="libretto-button h-10"
-                  >
-                    Unhost
-                  </button>
-                </>
-              )}
+          </div>
+          {!detail.sharing_enabled && (
+            <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
+              Workflow sharing is disabled. A workspace owner can enable it in{" "}
+              <a href="/dashboard/settings" className="underline">
+                Settings
+              </a>
+              .
             </div>
-          </section>
-        </div>
+          )}
 
-        {runs?.has_publication_history && (
-          <section className={cardClass}>
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div className="divide-y divide-rule">
+            <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
               <div>
-                <h2 className="text-lg font-medium text-ink">
-                  External Hosted runs
-                </h2>
-                <p className="mt-1 text-sm text-muted">
-                  Times and outcomes only. Consumer identity and run data stay
-                  private.
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium text-ink">Open workflow</h3>
+                  {detail.open_workflow && (
+                    <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                      {detail.open_workflow.stale ? "Update available" : "Published"}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-muted">
+                  Public source that others can inspect and import.
                 </p>
               </div>
-              <div className="grid grid-cols-3 gap-3 text-center">
-                {[
-                  ["30-day runs", runs.metrics.runs_last_30_days],
-                  ["Succeeded", runs.metrics.succeeded_last_30_days],
-                  ["Failed", runs.metrics.failed_last_30_days],
-                ].map(([label, value]) => (
-                  <div key={label} className="rounded-md border border-rule px-3 py-2">
-                    <p className="text-lg text-ink">{value}</p>
-                    <p className="text-[10px] uppercase tracking-wide text-muted">
-                      {label}
-                    </p>
-                  </div>
-                ))}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={!canPublish || busy !== null}
+                  onClick={() =>
+                    void runAction("open", async () => shareOpen())
+                  }
+                  className={primaryButtonClass}
+                >
+                  {busy === "open"
+                    ? "Publishing…"
+                    : detail.open_workflow
+                      ? "Refresh"
+                      : "Publish open"}
+                </button>
+                {detail.open_workflow && (
+                  <>
+                    <a
+                      href={detail.open_workflow.open_workflow_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={secondaryButtonClass}
+                    >
+                      View
+                    </a>
+                    <button
+                      type="button"
+                      disabled={busy !== null}
+                      onClick={() => {
+                        if (!window.confirm("Remove this Open workflow?")) return;
+                        void runAction("unshare", async () => {
+                          await orpcCall("/v1/workflows/unshare", { workflow });
+                          setNotice("Open workflow removed.");
+                        });
+                      }}
+                      className={dangerButtonClass}
+                    >
+                      Remove
+                    </button>
+                  </>
+                )}
               </div>
             </div>
-            <div className="mt-5 overflow-x-auto">
-              <table className="w-full min-w-[520px] border-collapse">
-                <thead>
-                  <tr>
-                    <th className="border-b border-rule px-3 py-2 text-left text-xs text-muted">
-                      Ran at
-                    </th>
-                    <th className="border-b border-rule px-3 py-2 text-left text-xs text-muted">
-                      Outcome
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {runs.runs.map((run, index) => (
-                    <tr key={`${run.ran_at}-${index}`}>
-                      <td className="border-b border-rule px-3 py-3 text-sm text-muted">
-                        {formatDate(run.ran_at)}
-                      </td>
-                      <td className="border-b border-rule px-3 py-3 text-sm text-ink">
-                        {run.outcome.replace("_", " ")}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {runs.runs.length === 0 && (
-                <p className="py-6 text-center text-sm text-muted">
-                  No external runs yet.
+
+            <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-end lg:justify-between">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
+                  {detail.hosted_workflow && (
+                    <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                      {detail.hosted_workflow.stale ? "Update available" : "Published"}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-muted">
+                  Opaque API that external users run with their own credentials.
                 </p>
-              )}
+                <label className="mt-3 block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
+                  Public description
+                  <input
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                    maxLength={2000}
+                    className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                  />
+                </label>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={!canPublish || busy !== null}
+                  onClick={() =>
+                    void runAction("host", async () => {
+                      await orpcCall("/v1/workflows/host", {
+                        workflow,
+                        description: description.trim() || undefined,
+                      });
+                      setNotice("Hosted workflow published.");
+                    })
+                  }
+                  className={primaryButtonClass}
+                >
+                  {busy === "host"
+                    ? "Publishing…"
+                    : detail.hosted_workflow
+                      ? "Update hosted"
+                      : "Publish hosted"}
+                </button>
+                {detail.hosted_workflow && (
+                  <>
+                    <a
+                      href={detail.hosted_workflow.page_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={secondaryButtonClass}
+                    >
+                      View
+                    </a>
+                    <button
+                      type="button"
+                      disabled={busy !== null}
+                      onClick={() => {
+                        if (!window.confirm("Unhost this workflow?")) return;
+                        void runAction("unhost", async () => {
+                          await orpcCall("/v1/workflows/unhost", { workflow });
+                          setNotice("Hosted workflow removed.");
+                        });
+                      }}
+                      className={dangerButtonClass}
+                    >
+                      Unhost
+                    </button>
+                  </>
+                )}
+              </div>
             </div>
-          </section>
-        )}
+          </div>
+        </section>
       </div>
     </DashboardShell>
   );

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -58,9 +58,6 @@ type ShareResponse =
     }
   | { status: "review_expired" };
 
-type RunTab = "workflow" | "hosted";
-type PublishingMode = "open" | "hosted" | null;
-
 const panelClass =
   "overflow-hidden rounded-xl border border-rule bg-panel/55 shadow-[0_12px_40px_rgba(0,0,0,0.14)]";
 const primaryButtonClass =
@@ -221,9 +218,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [detail, setDetail] = useState<WorkflowDetail | null>(null);
   const [hostedRuns, setHostedRuns] = useState<HostedRunSummary | null>(null);
   const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
-  const [activeTab, setActiveTab] = useState<RunTab>("workflow");
   const [publishingOpen, setPublishingOpen] = useState(false);
-  const [publishingMode, setPublishingMode] = useState<PublishingMode>(null);
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -339,8 +334,8 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
 
   const canPublish =
     detail.sharing_enabled && detail.deployment_status === "ready";
-  const hasHostedTab =
-    Boolean(detail.hosted_workflow) || hostedRuns.has_publication_history;
+  const hasPublicWorkflow =
+    Boolean(detail.open_workflow) || Boolean(detail.hosted_workflow);
 
   return (
     <DashboardShell
@@ -370,255 +365,220 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           <div className="border-b border-rule px-5 py-4">
             <h2 className="text-base font-medium text-ink">Runs</h2>
           </div>
-          {hasHostedTab && (
-            <div className="border-b border-rule bg-bg/20 px-5 py-3">
-              <div
-                className="inline-flex rounded-lg border border-rule bg-bg/50 p-1"
-                role="tablist"
-                aria-label="Workflow run type"
-              >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "workflow"}
-                onClick={() => setActiveTab("workflow")}
-                className={`rounded-md px-3 py-2 text-xs transition-colors ${
-                  activeTab === "workflow"
-                    ? "bg-panel-hi text-ink shadow-sm"
-                    : "text-muted hover:text-ink"
-                }`}
-              >
-                Workflow runs
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === "hosted"}
-                onClick={() => setActiveTab("hosted")}
-                className={`rounded-md px-3 py-2 text-xs transition-colors ${
-                  activeTab === "hosted"
-                    ? "bg-panel-hi text-ink shadow-sm"
-                    : "text-muted hover:text-ink"
-                }`}
-              >
-                Hosted runs
-                <span className="ml-1.5 text-[10px] text-muted">external</span>
-              </button>
-            </div>
-            </div>
-          )}
-          {activeTab === "hosted" && hasHostedTab ? (
-            <HostedRunsTable summary={hostedRuns} />
-          ) : (
-            <WorkflowRunsTable runs={workflowRuns} />
-          )}
+          <WorkflowRunsTable runs={workflowRuns} />
         </section>
 
-        <section className={panelClass}>
-          <button
-            type="button"
-            aria-expanded={publishingOpen}
-            onClick={() => setPublishingOpen((open) => !open)}
-            className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-panel-hi/25"
-          >
-            <span className="flex items-center gap-3">
-              <span className="text-sm font-medium text-ink">Publishing</span>
-              {(detail.open_workflow || detail.hosted_workflow) && (
-                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                  {[detail.open_workflow, detail.hosted_workflow].filter(Boolean).length} live
-                </span>
-              )}
-            </span>
-            <span className="text-xs text-muted">
-              {publishingOpen ? "Hide" : "Manage"} <span aria-hidden>{publishingOpen ? "↑" : "↓"}</span>
-            </span>
-          </button>
-          {publishingOpen && (
-            <div className="border-t border-rule">
-              {!detail.sharing_enabled && (
-                <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
-                  Publishing is disabled. Enable it in{" "}
-                  <a href="/dashboard/settings" className="underline">
-                    Settings
-                  </a>
-                  .
+        {detail.open_workflow && (
+          <section className={panelClass}>
+            <div className="flex items-center justify-between gap-4 border-b border-rule px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div>
+                  <h2 className="text-base font-medium text-ink">Open workflow</h2>
+                  <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
+                    Source code
+                  </p>
                 </div>
-              )}
-
-              <div className="grid gap-3 p-4 sm:grid-cols-2">
-                {([
-                  {
-                    mode: "open" as const,
-                    title: "Open workflow",
-                    kind: "Source code",
-                    publication: detail.open_workflow,
-                  },
-                  {
-                    mode: "hosted" as const,
-                    title: "Hosted workflow",
-                    kind: "Runnable API",
-                    publication: detail.hosted_workflow,
-                  },
-                ]).map((option) => (
-                  <button
-                    key={option.mode}
-                    type="button"
-                    aria-pressed={publishingMode === option.mode}
-                    onClick={() =>
-                      setPublishingMode((current) =>
-                        current === option.mode ? null : option.mode,
-                      )
-                    }
-                    className={`flex items-center justify-between rounded-lg border px-4 py-4 text-left transition-colors ${
-                      publishingMode === option.mode
-                        ? "border-accent/45 bg-green-9/10"
-                        : "border-rule bg-bg/25 hover:border-accent/25 hover:bg-panel-hi/25"
-                    }`}
-                  >
-                    <span>
-                      <span className="block text-sm font-medium text-ink">
-                        {option.title}
-                      </span>
-                      <span className="mt-1 block text-[10px] uppercase tracking-[0.08em] text-muted">
-                        {option.kind}
-                      </span>
-                    </span>
-                    <span className="flex items-center gap-3">
-                      <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                        {option.publication
-                          ? option.publication.stale
-                            ? "Older"
-                            : "Live"
-                          : "Off"}
-                      </span>
-                      <span aria-hidden className="text-muted">›</span>
-                    </span>
-                  </button>
-                ))}
+                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                  {detail.open_workflow.stale ? "Older version" : "Live"}
+                </span>
               </div>
+              <a
+                href={detail.open_workflow.open_workflow_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-muted no-underline hover:text-ink"
+              >
+                Public page ↗
+              </a>
+            </div>
+            {detail.open_workflow.stale && (
+              <div className="px-5 py-4">
+                <button
+                  type="button"
+                  disabled={!canPublish || busy !== null}
+                  onClick={() => void runAction("open", async () => shareOpen())}
+                  className={`${primaryButtonClass} min-w-40`}
+                >
+                  {busy === "open" ? "Publishing…" : "Publish latest"}
+                </button>
+              </div>
+            )}
+            <div className="flex justify-end border-t border-rule px-5 py-3">
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() => {
+                  if (!window.confirm("Stop sharing this workflow's source?")) return;
+                  void runAction("unshare", async () => {
+                    await orpcCall("/v1/workflows/unshare", { workflow });
+                    setNotice("Source sharing stopped.");
+                  });
+                }}
+                className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
+              >
+                Stop sharing
+              </button>
+            </div>
+          </section>
+        )}
 
-              {publishingMode === "open" && (
-                <div className="border-t border-rule bg-bg/15">
-                  <div className="px-5 py-5">
-                    <h3 className="text-base font-medium text-ink">Open workflow</h3>
-                    {detail.open_workflow?.stale && (
-                      <p className="mt-1 text-xs text-muted">
-                        The public copy uses an older deployment.
+        {detail.hosted_workflow && (
+          <section className={panelClass}>
+            <div className="flex items-center justify-between gap-4 border-b border-rule px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div>
+                  <h2 className="text-base font-medium text-ink">Hosted workflow</h2>
+                  <p className="mt-1 text-[10px] uppercase tracking-[0.08em] text-muted">
+                    Runnable API
+                  </p>
+                </div>
+                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                  {detail.hosted_workflow.stale ? "Older version" : "Live"}
+                </span>
+              </div>
+              <a
+                href={detail.hosted_workflow.page_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-muted no-underline hover:text-ink"
+              >
+                Hosted page ↗
+              </a>
+            </div>
+            <div className="px-5 py-5">
+              <label className="block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
+                Description
+                <input
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  maxLength={2000}
+                  className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                />
+              </label>
+              <button
+                type="button"
+                disabled={!canPublish || busy !== null}
+                onClick={() =>
+                  void runAction("host", async () => {
+                    await orpcCall("/v1/workflows/host", {
+                      workflow,
+                      description: description.trim() || undefined,
+                    });
+                    setNotice("Hosted workflow deployed.");
+                  })
+                }
+                className={`${primaryButtonClass} mt-4 min-w-40`}
+              >
+                {busy === "host"
+                  ? "Deploying…"
+                  : detail.hosted_workflow.stale
+                    ? "Deploy latest"
+                    : "Redeploy"}
+              </button>
+            </div>
+            <div className="border-t border-rule px-5 py-4">
+              <h3 className="text-sm font-medium text-ink">External runs</h3>
+            </div>
+            <HostedRunsTable summary={hostedRuns} />
+            <div className="flex justify-end border-t border-rule px-5 py-3">
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() => {
+                  if (!window.confirm("Stop hosting this workflow?")) return;
+                  void runAction("unhost", async () => {
+                    await orpcCall("/v1/workflows/unhost", { workflow });
+                    setNotice("Hosted workflow removed.");
+                  });
+                }}
+                className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
+              >
+                Stop hosting
+              </button>
+            </div>
+          </section>
+        )}
+
+        {(!detail.open_workflow || !detail.hosted_workflow) && (
+          <section className={panelClass}>
+            <button
+              type="button"
+              aria-expanded={publishingOpen}
+              onClick={() => setPublishingOpen((open) => !open)}
+              className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-panel-hi/25"
+            >
+              <span>
+                <span className="block text-sm font-medium text-ink">
+                  {hasPublicWorkflow
+                    ? "Add another public version"
+                    : "Make workflow publicly available"}
+                </span>
+                {!hasPublicWorkflow && (
+                  <span className="mt-1 block text-xs text-muted">
+                    Share its source or publish a runnable API.
+                  </span>
+                )}
+              </span>
+              <span className="text-xs text-muted" aria-hidden>
+                {publishingOpen ? "↑" : "↓"}
+              </span>
+            </button>
+            {publishingOpen && (
+              <div className="border-t border-rule">
+                {!detail.sharing_enabled && (
+                  <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
+                    Publishing is disabled. Enable it in{" "}
+                    <a href="/dashboard/settings" className="underline">
+                      Settings
+                    </a>
+                    .
+                  </div>
+                )}
+                <div className="grid gap-3 p-4 sm:grid-cols-2">
+                  {!detail.open_workflow && (
+                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
+                      <h3 className="text-sm font-medium text-ink">Open workflow</h3>
+                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
+                        Publish source code others can inspect and import.
                       </p>
-                    )}
-                    {(!detail.open_workflow || detail.open_workflow.stale) && (
                       <button
                         type="button"
                         disabled={!canPublish || busy !== null}
                         onClick={() =>
                           void runAction("open", async () => shareOpen())
                         }
-                        className={`${primaryButtonClass} mt-5 min-w-44`}
+                        className={`${primaryButtonClass} mt-4 w-full`}
                       >
-                        {busy === "open"
-                          ? "Publishing…"
-                          : detail.open_workflow
-                            ? "Publish latest"
-                            : "Publish source"}
+                        {busy === "open" ? "Publishing…" : "Publish Open workflow"}
                       </button>
-                    )}
-                  </div>
-                  {detail.open_workflow && (
-                    <div className="flex items-center justify-between border-t border-rule px-5 py-3 text-xs">
-                      <a
-                        href={detail.open_workflow.open_workflow_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-muted no-underline hover:text-ink"
-                      >
-                        Public page ↗
-                      </a>
+                    </div>
+                  )}
+                  {!detail.hosted_workflow && (
+                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
+                      <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
+                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
+                        Publish an API others can run without seeing the source.
+                      </p>
                       <button
                         type="button"
-                        disabled={busy !== null}
-                        onClick={() => {
-                          if (!window.confirm("Stop sharing this workflow's source?")) return;
-                          void runAction("unshare", async () => {
-                            await orpcCall("/v1/workflows/unshare", { workflow });
-                            setNotice("Source sharing stopped.");
-                          });
-                        }}
-                        className="text-red-200/75 hover:text-red-200 disabled:opacity-40"
+                        disabled={!canPublish || busy !== null}
+                        onClick={() =>
+                          void runAction("host", async () => {
+                            await orpcCall("/v1/workflows/host", { workflow });
+                            setNotice("Hosted workflow published.");
+                          })
+                        }
+                        className={`${primaryButtonClass} mt-4 w-full`}
                       >
-                        Stop sharing
+                        {busy === "host" ? "Publishing…" : "Publish Hosted workflow"}
                       </button>
                     </div>
                   )}
                 </div>
-              )}
-
-              {publishingMode === "hosted" && (
-                <div className="border-t border-rule bg-bg/15">
-                  <div className="px-5 py-5">
-                    <h3 className="text-base font-medium text-ink">Hosted workflow</h3>
-                    <label className="mt-4 block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
-                      Description
-                      <input
-                        value={description}
-                        onChange={(event) => setDescription(event.target.value)}
-                        maxLength={2000}
-                        className="mt-1.5 h-9 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
-                      />
-                    </label>
-                    <button
-                      type="button"
-                      disabled={!canPublish || busy !== null}
-                      onClick={() =>
-                        void runAction("host", async () => {
-                          await orpcCall("/v1/workflows/host", {
-                            workflow,
-                            description: description.trim() || undefined,
-                          });
-                          setNotice("Hosted workflow published.");
-                        })
-                      }
-                      className={`${primaryButtonClass} mt-4 min-w-44`}
-                    >
-                      {busy === "host"
-                        ? "Publishing…"
-                        : detail.hosted_workflow?.stale
-                          ? "Publish latest"
-                          : detail.hosted_workflow
-                            ? "Save"
-                            : "Publish hosted"}
-                    </button>
-                  </div>
-                  {detail.hosted_workflow && (
-                    <div className="flex items-center justify-between border-t border-rule px-5 py-3 text-xs">
-                      <a
-                        href={detail.hosted_workflow.page_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-muted no-underline hover:text-ink"
-                      >
-                        Hosted page ↗
-                      </a>
-                      <button
-                        type="button"
-                        disabled={busy !== null}
-                        onClick={() => {
-                          if (!window.confirm("Stop hosting this workflow?")) return;
-                          void runAction("unhost", async () => {
-                            await orpcCall("/v1/workflows/unhost", { workflow });
-                            setNotice("Hosted workflow removed.");
-                          });
-                        }}
-                        className="text-red-200/75 hover:text-red-200 disabled:opacity-40"
-                      >
-                        Stop hosting
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </section>
+              </div>
+            )}
+          </section>
+        )}
       </div>
     </DashboardShell>
   );

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -223,6 +223,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [hostedRuns, setHostedRuns] = useState<HostedRunSummary | null>(null);
   const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
   const [activeTab, setActiveTab] = useState<RunTab>("workflow");
+  const [publishingOpen, setPublishingOpen] = useState(false);
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -366,44 +367,46 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
         )}
 
         <section className={panelClass}>
-          <div className="flex items-end justify-between border-b border-rule px-5 pt-5">
-            <div>
-              <h2 className="text-base font-medium text-ink">Runs</h2>
-              <p className="mt-1 pb-4 text-xs text-muted">
-                Execution history for this workflow.
-              </p>
-            </div>
-            <div className="flex gap-5" role="tablist" aria-label="Workflow run type">
+          <div className="border-b border-rule px-5 py-4">
+            <h2 className="text-base font-medium text-ink">Runs</h2>
+          </div>
+          {hasHostedTab && (
+            <div className="border-b border-rule bg-bg/20 px-5 py-3">
+              <div
+                className="inline-flex rounded-lg border border-rule bg-bg/50 p-1"
+                role="tablist"
+                aria-label="Workflow run type"
+              >
               <button
                 type="button"
                 role="tab"
                 aria-selected={activeTab === "workflow"}
                 onClick={() => setActiveTab("workflow")}
-                className={`border-b-2 pb-4 text-xs transition-colors ${
+                className={`rounded-md px-3 py-2 text-xs transition-colors ${
                   activeTab === "workflow"
-                    ? "border-accent text-ink"
-                    : "border-transparent text-muted hover:text-ink"
+                    ? "bg-panel-hi text-ink shadow-sm"
+                    : "text-muted hover:text-ink"
                 }`}
               >
                 Workflow runs
               </button>
-              {hasHostedTab && (
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={activeTab === "hosted"}
-                  onClick={() => setActiveTab("hosted")}
-                  className={`border-b-2 pb-4 text-xs transition-colors ${
-                    activeTab === "hosted"
-                      ? "border-accent text-ink"
-                      : "border-transparent text-muted hover:text-ink"
-                  }`}
-                >
-                  Hosted runs
-                </button>
-              )}
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === "hosted"}
+                onClick={() => setActiveTab("hosted")}
+                className={`rounded-md px-3 py-2 text-xs transition-colors ${
+                  activeTab === "hosted"
+                    ? "bg-panel-hi text-ink shadow-sm"
+                    : "text-muted hover:text-ink"
+                }`}
+              >
+                Hosted runs
+                <span className="ml-1.5 text-[10px] text-muted">external</span>
+              </button>
             </div>
-          </div>
+            </div>
+          )}
           {activeTab === "hosted" && hasHostedTab ? (
             <HostedRunsTable summary={hostedRuns} />
           ) : (
@@ -412,12 +415,26 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
         </section>
 
         <section className={panelClass}>
-          <div className="border-b border-rule px-5 py-4">
-            <h2 className="text-sm font-medium text-ink">Publishing</h2>
-            <p className="mt-1 text-xs text-muted">
-              Optional public versions of this workflow.
-            </p>
-          </div>
+          <button
+            type="button"
+            aria-expanded={publishingOpen}
+            onClick={() => setPublishingOpen((open) => !open)}
+            className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-panel-hi/25"
+          >
+            <span className="flex items-center gap-3">
+              <span className="text-sm font-medium text-ink">Publishing</span>
+              {(detail.open_workflow || detail.hosted_workflow) && (
+                <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
+                  {[detail.open_workflow, detail.hosted_workflow].filter(Boolean).length} live
+                </span>
+              )}
+            </span>
+            <span className="text-xs text-muted">
+              {publishingOpen ? "Hide" : "Manage"} <span aria-hidden>{publishingOpen ? "↑" : "↓"}</span>
+            </span>
+          </button>
+          {publishingOpen && (
+            <div className="border-t border-rule">
           {!detail.sharing_enabled && (
             <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
               Workflow sharing is disabled. A workspace owner can enable it in{" "}
@@ -432,32 +449,34 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
               <div>
                 <div className="flex items-center gap-2">
-                  <h3 className="text-sm font-medium text-ink">Open workflow</h3>
+                  <h3 className="text-sm font-medium text-ink">Share source</h3>
                   {detail.open_workflow && (
                     <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                      {detail.open_workflow.stale ? "Update available" : "Published"}
+                      {detail.open_workflow.stale ? "Older version live" : "Live"}
                     </span>
                   )}
                 </div>
                 <p className="mt-1 text-xs text-muted">
-                  Public source that others can inspect and import.
+                  Let others inspect and import this workflow.
                 </p>
               </div>
               <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  disabled={!canPublish || busy !== null}
-                  onClick={() =>
-                    void runAction("open", async () => shareOpen())
-                  }
-                  className={primaryButtonClass}
-                >
-                  {busy === "open"
-                    ? "Publishing…"
-                    : detail.open_workflow
-                      ? "Refresh"
-                      : "Publish open"}
-                </button>
+                {(!detail.open_workflow || detail.open_workflow.stale) && (
+                  <button
+                    type="button"
+                    disabled={!canPublish || busy !== null}
+                    onClick={() =>
+                      void runAction("open", async () => shareOpen())
+                    }
+                    className={primaryButtonClass}
+                  >
+                    {busy === "open"
+                      ? "Publishing…"
+                      : detail.open_workflow
+                        ? "Publish latest version"
+                        : "Share source"}
+                  </button>
+                )}
                 {detail.open_workflow && (
                   <>
                     <a
@@ -466,21 +485,21 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                       rel="noreferrer"
                       className={secondaryButtonClass}
                     >
-                      View
+                      Open public page
                     </a>
                     <button
                       type="button"
                       disabled={busy !== null}
                       onClick={() => {
-                        if (!window.confirm("Remove this Open workflow?")) return;
+                        if (!window.confirm("Stop sharing this workflow's source?")) return;
                         void runAction("unshare", async () => {
                           await orpcCall("/v1/workflows/unshare", { workflow });
-                          setNotice("Open workflow removed.");
+                          setNotice("Source sharing stopped.");
                         });
                       }}
                       className={dangerButtonClass}
                     >
-                      Remove
+                      Stop sharing
                     </button>
                   </>
                 )}
@@ -490,15 +509,15 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             <div className="flex flex-col gap-4 px-5 py-4 lg:flex-row lg:items-end lg:justify-between">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
+                  <h3 className="text-sm font-medium text-ink">Host workflow</h3>
                   {detail.hosted_workflow && (
                     <span className="rounded-full border border-rule px-2 py-0.5 text-[9px] uppercase tracking-wide text-muted">
-                      {detail.hosted_workflow.stale ? "Update available" : "Published"}
+                      {detail.hosted_workflow.stale ? "Older version live" : "Live"}
                     </span>
                   )}
                 </div>
                 <p className="mt-1 text-xs text-muted">
-                  Opaque API that external users run with their own credentials.
+                  Let others run it without seeing the source.
                 </p>
                 <label className="mt-3 block max-w-xl text-[10px] uppercase tracking-[0.08em] text-muted">
                   Public description
@@ -528,8 +547,10 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   {busy === "host"
                     ? "Publishing…"
                     : detail.hosted_workflow
-                      ? "Update hosted"
-                      : "Publish hosted"}
+                      ? detail.hosted_workflow.stale
+                        ? "Publish latest version"
+                        : "Save changes"
+                      : "Host workflow"}
                 </button>
                 {detail.hosted_workflow && (
                   <>
@@ -539,13 +560,13 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                       rel="noreferrer"
                       className={secondaryButtonClass}
                     >
-                      View
+                      Open hosted page
                     </a>
                     <button
                       type="button"
                       disabled={busy !== null}
                       onClick={() => {
-                        if (!window.confirm("Unhost this workflow?")) return;
+                        if (!window.confirm("Stop hosting this workflow?")) return;
                         void runAction("unhost", async () => {
                           await orpcCall("/v1/workflows/unhost", { workflow });
                           setNotice("Hosted workflow removed.");
@@ -553,13 +574,15 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                       }}
                       className={dangerButtonClass}
                     >
-                      Unhost
+                      Stop hosting
                     </button>
                   </>
                 )}
               </div>
             </div>
           </div>
+            </div>
+          )}
         </section>
       </div>
     </DashboardShell>

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as DashboardCloudBrowsersRouteImport } from './routes/dashboard_.
 import { Route as DashboardChromeExtensionRouteImport } from './routes/dashboard_.chrome-extension'
 import { Route as DashboardSectionRouteImport } from './routes/dashboard_.$section'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as DashboardWorkflowsWorkflowRouteImport } from './routes/dashboard_.workflows_.$workflow'
 
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
   id: '/verify-email',
@@ -167,6 +168,12 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
   path: '/$slug',
   getParentRoute: () => BlogRouteRoute,
 } as any)
+const DashboardWorkflowsWorkflowRoute =
+  DashboardWorkflowsWorkflowRouteImport.update({
+    id: '/dashboard_/workflows_/$workflow',
+    path: '/dashboard/workflows/$workflow',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -195,6 +202,7 @@ export interface FileRoutesByFullPath {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
+  '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -222,6 +230,7 @@ export interface FileRoutesByTo {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog': typeof BlogIndexRoute
+  '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -251,6 +260,7 @@ export interface FileRoutesById {
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
+  '/dashboard_/workflows_/$workflow': typeof DashboardWorkflowsWorkflowRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -281,6 +291,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog/'
+    | '/dashboard/workflows/$workflow'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -308,6 +319,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog'
+    | '/dashboard/workflows/$workflow'
   id:
     | '__root__'
     | '/'
@@ -336,6 +348,7 @@ export interface FileRouteTypes {
     | '/vs/playwright-codegen'
     | '/vs/stagehand'
     | '/blog/'
+    | '/dashboard_/workflows_/$workflow'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -363,6 +376,7 @@ export interface RootRouteChildren {
   VsBrowserUseRoute: typeof VsBrowserUseRoute
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
   VsStagehandRoute: typeof VsStagehandRoute
+  DashboardWorkflowsWorkflowRoute: typeof DashboardWorkflowsWorkflowRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -549,6 +563,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof BlogRouteRoute
     }
+    '/dashboard_/workflows_/$workflow': {
+      id: '/dashboard_/workflows_/$workflow'
+      path: '/dashboard/workflows/$workflow'
+      fullPath: '/dashboard/workflows/$workflow'
+      preLoaderRoute: typeof DashboardWorkflowsWorkflowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -591,7 +612,17 @@ const rootRouteChildren: RootRouteChildren = {
   VsBrowserUseRoute: VsBrowserUseRoute,
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,
   VsStagehandRoute: VsStagehandRoute,
+  DashboardWorkflowsWorkflowRoute: DashboardWorkflowsWorkflowRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/apps/website/src/routes/dashboard_.workflows_.$workflow.tsx
+++ b/apps/website/src/routes/dashboard_.workflows_.$workflow.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { WorkflowDetailPage } from "../WorkflowDetailPage";
+
+export const Route = createFileRoute("/dashboard_/workflows_/$workflow")({
+  head: ({ params }) => ({
+    meta: [
+      { title: `${params.workflow} | Libretto` },
+      { name: "robots", content: "noindex, nofollow" },
+    ],
+  }),
+  component: WorkflowPage,
+});
+
+function WorkflowPage() {
+  const { workflow } = Route.useParams();
+  return <WorkflowDetailPage workflow={workflow} />;
+}

--- a/apps/website/src/routes/open-workflows.tsx
+++ b/apps/website/src/routes/open-workflows.tsx
@@ -4,7 +4,7 @@ import { OpenWorkflowsPage } from "../OpenWorkflowsPage";
 export const Route = createFileRoute("/open-workflows")({
   head: () => ({
     meta: [
-      { title: "Open workflows | Libretto" },
+      { title: "Open source workflows | Libretto" },
       {
         name: "description",
         content: "Add reusable browser workflows to your Libretto account.",

--- a/apps/website/src/routes/open-workflows_.$id.tsx
+++ b/apps/website/src/routes/open-workflows_.$id.tsx
@@ -3,7 +3,7 @@ import { OpenWorkflowPage } from "../OpenWorkflowsPage";
 
 export const Route = createFileRoute("/open-workflows_/$id")({
   head: () => ({
-    meta: [{ title: "Open workflow | Libretto" }],
+    meta: [{ title: "Open source workflow | Libretto" }],
   }),
   component: OpenWorkflowRoute,
 });


### PR DESCRIPTION
## Summary
- link deployed workflows to an authenticated individual workflow page
- keep normal workflow runs as the primary page table
- show Make workflow publicly available only while neither publication type is live
- treat Open and Hosted as alternative modes in the normal case; when one is live, hide the other completely
- represent both sections only for workflows that are already published both ways
- keep the Open workflow section lightweight
- place Hosted description, deploy/redeploy controls, metrics, and external run history together
- show external run history only while a Hosted publication is currently live
- broaden workspace sharing settings copy to both publication types

## Verification
- website type-check
- website production build
- browser-verified unpublished, Open-only, Hosted-only, and dual-publication states

Stacked on #549 and PR #547. Cloud API support is in saffron-health/libretto-cloud#250 and #251.