### PR TITLE
Add disable_default_proxy for Libretto Cloud jobs, schedules, and sessions

### DIFF
--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -27,12 +27,15 @@ Request fields:
 - `callback_secret`: optional callback secret
 - `skip_callbacks`: optional boolean
 - `residential_proxy`: optional residential proxy location object
+- `disable_default_proxy`: optional boolean; Kernel only. Disables Kernel's default residential stealth proxy so traffic uses direct egress. Mutually exclusive with `residential_proxy`. Use when sites fail with `ERR_TUNNEL_CONNECTION_FAILED` on the default proxy.
 
 If you set `callback_url`, you must also set `callback_secret`.
 
 Prefer declaring `startUrl`, `gpu`, and `viewport` on the workflow definition so they travel with the deploy artifact. Use the job-level fields when you need a one-off override, or until the hosted executor applies workflow launch metadata automatically.
 
 Use `residential_proxy` for location-sensitive runs that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
+
+Use `disable_default_proxy` when the default managed proxy cannot reach the target (for example `ERR_TUNNEL_CONNECTION_FAILED`). It cannot be combined with `residential_proxy`.
 
 Callback delivery order:
 

--- a/docs/libretto-cloud-api/schedules.mdx
+++ b/docs/libretto-cloud-api/schedules.mdx
@@ -31,6 +31,7 @@ Request fields:
 - `callback_secret`: optional
 - `skip_callbacks`: optional, default `false`
 - `residential_proxy`: optional residential proxy location object
+- `disable_default_proxy`: optional boolean; Kernel only. Disables Kernel's default residential stealth proxy so traffic uses direct egress. Mutually exclusive with `residential_proxy`.
 - `enabled`: optional, default `true`
 
 If you set `callback_url`, you must also set `callback_secret`.
@@ -38,6 +39,8 @@ If you set `callback_url`, you must also set `callback_secret`.
 Prefer declaring `startUrl`, `gpu`, and `viewport` on the workflow definition so they travel with the deploy artifact. Use the schedule-level fields when you need a one-off override, or until the hosted executor applies workflow launch metadata automatically.
 
 Use `residential_proxy` for recurring workflows that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
+
+Use `disable_default_proxy` when the default managed proxy cannot reach the target (for example `ERR_TUNNEL_CONNECTION_FAILED`). It cannot be combined with `residential_proxy`.
 
 Response fields:
 
@@ -85,10 +88,12 @@ Request fields:
 - `callback_secret`: optional string or `null`
 - `skip_callbacks`: optional
 - `residential_proxy`: optional object or `null`
+- `disable_default_proxy`: optional boolean; Kernel only. Mutually exclusive with a non-null `residential_proxy`.
 - `enabled`: optional
 
 To clear the callback, set both `callback_url` and `callback_secret` to `null`.
 To clear the configured residential proxy location, set `residential_proxy` to `null`.
+To clear direct-egress mode and restore the default proxy, set `disable_default_proxy` to `false`.
 
 Response fields:
 
@@ -118,6 +123,7 @@ The `schedule` object returned by the schedules endpoints includes:
 - `timezone`
 - `timeout_seconds`
 - `residential_proxy`
+- `disable_default_proxy`
 - `callback_url`
 - `skip_callbacks`
 - `enabled`

--- a/docs/libretto-cloud-api/sessions.mdx
+++ b/docs/libretto-cloud-api/sessions.mdx
@@ -19,8 +19,11 @@ Request fields:
 - `viewport`: optional `{ width, height }` viewport
 - `headless`: optional boolean browser mode
 - `residential_proxy`: optional residential proxy location object
+- `disable_default_proxy`: optional boolean; Kernel only. Disables Kernel's default residential stealth proxy so traffic uses direct egress. Mutually exclusive with `residential_proxy`.
 
 Prefer `start_url` over navigating with Playwright immediately after connect. Use `residential_proxy` for location-sensitive sessions that need traffic to originate from a specific residential proxy country, US state, city, ZIP code, or ASN. See [Residential proxy locations](/libretto-cloud-hosting/stealth#residential-proxy-locations) for the supported fields and combination rules.
+
+Use `disable_default_proxy` when the default managed proxy cannot reach the target (for example `ERR_TUNNEL_CONNECTION_FAILED`). It cannot be combined with `residential_proxy`. When both `start_url` and `disable_default_proxy` are set, Libretto Cloud still opens `start_url` after switching to direct egress, so clients should treat the start URL as preloaded.
 
 Response fields:
 

--- a/docs/libretto-cloud-hosting/stealth.mdx
+++ b/docs/libretto-cloud-hosting/stealth.mdx
@@ -45,6 +45,18 @@ Supported fields:
 
 For recurring workflows, pass the same object to `residential_proxy` on `/v1/schedules/create` or `/v1/schedules/update`. To clear a schedule's configured proxy location, set `residential_proxy` to `null` on `/v1/schedules/update`.
 
+## Disable default proxy (direct egress)
+
+Some sites fail through Kernel's default residential stealth proxy with errors like `ERR_TUNNEL_CONNECTION_FAILED`. For those targets, pass `disable_default_proxy: true` when you create a job, browser session, or schedule. Libretto Cloud flips the Kernel session to direct egress before any `start_url` navigation.
+
+`disable_default_proxy` is Kernel-only and mutually exclusive with `residential_proxy`.
+
+```bash theme={null}
+npx libretto cloud jobs create check-eligibility \
+  --start-url 'https://example.com/dashboard' \
+  --disable-default-proxy
+```
+
 ## Workflow behavior
 
 On Libretto Cloud, if a workflow reaches a CAPTCHA, Cloudflare check, or similar interstitial, wait up to 2 minutes before treating it as blocked. That gives the hosted browser time to finish the provider-side solve and continue to the page your workflow expects.

--- a/packages/libretto/src/cli/commands/cloud-jobs.ts
+++ b/packages/libretto/src/cli/commands/cloud-jobs.ts
@@ -97,6 +97,10 @@ export const createCloudJobInput = SimpleCLI.input({
       name: "residential-proxy",
       help: "Residential proxy config as a JSON object",
     }),
+    disableDefaultProxy: SimpleCLI.flag({
+      name: "disable-default-proxy",
+      help: "Disable Kernel's default residential stealth proxy (direct egress). Mutually exclusive with --residential-proxy. Needed for sites that fail with ERR_TUNNEL_CONNECTION_FAILED on the default proxy.",
+    }),
   },
 })
   .refine((input) => Boolean(input.workflow), createJobUsage)
@@ -113,6 +117,10 @@ export const createCloudJobInput = SimpleCLI.input({
       (!input.callbackUrl && !input.callbackSecret) ||
       Boolean(input.callbackUrl && input.callbackSecret),
     "Pass both --callback-url and --callback-secret, or omit both.",
+  )
+  .refine(
+    (input) => !(input.disableDefaultProxy && input.residentialProxy),
+    "Cannot pass both --disable-default-proxy and --residential-proxy.",
   );
 
 export const createCloudJobCommand = SimpleCLI.command({
@@ -149,6 +157,9 @@ export const createCloudJobCommand = SimpleCLI.command({
     if (input.skipCallbacks) payload.skip_callbacks = true;
     if (residentialProxy !== undefined) {
       payload.residential_proxy = residentialProxy;
+    }
+    if (input.disableDefaultProxy) {
+      payload.disable_default_proxy = true;
     }
 
     const response = await orpcCall<CreateJobResponse>({

--- a/packages/libretto/src/cli/commands/cloud-schedules.ts
+++ b/packages/libretto/src/cli/commands/cloud-schedules.ts
@@ -102,6 +102,10 @@ export const createCloudScheduleInput = SimpleCLI.input({
       name: "residential-proxy",
       help: "Residential proxy config as a JSON object",
     }),
+    disableDefaultProxy: SimpleCLI.flag({
+      name: "disable-default-proxy",
+      help: "Disable Kernel's default residential stealth proxy (direct egress). Mutually exclusive with --residential-proxy. Needed for sites that fail with ERR_TUNNEL_CONNECTION_FAILED on the default proxy.",
+    }),
     disabled: SimpleCLI.flag({
       help: "Create the schedule disabled",
     }),
@@ -117,6 +121,10 @@ export const createCloudScheduleInput = SimpleCLI.input({
       (!input.callbackUrl && !input.callbackSecret) ||
       Boolean(input.callbackUrl && input.callbackSecret),
     "Pass both --callback-url and --callback-secret, or omit both.",
+  )
+  .refine(
+    (input) => !(input.disableDefaultProxy && input.residentialProxy),
+    "Cannot pass both --disable-default-proxy and --residential-proxy.",
   );
 
 export const createCloudScheduleCommand = SimpleCLI.command({
@@ -153,6 +161,9 @@ export const createCloudScheduleCommand = SimpleCLI.command({
     if (input.skipCallbacks) payload.skip_callbacks = true;
     if (residentialProxy !== undefined) {
       payload.residential_proxy = residentialProxy;
+    }
+    if (input.disableDefaultProxy) {
+      payload.disable_default_proxy = true;
     }
 
     const response = await orpcCall<CreateScheduleResponse>({

--- a/packages/libretto/src/cli/core/providers/libretto-cloud.ts
+++ b/packages/libretto/src/cli/core/providers/libretto-cloud.ts
@@ -31,6 +31,9 @@ export function createLibrettoCloudProvider(): ProviderApi {
       const startUrl = options?.startUrl?.trim() || undefined;
       const gpu = options?.gpu;
       const viewport = options?.viewport;
+      const disableDefaultProxy =
+        options?.disableDefaultProxy ??
+        readBooleanEnv("LIBRETTO_DISABLE_DEFAULT_PROXY", false);
       const resp = await fetch(`${endpoint}/v1/sessions/create`, {
         method: "POST",
         headers: {
@@ -53,6 +56,7 @@ export function createLibrettoCloudProvider(): ProviderApi {
                   },
                 }
               : {}),
+            ...(disableDefaultProxy ? { disable_default_proxy: true } : {}),
           },
         }),
       });
@@ -91,7 +95,8 @@ export function createLibrettoCloudProvider(): ProviderApi {
         sessionId: readySession.session_id,
         cdpEndpoint: readySession.cdp_url,
         liveViewUrl: readySession.live_view_url ?? undefined,
-        // Hosted sessions apply start_url before CDP is returned when set.
+        // Hosted sessions apply start_url before CDP is returned when set
+        // (including after disable_default_proxy flips Kernel to direct egress).
         startUrlPreloaded: Boolean(startUrl),
       };
     },
@@ -288,6 +293,12 @@ function readPositiveNumberEnv(name: string, fallback: number): number {
   if (!raw) return fallback;
   const parsed = Number(raw);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readBooleanEnv(name: string, defaultValue: boolean): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return defaultValue;
+  return value === "1" || value === "true" || value === "yes";
 }
 
 function sendStartupStatus(message: string): void {

--- a/packages/libretto/src/cli/core/providers/types.ts
+++ b/packages/libretto/src/cli/core/providers/types.ts
@@ -5,6 +5,10 @@ export type ProviderSessionCreateOptions = {
   startUrl?: string;
   gpu?: boolean;
   viewport?: { width: number; height: number };
+  // Libretto Cloud / Kernel only: turn off the provider's default residential
+  // stealth proxy so traffic uses direct egress. Mutually exclusive with a
+  // custom residential_proxy on the Cloud API.
+  disableDefaultProxy?: boolean;
 };
 
 export type ProviderSession = {

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -1,5 +1,7 @@
 import { existsSync } from "node:fs";
 import { chmod, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -378,6 +380,8 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("--start-url");
     expect(result.stdout).toContain("--gpu");
     expect(result.stdout).toContain("--viewport");
+    expect(result.stdout).toContain("--residential-proxy");
+    expect(result.stdout).toContain("--disable-default-proxy");
     expect(result.stderr).toBe("");
   });
 
@@ -390,6 +394,79 @@ describe("basic CLI subprocess behavior", () => {
       "LIBRETTO_API_KEY is required to create Libretto Cloud jobs.",
     );
     expect(result.stderr).toContain("libretto cloud auth api-key issue");
+  });
+
+  test("cloud jobs create rejects --disable-default-proxy with --residential-proxy", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli(
+      `cloud jobs create testWorkflow --disable-default-proxy --residential-proxy '{"country":"US"}'`,
+      { LIBRETTO_API_KEY: "test-key" },
+    );
+
+    expect(result.stderr).toContain(
+      "Cannot pass both --disable-default-proxy and --residential-proxy.",
+    );
+  });
+
+  test("cloud jobs create sends disable_default_proxy with start_url", async ({
+    librettoCli,
+  }) => {
+    const requests: Array<{ path: string; body: unknown }> = [];
+    const server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const rawBody = Buffer.concat(chunks).toString("utf8");
+      requests.push({
+        path: request.url ?? "",
+        body: rawBody.length > 0 ? JSON.parse(rawBody) : null,
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify({
+          json: {
+            success: true,
+            job_id: "job-direct-egress",
+            status: "queued",
+            message: "Job queued.",
+          },
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    const apiUrl = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const result = await librettoCli(
+        "cloud jobs create esnad-floating-tenders --start-url https://etendering.tenderboard.gov.om/product/publicDash --disable-default-proxy",
+        {
+          LIBRETTO_API_KEY: "test-key",
+          LIBRETTO_API_URL: apiUrl,
+        },
+      );
+
+      expect(result.stdout).toContain("Job created: job-direct-egress");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.path).toBe("/v1/jobs/create");
+      expect(requests[0]?.body).toEqual({
+        json: {
+          workflow: "esnad-floating-tenders",
+          params: {},
+          start_url:
+            "https://etendering.tenderboard.gov.om/product/publicDash",
+          disable_default_proxy: true,
+        },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   test("prints cloud schedules create help", async ({ librettoCli }) => {
@@ -405,6 +482,8 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("--start-url");
     expect(result.stdout).toContain("--gpu");
     expect(result.stdout).toContain("--viewport");
+    expect(result.stdout).toContain("--residential-proxy");
+    expect(result.stdout).toContain("--disable-default-proxy");
     expect(result.stderr).toBe("");
   });
 
@@ -420,6 +499,19 @@ describe("basic CLI subprocess behavior", () => {
       "LIBRETTO_API_KEY is required to create Libretto Cloud schedules.",
     );
     expect(result.stderr).toContain("libretto cloud auth api-key issue");
+  });
+
+  test("cloud schedules create rejects --disable-default-proxy with --residential-proxy", async ({
+    librettoCli,
+  }) => {
+    const result = await librettoCli(
+      `cloud schedules create testWorkflow --cron "0 * * * *" --disable-default-proxy --residential-proxy '{"country":"US"}'`,
+      { LIBRETTO_API_KEY: "test-key" },
+    );
+
+    expect(result.stderr).toContain(
+      "Cannot pass both --disable-default-proxy and --residential-proxy.",
+    );
   });
 
   test("prints cloud share help", async ({ librettoCli }) => {

--- a/packages/libretto/test/browser.spec.ts
+++ b/packages/libretto/test/browser.spec.ts
@@ -570,6 +570,75 @@ describe("Libretto Cloud provider", () => {
     });
   });
 
+  it("forwards disableDefaultProxy and still marks startUrlPreloaded", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-direct-egress",
+              status: "open",
+              cdp_url:
+                "wss://cloud.example.test/devtools/session-direct-egress",
+              live_view_url: null,
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const session = await createLibrettoCloudProvider().createSession({
+      startUrl: "https://etendering.tenderboard.gov.om/product/publicDash",
+      disableDefaultProxy: true,
+    });
+
+    expect(session.startUrlPreloaded).toBe(true);
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      json: {
+        timeout_seconds: 3600,
+        start_url: "https://etendering.tenderboard.gov.om/product/publicDash",
+        disable_default_proxy: true,
+      },
+    });
+  });
+
+  it("reads LIBRETTO_DISABLE_DEFAULT_PROXY for cloud browser sessions", async () => {
+    vi.stubEnv("LIBRETTO_API_KEY", "test-key");
+    vi.stubEnv("LIBRETTO_DISABLE_DEFAULT_PROXY", "1");
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, _init?: RequestInit) => {
+        const pathname = new URL(String(url)).pathname;
+        if (pathname === "/v1/sessions/create") {
+          return jsonResponse({
+            json: {
+              session_id: "session-env-proxy",
+              status: "open",
+              cdp_url: "wss://cloud.example.test/devtools/session-env-proxy",
+              live_view_url: null,
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createLibrettoCloudProvider().createSession();
+
+    expect(await readJsonBody(fetchMock.mock.calls[0]?.[1])).toEqual({
+      json: {
+        timeout_seconds: 3600,
+        disable_default_proxy: true,
+      },
+    });
+  });
+
   it("waits for queued sessions to receive a CDP URL", async () => {
     vi.stubEnv("LIBRETTO_API_KEY", "test-key");
     vi.stubEnv("LIBRETTO_TIMEOUT_SECONDS", "123");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `--disable-default-proxy` to `libretto cloud jobs create` and `libretto cloud schedules create`, sending `disable_default_proxy: true` to the Cloud API.
- Reject combining `--disable-default-proxy` with `--residential-proxy` client-side.
- Plumb `disableDefaultProxy` (and `LIBRETTO_DISABLE_DEFAULT_PROXY`) into Libretto Cloud session create; keep `startUrlPreloaded` when `start_url` is set.
- Document the field in Cloud API / stealth docs and cover help, mutual exclusion, payload, and provider forwarding in tests.

## Test plan
- [x] `help cloud jobs create` / `help cloud schedules create` show `--disable-default-proxy`
- [x] Combining `--disable-default-proxy` and `--residential-proxy` fails with a clear error
- [x] Mocked `cloud jobs create --start-url ... --disable-default-proxy` sends `disable_default_proxy: true`
- [x] Cloud provider unit tests forward `disableDefaultProxy` / env and keep `startUrlPreloaded`
- [x] CI type-check / lint / unit tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab90bec0-ece3-4618-a0af-2f997973778b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab90bec0-ece3-4618-a0af-2f997973778b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

