### PR TITLE
Teach start.md sandbox Chromium fallback to Libretto Cloud

### DIFF
--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -91,5 +91,4 @@ After verifying Libretto is setup and working properly, summarize the steps take
 
 - Fix only setup-related failures.
 - Do not make unrelated changes or invent secrets.
-- Do not spend time installing OS packages or fighting sandbox Chromium dependency gaps; run Libretto Cloud auth/verify yourself and share any browser URL with the user.
 - Do not ask the user to run CLI commands.

--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -91,4 +91,3 @@ After verifying Libretto is setup and working properly, summarize the steps take
 
 - Fix only setup-related failures.
 - Do not make unrelated changes or invent secrets.
-- Do not ask the user to run CLI commands.

--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -70,15 +70,13 @@ Agent sandboxes (for example Claude Cowork) can install npm packages but often c
 
 Fall back in this order:
 
-1. Ask the user to run `npx libretto login` if they are not already logged in, then verify with Libretto Cloud:
+1. Check auth with `npx libretto cloud auth whoami`. If not logged in, run `npx libretto cloud auth login` yourself (use `npx libretto cloud auth signup` when they need a new account). That command prints a browser sign-in/sign-up URL and waits; share the URL with the user, do not ask them to run the CLI. After auth succeeds, verify with Libretto Cloud:
 
 ```bash
 npx libretto run src/workflows/scrape-page.ts --provider libretto-cloud
 ```
 
-2. If cloud login is unavailable, ask the user to run the local `--headless` command on their host machine and confirm the result.
-
-If the package is installed, the smoke workflow exists, and you have given a clear next verify command (cloud or host), treat setup as complete even when the sandbox cannot host a browser.
+2. If cloud auth cannot complete in this environment, stop fighting local Chromium. Treat setup as complete once the package is installed and the smoke workflow exists, and report that browser verification needs Libretto Cloud or a host machine with working Chromium. Do not ask the user to run CLI commands.
 
 ## 5. Finish
 
@@ -93,4 +91,5 @@ After verifying Libretto is setup and working properly, summarize the steps take
 
 - Fix only setup-related failures.
 - Do not make unrelated changes or invent secrets.
-- Do not spend time installing OS packages or fighting sandbox Chromium dependency gaps; use the Libretto Cloud or host-machine fallback.
+- Do not spend time installing OS packages or fighting sandbox Chromium dependency gaps; run Libretto Cloud auth/verify yourself and share any browser URL with the user.
+- Do not ask the user to run CLI commands.

--- a/apps/website/public/start.md
+++ b/apps/website/public/start.md
@@ -58,11 +58,27 @@ export default workflow("scrape-page", async ({ page }) => {
 });
 ```
 
-Run it:
+Run it with a local browser first:
 
 ```bash
 npx libretto run src/workflows/scrape-page.ts --headless
 ```
+
+### If local Chromium fails in a sandbox
+
+Agent sandboxes (for example Claude Cowork) can install npm packages but often cannot launch local Chromium: missing shared libraries (such as `libXdamage.so.1`), no sudo, and blocked `playwright install-deps` / apt. Do not keep retrying apt, sudo, or OS dependency installs.
+
+Fall back in this order:
+
+1. Ask the user to run `npx libretto login` if they are not already logged in, then verify with Libretto Cloud:
+
+```bash
+npx libretto run src/workflows/scrape-page.ts --provider libretto-cloud
+```
+
+2. If cloud login is unavailable, ask the user to run the local `--headless` command on their host machine and confirm the result.
+
+If the package is installed, the smoke workflow exists, and you have given a clear next verify command (cloud or host), treat setup as complete even when the sandbox cannot host a browser.
 
 ## 5. Finish
 
@@ -77,3 +93,4 @@ After verifying Libretto is setup and working properly, summarize the steps take
 
 - Fix only setup-related failures.
 - Do not make unrelated changes or invent secrets.
+- Do not spend time installing OS packages or fighting sandbox Chromium dependency gaps; use the Libretto Cloud or host-machine fallback.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In Claude Cowork / similar Linux agent sandboxes, `https://libretto.sh/start.md` told agents to verify with local `npx libretto run … --headless`. npm install can succeed, but local Chromium fails (missing libs like `libXdamage.so.1`, no sudo, blocked `playwright install-deps` / apt). Agents then burned time retrying OS deps.

This updates `apps/website/public/start.md` so verify tries a local headless run first, then falls back to Libretto Cloud (`npx libretto login` if needed, then `--provider libretto-cloud`), or asks the user to run the headless command on their host. Setup can complete when the package, smoke workflow, and a clear next verify command are in place even if the sandbox cannot host a browser. Agents must not spend time installing OS packages or fighting sandbox Chromium gaps.

## Test plan

- [ ] Read `apps/website/public/start.md` and confirm the verify intro is "Run it with a local browser first:", the sandbox subsection lists cloud then host fallbacks, and the new constraint is present
- [ ] Mentally re-run a Cowork-style setup prompt against `https://libretto.sh/start.md`: on Chromium/`libXdamage` failure, expect stop-retrying-deps + `libretto-cloud` / host verify instead of apt loops

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eef5a77c-6109-459e-9dcd-e2cc0a53e98b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eef5a77c-6109-459e-9dcd-e2cc0a53e98b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

