### PR TITLE
Document claimSmsOtp in runtime and hosting auth guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,7 @@
             "pages": [
               "reference/runtime/workflow",
               "reference/runtime/authentication",
+              "reference/runtime/sms-otp",
               "reference/runtime/network-requests",
               "reference/runtime/file-downloads",
               "reference/runtime/page-fallbacks",

--- a/docs/libretto-cloud-api/sms-otp.mdx
+++ b/docs/libretto-cloud-api/sms-otp.mdx
@@ -50,6 +50,8 @@ Release the number and remove it from your tenant pool. Irreversible.
 
 `claimSmsOtp` first locks the inbox (exclusive claim), then returns a handle. Always await the claim before clicking send-code so the lock is held when the SMS arrives. Call `otp.wait()` after send-code.
 
+Full runtime API: [`claimSmsOtp`](/reference/runtime/sms-otp).
+
 Pass one of `phoneNumber`, `phoneNumberId`, or `phoneNumberLabel` to select the inbox.
 
 Auth is automatic — do not put an API key in workflow source:

--- a/docs/libretto-cloud-hosting/website-authentication.mdx
+++ b/docs/libretto-cloud-hosting/website-authentication.mdx
@@ -120,4 +120,4 @@ export default workflow("portalReport", {
 });
 ```
 
-See [`claimSmsOtp`](/reference/runtime/sms-otp) for the runtime API and [SMS OTP](/libretto-cloud-api/sms-otp) for number pool setup and claim routes.
+See [`claimSmsOtp`](/reference/runtime/sms-otp).

--- a/docs/libretto-cloud-hosting/website-authentication.mdx
+++ b/docs/libretto-cloud-hosting/website-authentication.mdx
@@ -12,6 +12,7 @@ Hosted website authentication uses the same workflow code as local runs:
 - `credentials` declares which secrets the workflow can use for login.
 - `authProfile` declares the provider-native browser profile to reuse.
 - `librettoAuthenticate` checks whether the profile is signed in and runs sign-in if needed.
+- `claimSmsOtp` waits for a portal SMS one-time code on a tenant inbox number when the login texts MFA codes.
 
 ```typescript theme={null}
 import { librettoAuthenticate, workflow } from "libretto";
@@ -76,3 +77,47 @@ Local profiles are Playwright storage-state JSON files under `.libretto/profiles
 Hosted profiles are managed by the browser provider selected by Libretto Cloud. They are useful for deployed jobs and local CLI runs that use `--provider libretto-cloud`.
 
 The two are intentionally separate. To seed a hosted profile, run the workflow with Libretto Cloud and let sign-in create or refresh the provider-native profile.
+
+### SMS one-time codes
+
+When a portal texts a one-time code, use Libretto Cloud SMS OTP instead of scraping an inbox or putting an API key in workflow source.
+
+1. Provision a tenant inbox number (`libretto cloud sms-numbers provision --label <portal>` or the dashboard Phone numbers page).
+2. Register that full phone number (with country code) as the MFA phone on the portal account. Prefer one number per portal.
+3. In the workflow, await `claimSmsOtp` before clicking send-code, then `otp.wait()` for the code.
+
+Hosted jobs inject a short-lived job token automatically. Locally set `LIBRETTO_API_KEY` (same key as deploy and CLI).
+
+```typescript theme={null}
+import { claimSmsOtp, librettoAuthenticate, workflow } from "libretto";
+
+export default workflow("portalReport", {
+  startUrl: "https://portal.example.com",
+  credentials: ["username", "password"],
+  authProfile: { name: "portal", refresh: true },
+  async handler(ctx, input) {
+    await librettoAuthenticate(ctx, {
+      credentials: input.credentials,
+      isSignedIn: async ({ page }) =>
+        await page
+          .getByRole("button", { name: /account|sign out/i })
+          .isVisible()
+          .catch(() => false),
+      signIn: async ({ page }, credentials) => {
+        await page.goto("https://portal.example.com/login");
+        await page.getByLabel("Email").fill(credentials.username);
+        await page.getByLabel("Password").fill(credentials.password);
+        await page.getByRole("button", { name: /log in/i }).click();
+
+        const otp = await claimSmsOtp({ phoneNumberLabel: "uhc" });
+        await page.getByRole("button", { name: /send code/i }).click();
+        const { code } = await otp.wait();
+        await page.getByLabel("Code").fill(code);
+        await page.getByRole("button", { name: /verify/i }).click();
+      },
+    });
+  },
+});
+```
+
+See [`claimSmsOtp`](/reference/runtime/sms-otp) for the runtime API and [SMS OTP](/libretto-cloud-api/sms-otp) for number pool setup and claim routes.

--- a/docs/reference/runtime/authentication.mdx
+++ b/docs/reference/runtime/authentication.mdx
@@ -85,3 +85,5 @@ After `signIn` runs, `librettoAuthenticate` calls `isSignedIn` again. If the ses
   Pair `librettoAuthenticate` with `authProfile: { name, refresh: true }` when
   a successful sign-in should update the profile for future runs.
 </Note>
+
+When sign-in needs a portal SMS one-time code, use [`claimSmsOtp`](/reference/runtime/sms-otp) inside `signIn`.

--- a/docs/reference/runtime/sms-otp.mdx
+++ b/docs/reference/runtime/sms-otp.mdx
@@ -1,0 +1,104 @@
+---
+title: SMS OTP
+"og:image": "https://libretto.sh/docs/og/reference/runtime/sms-otp.png"
+---
+
+> Claim a Libretto Cloud SMS inbox, then wait for an inbound one-time code during a portal login.
+
+### `claimSmsOtp()`
+
+`claimSmsOtp` locks a tenant SMS inbox number, then returns a handle whose `wait()` method polls until the inbound code arrives. Use it when a portal texts a one-time code. Prefer authenticator TOTP (`*_totp_secret`) when the portal supports it.
+
+Provision inbox numbers outside the workflow (CLI or dashboard), register the full phone number on the portal MFA settings, then call `claimSmsOtp` in the sign-in path. See [SMS OTP on Libretto Cloud](/libretto-cloud-api/sms-otp) for pool APIs and isolation rules.
+
+```typescript theme={null}
+async function claimSmsOtp(options: ClaimSmsOtpOptions): Promise<SmsOtpClaim>;
+```
+
+Await the claim before clicking send-code so the lock is held when the SMS arrives. Call `otp.wait()` after send-code.
+
+Auth is automatic — do not put an API key in workflow source:
+
+- Local runs: set `LIBRETTO_API_KEY` (same key as deploy and CLI).
+- Hosted Cloud jobs: dispatch injects a short-lived job token; `claimSmsOtp` picks it up with no extra args.
+
+#### Options
+
+Pass exactly one of `phoneNumberId`, `phoneNumberLabel`, or `phoneNumber` to select the inbox.
+
+<ParamField path="phoneNumberId" type="string">
+  Pool phone-number id from `/v1/smsNumbers`.
+</ParamField>
+
+<ParamField path="phoneNumberLabel" type="string">
+  Label set when the inbox was provisioned (for example `uhc`). Prefer one
+  number per portal.
+</ParamField>
+
+<ParamField path="phoneNumber" type="string">
+  Full phone number with country code (for example `+15551234567`) from the
+  tenant pool.
+</ParamField>
+
+<ParamField path="timeoutMs" type="number">
+  How long to wait for the inbound SMS after the claim opens. Also sets the
+  inbox claim lock (clamped to 30–300 seconds on the API). Defaults to
+  `120000`.
+</ParamField>
+
+<ParamField path="pollIntervalMs" type="number">
+  Poll interval while waiting for the code. Defaults to `1500`.
+</ParamField>
+
+<ParamField path="apiKey" type="string">
+  Optional override. Prefer omitting this so local runs use
+  `LIBRETTO_API_KEY` and hosted jobs use the injected job token.
+</ParamField>
+
+<ParamField path="apiUrl" type="string">
+  Libretto Cloud API base URL. Defaults to `LIBRETTO_API_URL` or
+  `https://api.libretto.sh`.
+</ParamField>
+
+#### Return value
+
+<ResponseField name="phoneNumber" type="string">
+  The claimed inbox number (with country code).
+</ResponseField>
+
+<ResponseField name="claimId" type="string">
+  Id of the open claim.
+</ResponseField>
+
+<ResponseField name="phoneNumberId" type="string">
+  Pool phone-number id for the claimed inbox.
+</ResponseField>
+
+<ResponseField name="wait" type="() => Promise&lt;SmsOtpCode&gt;">
+  Polls until the claim is fulfilled, then returns `{ code, phoneNumber,
+  claimId }` once. Expires the claim if the wait times out or errors.
+</ResponseField>
+
+#### Example
+
+```typescript theme={null}
+import { claimSmsOtp, workflow } from "libretto";
+
+export default workflow("portal-login", {
+  credentials: ["username", "password"],
+  async handler(ctx, input) {
+    // ... fill username/password, then:
+    const otp = await claimSmsOtp({ phoneNumberLabel: "uhc" });
+    // Inbox is locked. otp.phoneNumber is the claimed number.
+
+    await ctx.page.click('button:has-text("Send code")');
+    const { code } = await otp.wait();
+    await ctx.page.fill('input[name="otp"]', code);
+  },
+});
+```
+
+<Note>
+  Do not run concurrent SMS OTP claims on the same inbox number. A claim locks
+  the inbox for up to 5 minutes; consuming the code unlocks it.
+</Note>

--- a/docs/understand-libretto/website-authentication.mdx
+++ b/docs/understand-libretto/website-authentication.mdx
@@ -101,7 +101,7 @@ npx libretto open https://portal.example.com --headed --session portal-login
 npx libretto save portal --session portal-login --sites portal.example.com
 ```
 
-Use this when the login cannot be scripted with Playwright, such as CAPTCHAs, device approvals, or magic links. For repeatable SMS one-time codes on Libretto Cloud, see [`claimSmsOtp`](/reference/runtime/sms-otp) and [SMS OTP](/libretto-cloud-api/sms-otp). Once an auth profile is saved, the workflow can use `authProfile: "portal"` or `authProfile: { name: "portal", refresh: true }` without repeating the manual login every run.
+Use this when the login cannot be scripted with Playwright, such as CAPTCHAs, device approvals, or magic links. For repeatable SMS one-time codes on Libretto Cloud, see [`claimSmsOtp`](/reference/runtime/sms-otp). Once an auth profile is saved, the workflow can use `authProfile: "portal"` or `authProfile: { name: "portal", refresh: true }` without repeating the manual login every run.
 
 If you already have a signed-in Chrome profile and explicitly want to copy from it, start that Chrome profile with remote debugging enabled and import only the sites you need:
 

--- a/docs/understand-libretto/website-authentication.mdx
+++ b/docs/understand-libretto/website-authentication.mdx
@@ -101,7 +101,7 @@ npx libretto open https://portal.example.com --headed --session portal-login
 npx libretto save portal --session portal-login --sites portal.example.com
 ```
 
-Use this when the login cannot be scripted with Playwright, such as CAPTCHAs, device approvals, or magic links. For repeatable SMS one-time codes on Libretto Cloud, see [SMS OTP](/libretto-cloud-api/sms-otp). Once an auth profile is saved, the workflow can use `authProfile: "portal"` or `authProfile: { name: "portal", refresh: true }` without repeating the manual login every run.
+Use this when the login cannot be scripted with Playwright, such as CAPTCHAs, device approvals, or magic links. For repeatable SMS one-time codes on Libretto Cloud, see [`claimSmsOtp`](/reference/runtime/sms-otp) and [SMS OTP](/libretto-cloud-api/sms-otp). Once an auth profile is saved, the workflow can use `authProfile: "portal"` or `authProfile: { name: "portal", refresh: true }` without repeating the manual login every run.
 
 If you already have a signed-in Chrome profile and explicitly want to copy from it, start that Chrome profile with remote debugging enabled and import only the sites you need:
 
@@ -119,6 +119,8 @@ Hosted runs do not upload local `.libretto/profiles/<name>.json` files. They use
 
 For the hosted model, provider behavior, and profile persistence details, see [Website authentication in Libretto Cloud](/libretto-cloud-hosting/website-authentication).
 
-### Runtime helper
+### Runtime helpers
 
 Use [`librettoAuthenticate`](/reference/runtime/authentication) when a workflow has an auth profile and scripted sign-in. The helper runs your `isSignedIn` check, calls your `signIn` function if needed, and checks again before the workflow continues.
+
+Use [`claimSmsOtp`](/reference/runtime/sms-otp) inside `signIn` (or any scripted login) when the portal texts a one-time code. Provision the inbox outside the workflow, claim it before send-code, then wait for the code.


### PR DESCRIPTION
## Summary
- Add a Reference → Runtime page for `claimSmsOtp` (options, return value, example).
- Cover SMS OTP in Hosting → Website authentication with a short setup + sign-in example.
- Cross-link from Understand Libretto website auth, runtime authentication, and the Cloud API SMS OTP page.

## Test plan
- [ ] Docs nav shows Reference → Runtime → SMS OTP
- [ ] Hosting website-authentication section links to runtime + API pages
- [ ] Preview/docs site renders the new page without broken links


Made with [Cursor](https://cursor.com)