### PR TITLE
Prerender /dashboard/phone_numbers

### DIFF
--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -11,25 +11,13 @@ import {
 import { InstallSnippet } from "./components/InstallSnippet";
 import { GitHubIcon } from "./icons";
 import { DEBUGGER_PROMPT, GITHUB_APP_INSTALL_URL } from "./prAgentSetup";
+import type { DashboardSection } from "./dashboardSections";
 
 const CLOUD_SETUP_PROMPT =
   "Fetch and follow https://libretto.sh/cloud.md to set up Libretto Cloud hosted browsers for this project.";
 
-export const dashboardSections = [
-  "workflows",
-  "schedules",
-  "workflow_runs",
-  "browser_sessions",
-  "connected_repos",
-  "users",
-  "settings",
-  "secrets",
-  "phone_numbers",
-  "api_keys",
-  "billing",
-] as const;
-
-export type DashboardSection = (typeof dashboardSections)[number];
+export { dashboardSections } from "./dashboardSections";
+export type { DashboardSection } from "./dashboardSections";
 
 interface NavItem {
   id: DashboardSection;

--- a/apps/website/src/dashboardSections.ts
+++ b/apps/website/src/dashboardSections.ts
@@ -1,0 +1,27 @@
+/**
+ * The dashboard's sections, in one React-free module so vite.config.ts can
+ * import it for the prerender list. A section listed here but missing from
+ * that list is served as a Vercel 404 — the router's fallback redirect never
+ * runs, because there is no prerendered HTML to load.
+ */
+export const dashboardSections = [
+  "workflows",
+  "schedules",
+  "workflow_runs",
+  "browser_sessions",
+  "connected_repos",
+  "users",
+  "settings",
+  "secrets",
+  "phone_numbers",
+  "api_keys",
+  "billing",
+] as const;
+
+export type DashboardSection = (typeof dashboardSections)[number];
+
+/** Paths the build must prerender, derived so the two cannot drift. */
+export const dashboardPrerenderPaths = [
+  "/dashboard",
+  ...dashboardSections.map((section) => `/dashboard/${section}`),
+];

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -4,23 +4,12 @@ import tailwindcss from "@tailwindcss/vite";
 import { comptime } from "comptime.ts/vite";
 import { defineConfig, type Plugin } from "vite";
 import { loadBlogPostInputs } from "./scripts/blog-posts.ts";
+import { dashboardPrerenderPaths } from "./src/dashboardSections.ts";
 
 const comptimePlugin = await comptime();
 const blogPosts = await loadBlogPostInputs();
 const blogPostPaths = blogPosts.map((post) => `/blog/${post.slug}`);
-const dashboardPaths = [
-  "/dashboard",
-  "/dashboard/workflows",
-  "/dashboard/schedules",
-  "/dashboard/workflow_runs",
-  "/dashboard/browser_sessions",
-  "/dashboard/connected_repos",
-  "/dashboard/users",
-  "/dashboard/settings",
-  "/dashboard/secrets",
-  "/dashboard/api_keys",
-  "/dashboard/billing",
-];
+const dashboardPaths = dashboardPrerenderPaths;
 
 function localDocsRedirectPlugin(): Plugin {
   return {


### PR DESCRIPTION
## Problem

`/dashboard/phone_numbers` returns a Vercel **404: NOT_FOUND** in production. The section exists in the dashboard app — nav item, `sectionMeta`, `PhoneNumbersTable`, the lot — but `vite.config.ts` carried a *hardcoded* prerender list that was never updated when the section shipped. With no prerendered HTML at that path, Vercel answers before the SPA loads, so the router's `redirect({to: "/dashboard/$section", params: {section: "workflows"}})` fallback never gets a chance to run.

A customer hit this on their first visit to the page while setting up SMS OTP.

## Fix

Derive the prerender list from the section list rather than maintaining both. `dashboardSections` moves to `src/dashboardSections.ts`, a React-free module `vite.config.ts` can import; `AuthenticatedDashboardPage` re-exports it so existing importers are unchanged.

The two lists could drift silently before. Now they can't.

## Verification

`pnpm build` in a clean worktree off `main`:

```
$ ls dist/client/dashboard/
api_keys  billing  browser_sessions  connected_repos  index.html
phone_numbers  schedules  secrets  settings  users
workflow_runs  workflows
```

`phone_numbers` is emitted. `pnpm type-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)