### PR TITLE
Add unified workflow publishing commands and docs

### DIFF
--- a/.agents/skills/libretto/references/sharing-workflows-externally.md
+++ b/.agents/skills/libretto/references/sharing-workflows-externally.md
@@ -1,32 +1,27 @@
 # Sharing workflows externally
 
-Share a deployed workflow outside the workspace from the Libretto website dashboard. Workflows stay private until someone shares them there.
+Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
-## Options
+## What publication includes
 
-| Option | What others get | Source visible? |
-| --- | --- | --- |
-| Open workflows | Source they can fork or import as their own Cloud deployment | Yes |
-| Hosted workflows | A public run API. Callers use their own API key and credentials | No |
+Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Workspace code sharing must be on in organization settings before either option is available. The dashboard prompts if it is off.
+Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Share from the dashboard
+## Publish
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow and expand Share workflow outside this workspace.
-4. Choose one:
-   - Publish open source workflow — lists source on [Open source workflows](https://libretto.sh/open-workflows)
-   - Host workflow — lists a run API on [Hosted Workflow APIs](https://libretto.sh/hosted-workflows)
-5. If the UI asks to enable sharing, turn it on in [Settings](https://libretto.sh/dashboard/settings), then confirm.
+3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
 
-The same workflow can use both options when both source listing and a public run API are wanted.
+The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
 
 ## What stays private
 
 - Credentials and secret values
 - Organization run history and job logs
-- Workflow source on hosted listings (callers see schemas and how to call the run API, not the code)
+- Publisher and caller inputs, outputs, logs, and run history

--- a/.claude/skills/libretto/references/sharing-workflows-externally.md
+++ b/.claude/skills/libretto/references/sharing-workflows-externally.md
@@ -1,32 +1,27 @@
 # Sharing workflows externally
 
-Share a deployed workflow outside the workspace from the Libretto website dashboard. Workflows stay private until someone shares them there.
+Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
-## Options
+## What publication includes
 
-| Option | What others get | Source visible? |
-| --- | --- | --- |
-| Open workflows | Source they can fork or import as their own Cloud deployment | Yes |
-| Hosted workflows | A public run API. Callers use their own API key and credentials | No |
+Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Workspace code sharing must be on in organization settings before either option is available. The dashboard prompts if it is off.
+Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Share from the dashboard
+## Publish
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow and expand Share workflow outside this workspace.
-4. Choose one:
-   - Publish open source workflow — lists source on [Open source workflows](https://libretto.sh/open-workflows)
-   - Host workflow — lists a run API on [Hosted Workflow APIs](https://libretto.sh/hosted-workflows)
-5. If the UI asks to enable sharing, turn it on in [Settings](https://libretto.sh/dashboard/settings), then confirm.
+3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
 
-The same workflow can use both options when both source listing and a public run API are wanted.
+The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
 
 ## What stays private
 
 - Credentials and secret values
 - Organization run history and job logs
-- Workflow source on hosted listings (callers see schemas and how to call the run API, not the code)
+- Publisher and caller inputs, outputs, logs, and run history

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -140,7 +140,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
   </Card>
 
   <Card title="Sharing externally" icon="share" href="/libretto-cloud-hosting/sharing-workflows-externally">
-    Publish open workflows or hosted public run APIs from the website UI.
+    Publish a hosted public run API with reviewed, visible source code.
   </Card>
 
   <Card title="Observability and Debugging" icon="bug" href="/libretto-cloud-hosting/observability-and-debugging">

--- a/docs/libretto-cloud-hosting/sharing-workflows-externally.mdx
+++ b/docs/libretto-cloud-hosting/sharing-workflows-externally.mdx
@@ -4,35 +4,40 @@ sidebarTitle: Sharing externally
 "og:image": "https://libretto.sh/docs/og/libretto-cloud-hosting/sharing-workflows-externally.png"
 ---
 
-> Share a deployed workflow outside your workspace from the Libretto dashboard. Workflows stay private until you share them.
+> Publish a deployed workflow outside your workspace as a hosted API with visible source code. Workflows stay private until you publish them.
 
-Deploying a workflow makes it available inside your organization so you can run it with your API key. To list it publicly or let others call it, share it from the website after deploy.
+Deploying a workflow makes it available inside your organization. Publishing it externally creates a public run API and shares the reviewed source so others can inspect or adapt it.
 
-### Sharing options
+### What publication includes
 
-| Option | What others get | Source visible? |
-| --- | --- | --- |
-| Open workflows | Source they can fork locally or import as their own Cloud deployment | Yes |
-| Hosted workflows | A public run API. Callers use their own API key and credentials | No |
+Every published workflow has one public page with:
 
-Open workflows are for reuse and inspection. Hosted workflows are for an opaque API: callers see input and output schemas and how to invoke the run endpoint, not your code.
+- A hosted run endpoint that callers use with their own Libretto API key and credentials
+- Input and output types
+- Required credential names
+- Source files that visitors can inspect or adapt
 
-Workspace code sharing must be on in organization settings before you can publish an open workflow or host a public run API. The dashboard prompts you if the setting is off.
+Libretto reviews the source for secrets and other sensitive information before publishing. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-### Share from the dashboard
+### Publish from the dashboard
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open your workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
 3. Open the workflow and expand Share workflow outside this workspace.
-4. Choose one:
-   - Publish open source workflow — lists the source on [Open source workflows](https://libretto.sh/open-workflows)
-   - Host workflow — lists an opaque run API on [Hosted workflows](https://libretto.sh/hosted-workflows)
-5. If the UI asks you to enable sharing, turn it on in [Settings](https://libretto.sh/dashboard/settings), then confirm.
+4. Add an optional description and select Publish externally.
+5. Resolve any blocked privacy findings or acknowledge warnings after reviewing them.
+6. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
 
-You can offer both options for the same workflow if you want source listing and a public run API.
+You can also publish from a terminal:
+
+```bash
+libretto cloud publish myWorkflow
+```
+
+Use `--acknowledge-warnings` only after reviewing the findings printed by the command. Remove both the public API and source with `libretto cloud unpublish myWorkflow`.
 
 ### What stays private
 
 - Credentials and secret values
 - Your organization's run history and job logs
-- Workflow source on hosted listings (callers see schemas and how to call the run API, not your code)
+- The publisher's and callers' inputs, outputs, logs, and run history

--- a/packages/libretto/skills/libretto/references/sharing-workflows-externally.md
+++ b/packages/libretto/skills/libretto/references/sharing-workflows-externally.md
@@ -1,32 +1,27 @@
 # Sharing workflows externally
 
-Share a deployed workflow outside the workspace from the Libretto website dashboard. Workflows stay private until someone shares them there.
+Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
-## Options
+## What publication includes
 
-| Option | What others get | Source visible? |
-| --- | --- | --- |
-| Open workflows | Source they can fork or import as their own Cloud deployment | Yes |
-| Hosted workflows | A public run API. Callers use their own API key and credentials | No |
+Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Workspace code sharing must be on in organization settings before either option is available. The dashboard prompts if it is off.
+Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Share from the dashboard
+## Publish
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow and expand Share workflow outside this workspace.
-4. Choose one:
-   - Publish open source workflow — lists source on [Open source workflows](https://libretto.sh/open-workflows)
-   - Host workflow — lists a run API on [Hosted Workflow APIs](https://libretto.sh/hosted-workflows)
-5. If the UI asks to enable sharing, turn it on in [Settings](https://libretto.sh/dashboard/settings), then confirm.
+3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
 
-The same workflow can use both options when both source listing and a public run API are wanted.
+The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
 
 ## What stays private
 
 - Credentials and secret values
 - Organization run history and job logs
-- Workflow source on hosted listings (callers see schemas and how to call the run API, not the code)
+- Publisher and caller inputs, outputs, logs, and run history

--- a/packages/libretto/src/cli/commands/cloud-publishing.ts
+++ b/packages/libretto/src/cli/commands/cloud-publishing.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { SimpleCLI } from "affordance";
+import { orpcCall } from "../core/auth-fetch.js";
+import { withCloudApiKey, type CloudApiKeyContext } from "./shared.js";
+
+type PrivacyFinding = {
+  severity: "warning" | "blocked";
+  file: string;
+  line: number | null;
+  explanation: string;
+  suggestedFix: string;
+};
+
+type PublishResponse =
+  | {
+      status: "created" | "existing" | "refreshed";
+      workflow: string;
+      hosted_workflow: string;
+      page_url: string;
+      deployment_version: number;
+    }
+  | {
+      status: "needs_review" | "blocked";
+      workflow: string;
+      review_id: string;
+      findings: PrivacyFinding[];
+    }
+  | { status: "review_expired"; workflow: string };
+
+function printFindings(findings: PrivacyFinding[]): void {
+  for (const finding of findings) {
+    const location = `${finding.file}${finding.line ? `:${finding.line}` : ""}`;
+    console.error(
+      `${finding.severity.toUpperCase()} ${location}: ${finding.explanation}`,
+    );
+    console.error(`Fix: ${finding.suggestedFix}`);
+  }
+}
+
+export async function publishWorkflowWithPrivacyReview(
+  ctx: CloudApiKeyContext,
+  input: { workflow: string; description?: string; acknowledgeWarnings: boolean },
+): Promise<PublishResponse> {
+  const first = await orpcCall<PublishResponse>({
+    apiUrl: ctx.apiUrl,
+    path: "/v1/workflows/publish",
+    input: {
+      workflow: input.workflow,
+      description: input.description,
+      privacyReview: { capability: "workflow_privacy_review_v1" },
+    },
+    credential: ctx.credential,
+  });
+  if (first.status === "blocked") {
+    printFindings(first.findings);
+    throw new Error("Publishing is blocked. Fix the findings and deploy again.");
+  }
+  if (first.status !== "needs_review") return first;
+  printFindings(first.findings);
+  if (!input.acknowledgeWarnings) {
+    throw new Error(
+      "Review the warnings, then run the command again with --acknowledge-warnings to publish this exact deployment.",
+    );
+  }
+  return orpcCall<PublishResponse>({
+    apiUrl: ctx.apiUrl,
+    path: "/v1/workflows/publish",
+    input: {
+      workflow: input.workflow,
+      description: input.description,
+      privacyReview: {
+        capability: "workflow_privacy_review_v1",
+        reviewId: first.review_id,
+        acknowledgeWarnings: true,
+      },
+    },
+    credential: ctx.credential,
+  });
+}
+
+export const publishWorkflowCommand = SimpleCLI.command({
+  description: "Publish a deployed workflow outside your workspace",
+})
+  .input(
+    SimpleCLI.input({
+      positionals: [
+        SimpleCLI.positional("workflow", z.string().min(1), {
+          help: "Deployed workflow name to publish",
+        }),
+      ],
+      named: {
+        description: SimpleCLI.option(z.string().optional(), {
+          help: "Public workflow description",
+        }),
+        acknowledgeWarnings: SimpleCLI.flag({
+          help: "Publish after acknowledging privacy review warnings",
+        }),
+      },
+    }),
+  )
+  .use(withCloudApiKey("publish a Libretto Cloud workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await publishWorkflowWithPrivacyReview(ctx, input);
+    if (!("page_url" in response)) {
+      throw new Error(
+        response.status === "review_expired"
+          ? "The privacy review expired. Run publish again."
+          : "The workflow was not published.",
+      );
+    }
+    console.log(`Published workflow: ${response.hosted_workflow}`);
+    console.log(`Public page: ${response.page_url}`);
+    console.log(`Deployment version: ${response.deployment_version}`);
+    console.log("Source code: public");
+    return response.page_url;
+  });
+
+export const unpublishWorkflowCommand = SimpleCLI.command({
+  description: "Remove a workflow's public API and source code",
+})
+  .input(
+    SimpleCLI.input({
+      positionals: [
+        SimpleCLI.positional("workflow", z.string().min(1), {
+          help: "Published workflow name to remove",
+        }),
+      ],
+      named: {},
+    }),
+  )
+  .use(withCloudApiKey("unpublish a Libretto Cloud workflow"))
+  .handle(async ({ input, ctx }) => {
+    const response = await orpcCall<{ hosted_workflow: string }>({
+      apiUrl: ctx.apiUrl,
+      path: "/v1/workflows/unpublish",
+      input: { workflow: input.workflow },
+      credential: ctx.credential,
+    });
+    console.log(`Unpublished workflow: ${response.hosted_workflow}`);
+    return response.hosted_workflow;
+  });

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -6,6 +6,10 @@ import { cloudJobCommands } from "./commands/cloud-jobs.js";
 import { cloudScheduleCommands } from "./commands/cloud-schedules.js";
 import { cloudSmsNumberCommands } from "./commands/cloud-sms-numbers.js";
 import { settingsCommands } from "./commands/cloud-settings.js";
+import {
+  publishWorkflowCommand,
+  unpublishWorkflowCommand,
+} from "./commands/cloud-publishing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
 import { experimentsCommand } from "./commands/experiments.js";
@@ -33,6 +37,8 @@ export const cliRoutes = {
       schedules: cloudScheduleCommands,
       "sms-numbers": cloudSmsNumberCommands,
       settings: settingsCommands,
+      publish: publishWorkflowCommand,
+      unpublish: unpublishWorkflowCommand,
     },
   }),
   experiments: experimentsCommand,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -361,8 +361,8 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("jobs");
     expect(result.stdout).toContain("schedules");
     expect(result.stdout).toContain("settings");
-    expect(result.stdout).not.toMatch(/\bshare\b/);
-    expect(result.stdout).not.toMatch(/\bsharing\b/);
+    expect(result.stdout).toMatch(/\bpublish\b/);
+    expect(result.stdout).toMatch(/\bunpublish\b/);
     expect(result.stdout).not.toMatch(/\bhost\b/);
     expect(result.stdout).not.toMatch(/\bunhost\b/);
     expect(result.stderr).toBe("");

--- a/packages/libretto/test/cloud-publishing.spec.ts
+++ b/packages/libretto/test/cloud-publishing.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cli/core/auth-fetch.js", () => ({
+  orpcCall: vi.fn(),
+}));
+
+import { orpcCall } from "../src/cli/core/auth-fetch.js";
+import { publishWorkflowWithPrivacyReview } from "../src/cli/commands/cloud-publishing.js";
+
+const context = {
+  apiUrl: "https://api.libretto.test",
+  credential: { source: "env-api-key" as const, apiKey: "test-key" },
+};
+
+const warning = {
+  id: "finding-1",
+  severity: "warning" as const,
+  category: "private_url" as const,
+  file: "workflow.ts",
+  line: 12,
+  explanation: "A private URL may be embedded here.",
+  suggestedFix: "Move the URL to a secret.",
+};
+
+describe("cloud publish privacy review", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("blocks publication when the privacy review blocks the source", async () => {
+    vi.mocked(orpcCall).mockResolvedValueOnce({
+      workflow: "syncClaims",
+      status: "blocked",
+      review_id: "2edbf679-dda3-4df8-822b-9dc2228c48f8",
+      findings: [{ ...warning, severity: "blocked" }],
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      publishWorkflowWithPrivacyReview(context, {
+        workflow: "syncClaims",
+        acknowledgeWarnings: false,
+      }),
+    ).rejects.toThrow("Publishing is blocked");
+    expect(orpcCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires explicit warning acknowledgement", async () => {
+    vi.mocked(orpcCall).mockResolvedValueOnce({
+      workflow: "syncClaims",
+      status: "needs_review",
+      review_id: "2edbf679-dda3-4df8-822b-9dc2228c48f8",
+      findings: [warning],
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      publishWorkflowWithPrivacyReview(context, {
+        workflow: "syncClaims",
+        acknowledgeWarnings: false,
+      }),
+    ).rejects.toThrow("--acknowledge-warnings");
+    expect(orpcCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("acknowledges the exact review before publishing", async () => {
+    const reviewId = "2edbf679-dda3-4df8-822b-9dc2228c48f8";
+    vi.mocked(orpcCall)
+      .mockResolvedValueOnce({
+        workflow: "syncClaims",
+        status: "needs_review",
+        review_id: reviewId,
+        findings: [warning],
+      })
+      .mockResolvedValueOnce({
+        workflow: "syncClaims",
+        hosted_workflow: "acme/syncClaims",
+        page_url: "https://libretto.test/hosted-workflows/acme/syncClaims",
+        deployment_version: 4,
+        status: "created",
+      });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      publishWorkflowWithPrivacyReview(context, {
+        workflow: "syncClaims",
+        description: "Sync claims",
+        acknowledgeWarnings: true,
+      }),
+    ).resolves.toMatchObject({ status: "created" });
+    expect(orpcCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          privacyReview: {
+            capability: "workflow_privacy_review_v1",
+            reviewId,
+            acknowledgeWarnings: true,
+          },
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `libretto cloud publish` and `libretto cloud unpublish` as the only external-publication CLI commands
- preserve blocked findings, warning acknowledgement, review expiry, and exact review-id retry behavior in the CLI
- rewrite user and shipped-agent guidance around one publication containing a hosted API, schemas, and reviewed public source
- keep generated skill mirrors synchronized

## Validation
- `pnpm --filter libretto exec vitest run test/basic.spec.ts test/cloud-publishing.spec.ts` (93 tests)
- `pnpm --filter libretto type-check`
- `pnpm lint`
- `pnpm check:mirrors`
