### PR TITLE
Unify public workflow UI and refresh the homepage hero

### DIFF
--- a/.agents/skills/libretto/references/sharing-workflows-externally.md
+++ b/.agents/skills/libretto/references/sharing-workflows-externally.md
@@ -1,6 +1,6 @@
 # Sharing workflows externally
 
-Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
+Share a deployed workflow publicly as a hosted API with visible source code. Workflows stay private until someone shares them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
@@ -8,17 +8,17 @@ Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hos
 
 Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
+Libretto reviews the source for sensitive information before it shares anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Publish
+## Share publicly
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+3. Open the workflow, expand Share workflow outside this workspace, and select Share publicly.
 4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
-5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then share again.
 
-The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
+The CLI uses the same method: `libretto cloud share <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unshare <workflow>` to remove both the API and source.
 
 ## What stays private
 

--- a/.claude/skills/libretto/references/sharing-workflows-externally.md
+++ b/.claude/skills/libretto/references/sharing-workflows-externally.md
@@ -1,6 +1,6 @@
 # Sharing workflows externally
 
-Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
+Share a deployed workflow publicly as a hosted API with visible source code. Workflows stay private until someone shares them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
@@ -8,17 +8,17 @@ Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hos
 
 Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
+Libretto reviews the source for sensitive information before it shares anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Publish
+## Share publicly
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+3. Open the workflow, expand Share workflow outside this workspace, and select Share publicly.
 4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
-5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then share again.
 
-The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
+The CLI uses the same method: `libretto cloud share <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unshare <workflow>` to remove both the API and source.
 
 ## What stays private
 

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -2637,8 +2637,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
     if (!sharing || !canManage) return;
     const enabled = !sharing.enabled;
     const confirmation = enabled
-      ? "Enable public workflow sharing? Workspace members will be able to share workflows with people outside this workspace. Existing workflows remain private until explicitly shared."
-      : "Disable public workflow sharing? Every Open and Hosted workflow from this workspace will be removed. Re-enabling sharing will not restore them automatically.";
+      ? "Enable external workflow publishing? Workspace members will be able to publish workflows with a public API and visible source. Existing workflows remain private until explicitly published."
+      : "Disable external workflow publishing? Every public workflow API and source listing from this workspace will be removed. Re-enabling publishing will not restore them automatically.";
     if (!window.confirm(confirmation)) {
       return;
     }
@@ -2654,8 +2654,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       setSharing(updated);
       setNotice(
         enabled
-          ? "Workflow sharing is enabled. Workflows remain private until someone explicitly shares them."
-          : "Workflow sharing is disabled and existing Open and Hosted workflows were removed.",
+          ? "External publishing is enabled. Workflows remain private until someone explicitly publishes them."
+          : "External publishing is disabled and existing public workflow APIs and source listings were removed.",
       );
     } catch (err) {
       setError(
@@ -2691,7 +2691,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       <details className="group rounded-xl border border-rule bg-panel/65 shadow-[0_12px_40px_rgba(0,0,0,0.16)]">
         <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-5 sm:p-6">
           <h2 className="text-base font-medium text-ink">
-            Public workflow sharing
+            External workflow publishing
           </h2>
           <span
             aria-hidden="true"
@@ -2705,9 +2705,9 @@ function SettingsPanel({ session }: { session: CloudSession }) {
             id="workflow-sharing-description"
             className="max-w-2xl text-sm leading-6 text-muted"
           >
-            Allow workspace members to share workflows for people outside
-            this workspace. They can share source code or provide a Hosted
-            workflow with a public run API.
+            Allow workspace members to publish workflows for people outside
+            this workspace. Each publication includes a Hosted workflow API
+            and reviewed source code.
           </p>
           <button
             type="button"
@@ -2747,8 +2747,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
             )}
             {sharing?.enabled && (
               <span className="mt-1 block">
-                Disabling this setting removes every current Open and Hosted
-                listing. Re-enabling it does not restore previous listings.
+                Disabling this setting removes every current public API and
+                source listing. Re-enabling it does not restore previous listings.
               </span>
             )}
           </div>

--- a/apps/website/src/AuthenticatedDashboardPage.tsx
+++ b/apps/website/src/AuthenticatedDashboardPage.tsx
@@ -2637,8 +2637,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
     if (!sharing || !canManage) return;
     const enabled = !sharing.enabled;
     const confirmation = enabled
-      ? "Enable external workflow publishing? Workspace members will be able to publish workflows with a public API and visible source. Existing workflows remain private until explicitly published."
-      : "Disable external workflow publishing? Every public workflow API and source listing from this workspace will be removed. Re-enabling publishing will not restore them automatically.";
+      ? "Enable public workflow sharing? Workspace members will be able to share workflows with a public API and visible source. Existing workflows remain private until explicitly shared."
+      : "Disable public workflow sharing? Every public workflow API and source listing from this workspace will be removed. Re-enabling sharing will not restore them automatically.";
     if (!window.confirm(confirmation)) {
       return;
     }
@@ -2654,8 +2654,8 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       setSharing(updated);
       setNotice(
         enabled
-          ? "External publishing is enabled. Workflows remain private until someone explicitly publishes them."
-          : "External publishing is disabled and existing public workflow APIs and source listings were removed.",
+          ? "Public sharing is enabled. Workflows remain private until someone explicitly shares them."
+          : "Public sharing is disabled and existing public workflow APIs and source listings were removed.",
       );
     } catch (err) {
       setError(
@@ -2691,7 +2691,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
       <details className="group rounded-xl border border-rule bg-panel/65 shadow-[0_12px_40px_rgba(0,0,0,0.16)]">
         <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-5 sm:p-6">
           <h2 className="text-base font-medium text-ink">
-            External workflow publishing
+            Public workflow sharing
           </h2>
           <span
             aria-hidden="true"
@@ -2705,7 +2705,7 @@ function SettingsPanel({ session }: { session: CloudSession }) {
             id="workflow-sharing-description"
             className="max-w-2xl text-sm leading-6 text-muted"
           >
-            Allow workspace members to publish workflows for people outside
+            Allow workspace members to share workflows with people outside
             this workspace. Each publication includes a Hosted workflow API
             and reviewed source code.
           </p>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -87,8 +87,8 @@ function Hero({
           htmlStyle={{ opacity: 0 }}
           className="mx-auto mb-8 max-w-[720px] text-center leading-relaxed [text-wrap:pretty]"
         >
-          Libretto helps coding agents autonomously manage integrations—browser
-          workflows, web scrapers, on-prem desktop apps, and more.
+          Libretto helps coding agents autonomously manage integrations: browser
+          workflows, web scrapers, on-prem apps, and more.
         </Text>
         <div
           data-animate={AnimationTarget.Content}

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -96,10 +96,13 @@ function Hero({
           className="flex flex-col items-center justify-center gap-3"
         >
           <InstallSnippet />
+          <span className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+            or
+          </span>
           <Button
             href="https://cal.com/team/libretto/15-min"
             variant="outline"
-            className="mt-2 min-w-56"
+            className="mt-1 min-w-56"
             data-fathom-event="Hero demo click"
           >
             Talk to a dev · 15 min

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -18,6 +18,7 @@ import { VersionBadge } from "./components/VersionBadge";
 import { ProductListing } from "./components/ProductListing";
 import { SectionDivider } from "./components/SectionDivider.js";
 import { BackedByYC } from "./components/BackedByYC";
+import { Button } from "./components/Button";
 
 function Hero({
   paneUnlocked,
@@ -95,16 +96,14 @@ function Hero({
           className="flex flex-col items-center justify-center gap-3"
         >
           <InstallSnippet />
-          <div className="text-xs text-muted">
-            or{" "}
-            <a
-              href="https://cal.com/team/libretto/demo"
-              className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
-              data-fathom-event="Hero demo click"
-            >
-              TALK TO A DEV
-            </a>
-          </div>
+          <Button
+            href="https://cal.com/michael-kronovet/meeting"
+            variant="outline"
+            className="min-w-64"
+            data-fathom-event="Hero demo click"
+          >
+            Talk to a dev · 15 min
+          </Button>
           <div className="mt-10">
             <BackedByYC />
           </div>

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -96,7 +96,7 @@ function Hero({
           className="flex flex-col items-center justify-center gap-3"
         >
           <InstallSnippet />
-          <span className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+          <span className="mt-1 font-mono text-[11px] uppercase tracking-[0.12em] text-muted">
             or
           </span>
           <Button

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -81,13 +81,13 @@ function Hero({
         </Text>
         <Text
           as="p"
-          size="lg"
+          size="xl"
           data-animate={AnimationTarget.Content}
           htmlStyle={{ opacity: 0 }}
-          className="mx-auto mb-8 max-w-[640px] text-center leading-relaxed md:text-base [text-wrap:pretty]"
+          className="mx-auto mb-8 max-w-[780px] text-center leading-relaxed [text-wrap:pretty]"
         >
-          Libretto helps agents build the most token-efficient automations
-          across public websites and on-prem systems.
+          Libretto helps coding agents autonomously manage integrations—browser
+          workflows, web scrapers, on-prem desktop apps, and more.
         </Text>
         <div
           data-animate={AnimationTarget.Content}

--- a/apps/website/src/HomePage.tsx
+++ b/apps/website/src/HomePage.tsx
@@ -82,10 +82,10 @@ function Hero({
         </Text>
         <Text
           as="p"
-          size="xl"
+          size="lg"
           data-animate={AnimationTarget.Content}
           htmlStyle={{ opacity: 0 }}
-          className="mx-auto mb-8 max-w-[780px] text-center leading-relaxed [text-wrap:pretty]"
+          className="mx-auto mb-8 max-w-[720px] text-center leading-relaxed [text-wrap:pretty]"
         >
           Libretto helps coding agents autonomously manage integrations—browser
           workflows, web scrapers, on-prem desktop apps, and more.
@@ -97,9 +97,9 @@ function Hero({
         >
           <InstallSnippet />
           <Button
-            href="https://cal.com/michael-kronovet/meeting"
+            href="https://cal.com/team/libretto/15-min"
             variant="outline"
-            className="min-w-64"
+            className="mt-2 min-w-56"
             data-fathom-event="Hero demo click"
           >
             Talk to a dev · 15 min

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -356,7 +356,7 @@ function EndpointBar({ method, url }: { method: string; url: string }) {
         {method}
       </span>
       <div className="min-w-0 flex-1 px-3 py-3">
-        <code className="break-all font-mono text-[11px] leading-5 text-ink xl:whitespace-nowrap">
+        <code className="break-all font-mono text-[11px] leading-5 text-ink">
           {url}
         </code>
       </div>

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -355,8 +355,8 @@ function EndpointBar({ method, url }: { method: string; url: string }) {
       <span className="inline-flex shrink-0 items-center border-r border-rule bg-accent/[0.08] px-4 font-mono text-[11px] font-semibold tracking-[0.1em] text-accent-bright">
         {method}
       </span>
-      <div className="min-w-0 flex-1 overflow-x-auto px-4 py-3 [scrollbar-width:none]">
-        <code className="whitespace-nowrap font-mono text-[12px] leading-5 text-ink">
+      <div className="min-w-0 flex-1 px-4 py-3">
+        <code className="break-all font-mono text-[12px] leading-5 text-ink sm:whitespace-nowrap">
           {url}
         </code>
       </div>
@@ -878,14 +878,16 @@ export function HostedWorkflowPage({
         })}
       </div>
 
+      {activeView === "api" && (
+        <div className="mt-6">
+          <EndpointBar method="POST" url={runUrl} />
+        </div>
+      )}
+
       <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start">
         <div className="min-w-0 space-y-6">
           {activeView === "api" ? (
             <>
-              <section>
-                <EndpointBar method="POST" url={runUrl} />
-              </section>
-
               <section>
                 <div className="border-b border-rule pb-4">
                   <h2 className="text-2xl font-medium tracking-tight text-ink">

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -871,7 +871,7 @@ export function HostedWorkflowPage({
                   : "border-transparent text-muted hover:bg-panel-hi hover:text-ink"
               }`}
             >
-              {view === "api" ? "Use the API" : "Source code"}
+              {view === "api" ? "API docs" : "Source code"}
             </button>
           );
         })}

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -440,10 +440,10 @@ function RawJsonDetails({ value, label }: { value: unknown; label: string }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="border-t border-rule/80">
+    <div className="pt-3">
       <button
         type="button"
-        className="flex w-full items-center justify-between px-4 py-3 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-faint transition hover:bg-white/[0.03] hover:text-muted"
+        className="inline-flex items-center gap-3 rounded-md border border-rule bg-panel px-3 py-2 text-left font-mono text-[11px] uppercase tracking-[0.1em] text-muted transition hover:border-accent/40 hover:bg-panel-hi hover:text-ink"
         aria-expanded={open}
         onClick={() => setOpen((current) => !current)}
       >
@@ -453,7 +453,7 @@ function RawJsonDetails({ value, label }: { value: unknown; label: string }) {
       {open && (
         <pre
           aria-label={label}
-          className="max-h-[min(50vh,22rem)] overflow-auto border-t border-rule/80 bg-[#0f120f] p-4 [scrollbar-color:rgba(255,255,255,0.18)_transparent] [scrollbar-width:thin]"
+          className="mt-3 max-h-[min(50vh,22rem)] overflow-auto rounded-md border border-rule/80 bg-[#0f120f] p-4 [scrollbar-color:rgba(255,255,255,0.18)_transparent] [scrollbar-width:thin]"
         >
           <code
             className={CODE_TOKEN_CLASSES}
@@ -924,7 +924,7 @@ export function HostedWorkflowPage({
               Use this workflow
             </p>
             <p className="mt-1.5 text-xs leading-5 text-muted">
-              Call the API or deploy an editable copy.
+              Call the API directly or deploy an editable copy.
             </p>
             <Button
               type="button"

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -883,9 +883,6 @@ export function HostedWorkflowPage({
           {activeView === "api" ? (
             <>
               <section>
-                <h2 className="mb-4 text-2xl font-medium tracking-tight text-ink">
-                  API endpoint
-                </h2>
                 <EndpointBar method="POST" url={runUrl} />
               </section>
 

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -352,17 +352,17 @@ function EndpointBar({ method, url }: { method: string; url: string }) {
 
   return (
     <div className="flex min-w-0 items-stretch overflow-hidden rounded-lg border border-rule bg-panel shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
-      <span className="inline-flex shrink-0 items-center border-r border-rule bg-accent/[0.08] px-4 font-mono text-[11px] font-semibold tracking-[0.1em] text-accent-bright">
+      <span className="inline-flex shrink-0 items-center border-r border-rule bg-accent/[0.08] px-3 font-mono text-[10px] font-semibold tracking-[0.1em] text-accent-bright">
         {method}
       </span>
-      <div className="min-w-0 flex-1 px-4 py-3">
-        <code className="break-all font-mono text-[12px] leading-5 text-ink sm:whitespace-nowrap">
+      <div className="min-w-0 flex-1 px-3 py-3">
+        <code className="break-all font-mono text-[11px] leading-5 text-ink xl:whitespace-nowrap">
           {url}
         </code>
       </div>
       <button
         type="button"
-        className="shrink-0 border-l border-rule px-4 font-mono text-[10px] uppercase tracking-[0.1em] text-muted transition hover:bg-panel-hi hover:text-ink"
+        className="shrink-0 border-l border-rule px-3 font-mono text-[10px] uppercase tracking-[0.1em] text-muted transition hover:bg-panel-hi hover:text-ink"
         onClick={() => {
           void navigator.clipboard.writeText(url).catch(() => {});
           setCopied(true);
@@ -878,16 +878,12 @@ export function HostedWorkflowPage({
         })}
       </div>
 
-      {activeView === "api" && (
-        <div className="mt-6">
-          <EndpointBar method="POST" url={runUrl} />
-        </div>
-      )}
-
       <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start">
         <div className="min-w-0 space-y-6">
           {activeView === "api" ? (
             <>
+              <EndpointBar method="POST" url={runUrl} />
+
               <section>
                 <div className="border-b border-rule pb-4">
                   <h2 className="text-2xl font-medium tracking-tight text-ink">

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -871,7 +871,7 @@ export function HostedWorkflowPage({
                   : "border-transparent text-muted hover:bg-panel-hi hover:text-ink"
               }`}
             >
-              {view === "api" ? "API docs" : "Source code"}
+              {view === "api" ? "API spec" : "Source code"}
             </button>
           );
         })}

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -936,7 +936,7 @@ export function HostedWorkflowPage({
                 window.setTimeout(() => setCopied(false), 1500);
               }}
             >
-              {copied ? "Copied" : "Copy API instructions"}
+              {copied ? "Copied" : "Copy prompt to use API"}
             </Button>
             {!session && (
               <Button

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -71,7 +71,6 @@ function matchesQuery(workflow: HostedWorkflowSummary, query: string): boolean {
     workflow.description ?? "",
     workflow.publisher_name,
     workflow.tenant_slug,
-    ...workflow.credential_requirements.map((req) => req.name),
   ]
     .join(" ")
     .toLowerCase();
@@ -578,7 +577,7 @@ export function HostedWorkflowsPage() {
 
       <div className="mb-8 max-w-xl">
         <label className="relative block">
-          <span className="sr-only">Search hosted workflows</span>
+          <span className="sr-only">Search published workflows</span>
           <span
             aria-hidden="true"
             className="pointer-events-none absolute inset-y-0 left-3.5 flex items-center font-mono text-sm text-faint"
@@ -589,7 +588,7 @@ export function HostedWorkflowsPage() {
             type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search name, publisher, or secret…"
+            placeholder="Search workflows or publishers…"
             className="h-11 w-full rounded-lg border border-rule bg-panel py-2 pr-4 pl-8 text-sm text-ink outline-none transition placeholder:text-faint focus:border-accent/45 focus:bg-panel-hi focus:shadow-[0_0_0_3px_rgba(18,206,65,0.08)]"
           />
         </label>
@@ -627,18 +626,13 @@ export function HostedWorkflowsPage() {
             href={hostedPath(workflow)}
             className="group rounded-lg border border-rule bg-panel p-5 no-underline transition hover:border-accent/35 hover:bg-panel-hi hover:shadow-[0_0_24px_rgba(18,206,65,0.06)]"
           >
-            <div className="flex items-start justify-between gap-3">
-              <Text
-                as="p"
-                size="xs"
-                className="uppercase tracking-[0.14em] text-accent"
-              >
-                {workflow.publisher_name}
-              </Text>
-              <span className="font-mono text-[10px] text-faint">
-                v{workflow.deployment_version}
-              </span>
-            </div>
+            <Text
+              as="p"
+              size="xs"
+              className="uppercase tracking-[0.14em] text-accent"
+            >
+              {workflow.publisher_name}
+            </Text>
             <h2 className="mt-3 font-mono text-lg font-medium tracking-tight text-ink group-hover:text-accent-bright">
               {workflow.workflow_name}
             </h2>
@@ -646,19 +640,6 @@ export function HostedWorkflowsPage() {
               {workflow.description?.trim() ||
                 "A published Libretto workflow you can call or adapt from its source."}
             </Text>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <span className="rounded border border-rule px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-faint">
-                Hosted API
-              </span>
-              {workflow.credential_requirements.length > 0 && (
-                <Text as="span" size="xs" className="text-faint">
-                  {workflow.credential_requirements.length}{" "}
-                  {workflow.credential_requirements.length === 1
-                    ? "credential"
-                    : "credentials"}
-                </Text>
-              )}
-            </div>
           </a>
         ))}
       </section>
@@ -791,12 +772,7 @@ export function HostedWorkflowPage({
               Review the published source before calling the API or adapting
               the workflow.
             </SectionHeading>
-            <SourceBrowser
-              files={workflow.files.map((file) => ({
-                file_name: file.file_name,
-                code: file.code,
-              }))}
-            />
+            <SourceBrowser files={workflow.files} />
           </section>
         </div>
 

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -854,7 +854,7 @@ export function HostedWorkflowPage({
       <div
         role="tablist"
         aria-label="Workflow details"
-        className="mt-8 flex border-b border-rule"
+        className="mt-8 grid max-w-md grid-cols-2 gap-1 rounded-lg border border-rule bg-panel p-1"
       >
         {(["api", "source"] as const).map((view) => {
           const selected = activeView === view;
@@ -865,14 +865,13 @@ export function HostedWorkflowPage({
               role="tab"
               aria-selected={selected}
               onClick={() => setActiveView(view)}
-              className={`relative px-5 py-3 font-mono text-xs uppercase tracking-[0.1em] transition ${
-                selected ? "text-accent-bright" : "text-muted hover:text-ink"
+              className={`rounded-md border px-5 py-3 font-mono text-xs uppercase tracking-[0.1em] transition ${
+                selected
+                  ? "border-accent/35 bg-accent/[0.12] text-accent-bright shadow-[inset_0_0_18px_rgba(18,206,65,0.06)]"
+                  : "border-transparent text-muted hover:bg-panel-hi hover:text-ink"
               }`}
             >
               {view === "api" ? "Use the API" : "Source code"}
-              {selected && (
-                <span className="absolute inset-x-0 -bottom-px h-px bg-accent" />
-              )}
             </button>
           );
         })}

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -933,7 +933,7 @@ export function HostedWorkflowPage({
               Use this workflow
             </p>
             <p className="mt-1.5 text-xs leading-5 text-muted">
-              Call the API directly or deploy an editable copy.
+              Call the API directly or deploy your own copy.
             </p>
             <Button
               type="button"
@@ -945,7 +945,7 @@ export function HostedWorkflowPage({
                 window.setTimeout(() => setCopied(false), 1500);
               }}
             >
-              {copied ? "Copied" : "Copy prompt to use API"}
+              {copied ? "Copied" : "Prompt to use the hosted API"}
             </Button>
             {!session && (
               <Button
@@ -1041,7 +1041,7 @@ export function HostedWorkflowPage({
                     {busy
                       ? "Deploying…"
                       : session
-                        ? "Fork and deploy a copy"
+                        ? "Fork and deploy your own copy"
                         : "Sign up to fork a copy"}
                   </Button>
                   {!workflow.import_available && (

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -348,14 +348,29 @@ function SectionHeading({
 }
 
 function EndpointBar({ method, url }: { method: string; url: string }) {
+  const [copied, setCopied] = useState(false);
+
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-rule bg-panel p-3 sm:flex-row sm:items-center">
-      <span className="inline-flex h-8 shrink-0 items-center justify-center rounded-md bg-accent/15 px-3 font-mono text-xs font-semibold tracking-[0.08em] text-accent-bright">
+    <div className="flex min-w-0 items-stretch overflow-hidden rounded-lg border border-rule bg-panel shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
+      <span className="inline-flex shrink-0 items-center border-r border-rule bg-accent/[0.08] px-4 font-mono text-[11px] font-semibold tracking-[0.1em] text-accent-bright">
         {method}
       </span>
-      <code className="min-w-0 break-all font-mono text-[12px] leading-5 text-ink sm:text-[13px]">
-        {url}
-      </code>
+      <div className="min-w-0 flex-1 overflow-x-auto px-4 py-3 [scrollbar-width:none]">
+        <code className="whitespace-nowrap font-mono text-[12px] leading-5 text-ink">
+          {url}
+        </code>
+      </div>
+      <button
+        type="button"
+        className="shrink-0 border-l border-rule px-4 font-mono text-[10px] uppercase tracking-[0.1em] text-muted transition hover:bg-panel-hi hover:text-ink"
+        onClick={() => {
+          void navigator.clipboard.writeText(url).catch(() => {});
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
     </div>
   );
 }
@@ -868,10 +883,9 @@ export function HostedWorkflowPage({
           {activeView === "api" ? (
             <>
               <section>
-                <SectionHeading title="Run endpoint">
-                  Send a POST request to run this workflow in your Libretto
-                  workspace.
-                </SectionHeading>
+                <h2 className="mb-4 text-2xl font-medium tracking-tight text-ink">
+                  API endpoint
+                </h2>
                 <EndpointBar method="POST" url={runUrl} />
               </section>
 

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -377,34 +377,33 @@ function ParamRow({
 }) {
   return (
     <div
-      className="grid gap-2 border-b border-rule/70 px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] sm:gap-4"
-      style={{ paddingLeft: `${16 + depth * 16}px` }}
+      className="border-b border-rule/70 py-4 last:border-b-0"
+      style={{ paddingLeft: `${depth * 20}px` }}
     >
-      <div className="min-w-0">
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-          <code className="font-mono text-[13px] text-ink">{name}</code>
-          <span className="font-mono text-[11px] text-accent/80">{typeLabel}</span>
-          <span
-            className={`font-mono text-[10px] uppercase tracking-[0.08em] ${
-              required ? "text-amber" : "text-faint"
-            }`}
-          >
-            {required ? "required" : "optional"}
-          </span>
+      <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <code className="font-mono text-[14px] font-medium text-ink">{name}</code>
+        <span className="font-mono text-[12px] text-accent/80">{typeLabel}</span>
+        <span
+          className={`text-xs ${required ? "text-muted" : "text-faint"}`}
+        >
+          {required ? "Required" : "Optional"}
+        </span>
+      </div>
+      {description && (
+        <p className="mt-2 text-sm leading-6 text-muted">{description}</p>
+      )}
+      {extras.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {extras.map((extra) => (
+            <span
+              key={extra}
+              className="rounded border border-rule/80 px-1.5 py-0.5 font-mono text-[10px] text-faint"
+            >
+              {extra}
+            </span>
+          ))}
         </div>
-      </div>
-      <div className="min-w-0 space-y-1.5">
-        {description ? (
-          <p className="text-sm leading-6 text-muted">{description}</p>
-        ) : (
-          <p className="text-sm leading-6 text-faint">No description.</p>
-        )}
-        {extras.map((extra) => (
-          <p key={extra} className="font-mono text-[11px] leading-5 text-faint">
-            {extra}
-          </p>
-        ))}
-      </div>
+      )}
     </div>
   );
 }
@@ -482,7 +481,10 @@ function SchemaReference({
   return (
     <section>
       <div className="border-b border-rule pb-4">
-        <SectionHeading title={title}>{description}</SectionHeading>
+        <h2 className="text-2xl font-medium tracking-tight text-ink">{title}</h2>
+        <Text as="p" size="sm" className="mt-2 leading-6 text-muted">
+          {description}
+        </Text>
       </div>
       {schema == null ? (
         <p className="py-5 text-sm text-muted">{emptyLabel}</p>
@@ -497,20 +499,14 @@ function SchemaReference({
           />
         </div>
       ) : (
-        <div>
-          <div className="hidden border-b border-rule/70 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.12em] text-faint sm:grid sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] sm:gap-4">
-            <span>Property</span>
-            <span>Details</span>
-          </div>
-          <SchemaTreeRows nodes={nodes} />
-        </div>
+        <SchemaTreeRows nodes={nodes} />
       )}
       {schema != null && <RawJsonDetails value={schema} label={`${title} JSON`} />}
     </section>
   );
 }
 
-function AccessReference({
+function CredentialsReference({
   requirements,
 }: {
   requirements: HostedWorkflowDetail["credential_requirements"];
@@ -518,23 +514,19 @@ function AccessReference({
   return (
     <section>
       <div className="border-b border-rule pb-4">
-        <SectionHeading title="Access">
-          Use your own Libretto API key and credentials. They stay in your
-          workspace and are never shared with the publisher.
-        </SectionHeading>
+        <h2 className="text-2xl font-medium tracking-tight text-ink">
+          Credentials
+        </h2>
+        <Text as="p" size="sm" className="mt-2 leading-6 text-muted">
+          Pass these values under <code className="text-ink">credentials</code>{" "}
+          in the request body.
+        </Text>
       </div>
       <div>
-        <ParamRow
-          name="x-api-key"
-          typeLabel="header"
-          required
-          description="Your Libretto API key."
-          extras={[]}
-        />
         {requirements.map((req) => (
           <ParamRow
             key={req.name}
-            name={`credentials.${req.name}`}
+            name={req.name}
             typeLabel="string"
             required
             description={
@@ -545,8 +537,8 @@ function AccessReference({
           />
         ))}
         {requirements.length === 0 && (
-          <p className="border-b border-rule/70 px-4 py-4 text-sm text-muted">
-            This workflow does not require any additional credentials.
+          <p className="border-b border-rule/70 py-4 text-sm text-muted">
+            No credentials required.
           </p>
         )}
       </div>
@@ -883,7 +875,22 @@ export function HostedWorkflowPage({
                 <EndpointBar method="POST" url={runUrl} />
               </section>
 
-              <AccessReference
+              <section>
+                <div className="border-b border-rule pb-4">
+                  <h2 className="text-2xl font-medium tracking-tight text-ink">
+                    Authentication
+                  </h2>
+                </div>
+                <ParamRow
+                  name="x-api-key"
+                  typeLabel="header"
+                  required
+                  description="Send your Libretto API key with every request."
+                  extras={[]}
+                />
+              </section>
+
+              <CredentialsReference
                 requirements={workflow.credential_requirements}
               />
 
@@ -914,11 +921,10 @@ export function HostedWorkflowPage({
         <aside className="h-fit lg:sticky lg:top-24">
           <div className="rounded-lg border border-rule bg-panel p-4">
             <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-              Coding agent
+              Use this workflow
             </p>
             <p className="mt-1.5 text-xs leading-5 text-muted">
-              Prompt for a coding agent to call this hosted run endpoint with
-              credentials and the input schema.
+              Call the API or deploy an editable copy.
             </p>
             <Button
               type="button"
@@ -930,7 +936,7 @@ export function HostedWorkflowPage({
                 window.setTimeout(() => setCopied(false), 1500);
               }}
             >
-              {copied ? "Copied" : "Copy prompt to call this API"}
+              {copied ? "Copied" : "Copy API instructions"}
             </Button>
             {!session && (
               <Button
@@ -942,10 +948,7 @@ export function HostedWorkflowPage({
               </Button>
             )}
 
-            <div className="mt-5 border-t border-rule/80 pt-5">
-              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-                Your own copy
-              </p>
+            <div className="mt-3">
               {build ? (
                 <>
                   <p className="mt-1.5 text-xs leading-5 text-muted">
@@ -964,7 +967,7 @@ export function HostedWorkflowPage({
               ) : configuring ? (
                 <form onSubmit={submitOwnCopy}>
                   <p className="mt-1.5 text-xs leading-5 text-muted">
-                    Connect the credentials required by your private copy.
+                    Add the credentials needed by your copy.
                   </p>
                   <div className="mt-3 space-y-3">
                     {workflow.credential_names.map((name) => {
@@ -1007,7 +1010,7 @@ export function HostedWorkflowPage({
                     <span className="text-xs text-ink">Auto-repair failed runs</span>
                   </label>
                   <Button type="submit" disabled={busy} className="mt-3 w-full">
-                    {busy ? "Deploying…" : "Fork and deploy"}
+                    {busy ? "Deploying…" : "Deploy copy"}
                   </Button>
                   <button
                     type="button"
@@ -1019,21 +1022,18 @@ export function HostedWorkflowPage({
                 </form>
               ) : (
                 <>
-                  <p className="mt-1.5 text-xs leading-5 text-muted">
-                    Fork the source and deploy a private copy to your workspace.
-                  </p>
                   <Button
                     type="button"
-                    variant="secondary"
+                    variant="outline"
                     onClick={startDeployingOwnCopy}
                     disabled={!workflow.import_available || busy}
-                    className="mt-3 w-full"
+                    className="w-full"
                   >
                     {busy
                       ? "Deploying…"
                       : session
-                        ? "Fork and deploy your own"
-                        : "Sign up to fork and deploy"}
+                        ? "Fork and deploy a copy"
+                        : "Sign up to fork a copy"}
                   </Button>
                   {!workflow.import_available && (
                     <p className="mt-2 text-xs leading-5 text-red-200">

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "./cloudApi";
 import { withReturnTo } from "./authRedirect";
 import { Prism } from "./prism";
+import { SourceBrowser } from "./SourceBrowser";
 
 export type HostedWorkflowSummary = {
   tenant_slug: string;
@@ -27,6 +28,7 @@ export type HostedWorkflowSummary = {
 type HostedWorkflowDetail = HostedWorkflowSummary & {
   input_schema: unknown;
   output_schema: unknown;
+  files: Array<{ file_name: string; code: string }>;
 };
 
 type SchemaNode = {
@@ -276,7 +278,7 @@ function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
         ].join("\n");
 
   return [
-    "Use this Libretto hosted workflow via the API (opaque — no source access).",
+    "Use this published Libretto workflow through its hosted API or adapt its public source code.",
     "",
     `Hosted workflow: ${hostedKey(workflow)}`,
     workflow.description?.trim()
@@ -566,11 +568,11 @@ export function HostedWorkflowsPage() {
           wrap="balance"
           className="font-[300] leading-[1.05] tracking-[-0.035em] text-ink"
         >
-          Hosted Workflow APIs
+          Published workflows
         </Text>
         <Text as="p" size="md" className="mt-5 max-w-xl leading-7 text-muted">
           Public run endpoints you call with your own API key. Input and output
-          types are listed; source stays with the publisher.
+          types and reviewed source code are included on every listing.
         </Text>
       </header>
 
@@ -642,7 +644,7 @@ export function HostedWorkflowsPage() {
             </h2>
             <Text as="p" size="sm" className="mt-3 line-clamp-3 leading-6 text-muted">
               {workflow.description?.trim() ||
-                "A hosted Libretto workflow you can call as an opaque API."}
+                "A published Libretto workflow you can call or adapt from its source."}
             </Text>
             <div className="mt-4 flex flex-wrap gap-2">
               <span className="rounded border border-rule px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-faint">
@@ -715,7 +717,7 @@ export function HostedWorkflowPage({
         href="/hosted-workflows"
         className="inline-flex pt-4 font-mono text-xs text-muted no-underline transition hover:text-ink"
       >
-        ← Hosted Workflow APIs
+        ← Published workflows
       </a>
 
       <header className="mt-8 max-w-3xl">
@@ -738,7 +740,7 @@ export function HostedWorkflowPage({
             v{workflow.deployment_version}
           </span>
           <span className="rounded border border-rule px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-faint">
-            Hosted API — source not shared
+            Hosted API + source
           </span>
         </div>
       </header>
@@ -783,6 +785,19 @@ export function HostedWorkflowPage({
             schema={workflow.output_schema}
             emptyLabel="No output schema is published for this workflow."
           />
+
+          <section>
+            <SectionHeading eyebrow="Source" title="Workflow code">
+              Review the published source before calling the API or adapting
+              the workflow.
+            </SectionHeading>
+            <SourceBrowser
+              files={workflow.files.map((file) => ({
+                file_name: file.file_name,
+                code: file.code,
+              }))}
+            />
+          </section>
         </div>
 
         <aside className="h-fit lg:sticky lg:top-24">

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { Button } from "./components/Button";
 import { Footer } from "./components/Footer";
 import { Navbar } from "./components/Navbar";
@@ -6,6 +12,7 @@ import { Text } from "./components/Text";
 import {
   getAuthStatus,
   getCloudSession,
+  orpcCall,
   publicCloudGet,
   cloudApiUrl,
   type CloudSession,
@@ -28,7 +35,22 @@ export type HostedWorkflowSummary = {
 type HostedWorkflowDetail = HostedWorkflowSummary & {
   input_schema: unknown;
   output_schema: unknown;
+  source_share_id: string;
+  credential_names: string[];
+  import_available: boolean;
   files: Array<{ file_name: string; code: string }>;
+};
+
+type SecretRow = {
+  credential_id: string;
+  name: string;
+};
+
+type WorkflowBuildStatus = {
+  build_id: string;
+  status: "deploying" | "ready" | "failed";
+  workflow_name: string | null;
+  error: string | null;
 };
 
 type SchemaNode = {
@@ -458,14 +480,14 @@ function SchemaReference({
   const nodes = useMemo(() => schemaRootNodes(schema), [schema]);
 
   return (
-    <section className="rounded-lg border border-rule bg-panel">
-      <div className="border-b border-rule px-4 py-4">
+    <section>
+      <div className="border-b border-rule pb-4">
         <SectionHeading title={title}>{description}</SectionHeading>
       </div>
       {schema == null ? (
-        <p className="px-4 py-5 text-sm text-muted">{emptyLabel}</p>
+        <p className="py-5 text-sm text-muted">{emptyLabel}</p>
       ) : nodes.length === 0 ? (
-        <div className="px-4 py-5">
+        <div className="py-2">
           <ParamRow
             name="(schema)"
             typeLabel={formatSchemaType(schema)}
@@ -488,47 +510,46 @@ function SchemaReference({
   );
 }
 
-function CredentialsSection({
+function AccessReference({
   requirements,
 }: {
   requirements: HostedWorkflowDetail["credential_requirements"];
 }) {
   return (
-    <section className="rounded-lg border border-rule bg-panel">
-      <div className="border-b border-rule px-4 py-4">
-        <SectionHeading
-          eyebrow="Request body"
-          title="Credentials"
-        >
-          Pass these under <code className="text-ink">credentials</code> in the
-          run body. Each value is a secret name or credential id from your
-          tenant — not the publisher&apos;s.
+    <section>
+      <div className="border-b border-rule pb-4">
+        <SectionHeading title="Access">
+          Use your own Libretto API key and credentials. They stay in your
+          workspace and are never shared with the publisher.
         </SectionHeading>
       </div>
-      {requirements.length === 0 ? (
-        <p className="px-4 py-5 text-sm text-muted">
-          This workflow does not require credentials.
-        </p>
-      ) : (
-        <div>
-          <div className="hidden border-b border-rule/70 px-4 py-2 font-mono text-[10px] uppercase tracking-[0.12em] text-faint sm:grid sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)] sm:gap-4">
-            <span>Name</span>
-            <span>Details</span>
-          </div>
-          {requirements.map((req) => (
-            <ParamRow
-              key={req.name}
-              name={req.name}
-              typeLabel="string"
-              required
-              description={req.description}
-              extras={[
-                "Map this key to a secret name or credential id in your tenant.",
-              ]}
-            />
-          ))}
-        </div>
-      )}
+      <div>
+        <ParamRow
+          name="x-api-key"
+          typeLabel="header"
+          required
+          description="Your Libretto API key."
+          extras={[]}
+        />
+        {requirements.map((req) => (
+          <ParamRow
+            key={req.name}
+            name={`credentials.${req.name}`}
+            typeLabel="string"
+            required
+            description={
+              req.description ||
+              "A secret name or credential id from your workspace."
+            }
+            extras={[]}
+          />
+        ))}
+        {requirements.length === 0 && (
+          <p className="border-b border-rule/70 px-4 py-4 text-sm text-muted">
+            This workflow does not require any additional credentials.
+          </p>
+        )}
+      </div>
     </section>
   );
 }
@@ -656,6 +677,14 @@ export function HostedWorkflowPage({
 }) {
   const [workflow, setWorkflow] = useState<HostedWorkflowDetail | null>(null);
   const [session, setSession] = useState<CloudSession | null>(null);
+  const [hasTenant, setHasTenant] = useState(false);
+  const [secrets, setSecrets] = useState<SecretRow[]>([]);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [configuring, setConfiguring] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [autoRepair, setAutoRepair] = useState(true);
+  const [build, setBuild] = useState<WorkflowBuildStatus | null>(null);
+  const [activeView, setActiveView] = useState<"api" | "source">("api");
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -675,10 +704,107 @@ export function HostedWorkflowPage({
       .then(async (result) => {
         setSession(result);
         if (!result) return;
-        await getAuthStatus().catch(() => null);
+        const status = await getAuthStatus();
+        setHasTenant(status.hasTenant);
+        if (!status.hasTenant) return;
+        const secretResult = await orpcCall<{ secrets: SecretRow[] }>(
+          "/v1/dashboard/secrets",
+        );
+        setSecrets(secretResult.secrets);
       })
       .catch(() => setSession(null));
   }, [tenantSlug, workflowName]);
+
+  useEffect(() => {
+    if (!build || build.status === "ready" || build.status === "failed") return;
+    const timer = window.setInterval(() => {
+      orpcCall<WorkflowBuildStatus>("/v1/workflows/buildStatus", {
+        build_id: build.build_id,
+      })
+        .then(setBuild)
+        .catch((reason) =>
+          setError(
+            reason instanceof Error
+              ? reason.message
+              : "Could not check build status.",
+          ),
+        );
+    }, 3000);
+    return () => window.clearInterval(timer);
+  }, [build]);
+
+  const savedSecrets = useMemo(
+    () => new Map(secrets.map((secret) => [secret.name, secret])),
+    [secrets],
+  );
+  const secretsNeedingValues = useMemo(
+    () =>
+      workflow?.credential_names.filter((name) => !savedSecrets.has(name)) ?? [],
+    [savedSecrets, workflow],
+  );
+
+  async function deployOwnCopy() {
+    if (!workflow) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const credentialIds: string[] = [];
+      for (const name of workflow.credential_names) {
+        const saved = savedSecrets.get(name);
+        if (saved) {
+          credentialIds.push(saved.credential_id);
+          continue;
+        }
+        const value = values[name];
+        if (!value?.trim()) throw new Error(`Enter a value for ${name}.`);
+        const created = await orpcCall<{ credential_id: string }>(
+          "/v1/dashboard/createSecret",
+          { name, value },
+        );
+        credentialIds.push(created.credential_id);
+      }
+      const result = await orpcCall<{
+        build_id: string;
+        status: "deploying";
+        workflow_name: string;
+      }>("/v1/openWorkflows/import", {
+        share_id: workflow.source_share_id,
+        credential_ids: credentialIds,
+        auto_repair: autoRepair,
+      });
+      setBuild({ ...result, error: null });
+      setConfiguring(false);
+    } catch (reason) {
+      setError(
+        reason instanceof Error ? reason.message : "Could not deploy this workflow.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startDeployingOwnCopy() {
+    if (!workflow) return;
+    const returnTo = hostedPath(workflow);
+    if (!session) {
+      window.location.assign(withReturnTo("/signin", returnTo));
+      return;
+    }
+    if (!hasTenant) {
+      window.location.assign(withReturnTo("/onboarding", returnTo));
+      return;
+    }
+    if (secretsNeedingValues.length === 0) {
+      void deployOwnCopy();
+      return;
+    }
+    setConfiguring(true);
+  }
+
+  function submitOwnCopy(event: FormEvent) {
+    event.preventDefault();
+    void deployOwnCopy();
+  }
 
   if (!workflow) {
     return pageShell(
@@ -716,64 +842,73 @@ export function HostedWorkflowPage({
           {workflow.description?.trim() ||
             "A public Libretto hosted workflow you can call with your API key."}
         </Text>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <span className="rounded border border-rule px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-faint">
-            v{workflow.deployment_version}
-          </span>
-          <span className="rounded border border-rule px-2 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-faint">
-            Hosted API + source
-          </span>
-        </div>
       </header>
 
-      <div className="mt-8">
-        <EndpointBar method="POST" url={runUrl} />
+      <div
+        role="tablist"
+        aria-label="Workflow details"
+        className="mt-8 flex border-b border-rule"
+      >
+        {(["api", "source"] as const).map((view) => {
+          const selected = activeView === view;
+          return (
+            <button
+              key={view}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => setActiveView(view)}
+              className={`relative px-5 py-3 font-mono text-xs uppercase tracking-[0.1em] transition ${
+                selected ? "text-accent-bright" : "text-muted hover:text-ink"
+              }`}
+            >
+              {view === "api" ? "Use the API" : "Source code"}
+              {selected && (
+                <span className="absolute inset-x-0 -bottom-px h-px bg-accent" />
+              )}
+            </button>
+          );
+        })}
       </div>
 
       <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start">
         <div className="min-w-0 space-y-6">
-          <section className="rounded-lg border border-rule bg-panel px-4 py-4">
-            <SectionHeading eyebrow="Security" title="Authentication">
-              Send your Libretto API key in the{" "}
-              <code className="text-ink">x-api-key</code> header. Jobs and
-              secrets stay in your tenant; the publisher cannot see them.
-            </SectionHeading>
-            <div className="overflow-hidden rounded-md border border-rule/80">
-              <ParamRow
-                name="x-api-key"
-                typeLabel="string"
-                required
-                description="API key from your Libretto workspace."
-                extras={["Header"]}
+          {activeView === "api" ? (
+            <>
+              <section>
+                <SectionHeading title="Run endpoint">
+                  Send a POST request to run this workflow in your Libretto
+                  workspace.
+                </SectionHeading>
+                <EndpointBar method="POST" url={runUrl} />
+              </section>
+
+              <AccessReference
+                requirements={workflow.credential_requirements}
               />
-            </div>
-          </section>
 
-          <CredentialsSection
-            requirements={workflow.credential_requirements}
-          />
+              <SchemaReference
+                title="Request fields"
+                description="Pass these fields under params in the JSON request body."
+                schema={workflow.input_schema}
+                emptyLabel="This workflow has no declared request fields."
+              />
 
-          <SchemaReference
-            title="Request body · params"
-            description="JSON fields under params in the run request body."
-            schema={workflow.input_schema}
-            emptyLabel="No input schema is published for this workflow."
-          />
-
-          <SchemaReference
-            title="Response · result"
-            description="Shape of the workflow result when the job completes."
-            schema={workflow.output_schema}
-            emptyLabel="No output schema is published for this workflow."
-          />
-
-          <section>
-            <SectionHeading eyebrow="Source" title="Workflow code">
-              Review the published source before calling the API or adapting
-              the workflow.
-            </SectionHeading>
-            <SourceBrowser files={workflow.files} />
-          </section>
+              <SchemaReference
+                title="Response fields"
+                description="The workflow returns these fields when the job completes."
+                schema={workflow.output_schema}
+                emptyLabel="This workflow has no declared response fields."
+              />
+            </>
+          ) : (
+            <section>
+              <SectionHeading title="Workflow code">
+                Review or adapt the source included with this shared workflow.
+              </SectionHeading>
+              <SourceBrowser files={workflow.files} />
+            </section>
+          )}
         </div>
 
         <aside className="h-fit lg:sticky lg:top-24">
@@ -797,17 +932,118 @@ export function HostedWorkflowPage({
             >
               {copied ? "Copied" : "Copy prompt to call this API"}
             </Button>
-            <Button
-              href={
-                session
-                  ? "/dashboard/api_keys"
-                  : withReturnTo("/signin", returnTo)
-              }
-              variant="secondary"
-              className="mt-4 w-full"
-            >
-              {session ? "Manage API keys" : "Sign up to generate an API key"}
-            </Button>
+            {!session && (
+              <Button
+                href={withReturnTo("/signin", returnTo)}
+                variant="secondary"
+                className="mt-3 w-full"
+              >
+                Sign up to generate an API key
+              </Button>
+            )}
+
+            <div className="mt-5 border-t border-rule/80 pt-5">
+              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+                Your own copy
+              </p>
+              {build ? (
+                <>
+                  <p className="mt-1.5 text-xs leading-5 text-muted">
+                    {build.status === "deploying"
+                      ? "Forking the source and deploying a private copy…"
+                      : build.status === "ready"
+                        ? "Your private copy is ready in Libretto Cloud."
+                        : build.error || "The private copy could not be deployed."}
+                  </p>
+                  {build.status === "ready" && (
+                    <Button href="/dashboard/workflows" className="mt-3 w-full">
+                      View your workflows
+                    </Button>
+                  )}
+                </>
+              ) : configuring ? (
+                <form onSubmit={submitOwnCopy}>
+                  <p className="mt-1.5 text-xs leading-5 text-muted">
+                    Connect the credentials required by your private copy.
+                  </p>
+                  <div className="mt-3 space-y-3">
+                    {workflow.credential_names.map((name) => {
+                      const saved = savedSecrets.has(name);
+                      return (
+                        <label key={name} className="block">
+                          <span className="mb-1.5 block font-mono text-xs text-muted">
+                            {name}
+                          </span>
+                          {saved ? (
+                            <span className="block rounded-md border border-accent/30 bg-green-3/20 px-3 py-2 text-xs text-accent-bright">
+                              Using saved credential
+                            </span>
+                          ) : (
+                            <input
+                              type="password"
+                              required
+                              autoComplete="off"
+                              value={values[name] || ""}
+                              onChange={(event) =>
+                                setValues((current) => ({
+                                  ...current,
+                                  [name]: event.target.value,
+                                }))
+                              }
+                              placeholder="Stored encrypted"
+                              className="h-9 w-full rounded-md border border-rule bg-bg px-3 text-xs outline-none focus:border-accent"
+                            />
+                          )}
+                        </label>
+                      );
+                    })}
+                  </div>
+                  <label className="mt-3 flex cursor-pointer items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={autoRepair}
+                      onChange={(event) => setAutoRepair(event.target.checked)}
+                    />
+                    <span className="text-xs text-ink">Auto-repair failed runs</span>
+                  </label>
+                  <Button type="submit" disabled={busy} className="mt-3 w-full">
+                    {busy ? "Deploying…" : "Fork and deploy"}
+                  </Button>
+                  <button
+                    type="button"
+                    onClick={() => setConfiguring(false)}
+                    className="mt-2 h-8 w-full text-xs text-muted"
+                  >
+                    Cancel
+                  </button>
+                </form>
+              ) : (
+                <>
+                  <p className="mt-1.5 text-xs leading-5 text-muted">
+                    Fork the source and deploy a private copy to your workspace.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={startDeployingOwnCopy}
+                    disabled={!workflow.import_available || busy}
+                    className="mt-3 w-full"
+                  >
+                    {busy
+                      ? "Deploying…"
+                      : session
+                        ? "Fork and deploy your own"
+                        : "Sign up to fork and deploy"}
+                  </Button>
+                  {!workflow.import_available && (
+                    <p className="mt-2 text-xs leading-5 text-red-200">
+                      The publisher must update this workflow before it can be forked.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+            {error && <p className="mt-3 text-xs leading-5 text-red-200">{error}</p>}
           </div>
         </aside>
       </div>

--- a/apps/website/src/OpenWorkflowsPage.tsx
+++ b/apps/website/src/OpenWorkflowsPage.tsx
@@ -13,7 +13,7 @@ import {
   type CloudSession,
 } from "./cloudApi";
 import { withReturnTo } from "./authRedirect";
-import { Prism } from "./prism";
+import { SourceBrowser } from "./SourceBrowser";
 
 export type OpenWorkflowSummary = {
   id: string;
@@ -42,9 +42,6 @@ type WorkflowBuildStatus = {
   workflow_name: string | null;
   error: string | null;
 };
-
-const CODE_TOKEN_CLASSES =
-  "font-mono text-[13px] leading-6 text-ink [&_.token.boolean]:text-[#79c0ff] [&_.token.builtin]:text-[#ffa657] [&_.token.class-name]:text-[#ffa657] [&_.token.comment]:text-[#8b949e] [&_.token.function]:text-[#d2a8ff] [&_.token.keyword]:text-[#ff7b72] [&_.token.number]:text-[#79c0ff] [&_.token.operator]:text-[#ff7b72] [&_.token.property]:text-[#79c0ff] [&_.token.punctuation]:text-[#c9d1d9] [&_.token.string]:text-[#a5d6ff] [&_.token.variable]:text-[#ffa657]";
 
 function pageShell(children: React.ReactNode) {
   return (
@@ -77,19 +74,6 @@ function matchesQuery(
     .split(/\s+/u)
     .filter(Boolean)
     .every((part) => haystack.includes(part));
-}
-
-function highlightCode(fileName: string, code: string): string {
-  if (/\.json$/iu.test(fileName) && Prism.languages.json) {
-    return Prism.highlight(code, Prism.languages.json, "json");
-  }
-  if (/\.[cm]?[tj]sx?$/iu.test(fileName) && Prism.languages.typescript) {
-    return Prism.highlight(code, Prism.languages.typescript, "typescript");
-  }
-  return code
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
 }
 
 function buildCliSetupPrompt(args: {
@@ -230,64 +214,6 @@ export function OpenWorkflowsPage() {
         ))}
       </section>
     </>,
-  );
-}
-
-function preferredSourceFile(
-  files: Array<{ file_name: string; code: string }>,
-): string {
-  const preferred =
-    files.find((file) => /^index\.[cm]?[tj]sx?$/iu.test(file.file_name)) ??
-    files.find((file) => /\.[cm]?[tj]sx?$/iu.test(file.file_name)) ??
-    files[0];
-  return preferred?.file_name ?? "";
-}
-
-function SourceBrowser({
-  files,
-}: {
-  files: Array<{ file_name: string; code: string }>;
-}) {
-  const [activeFile, setActiveFile] = useState(() => preferredSourceFile(files));
-  const active = files.find((file) => file.file_name === activeFile) ?? files[0];
-
-  if (!active) return null;
-
-  return (
-    <div className="overflow-hidden rounded-lg border border-rule bg-panel shadow-[0_0_24px_rgba(18,206,65,0.05)]">
-      <div className="flex flex-col lg:grid lg:min-h-[440px] lg:grid-cols-[180px_minmax(0,1fr)]">
-        <nav
-          aria-label="Source files"
-          className="flex gap-1 overflow-x-auto border-b border-rule bg-black/25 p-2 [scrollbar-width:none] lg:flex-col lg:gap-0.5 lg:overflow-visible lg:border-r lg:border-b-0 [&::-webkit-scrollbar]:hidden"
-        >
-          {files.map((file) => {
-            const selected = file.file_name === active.file_name;
-            return (
-              <button
-                key={file.file_name}
-                type="button"
-                onClick={() => setActiveFile(file.file_name)}
-                className={`shrink-0 rounded-md px-3 py-1.5 text-left font-mono text-xs transition lg:w-full lg:py-2 ${
-                  selected
-                    ? "bg-accent/10 text-accent-bright shadow-[inset_0_0_0_1px_rgba(18,206,65,0.18)]"
-                    : "text-muted hover:bg-white/4 hover:text-ink"
-                }`}
-              >
-                <span className="truncate">{file.file_name}</span>
-              </button>
-            );
-          })}
-        </nav>
-        <pre className="max-h-[min(60vh,28rem)] overflow-auto bg-[#0f120f] p-4 lg:max-h-none [scrollbar-color:rgba(255,255,255,0.18)_transparent] [scrollbar-width:thin]">
-          <code
-            className={CODE_TOKEN_CLASSES}
-            dangerouslySetInnerHTML={{
-              __html: highlightCode(active.file_name, active.code),
-            }}
-          />
-        </pre>
-      </div>
-    </div>
   );
 }
 

--- a/apps/website/src/SourceBrowser.tsx
+++ b/apps/website/src/SourceBrowser.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Prism } from "./prism";
+
+const CODE_TOKEN_CLASSES =
+  "font-mono text-[13px] leading-6 text-ink [&_.token.boolean]:text-[#79c0ff] [&_.token.builtin]:text-[#ffa657] [&_.token.class-name]:text-[#ffa657] [&_.token.comment]:text-[#8b949e] [&_.token.function]:text-[#d2a8ff] [&_.token.keyword]:text-[#ff7b72] [&_.token.number]:text-[#79c0ff] [&_.token.operator]:text-[#ff7b72] [&_.token.property]:text-[#79c0ff] [&_.token.punctuation]:text-[#c9d1d9] [&_.token.string]:text-[#a5d6ff] [&_.token.variable]:text-[#ffa657]";
+
+function highlightCode(fileName: string, code: string): string {
+  if (/\.json$/iu.test(fileName) && Prism.languages.json) {
+    return Prism.highlight(code, Prism.languages.json, "json");
+  }
+  if (/\.[cm]?[tj]sx?$/iu.test(fileName) && Prism.languages.typescript) {
+    return Prism.highlight(code, Prism.languages.typescript, "typescript");
+  }
+  return code
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function preferredSourceFile(
+  files: Array<{ file_name: string; code: string }>,
+): string {
+  const preferred =
+    files.find((file) => /^index\.[cm]?[tj]sx?$/iu.test(file.file_name)) ??
+    files.find((file) => /\.[cm]?[tj]sx?$/iu.test(file.file_name)) ??
+    files[0];
+  return preferred?.file_name ?? "";
+}
+
+export function SourceBrowser({
+  files,
+}: {
+  files: Array<{ file_name: string; code: string }>;
+}) {
+  const [activeFile, setActiveFile] = useState(() => preferredSourceFile(files));
+  const active = files.find((file) => file.file_name === activeFile) ?? files[0];
+  if (!active) return null;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-rule bg-panel shadow-[0_0_24px_rgba(18,206,65,0.05)]">
+      <div className="flex flex-col lg:grid lg:min-h-[440px] lg:grid-cols-[180px_minmax(0,1fr)]">
+        <nav
+          aria-label="Source files"
+          className="flex gap-1 overflow-x-auto border-b border-rule bg-black/25 p-2 [scrollbar-width:none] lg:flex-col lg:gap-0.5 lg:overflow-visible lg:border-r lg:border-b-0 [&::-webkit-scrollbar]:hidden"
+        >
+          {files.map((file) => {
+            const selected = file.file_name === active.file_name;
+            return (
+              <button
+                key={file.file_name}
+                type="button"
+                onClick={() => setActiveFile(file.file_name)}
+                className={`shrink-0 rounded-md px-3 py-1.5 text-left font-mono text-xs transition lg:w-full lg:py-2 ${
+                  selected
+                    ? "bg-accent/10 text-accent-bright shadow-[inset_0_0_0_1px_rgba(18,206,65,0.18)]"
+                    : "text-muted hover:bg-white/4 hover:text-ink"
+                }`}
+              >
+                <span className="truncate">{file.file_name}</span>
+              </button>
+            );
+          })}
+        </nav>
+        <pre className="max-h-[min(60vh,28rem)] overflow-auto bg-[#0f120f] p-4 lg:max-h-none [scrollbar-color:rgba(255,255,255,0.18)_transparent] [scrollbar-width:thin]">
+          <code
+            className={CODE_TOKEN_CLASSES}
+            dangerouslySetInnerHTML={{
+              __html: highlightCode(active.file_name, active.code),
+            }}
+          />
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   type CloudSession,
 } from "./cloudApi";
 import { DashboardShell } from "./AuthenticatedDashboardPage";
+import { CheckIcon, CopyIcon } from "./icons/index.js";
 
 type Publication = {
   description: string | null;
@@ -49,10 +50,26 @@ type WorkflowRun = {
 };
 
 type PrivacyFinding = {
+  severity: "warning" | "blocked";
+  category:
+    | "secret"
+    | "payment"
+    | "personal_information"
+    | "private_url"
+    | "other";
   file: string;
   line: number | null;
   explanation: string;
+  suggestedFix: string;
 };
+
+type PrivacyReviewState =
+  | {
+      status: "needs_review" | "blocked";
+      reviewId: string;
+      findings: PrivacyFinding[];
+    }
+  | { status: "review_expired" };
 
 type ShareResponse =
   | { status: "created" | "existing" | "refreshed" }
@@ -69,6 +86,157 @@ const primaryButtonClass =
   "inline-flex h-8 items-center justify-center rounded-md border border-accent/45 bg-green-9/55 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-ink transition-colors hover:bg-green-9/80 disabled:cursor-not-allowed disabled:opacity-40";
 const secondaryButtonClass =
   "inline-flex h-8 items-center justify-center rounded-md border border-rule bg-bg/35 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-muted no-underline transition-colors hover:border-accent/35 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40";
+
+function privacyReviewAgentPrompt(findings: PrivacyFinding[]) {
+  return [
+    "Fix these privacy findings before sharing this Libretto workflow publicly.",
+    "Do not include or repeat sensitive values in your response.",
+    "",
+    ...findings.flatMap((finding) => [
+      `${finding.file}${finding.line ? `:${finding.line}` : ""}`,
+      `Issue: ${finding.explanation}`,
+      `Suggested fix: ${finding.suggestedFix}`,
+      "",
+    ]),
+  ].join("\n");
+}
+
+function PrivacyReviewPanel({
+  review,
+  busy,
+  onAcknowledge,
+  onDismiss,
+  onRetry,
+}: {
+  review: PrivacyReviewState;
+  busy: boolean;
+  onAcknowledge: () => void;
+  onDismiss: () => void;
+  onRetry: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  if (review.status === "review_expired") {
+    return (
+      <section className="rounded-xl border border-amber-300/30 bg-amber-300/[0.06] px-5 py-4">
+        <h2 className="text-sm font-medium text-amber-100">
+          Privacy review expired
+        </h2>
+        <p className="mt-1 text-xs leading-5 text-muted">
+          Run the review again before sharing this workflow.
+        </p>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onRetry}
+          className={`${primaryButtonClass} mt-4`}
+        >
+          {busy ? "Reviewing…" : "Run review again"}
+        </button>
+      </section>
+    );
+  }
+
+  const blocked = review.status === "blocked";
+  return (
+    <section
+      className={`overflow-hidden rounded-xl border ${
+        blocked
+          ? "border-red-400/30 bg-red-500/[0.06]"
+          : "border-amber-300/30 bg-amber-300/[0.06]"
+      }`}
+    >
+      <div className="flex flex-col gap-4 border-b border-rule px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2
+            className={`text-sm font-medium ${
+              blocked ? "text-red-100" : "text-amber-100"
+            }`}
+          >
+            {blocked
+              ? "Sensitive information blocks sharing"
+              : "Review warnings before sharing"}
+          </h2>
+          <p className="mt-1 text-xs leading-5 text-muted">
+            {blocked
+              ? "Fix these findings in the workflow source, redeploy, and try again."
+              : "These findings may be specific to your workspace. Fix them or explicitly share anyway."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void navigator.clipboard
+              .writeText(privacyReviewAgentPrompt(review.findings))
+              .catch(() => {});
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          }}
+          className={`${secondaryButtonClass} shrink-0 gap-2 no-underline`}
+          aria-label="Copy privacy findings for a coding agent"
+        >
+          {copied ? (
+            <CheckIcon width={15} height={15} />
+          ) : (
+            <CopyIcon width={15} height={15} />
+          )}
+          {copied ? "Copied" : "Copy for coding agent"}
+        </button>
+      </div>
+      <div className="divide-y divide-rule">
+        {review.findings.map((finding) => (
+          <article
+            key={`${finding.file}:${finding.line ?? "file"}:${finding.explanation}`}
+            className="px-5 py-4"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <code className="text-xs text-ink">
+                {finding.file}
+                {finding.line ? `:${finding.line}` : ""}
+              </code>
+              <span
+                className={`rounded-full border px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.06em] ${
+                  finding.severity === "blocked"
+                    ? "border-red-400/30 text-red-200"
+                    : "border-amber-300/30 text-amber-100"
+                }`}
+              >
+                {finding.severity === "blocked" ? "Blocked" : "Warning"}
+              </span>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-ink">
+              {finding.explanation}
+            </p>
+            <p className="mt-2 text-xs leading-5 text-muted">
+              <span className="font-medium text-ink">Suggested fix:</span>{" "}
+              {finding.suggestedFix}
+            </p>
+          </article>
+        ))}
+      </div>
+      <div className="flex flex-wrap justify-end gap-3 border-t border-rule px-5 py-3">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onDismiss}
+          className={secondaryButtonClass}
+        >
+          Close
+        </button>
+        {!blocked && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onAcknowledge}
+            className={primaryButtonClass}
+          >
+            {busy ? "Sharing…" : "Share anyway"}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
@@ -228,6 +396,8 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [privacyReview, setPrivacyReview] =
+    useState<PrivacyReviewState | null>(null);
 
   async function refresh() {
     const [nextDetail, nextHostedRuns, nextWorkflowRuns] = await Promise.all([
@@ -302,32 +472,20 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       },
     });
     if (!("findings" in response) && response.status !== "review_expired") {
+      setPrivacyReview(null);
       setNotice("Workflow shared publicly.");
       return;
     }
     if (response.status === "review_expired") {
-      throw new Error("The privacy review expired. Share again to rerun it.");
+      setPrivacyReview({ status: "review_expired" });
+      return;
     }
     if (!("findings" in response)) return;
-    const findings = response.findings
-      .map(
-        (finding) =>
-          `${finding.file}${finding.line ? `:${finding.line}` : ""}: ${finding.explanation}`,
-      )
-      .join("\n");
-    if (response.status === "blocked") {
-      throw new Error(`Sharing is blocked by the privacy review:\n${findings}`);
-    }
-    if (
-      window.confirm(
-        `The privacy review found warnings:\n\n${findings}\n\nShare publicly anyway?`,
-      )
-    ) {
-      await sharePublicly({
-        reviewId: response.review_id,
-        acknowledgeWarnings: true,
-      });
-    }
+    setPrivacyReview({
+      status: response.status,
+      reviewId: response.review_id,
+      findings: response.findings,
+    });
   }
 
   if (!session || !detail || !hostedRuns) {
@@ -364,6 +522,25 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           <p className="rounded-md border border-accent/30 bg-green-9/10 px-4 py-3 text-sm text-accent-bright">
             {notice}
           </p>
+        )}
+        {privacyReview && (
+          <PrivacyReviewPanel
+            review={privacyReview}
+            busy={busy !== null}
+            onDismiss={() => setPrivacyReview(null)}
+            onRetry={() =>
+              void runAction("share", async () => sharePublicly())
+            }
+            onAcknowledge={() => {
+              if (privacyReview.status !== "needs_review") return;
+              void runAction("share", async () =>
+                sharePublicly({
+                  reviewId: privacyReview.reviewId,
+                  acknowledgeWarnings: true,
+                }),
+              );
+            }}
+          />
         )}
 
         <section className={panelClass}>

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -17,8 +17,13 @@ type WorkflowDetail = {
   deployment_status: "building" | "ready" | "failed";
   updated_at: string;
   sharing_enabled: boolean;
-  open_workflow: (Publication & { open_workflow_url: string }) | null;
-  hosted_workflow: (Publication & { page_url: string }) | null;
+  publication:
+    | (Publication & {
+        page_url: string;
+        hosted_workflow: string;
+        deployment_version: number;
+      })
+    | null;
 };
 
 type HostedRunSummary = {
@@ -239,7 +244,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
     setDetail(nextDetail);
     setHostedRuns(nextHostedRuns);
     setWorkflowRuns(nextWorkflowRuns.jobs);
-    setDescription(nextDetail.hosted_workflow?.description ?? "");
+    setDescription(nextDetail.publication?.description ?? "");
   }
 
   useEffect(() => {
@@ -278,13 +283,14 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
     }
   }
 
-  async function shareOpen(acknowledgement?: {
+  async function publishExternally(acknowledgement?: {
     reviewId: string;
     acknowledgeWarnings: boolean;
   }): Promise<void> {
-    const response = await orpcCall<ShareResponse>("/v1/workflows/share", {
+    const response = await orpcCall<ShareResponse>("/v1/workflows/publish", {
       workflow,
-      refresh: Boolean(detail?.open_workflow),
+      refresh: Boolean(detail?.publication),
+      description: description.trim() || undefined,
       privacyReview: {
         capability: "workflow_privacy_review_v1",
         ...(acknowledgement
@@ -296,7 +302,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       },
     });
     if (!("findings" in response) && response.status !== "review_expired") {
-      setNotice("Open source workflow published.");
+      setNotice("Workflow published externally.");
       return;
     }
     if (response.status === "review_expired") {
@@ -317,7 +323,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
         `The privacy review found warnings:\n\n${findings}\n\nPublish anyway?`,
       )
     ) {
-      await shareOpen({
+      await publishExternally({
         reviewId: response.review_id,
         acknowledgeWarnings: true,
       });
@@ -334,8 +340,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
 
   const canPublish =
     detail.sharing_enabled && detail.deployment_status === "ready";
-  const hasPublicWorkflow =
-    Boolean(detail.open_workflow) || Boolean(detail.hosted_workflow);
+  const hasPublicWorkflow = Boolean(detail.publication);
 
   return (
     <DashboardShell
@@ -368,90 +373,33 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           <WorkflowRunsTable runs={workflowRuns} />
         </section>
 
-        {detail.open_workflow && (
+        {detail.publication && (
           <section className={panelClass}>
             <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <div>
-                  <h2 className="text-base font-medium text-ink">
-                    Open source workflow
-                  </h2>
-                </div>
+                <h2 className="text-base font-medium text-ink">
+                  Published externally
+                </h2>
                 <span
                   className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
-                    detail.open_workflow.stale
+                    detail.publication.stale
                       ? "border-rule text-muted"
                       : "border-accent/30 bg-green-9/10 text-accent-bright"
                   }`}
                 >
-                  {detail.open_workflow.stale ? "Older version" : "Live"}
+                  {detail.publication.stale ? "Older version" : "Live"}
                 </span>
               </div>
               <div className="flex items-center gap-4">
-                {detail.open_workflow.stale && (
-                  <button
-                    type="button"
-                    disabled={!canPublish || busy !== null}
-                    onClick={() =>
-                      void runAction("open", async () => shareOpen())
-                    }
-                    className={primaryButtonClass}
-                  >
-                    {busy === "open" ? "Publishing…" : "Publish latest"}
-                  </button>
-                )}
                 <a
-                  href={detail.open_workflow.open_workflow_url}
+                  href={detail.publication.page_url}
                   target="_blank"
                   rel="noreferrer"
                   className="text-xs text-muted no-underline hover:text-ink"
                 >
                   Public page ↗
                 </a>
-                <button
-                  type="button"
-                  disabled={busy !== null}
-                  onClick={() => {
-                    if (!window.confirm("Stop sharing this workflow's source?")) return;
-                    void runAction("unshare", async () => {
-                      await orpcCall("/v1/workflows/unshare", { workflow });
-                      setNotice("Source sharing stopped.");
-                    });
-                  }}
-                  className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
-                >
-                  Stop sharing
-                </button>
               </div>
-            </div>
-          </section>
-        )}
-
-        {detail.hosted_workflow && (
-          <section className={panelClass}>
-            <div className="flex items-center justify-between gap-4 px-5 pb-2 pt-4">
-              <div className="flex items-center gap-3">
-                <div>
-                  <h2 className="text-base font-medium text-ink">Hosted workflow</h2>
-                </div>
-                <span
-                  className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
-                    detail.hosted_workflow.stale
-                      ? "border-rule text-muted"
-                      : "border-accent/30 bg-green-9/10 text-accent-bright"
-                  }`}
-                >
-                  {detail.hosted_workflow.stale ? "Older version" : "Live"}
-                </span>
-              </div>
-              <a
-                href={detail.hosted_workflow.page_url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs text-muted no-underline hover:text-ink"
-              >
-                Hosted page ↗
-              </a>
             </div>
             <div className="flex flex-col gap-3 border-b border-rule px-5 py-3 sm:flex-row sm:items-end">
               <label className="block min-w-0 flex-1 text-[10px] uppercase tracking-[0.08em] text-muted sm:max-w-xl">
@@ -467,25 +415,19 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 type="button"
                 disabled={!canPublish || busy !== null}
                 onClick={() =>
-                  void runAction("host", async () => {
-                    await orpcCall("/v1/workflows/host", {
-                      workflow,
-                      description: description.trim() || undefined,
-                    });
-                    setNotice("Hosted workflow deployed.");
-                  })
+                  void runAction("publish", async () => publishExternally())
                 }
                 className={
-                  detail.hosted_workflow.stale
+                  detail.publication.stale
                     ? primaryButtonClass
                     : "inline-flex h-8 items-center justify-center rounded-md border border-accent/35 bg-green-9/10 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-accent-bright transition-colors hover:bg-green-9/25 disabled:cursor-not-allowed disabled:opacity-40"
                 }
               >
-                {busy === "host"
-                  ? "Deploying…"
-                  : detail.hosted_workflow.stale
-                    ? "Deploy latest"
-                    : "Redeploy"}
+                {busy === "publish"
+                  ? "Publishing…"
+                  : detail.publication.stale
+                    ? "Publish latest"
+                    : "Republish"}
               </button>
             </div>
             <HostedRunsTable summary={hostedRuns} />
@@ -494,15 +436,16 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 type="button"
                 disabled={busy !== null}
                 onClick={() => {
-                  if (!window.confirm("Stop hosting this workflow?")) return;
-                  void runAction("unhost", async () => {
-                    await orpcCall("/v1/workflows/unhost", { workflow });
-                    setNotice("Hosted workflow removed.");
+                  if (!window.confirm("Remove the public API and source code?"))
+                    return;
+                  void runAction("unpublish", async () => {
+                    await orpcCall("/v1/workflows/unpublish", { workflow });
+                    setNotice("External publication removed.");
                   });
                 }}
                 className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
               >
-                Stop hosting
+                Unpublish
               </button>
             </div>
           </section>
@@ -521,7 +464,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   Share workflow outside this workspace
                 </span>
                 <span className="mt-1 block text-xs text-muted">
-                  Choose whether to share its source or a public Hosted run API.
+                  Publish a public run API with visible, reusable source code.
                 </span>
               </span>
               <span className="text-xs text-muted" aria-hidden>
@@ -539,50 +482,30 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     .
                   </div>
                 )}
-                <div className="grid gap-3 p-4 sm:grid-cols-2">
-                  {!detail.open_workflow && (
-                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
-                      <h3 className="text-sm font-medium text-ink">
-                        Open source workflow
-                      </h3>
-                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
-                        Publish a version others can inspect and import.
-                      </p>
-                      <button
-                        type="button"
-                        disabled={!canPublish || busy !== null}
-                        onClick={() =>
-                          void runAction("open", async () => shareOpen())
-                        }
-                        className={`${primaryButtonClass} mt-4 w-full`}
-                      >
-                        {busy === "open"
-                          ? "Publishing…"
-                          : "Publish open source workflow"}
-                      </button>
-                    </div>
-                  )}
-                  {!detail.hosted_workflow && (
-                    <div className="rounded-lg border border-rule bg-bg/25 p-4">
-                      <h3 className="text-sm font-medium text-ink">Hosted workflow</h3>
-                      <p className="mt-2 min-h-8 text-xs leading-5 text-muted">
-                        Host a version others can run as an opaque API.
-                      </p>
-                      <button
-                        type="button"
-                        disabled={!canPublish || busy !== null}
-                        onClick={() =>
-                          void runAction("host", async () => {
-                            await orpcCall("/v1/workflows/host", { workflow });
-                            setNotice("Hosted workflow is now public.");
-                          })
-                        }
-                        className={`${primaryButtonClass} mt-4 w-full`}
-                      >
-                        {busy === "host" ? "Hosting…" : "Host workflow"}
-                      </button>
-                    </div>
-                  )}
+                <div className="p-4">
+                  <label className="block text-[10px] uppercase tracking-[0.08em] text-muted">
+                    Description
+                    <input
+                      value={description}
+                      onChange={(event) => setDescription(event.target.value)}
+                      maxLength={2000}
+                      className="mt-1 h-8 w-full rounded-md border border-rule bg-bg/55 px-3 text-xs normal-case tracking-normal text-ink outline-none focus:border-accent/50"
+                    />
+                  </label>
+                  <p className="mt-3 text-xs leading-5 text-muted">
+                    Libretto reviews the source for sensitive information
+                    before publishing.
+                  </p>
+                  <button
+                    type="button"
+                    disabled={!canPublish || busy !== null}
+                    onClick={() =>
+                      void runAction("publish", async () => publishExternally())
+                    }
+                    className={`${primaryButtonClass} mt-4 w-full`}
+                  >
+                    {busy === "publish" ? "Publishing…" : "Publish externally"}
+                  </button>
                 </div>
               </div>
             )}

--- a/apps/website/src/WorkflowDetailPage.tsx
+++ b/apps/website/src/WorkflowDetailPage.tsx
@@ -223,7 +223,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
   const [detail, setDetail] = useState<WorkflowDetail | null>(null);
   const [hostedRuns, setHostedRuns] = useState<HostedRunSummary | null>(null);
   const [workflowRuns, setWorkflowRuns] = useState<WorkflowRun[]>([]);
-  const [publishingOpen, setPublishingOpen] = useState(false);
+  const [sharingOpen, setSharingOpen] = useState(false);
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -283,11 +283,11 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
     }
   }
 
-  async function publishExternally(acknowledgement?: {
+  async function sharePublicly(acknowledgement?: {
     reviewId: string;
     acknowledgeWarnings: boolean;
   }): Promise<void> {
-    const response = await orpcCall<ShareResponse>("/v1/workflows/publish", {
+    const response = await orpcCall<ShareResponse>("/v1/workflows/share", {
       workflow,
       refresh: Boolean(detail?.publication),
       description: description.trim() || undefined,
@@ -302,11 +302,11 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       },
     });
     if (!("findings" in response) && response.status !== "review_expired") {
-      setNotice("Workflow published externally.");
+      setNotice("Workflow shared publicly.");
       return;
     }
     if (response.status === "review_expired") {
-      throw new Error("The privacy review expired. Publish again to rerun it.");
+      throw new Error("The privacy review expired. Share again to rerun it.");
     }
     if (!("findings" in response)) return;
     const findings = response.findings
@@ -316,14 +316,14 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
       )
       .join("\n");
     if (response.status === "blocked") {
-      throw new Error(`Publishing is blocked by the privacy review:\n${findings}`);
+      throw new Error(`Sharing is blocked by the privacy review:\n${findings}`);
     }
     if (
       window.confirm(
-        `The privacy review found warnings:\n\n${findings}\n\nPublish anyway?`,
+        `The privacy review found warnings:\n\n${findings}\n\nShare publicly anyway?`,
       )
     ) {
-      await publishExternally({
+      await sharePublicly({
         reviewId: response.review_id,
         acknowledgeWarnings: true,
       });
@@ -338,7 +338,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
     );
   }
 
-  const canPublish =
+  const canShare =
     detail.sharing_enabled && detail.deployment_status === "ready";
   const hasPublicWorkflow = Boolean(detail.publication);
 
@@ -378,7 +378,7 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
             <div className="flex flex-col gap-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
                 <h2 className="text-base font-medium text-ink">
-                  Published externally
+                  Shared publicly
                 </h2>
                 <span
                   className={`rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-wide ${
@@ -413,9 +413,9 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
               </label>
               <button
                 type="button"
-                disabled={!canPublish || busy !== null}
+                disabled={!canShare || busy !== null}
                 onClick={() =>
-                  void runAction("publish", async () => publishExternally())
+                  void runAction("share", async () => sharePublicly())
                 }
                 className={
                   detail.publication.stale
@@ -423,11 +423,11 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                     : "inline-flex h-8 items-center justify-center rounded-md border border-accent/35 bg-green-9/10 px-3 font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-accent-bright transition-colors hover:bg-green-9/25 disabled:cursor-not-allowed disabled:opacity-40"
                 }
               >
-                {busy === "publish"
-                  ? "Publishing…"
+                {busy === "share"
+                  ? "Sharing…"
                   : detail.publication.stale
-                    ? "Publish latest"
-                    : "Republish"}
+                    ? "Share latest"
+                    : "Update shared version"}
               </button>
             </div>
             <HostedRunsTable summary={hostedRuns} />
@@ -438,14 +438,14 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                 onClick={() => {
                   if (!window.confirm("Remove the public API and source code?"))
                     return;
-                  void runAction("unpublish", async () => {
-                    await orpcCall("/v1/workflows/unpublish", { workflow });
-                    setNotice("External publication removed.");
+                  void runAction("unshare", async () => {
+                    await orpcCall("/v1/workflows/unshare", { workflow });
+                    setNotice("Workflow is no longer shared publicly.");
                   });
                 }}
                 className="text-xs text-red-200/75 hover:text-red-200 disabled:opacity-40"
               >
-                Unpublish
+                Stop sharing
               </button>
             </div>
           </section>
@@ -455,8 +455,8 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
           <section className={panelClass}>
             <button
               type="button"
-              aria-expanded={publishingOpen}
-              onClick={() => setPublishingOpen((open) => !open)}
+              aria-expanded={sharingOpen}
+              onClick={() => setSharingOpen((open) => !open)}
               className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition-colors hover:bg-panel-hi/25"
             >
               <span>
@@ -464,14 +464,14 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   Share workflow outside this workspace
                 </span>
                 <span className="mt-1 block text-xs text-muted">
-                  Publish a public run API with visible, reusable source code.
+                  Share a public run API with visible, reusable source code.
                 </span>
               </span>
               <span className="text-xs text-muted" aria-hidden>
-                {publishingOpen ? "↑" : "↓"}
+                {sharingOpen ? "↑" : "↓"}
               </span>
             </button>
-            {publishingOpen && (
+            {sharingOpen && (
               <div className="border-t border-rule">
                 {!detail.sharing_enabled && (
                   <div className="border-b border-amber-300/20 bg-amber-300/5 px-5 py-3 text-xs text-amber-100">
@@ -494,17 +494,17 @@ export function WorkflowDetailPage({ workflow }: { workflow: string }) {
                   </label>
                   <p className="mt-3 text-xs leading-5 text-muted">
                     Libretto reviews the source for sensitive information
-                    before publishing.
+                    before sharing.
                   </p>
                   <button
                     type="button"
-                    disabled={!canPublish || busy !== null}
+                    disabled={!canShare || busy !== null}
                     onClick={() =>
-                      void runAction("publish", async () => publishExternally())
+                      void runAction("share", async () => sharePublicly())
                     }
                     className={`${primaryButtonClass} mt-4 w-full`}
                   >
-                    {busy === "publish" ? "Publishing…" : "Publish externally"}
+                    {busy === "share" ? "Sharing…" : "Share publicly"}
                   </button>
                 </div>
               </div>

--- a/apps/website/src/components/BackedByYC.tsx
+++ b/apps/website/src/components/BackedByYC.tsx
@@ -7,9 +7,9 @@ export function BackedByYC({
 }) {
   return (
     <span
-      className={`inline-flex items-center gap-2 font-mono text-xs text-muted/60 sm:text-[13px] ${className}`}
+      className={`inline-flex items-center gap-2 font-mono text-[13px] text-muted/60 sm:text-sm ${className}`}
     >
-      <YCLogo className="size-4 shrink-0 sm:size-[18px]" width={18} height={18} />
+      <YCLogo className="size-[18px] shrink-0 sm:size-5" width={20} height={20} />
       <span className="leading-none">Backed by Y Combinator</span>
     </span>
   );

--- a/apps/website/src/components/Button.tsx
+++ b/apps/website/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 
 type ButtonSize = "default" | "sm";
-type ButtonVariant = "primary" | "secondary";
+type ButtonVariant = "primary" | "secondary" | "outline";
 
 const base =
   "libretto-button inline-flex shrink-0 cursor-pointer items-center justify-center whitespace-nowrap text-center no-underline outline-none disabled:pointer-events-none disabled:opacity-64";
@@ -14,6 +14,7 @@ const sizeClasses: Record<ButtonSize, string> = {
 const variantClasses: Record<ButtonVariant, string> = {
   primary: "",
   secondary: "libretto-button--secondary",
+  outline: "libretto-button--outline",
 };
 
 type ButtonAsButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/apps/website/src/index.css
+++ b/apps/website/src/index.css
@@ -280,6 +280,45 @@ body {
   text-decoration-color: var(--color-accent);
 }
 
+.libretto-button--outline {
+  color: var(--color-ink);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-gray-5) 70%, transparent) 0%,
+    color-mix(in oklch, var(--color-gray-3) 80%, transparent) 100%
+  );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.1),
+    inset 0 0 0 1px color-mix(in oklch, var(--color-gray-8) 50%, transparent),
+    0 2px 8px rgba(0, 0, 0, 0.24);
+}
+
+.libretto-button--outline:hover {
+  color: var(--color-ink);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-gray-7) 72%, transparent) 0%,
+    color-mix(in oklch, var(--color-gray-5) 82%, transparent) 100%
+  );
+  box-shadow:
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.14),
+    inset 0 0 0 1px color-mix(in oklch, var(--color-gray-9) 55%, transparent),
+    0 2px 10px rgba(0, 0, 0, 0.28);
+}
+
+.libretto-button--outline:focus-visible {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklch, var(--color-gray-9) 60%, transparent),
+    0 0 0 3px color-mix(in oklch, var(--color-gray-8) 28%, transparent);
+}
+
+.libretto-button--outline:active {
+  color: var(--color-ink);
+  background: color-mix(in oklch, var(--color-gray-5) 82%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklch, var(--color-gray-8) 55%, transparent);
+}
+
 .install-prompt {
   min-height: 2.5rem;
   border-radius: 8px;

--- a/apps/website/src/routes/marketplace.tsx
+++ b/apps/website/src/routes/marketplace.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/marketplace")({
   beforeLoad: () => {
     throw redirect({
-      to: "/open-workflows",
+      to: "/hosted-workflows",
     });
   },
 });

--- a/apps/website/src/routes/open-workflows.tsx
+++ b/apps/website/src/routes/open-workflows.tsx
@@ -1,16 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { OpenWorkflowsPage } from "../OpenWorkflowsPage";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/open-workflows")({
-  head: () => ({
-    meta: [
-      { title: "Open source workflows | Libretto" },
-      {
-        name: "description",
-        content:
-          "Browse shared Libretto workflow source, connect secrets, and deploy a private copy.",
-      },
-    ],
-  }),
-  component: OpenWorkflowsPage,
+  beforeLoad: () => {
+    throw redirect({ to: "/hosted-workflows" });
+  },
 });

--- a/apps/website/src/routes/open-workflows_.$id.tsx
+++ b/apps/website/src/routes/open-workflows_.$id.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { OpenWorkflowPage } from "../OpenWorkflowsPage";
+import { useEffect, useState } from "react";
+import { publicCloudGet } from "../cloudApi";
 
 export const Route = createFileRoute("/open-workflows_/$id")({
   head: () => ({
@@ -10,5 +11,23 @@ export const Route = createFileRoute("/open-workflows_/$id")({
 
 function OpenWorkflowRoute() {
   const { id } = Route.useParams();
-  return <OpenWorkflowPage shareId={id} />;
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    publicCloudGet<{
+      publisher_slug: string | null;
+      workflow_name: string;
+    }>(`/open-workflows/${encodeURIComponent(id)}/data`)
+      .then((workflow) => {
+        if (!workflow.publisher_slug) {
+          throw new Error("This workflow does not have a public publisher slug.");
+        }
+        window.location.replace(
+          `/hosted-workflows/${encodeURIComponent(workflow.publisher_slug)}/${encodeURIComponent(workflow.workflow_name)}`,
+        );
+      })
+      .catch((cause) =>
+        setError(cause instanceof Error ? cause.message : "Could not find this workflow."),
+      );
+  }, [id]);
+  return <p className="pt-24 text-center text-sm text-muted">{error ?? "Opening published workflow…"}</p>;
 }

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -140,7 +140,7 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
   </Card>
 
   <Card title="Sharing externally" icon="share" href="/libretto-cloud-hosting/sharing-workflows-externally">
-    Publish a hosted public run API with reviewed, visible source code.
+    Share a hosted public run API with reviewed, visible source code.
   </Card>
 
   <Card title="Observability and Debugging" icon="bug" href="/libretto-cloud-hosting/observability-and-debugging">

--- a/docs/libretto-cloud-hosting/sharing-workflows-externally.mdx
+++ b/docs/libretto-cloud-hosting/sharing-workflows-externally.mdx
@@ -4,9 +4,9 @@ sidebarTitle: Sharing externally
 "og:image": "https://libretto.sh/docs/og/libretto-cloud-hosting/sharing-workflows-externally.png"
 ---
 
-> Publish a deployed workflow outside your workspace as a hosted API with visible source code. Workflows stay private until you publish them.
+> Share a deployed workflow publicly as a hosted API with visible source code. Workflows stay private until you share them.
 
-Deploying a workflow makes it available inside your organization. Publishing it externally creates a public run API and shares the reviewed source so others can inspect or adapt it.
+Deploying a workflow makes it available inside your organization. Sharing it publicly creates a public run API and shares the reviewed source so others can inspect or adapt it.
 
 ### What publication includes
 
@@ -17,24 +17,24 @@ Every published workflow has one public page with:
 - Required credential names
 - Source files that visitors can inspect or adapt
 
-Libretto reviews the source for secrets and other sensitive information before publishing. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
+Libretto reviews the source for secrets and other sensitive information before sharing. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-### Publish from the dashboard
+### Share from the dashboard
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open your workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
 3. Open the workflow and expand Share workflow outside this workspace.
-4. Add an optional description and select Publish externally.
+4. Add an optional description and select Share publicly.
 5. Resolve any blocked privacy findings or acknowledge warnings after reviewing them.
-6. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
+6. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then share again.
 
-You can also publish from a terminal:
+You can also share from a terminal:
 
 ```bash
-libretto cloud publish myWorkflow
+libretto cloud share myWorkflow
 ```
 
-Use `--acknowledge-warnings` only after reviewing the findings printed by the command. Remove both the public API and source with `libretto cloud unpublish myWorkflow`.
+Use `--acknowledge-warnings` only after reviewing the findings printed by the command. Remove both the public API and source with `libretto cloud unshare myWorkflow`.
 
 ### What stays private
 

--- a/packages/libretto/skills/libretto/references/sharing-workflows-externally.md
+++ b/packages/libretto/skills/libretto/references/sharing-workflows-externally.md
@@ -1,6 +1,6 @@
 # Sharing workflows externally
 
-Publish a deployed workflow outside the workspace as a hosted API with visible source code. Workflows stay private until someone publishes them.
+Share a deployed workflow publicly as a hosted API with visible source code. Workflows stay private until someone shares them.
 
 Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hosting/sharing-workflows-externally)
 
@@ -8,17 +8,17 @@ Docs: [Sharing workflows externally](https://libretto.sh/docs/libretto-cloud-hos
 
 Each publication includes a hosted run endpoint, input and output types, required credential names, and source files that others can inspect or adapt.
 
-Libretto reviews the source for sensitive information before it publishes anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
+Libretto reviews the source for sensitive information before it shares anything. Blocked findings must be fixed; warnings require explicit acknowledgement. Workspace sharing must also be on in organization settings.
 
-## Publish
+## Share publicly
 
 1. Sign in at [libretto.sh](https://libretto.sh) and open the workspace dashboard.
 2. Deploy the workflow so it is ready in Cloud.
-3. Open the workflow, expand Share workflow outside this workspace, and select Publish externally.
+3. Open the workflow, expand Share workflow outside this workspace, and select Share publicly.
 4. Review any privacy findings. Fix blocked findings or explicitly acknowledge warnings.
-5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then publish again.
+5. If sharing is off, enable it in [Settings](https://libretto.sh/dashboard/settings), then share again.
 
-The CLI uses the same method: `libretto cloud publish <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unpublish <workflow>` to remove both the API and source.
+The CLI uses the same method: `libretto cloud share <workflow>`. Use `--acknowledge-warnings` only after reviewing the printed findings. Run `libretto cloud unshare <workflow>` to remove both the API and source.
 
 ## What stays private
 

--- a/packages/libretto/src/cli/commands/cloud-publishing.ts
+++ b/packages/libretto/src/cli/commands/cloud-publishing.ts
@@ -11,7 +11,7 @@ type PrivacyFinding = {
   suggestedFix: string;
 };
 
-type PublishResponse =
+type ShareResponse =
   | {
       status: "created" | "existing" | "refreshed";
       workflow: string;
@@ -37,13 +37,13 @@ function printFindings(findings: PrivacyFinding[]): void {
   }
 }
 
-export async function publishWorkflowWithPrivacyReview(
+export async function shareWorkflowWithPrivacyReview(
   ctx: CloudApiKeyContext,
   input: { workflow: string; description?: string; acknowledgeWarnings: boolean },
-): Promise<PublishResponse> {
-  const first = await orpcCall<PublishResponse>({
+): Promise<ShareResponse> {
+  const first = await orpcCall<ShareResponse>({
     apiUrl: ctx.apiUrl,
-    path: "/v1/workflows/publish",
+    path: "/v1/workflows/share",
     input: {
       workflow: input.workflow,
       description: input.description,
@@ -53,18 +53,18 @@ export async function publishWorkflowWithPrivacyReview(
   });
   if (first.status === "blocked") {
     printFindings(first.findings);
-    throw new Error("Publishing is blocked. Fix the findings and deploy again.");
+    throw new Error("Sharing is blocked. Fix the findings and deploy again.");
   }
   if (first.status !== "needs_review") return first;
   printFindings(first.findings);
   if (!input.acknowledgeWarnings) {
     throw new Error(
-      "Review the warnings, then run the command again with --acknowledge-warnings to publish this exact deployment.",
+      "Review the warnings, then run the command again with --acknowledge-warnings to share this exact deployment.",
     );
   }
-  return orpcCall<PublishResponse>({
+  return orpcCall<ShareResponse>({
     apiUrl: ctx.apiUrl,
-    path: "/v1/workflows/publish",
+    path: "/v1/workflows/share",
     input: {
       workflow: input.workflow,
       description: input.description,
@@ -78,14 +78,14 @@ export async function publishWorkflowWithPrivacyReview(
   });
 }
 
-export const publishWorkflowCommand = SimpleCLI.command({
-  description: "Publish a deployed workflow outside your workspace",
+export const shareWorkflowCommand = SimpleCLI.command({
+  description: "Share a deployed workflow publicly",
 })
   .input(
     SimpleCLI.input({
       positionals: [
         SimpleCLI.positional("workflow", z.string().min(1), {
-          help: "Deployed workflow name to publish",
+          help: "Deployed workflow name to share publicly",
         }),
       ],
       named: {
@@ -93,49 +93,49 @@ export const publishWorkflowCommand = SimpleCLI.command({
           help: "Public workflow description",
         }),
         acknowledgeWarnings: SimpleCLI.flag({
-          help: "Publish after acknowledging privacy review warnings",
+          help: "Share after acknowledging privacy review warnings",
         }),
       },
     }),
   )
-  .use(withCloudApiKey("publish a Libretto Cloud workflow"))
+  .use(withCloudApiKey("share a Libretto Cloud workflow publicly"))
   .handle(async ({ input, ctx }) => {
-    const response = await publishWorkflowWithPrivacyReview(ctx, input);
+    const response = await shareWorkflowWithPrivacyReview(ctx, input);
     if (!("page_url" in response)) {
       throw new Error(
         response.status === "review_expired"
-          ? "The privacy review expired. Run publish again."
-          : "The workflow was not published.",
+          ? "The privacy review expired. Run share again."
+          : "The workflow was not shared.",
       );
     }
-    console.log(`Published workflow: ${response.hosted_workflow}`);
+    console.log(`Shared workflow: ${response.hosted_workflow}`);
     console.log(`Public page: ${response.page_url}`);
     console.log(`Deployment version: ${response.deployment_version}`);
     console.log("Source code: public");
     return response.page_url;
   });
 
-export const unpublishWorkflowCommand = SimpleCLI.command({
-  description: "Remove a workflow's public API and source code",
+export const unshareWorkflowCommand = SimpleCLI.command({
+  description: "Stop sharing a workflow's public API and source code",
 })
   .input(
     SimpleCLI.input({
       positionals: [
         SimpleCLI.positional("workflow", z.string().min(1), {
-          help: "Published workflow name to remove",
+          help: "Publicly shared workflow name to remove",
         }),
       ],
       named: {},
     }),
   )
-  .use(withCloudApiKey("unpublish a Libretto Cloud workflow"))
+  .use(withCloudApiKey("stop sharing a Libretto Cloud workflow"))
   .handle(async ({ input, ctx }) => {
     const response = await orpcCall<{ hosted_workflow: string }>({
       apiUrl: ctx.apiUrl,
-      path: "/v1/workflows/unpublish",
+      path: "/v1/workflows/unshare",
       input: { workflow: input.workflow },
       credential: ctx.credential,
     });
-    console.log(`Unpublished workflow: ${response.hosted_workflow}`);
+    console.log(`Stopped sharing workflow: ${response.hosted_workflow}`);
     return response.hosted_workflow;
   });

--- a/packages/libretto/src/cli/router.ts
+++ b/packages/libretto/src/cli/router.ts
@@ -7,8 +7,8 @@ import { cloudScheduleCommands } from "./commands/cloud-schedules.js";
 import { cloudSmsNumberCommands } from "./commands/cloud-sms-numbers.js";
 import { settingsCommands } from "./commands/cloud-settings.js";
 import {
-  publishWorkflowCommand,
-  unpublishWorkflowCommand,
+  shareWorkflowCommand,
+  unshareWorkflowCommand,
 } from "./commands/cloud-publishing.js";
 import { deployCommand } from "./commands/deploy.js";
 import { executionCommands } from "./commands/execution.js";
@@ -37,8 +37,8 @@ export const cliRoutes = {
       schedules: cloudScheduleCommands,
       "sms-numbers": cloudSmsNumberCommands,
       settings: settingsCommands,
-      publish: publishWorkflowCommand,
-      unpublish: unpublishWorkflowCommand,
+      share: shareWorkflowCommand,
+      unshare: unshareWorkflowCommand,
     },
   }),
   experiments: experimentsCommand,

--- a/packages/libretto/test/basic.spec.ts
+++ b/packages/libretto/test/basic.spec.ts
@@ -361,8 +361,8 @@ describe("basic CLI subprocess behavior", () => {
     expect(result.stdout).toContain("jobs");
     expect(result.stdout).toContain("schedules");
     expect(result.stdout).toContain("settings");
-    expect(result.stdout).toMatch(/\bpublish\b/);
-    expect(result.stdout).toMatch(/\bunpublish\b/);
+    expect(result.stdout).toMatch(/\bshare\b/);
+    expect(result.stdout).toMatch(/\bunshare\b/);
     expect(result.stdout).not.toMatch(/\bhost\b/);
     expect(result.stdout).not.toMatch(/\bunhost\b/);
     expect(result.stderr).toBe("");

--- a/packages/libretto/test/cloud-publishing.spec.ts
+++ b/packages/libretto/test/cloud-publishing.spec.ts
@@ -5,7 +5,7 @@ vi.mock("../src/cli/core/auth-fetch.js", () => ({
 }));
 
 import { orpcCall } from "../src/cli/core/auth-fetch.js";
-import { publishWorkflowWithPrivacyReview } from "../src/cli/commands/cloud-publishing.js";
+import { shareWorkflowWithPrivacyReview } from "../src/cli/commands/cloud-publishing.js";
 
 const context = {
   apiUrl: "https://api.libretto.test",
@@ -22,13 +22,13 @@ const warning = {
   suggestedFix: "Move the URL to a secret.",
 };
 
-describe("cloud publish privacy review", () => {
+describe("cloud share privacy review", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
-  it("blocks publication when the privacy review blocks the source", async () => {
+  it("blocks sharing when the privacy review blocks the source", async () => {
     vi.mocked(orpcCall).mockResolvedValueOnce({
       workflow: "syncClaims",
       status: "blocked",
@@ -38,11 +38,11 @@ describe("cloud publish privacy review", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      publishWorkflowWithPrivacyReview(context, {
+      shareWorkflowWithPrivacyReview(context, {
         workflow: "syncClaims",
         acknowledgeWarnings: false,
       }),
-    ).rejects.toThrow("Publishing is blocked");
+    ).rejects.toThrow("Sharing is blocked");
     expect(orpcCall).toHaveBeenCalledTimes(1);
   });
 
@@ -56,7 +56,7 @@ describe("cloud publish privacy review", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      publishWorkflowWithPrivacyReview(context, {
+      shareWorkflowWithPrivacyReview(context, {
         workflow: "syncClaims",
         acknowledgeWarnings: false,
       }),
@@ -64,7 +64,7 @@ describe("cloud publish privacy review", () => {
     expect(orpcCall).toHaveBeenCalledTimes(1);
   });
 
-  it("acknowledges the exact review before publishing", async () => {
+  it("acknowledges the exact review before sharing", async () => {
     const reviewId = "2edbf679-dda3-4df8-822b-9dc2228c48f8";
     vi.mocked(orpcCall)
       .mockResolvedValueOnce({
@@ -83,7 +83,7 @@ describe("cloud publish privacy review", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      publishWorkflowWithPrivacyReview(context, {
+      shareWorkflowWithPrivacyReview(context, {
         workflow: "syncClaims",
         description: "Sync claims",
         acknowledgeWarnings: true,


### PR DESCRIPTION
## Summary
- replace the workflow detail page's separate source-share and hosted controls with one share/update/unshare experience
- show privacy-review findings inline, include suggested fixes, and provide a copyable coding-agent remediation prompt
- combine the hosted endpoint, API spec, credentials, source browser, and fork-and-deploy action on one public workflow page
- redirect legacy Open Workflow and Marketplace routes to the canonical shared-workflow catalog and detail pages
- update workspace copy to describe the hosted API and reviewed public source as one shared workflow
- refresh the homepage hero description and promote a 15-minute team call as a clear secondary action

This is the UI layer of the unified-sharing stack and builds on #567, which supplies the matching CLI and documentation contract.

## Validation
- `pnpm --dir apps/website type-check`
- `pnpm --dir apps/website build`
- `pnpm lint`
