### PR TITLE
Document how to read workflow output from job.result

### DIFF
--- a/docs/get-started/deploying.mdx
+++ b/docs/get-started/deploying.mdx
@@ -52,6 +52,8 @@ Use this if you want a provider other than Libretto Cloud Hosting.
 
 ## After deployment
 
+To read the object a hosted workflow returned, poll `jobs/get` and use `result`. See [Get the workflow output](/libretto-cloud-api/jobs-and-logs#get-the-workflow-output).
+
 Use these workflow guides to build, debug, and optimize production automations:
 
 <CardGroup cols={2}>

--- a/docs/get-started/first-workflow.mdx
+++ b/docs/get-started/first-workflow.mdx
@@ -45,6 +45,8 @@ export default workflow(
 ```bash theme={null}
 npx libretto run src/workflows/scrape-page.ts
 ```
+
+The object you `return` is the workflow output. On a hosted run, that output is `result` on the job. See [Get the workflow output](/libretto-cloud-api/jobs-and-logs#get-the-workflow-output).
   </Step>
 
   <Step title="Inspect page state when needed">

--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -7,6 +7,36 @@ title: Jobs and logs
 
 All routes on this page require `x-api-key`.
 
+### Get the workflow output
+
+`POST /v1/jobs/create` starts a run and returns a `job_id`. It does not return the data the workflow collected.
+
+Whatever the handler `return`s is stored on the completed job as `result`. That object matches the workflow `output` schema.
+
+Poll `POST /v1/jobs/get` until the job finishes, then read `result`. A `job.completed` webhook delivers the same field. See [Webhooks](/libretto-cloud-api/webhooks).
+
+```bash
+curl -X POST "https://api.libretto.sh/v1/jobs/get" \
+  -H "x-api-key: $LIBRETTO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "json": {
+      "id": "<job-id>"
+    }
+  }'
+```
+
+```json
+{
+  "job_id": "<job-id>",
+  "workflow": "scrape-page",
+  "status": "completed",
+  "result": {
+    "title": "Example Domain"
+  }
+}
+```
+
 ### Jobs
 
 #### POST `/v1/jobs/create`
@@ -51,6 +81,8 @@ Response fields:
 - `job_id`
 - `status`: always `running`
 - `message`
+
+This response does not include `result`. See [Get the workflow output](#get-the-workflow-output).
 
 #### POST `/v1/jobs/list`
 
@@ -97,7 +129,7 @@ Response fields:
 - `created_at`
 - `started_at`
 - `completed_at`
-- `result`
+- `result`: the workflow handler return value after the job completes. Matches `schemas.output`.
 - `error`
 - `mapped_stack`
 

--- a/docs/libretto-cloud-api/webhooks.mdx
+++ b/docs/libretto-cloud-api/webhooks.mdx
@@ -97,7 +97,7 @@ Stored webhook endpoints receive:
 - `workflow`
 - `deployment_id`
 - `status`
-- `result`
+- `result`: workflow handler return value on `job.completed`. Same field as `jobs/get`. See [Get the workflow output](/libretto-cloud-api/jobs-and-logs#get-the-workflow-output).
 - `error`
 - `mapped_stack`
 

--- a/docs/libretto-cloud-hosting/deployments.mdx
+++ b/docs/libretto-cloud-hosting/deployments.mdx
@@ -157,6 +157,8 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
   }'
 ```
 
+Read `result` on the completed job. That object is whatever the workflow handler returned. See [Get the workflow output](/libretto-cloud-api/jobs-and-logs#get-the-workflow-output).
+
 The `workflow` value must match the workflow name declared in code and discovered during deploy, not the deployment id, filename, or export alias.
 
 ### Schedule a deployed workflow

--- a/docs/libretto-cloud-hosting/overview.mdx
+++ b/docs/libretto-cloud-hosting/overview.mdx
@@ -124,6 +124,8 @@ Use Libretto Cloud when you want to ship and run workflows without owning the ru
       }'
     ```
 
+    Read `result` on the completed job. That object is whatever the workflow handler returned. See [Get the workflow output](/libretto-cloud-api/jobs-and-logs#get-the-workflow-output).
+
     See [Run a deployed workflow](/libretto-cloud-hosting/deployments#run-a-deployed-workflow) and [Jobs](/libretto-cloud-api/jobs-and-logs#jobs).
   </Step>
 </Steps>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Customer feedback from Humam AI: the docs never make it obvious that scraped (or any workflow) data lives on the completed job as `result`.

This draft states the contract in one place and points the hosted-run docs at it:

- `jobs/create` returns a `job_id`, not the payload
- the handler return value is `result` on `jobs/get` and on `job.completed` webhooks
- example JSON uses the existing `scrape-page` first-workflow shape

No API or CLI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d915d6f-2ae5-4281-b4be-127cb621fca1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d915d6f-2ae5-4281-b4be-127cb621fca1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

