### PR TITLE
Resume agent OAuth through website sign-in

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -8,6 +8,7 @@
     "brand-kit": "vite dev --host 0.0.0.0 --port 5174",
     "build": "tsc --noEmit && vite build",
     "type-check": "tsc --noEmit",
+    "test:vitest": "vitest run",
     "preview": "vite preview",
     "check": "pnpm -s type-check",
     "knip": "knip --cache --files --exports",
@@ -44,6 +45,7 @@
     "knip": "^6.0.6",
     "libretto": "workspace:*",
     "typescript": "~5.9.3",
-    "vite": "8.0.16"
+    "vite": "8.0.16",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/website/src/OAuthContinuePage.tsx
+++ b/apps/website/src/OAuthContinuePage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { withReturnTo } from "./authRedirect";
+import { authPost, getAuthStatus } from "./cloudApi";
+import { Navbar } from "./components/Navbar";
+import {
+  authResponseDestination,
+  signedOAuthQuery,
+  type OAuthAuthResponse,
+} from "./oauthFlow";
+
+export function OAuthContinuePage() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function continueOAuth() {
+      const oauthQuery = signedOAuthQuery(window.location.search);
+      if (!oauthQuery) {
+        setError(
+          "The authorization request is missing or invalid. Start the connection again from your agent.",
+        );
+        return;
+      }
+
+      const returnTo = `/oauth/continue?${oauthQuery}`;
+      const status = await getAuthStatus();
+      if (!status.emailVerified) {
+        window.location.assign(withReturnTo("/verify-email", returnTo));
+        return;
+      }
+      if (!status.hasTenant) {
+        window.location.assign(withReturnTo("/onboarding", returnTo));
+        return;
+      }
+
+      const result = await authPost<OAuthAuthResponse>(
+        "/api/auth/oauth2/continue",
+        { postLogin: true, oauth_query: oauthQuery },
+      );
+      const destination = authResponseDestination(result);
+      if (!destination) {
+        throw new Error("Libretto did not return an authorization destination.");
+      }
+      window.location.assign(destination);
+    }
+
+    continueOAuth().catch((reason: unknown) => {
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : "Could not continue authorization.",
+      );
+    });
+  }, []);
+
+  return (
+    <div className="crt-page min-h-screen bg-bg text-ink">
+      <Navbar />
+      <main className="mx-auto flex min-h-[calc(100vh-96px)] w-full max-w-[760px] items-center px-6 py-10">
+        <section className="w-full rounded-lg border border-rule bg-panel/85 p-6 text-center shadow-2xl shadow-black/25">
+          <p className="mb-3 font-mono text-xs uppercase text-accent">
+            Libretto Cloud
+          </p>
+          <h1 className="font-serif text-4xl font-light">
+            Continue to your agent
+          </h1>
+          {error ? (
+            <p className="mt-5 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-3 text-sm leading-5 text-red-200">
+              {error}
+            </p>
+          ) : (
+            <p className="mt-4 text-sm leading-6 text-muted">
+              Checking your account and workspace before showing the access
+              request.
+            </p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/website/src/SignInPage.tsx
+++ b/apps/website/src/SignInPage.tsx
@@ -9,17 +9,20 @@ import {
 import { Navbar } from "./components/Navbar";
 import {
   authPost,
+  cloudApiUrl,
   getAuthStatus,
   getCloudSession,
   orpcCall,
   type AuthStatus,
 } from "./cloudApi";
 import { GitHubIcon } from "./icons";
-
-type AuthResponse = {
-  redirect?: boolean;
-  url?: string;
-};
+import {
+  authResponseDestination,
+  oauthAuthorizeUrl,
+  signedOAuthQuery,
+  withOAuthQuery,
+  type OAuthAuthResponse,
+} from "./oauthFlow";
 
 type AuthMode = "signin" | "signup";
 
@@ -169,6 +172,11 @@ export function SignInPage() {
     getCloudSession()
       .then((session) => {
         if (!session) return;
+        const oauthQuery = signedOAuthQuery(window.location.search);
+        if (oauthQuery) {
+          window.location.assign(oauthAuthorizeUrl(cloudApiUrl, oauthQuery));
+          return;
+        }
         if (getCliLoginParams()) {
           approveCliLogin().catch((err) => {
             setError(err instanceof Error ? err.message : "CLI login approval failed.");
@@ -194,18 +202,25 @@ export function SignInPage() {
     setError(null);
     setNotice(null);
     try {
-      const result = await authPost<AuthResponse>("/api/auth/sign-in/email", {
-        email,
-        password,
-        callbackURL: getCliLoginParams()
-          ? currentSigninCallbackUrl()
-          : `${window.location.origin}${withReturnTo(
-              "/signin",
-              sanitizeReturnToForAuthState(getSafeReturnTo(), true),
-            )}`,
-      });
-      if (result.url) {
-        window.location.assign(result.url);
+      const result = await authPost<OAuthAuthResponse>(
+        "/api/auth/sign-in/email",
+        withOAuthQuery(
+          {
+            email,
+            password,
+            callbackURL: getCliLoginParams()
+              ? currentSigninCallbackUrl()
+              : `${window.location.origin}${withReturnTo(
+                  "/signin",
+                  sanitizeReturnToForAuthState(getSafeReturnTo(), true),
+                )}`,
+          },
+          window.location.search,
+        ),
+      );
+      const destination = authResponseDestination(result);
+      if (destination) {
+        window.location.assign(destination);
         return;
       }
       if (await approveCliLogin()) return;
@@ -226,14 +241,25 @@ export function SignInPage() {
     try {
       const returnTo = getSafeReturnTo();
       const callbackReturnTo = sanitizeReturnToForAuthState(returnTo, false);
-      await authPost<AuthResponse>("/api/auth/sign-up/email", {
-        name,
-        email,
-        password,
-        callbackURL: getCliLoginParams()
-          ? currentSigninCallbackUrl()
-          : `${window.location.origin}${withReturnTo("/verify-email", callbackReturnTo)}`,
-      });
+      const result = await authPost<OAuthAuthResponse>(
+        "/api/auth/sign-up/email",
+        withOAuthQuery(
+          {
+            name,
+            email,
+            password,
+            callbackURL: getCliLoginParams()
+              ? currentSigninCallbackUrl()
+              : `${window.location.origin}${withReturnTo("/verify-email", callbackReturnTo)}`,
+          },
+          window.location.search,
+        ),
+      );
+      const destination = authResponseDestination(result);
+      if (destination) {
+        window.location.assign(destination);
+        return;
+      }
       if (await approveCliLogin()) return;
       window.location.assign(withReturnTo("/verify-email", callbackReturnTo));
     } catch (err) {
@@ -252,17 +278,24 @@ export function SignInPage() {
         returnTo,
         mode === "signin",
       );
-      const result = await authPost<AuthResponse>("/api/auth/sign-in/social", {
-        provider,
-        callbackURL: getCliLoginParams()
-          ? currentSigninCallbackUrl()
-          : `${window.location.origin}${withReturnTo(
-              "/signin",
-              callbackReturnTo,
-            )}`,
-      });
-      if (result.url) {
-        window.location.assign(result.url);
+      const result = await authPost<OAuthAuthResponse>(
+        "/api/auth/sign-in/social",
+        withOAuthQuery(
+          {
+            provider,
+            callbackURL: getCliLoginParams()
+              ? currentSigninCallbackUrl()
+              : `${window.location.origin}${withReturnTo(
+                  "/signin",
+                  callbackReturnTo,
+                )}`,
+          },
+          window.location.search,
+        ),
+      );
+      const destination = authResponseDestination(result);
+      if (destination) {
+        window.location.assign(destination);
         return;
       }
       if (await approveCliLogin()) return;

--- a/apps/website/src/oauthFlow.spec.ts
+++ b/apps/website/src/oauthFlow.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  authResponseDestination,
+  oauthAuthorizeUrl,
+  signedOAuthQuery,
+  withOAuthQuery,
+} from "./oauthFlow";
+
+const signedQuery =
+  "client_id=agent-client&redirect_uri=https%3A%2F%2Fagent.example%2Fcallback&state=state-123&exp=1234&sig=signed-value";
+
+describe("OAuth authentication flow", () => {
+  it("preserves the signed authorization query for Google sign-in", () => {
+    expect(
+      withOAuthQuery(
+        { provider: "google", callbackURL: "https://libretto.sh/signin" },
+        `?${signedQuery}`,
+      ),
+    ).toEqual({
+      provider: "google",
+      callbackURL: "https://libretto.sh/signin",
+      oauth_query: signedQuery,
+    });
+  });
+
+  it("preserves the signed authorization query for GitHub sign-in", () => {
+    expect(
+      withOAuthQuery(
+        { provider: "github", callbackURL: "https://libretto.sh/signin" },
+        `?${signedQuery}`,
+      ),
+    ).toEqual({
+      provider: "github",
+      callbackURL: "https://libretto.sh/signin",
+      oauth_query: signedQuery,
+    });
+  });
+
+  it("preserves the same query for email sign-in", () => {
+    expect(
+      withOAuthQuery(
+        { email: "user@example.com", password: "secret" },
+        `?${signedQuery}`,
+      ),
+    ).toMatchObject({ oauth_query: signedQuery });
+  });
+
+  it("does not forward unsigned parameters after the signature", () => {
+    expect(signedOAuthQuery(`?${signedQuery}&admin=true`)).toBe(signedQuery);
+  });
+
+  it("resumes authorization for an existing session without signature fields", () => {
+    expect(oauthAuthorizeUrl("https://api.libretto.sh/", signedQuery)).toBe(
+      "https://api.libretto.sh/api/auth/oauth2/authorize?client_id=agent-client&redirect_uri=https%3A%2F%2Fagent.example%2Fcallback&state=state-123",
+    );
+  });
+
+  it("accepts either Better Auth redirect response field", () => {
+    expect(authResponseDestination({ url: "https://accounts.google.com" })).toBe(
+      "https://accounts.google.com",
+    );
+    expect(authResponseDestination({ uri: "https://github.com/login" })).toBe(
+      "https://github.com/login",
+    );
+  });
+});

--- a/apps/website/src/oauthFlow.ts
+++ b/apps/website/src/oauthFlow.ts
@@ -1,0 +1,43 @@
+export type OAuthAuthResponse = {
+  redirect?: boolean;
+  url?: string;
+  uri?: string;
+};
+
+/**
+ * Return only the signed portion of a Better Auth OAuth-provider query.
+ * Parameters after `sig` are not covered by the signature and must not be
+ * forwarded as part of the authorization request.
+ */
+export function signedOAuthQuery(search: string): string | null {
+  const params = new URLSearchParams(search);
+  if (!params.has("client_id") || !params.has("sig")) return null;
+
+  const signed = new URLSearchParams();
+  for (const [key, value] of params) {
+    signed.append(key, value);
+    if (key === "sig") break;
+  }
+  return signed.toString();
+}
+
+export function withOAuthQuery<T extends Record<string, unknown>>(
+  input: T,
+  search: string,
+): T & { oauth_query?: string } {
+  const oauthQuery = signedOAuthQuery(search);
+  return oauthQuery ? { ...input, oauth_query: oauthQuery } : input;
+}
+
+export function oauthAuthorizeUrl(apiUrl: string, oauthQuery: string): string {
+  const params = new URLSearchParams(oauthQuery);
+  params.delete("exp");
+  params.delete("sig");
+  return `${apiUrl.replace(/\/+$/, "")}/api/auth/oauth2/authorize?${params}`;
+}
+
+export function authResponseDestination(
+  response: OAuthAuthResponse,
+): string | null {
+  return response.url ?? response.uri ?? null;
+}

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as VsStagehandRouteImport } from './routes/vs/stagehand'
 import { Route as VsPlaywrightCodegenRouteImport } from './routes/vs/playwright-codegen'
 import { Route as VsBrowserUseRouteImport } from './routes/vs/browser-use'
 import { Route as OpenWorkflowsIdRouteImport } from './routes/open-workflows_.$id'
+import { Route as OauthContinueRouteImport } from './routes/oauth.continue'
 import { Route as MarketplaceIdRouteImport } from './routes/marketplace_.$id'
 import { Route as GithubSetupRouteImport } from './routes/github.setup'
 import { Route as DashboardPrAgentRouteImport } from './routes/dashboard_.pr-agent'
@@ -145,6 +146,11 @@ const OpenWorkflowsIdRoute = OpenWorkflowsIdRouteImport.update({
   path: '/open-workflows/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OauthContinueRoute = OauthContinueRouteImport.update({
+  id: '/oauth/continue',
+  path: '/oauth/continue',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MarketplaceIdRoute = MarketplaceIdRouteImport.update({
   id: '/marketplace_/$id',
   path: '/marketplace/$id',
@@ -218,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace/$id': typeof MarketplaceIdRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/open-workflows/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
@@ -249,6 +256,7 @@ export interface FileRoutesByTo {
   '/dashboard/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace/$id': typeof MarketplaceIdRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/open-workflows/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
@@ -282,6 +290,7 @@ export interface FileRoutesById {
   '/dashboard_/pr-agent': typeof DashboardPrAgentRoute
   '/github/setup': typeof GithubSetupRoute
   '/marketplace_/$id': typeof MarketplaceIdRoute
+  '/oauth/continue': typeof OauthContinueRoute
   '/open-workflows_/$id': typeof OpenWorkflowsIdRoute
   '/vs/browser-use': typeof VsBrowserUseRoute
   '/vs/playwright-codegen': typeof VsPlaywrightCodegenRoute
@@ -316,6 +325,7 @@ export interface FileRouteTypes {
     | '/dashboard/pr-agent'
     | '/github/setup'
     | '/marketplace/$id'
+    | '/oauth/continue'
     | '/open-workflows/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
@@ -347,6 +357,7 @@ export interface FileRouteTypes {
     | '/dashboard/pr-agent'
     | '/github/setup'
     | '/marketplace/$id'
+    | '/oauth/continue'
     | '/open-workflows/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
@@ -379,6 +390,7 @@ export interface FileRouteTypes {
     | '/dashboard_/pr-agent'
     | '/github/setup'
     | '/marketplace_/$id'
+    | '/oauth/continue'
     | '/open-workflows_/$id'
     | '/vs/browser-use'
     | '/vs/playwright-codegen'
@@ -411,6 +423,7 @@ export interface RootRouteChildren {
   DashboardPrAgentRoute: typeof DashboardPrAgentRoute
   GithubSetupRoute: typeof GithubSetupRoute
   MarketplaceIdRoute: typeof MarketplaceIdRoute
+  OauthContinueRoute: typeof OauthContinueRoute
   OpenWorkflowsIdRoute: typeof OpenWorkflowsIdRoute
   VsBrowserUseRoute: typeof VsBrowserUseRoute
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
@@ -568,6 +581,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OpenWorkflowsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/oauth/continue': {
+      id: '/oauth/continue'
+      path: '/oauth/continue'
+      fullPath: '/oauth/continue'
+      preLoaderRoute: typeof OauthContinueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/marketplace_/$id': {
       id: '/marketplace_/$id'
       path: '/marketplace/$id'
@@ -671,6 +691,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardPrAgentRoute: DashboardPrAgentRoute,
   GithubSetupRoute: GithubSetupRoute,
   MarketplaceIdRoute: MarketplaceIdRoute,
+  OauthContinueRoute: OauthContinueRoute,
   OpenWorkflowsIdRoute: OpenWorkflowsIdRoute,
   VsBrowserUseRoute: VsBrowserUseRoute,
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,

--- a/apps/website/src/routes/oauth.continue.tsx
+++ b/apps/website/src/routes/oauth.continue.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { OAuthContinuePage } from "../OAuthContinuePage";
+
+export const Route = createFileRoute("/oauth/continue")({
+  component: OAuthContinuePage,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   benchmarks:
     dependencies:
@@ -245,7 +248,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -13095,6 +13098,14 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
@@ -16630,6 +16641,21 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+      yaml: 2.9.0
+
   vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -16670,6 +16696,34 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary
- reuse the existing Libretto website sign-in page for agent OAuth instead of maintaining a separate email-only login
- preserve Better Auth's signed authorization query through email/password, Google, and GitHub authentication
- automatically resume authorization for an existing session
- add a generic `/oauth/continue` page that carries verification and workspace onboarding back into the agent consent flow
- ignore parameters appended after the signed portion of an OAuth query

## Companion PR
- saffron-health/libretto-cloud#256 configures the MCP authorization server to use these website pages

## Verification
- 15 website authentication tests, including explicit Google and GitHub query propagation
- website TypeScript check
- production client, SSR, and prerender build
