### PR TITLE
Route Vercel previews to the staging API

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -35,7 +35,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.libretto.sh https://api.github.com https://cdn.usefathom.com https://api.usefathom.com; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.libretto.sh https://browser-automations-staging-g2vofuk5ea-uc.a.run.app https://api.github.com https://cdn.usefathom.com https://api.usefathom.com; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     },

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -10,6 +10,8 @@ const comptimePlugin = await comptime();
 const blogPosts = await loadBlogPostInputs();
 const blogPostPaths = blogPosts.map((post) => `/blog/${post.slug}`);
 const dashboardPaths = dashboardPrerenderPaths;
+const stagingCloudApiUrl =
+  "https://browser-automations-staging-g2vofuk5ea-uc.a.run.app";
 
 function localDocsRedirectPlugin(): Plugin {
   return {
@@ -35,6 +37,14 @@ function localDocsRedirectPlugin(): Plugin {
 }
 
 export default defineConfig({
+  define:
+    process.env.VERCEL_ENV === "preview"
+      ? {
+          "import.meta.env.VITE_LIBRETTO_CLOUD_API_URL": JSON.stringify(
+            stagingCloudApiUrl,
+          ),
+        }
+      : undefined,
   plugins: [
     localDocsRedirectPlugin(),
     comptimePlugin,


### PR DESCRIPTION
## Summary
- inject the staging Cloud API URL only for Vercel Preview builds
- keep Vercel Production builds and `libretto.sh` on the production API
- allow the staging API in the website Content Security Policy

## Validation
- website Vitest suite
- website production build
- Vercel Preview build with staging URL present in the client bundle
- Vercel Production build with staging URL absent from the client bundle
- `pnpm -s lint`

## Dependency
Merge saffron-health/libretto-cloud#264 first so staging accepts credentialed requests from Libretto preview URLs.
