### PR TITLE
Preserve hosted auth with deployment-selected Libretto

### DIFF
--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -1046,7 +1046,8 @@ import { existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
-import { getWorkflowFromModuleExports, workflow } from "libretto";
+
+const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
 
 const BUNDLE_HASH = ${JSON.stringify(bundleHash)};
 const BUNDLE_GZIP_BASE64 = ${JSON.stringify(bundleBase64)};
@@ -1108,35 +1109,57 @@ function ensureBundleFile() {
   return BUNDLE_FILENAME;
 }
 
-function createWorkflowProxy(workflowName, metadata) {
-  const handler = async (ctx, input) => {
-    const impl = loadImplementation();
-    const target = getWorkflowFromModuleExports(impl, workflowName);
-    if (!target || typeof target.run !== "function") {
-      throw new Error(
-        \`Expected exported workflow "\${workflowName}" to be available in the bundled deployment implementation.\`,
-      );
-    }
-    return await target.run(ctx, input);
-  };
+function isWorkflow(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    value[LIBRETTO_WORKFLOW_BRAND] === true &&
+    typeof value.name === "string" &&
+    typeof value.run === "function"
+  );
+}
 
-  return workflow(workflowName, {
-    credentials: Array.isArray(metadata?.credentialNames)
+function findWorkflow(moduleExports, workflowName) {
+  for (const [exportName, value] of Object.entries(moduleExports)) {
+    if (
+      exportName === "workflows" &&
+      value &&
+      typeof value === "object" &&
+      !isWorkflow(value)
+    ) {
+      const match = Object.values(value).find(
+        (candidate) => isWorkflow(candidate) && candidate.name === workflowName,
+      );
+      if (match) return match;
+      continue;
+    }
+    if (isWorkflow(value) && value.name === workflowName) return value;
+  }
+  return null;
+}
+
+function createWorkflowProxy(workflowName, metadata) {
+  return {
+    [LIBRETTO_WORKFLOW_BRAND]: true,
+    name: workflowName,
+    credentialNames: Array.isArray(metadata?.credentialNames)
       ? metadata.credentialNames
       : [],
-    ...(metadata?.authProfileName
-      ? {
-          authProfile: {
-            name: metadata.authProfileName,
-            ...(typeof metadata.authProfileRefresh === "boolean" ? { refresh: metadata.authProfileRefresh } : {}),
-          },
-        }
-      : {}),
-    ...(typeof metadata?.startUrl === "string" ? { startUrl: metadata.startUrl } : {}),
-    ...(typeof metadata?.gpu === "boolean" ? { gpu: metadata.gpu } : {}),
-    ...(metadata?.viewport ? { viewport: metadata.viewport } : {}),
-    handler,
-  });
+    authProfileName: metadata?.authProfileName,
+    authProfileRefresh: metadata?.authProfileRefresh,
+    startUrl: metadata?.startUrl,
+    gpu: metadata?.gpu,
+    viewport: metadata?.viewport,
+    async run(ctx, input) {
+      const target = findWorkflow(loadImplementation(), workflowName);
+      if (!target) {
+        throw new Error(
+          \`Expected exported workflow "\${workflowName}" to be available in the bundled deployment implementation.\`,
+        );
+      }
+      return await target.run(ctx, input);
+    },
+  };
 }
 
 ${exportLines}
@@ -1280,13 +1303,19 @@ export async function createHostedDeployPackage(
   const absSourceDir = resolve(args.sourceDir);
   ensureSourcePackageManifest(absSourceDir);
 
+  const additionalExternals = [...new Set(args.additionalExternals ?? [])];
+  if (additionalExternals.includes("libretto")) {
+    throw new Error(
+      'Libretto must stay bundled with the workflow so Cloud runs the project\'s selected version. Remove "libretto" from --external and deploy again.',
+    );
+  }
+
   const absEntryPoint = resolveEntryPointPath(absSourceDir, args.entryPoint);
   const tempRoot = mkdtempSync(join(tmpdir(), "libretto-deploy-"));
   const outputDir = join(tempRoot, "deploy");
   mkdirSync(outputDir, { recursive: true });
   const librettoDependency = resolveLibrettoDependency(absSourceDir);
 
-  const additionalExternals = [...new Set(args.additionalExternals ?? [])];
   // These packages stay out of the implementation bundle. The generated
   // package.json carries them into deploy-time installation, and the deployed
   // code resolves them from node_modules.

--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -128,6 +128,44 @@ function readPackageManifest(path: string): PackageManifest {
   return readJsonFile<PackageManifest>(path);
 }
 
+function resolveInstalledPackageVersion(
+  sourceDir: string,
+  packageName: string,
+): string | null {
+  let currentDir: string;
+  try {
+    const sourceRequire = createRequire(
+      join(resolve(sourceDir), "package.json"),
+    );
+    currentDir = dirname(sourceRequire.resolve(packageName));
+  } catch {
+    return null;
+  }
+
+  while (true) {
+    const manifestPath = join(currentDir, "package.json");
+    if (existsSync(manifestPath)) {
+      const manifest = readPackageManifest(manifestPath);
+      if (manifest.name === packageName) {
+        return manifest.version ?? null;
+      }
+    }
+    if (isRootPath(currentDir)) return null;
+    currentDir = dirname(currentDir);
+  }
+}
+
+function supportsHostedRuntimeAuth(version: string | null): boolean {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version ?? "");
+  if (!match) return false;
+  const [, major = "0", minor = "0", patch = "0"] = match;
+  return (
+    Number(major) > 0 ||
+    Number(minor) > 6 ||
+    (Number(minor) === 6 && Number(patch) >= 44)
+  );
+}
+
 function ensureSourcePackageManifest(sourceDir: string): PackageManifest {
   const pkgJsonPath = join(sourceDir, "package.json");
   if (!existsSync(pkgJsonPath)) {
@@ -1013,6 +1051,7 @@ function discoverBundledWorkflows(args: {
 function createBootstrapSource(args: {
   bundleBuffer: Buffer;
   deploymentName: string;
+  runtimeSupportsHostedAuth: boolean;
   workflows: readonly WorkflowDeployMetadata[];
 }): string {
   const bundleHash = createHash("sha256")
@@ -1048,6 +1087,10 @@ import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
+const LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND = Symbol.for(
+  "libretto.workflow.runtime-auth",
+);
+const RUNTIME_SUPPORTS_HOSTED_AUTH = ${JSON.stringify(args.runtimeSupportsHostedAuth)};
 
 const BUNDLE_HASH = ${JSON.stringify(bundleHash)};
 const BUNDLE_GZIP_BASE64 = ${JSON.stringify(bundleBase64)};
@@ -1138,6 +1181,19 @@ function findWorkflow(moduleExports, workflowName) {
   return null;
 }
 
+function withoutLibrettoRuntime(input) {
+  if (
+    !input ||
+    typeof input !== "object" ||
+    Array.isArray(input) ||
+    !Object.prototype.hasOwnProperty.call(input, "__libretto")
+  ) {
+    return input;
+  }
+  const { __libretto: _runtime, ...withoutRuntime } = input;
+  return withoutRuntime;
+}
+
 function createWorkflowProxy(workflowName, metadata) {
   return {
     [LIBRETTO_WORKFLOW_BRAND]: true,
@@ -1157,7 +1213,12 @@ function createWorkflowProxy(workflowName, metadata) {
           \`Expected exported workflow "\${workflowName}" to be available in the bundled deployment implementation.\`,
         );
       }
-      return await target.run(ctx, input);
+      const targetInput =
+        RUNTIME_SUPPORTS_HOSTED_AUTH ||
+        target[LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND] === true
+          ? input
+          : withoutLibrettoRuntime(input);
+      return await target.run(ctx, targetInput);
     },
   };
 }
@@ -1270,6 +1331,9 @@ async function writeBundledDeployEntrypoint(args: {
       createBootstrapSource({
         bundleBuffer: Buffer.from(bundledImplementation.contents),
         deploymentName: args.deploymentName,
+        runtimeSupportsHostedAuth: supportsHostedRuntimeAuth(
+          resolveInstalledPackageVersion(args.absSourceDir, "libretto"),
+        ),
         workflows,
       }),
     );

--- a/packages/libretto/src/index.ts
+++ b/packages/libretto/src/index.ts
@@ -130,6 +130,7 @@ export {
   LibrettoWorkflow,
   LibrettoWorkflowInputError,
   LIBRETTO_WORKFLOW_BRAND,
+  LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND,
   validateWorkflowInput,
   workflow,
   type ExportedLibrettoWorkflow,

--- a/packages/libretto/src/shared/workflow/workflow.ts
+++ b/packages/libretto/src/shared/workflow/workflow.ts
@@ -16,6 +16,9 @@ import {
 } from "./runtime-auth.js";
 
 export const LIBRETTO_WORKFLOW_BRAND = Symbol.for("libretto.workflow");
+export const LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND = Symbol.for(
+  "libretto.workflow.runtime-auth",
+);
 
 export type LibrettoWorkflowContext = {
   session: string;
@@ -151,6 +154,7 @@ export class LibrettoWorkflow<
   OutputSchema extends z.ZodType = z.ZodType<unknown>,
 > {
   public readonly [LIBRETTO_WORKFLOW_BRAND] = true;
+  public readonly [LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND] = true;
   public readonly name: string;
   // Optional so the legacy 2-arg `workflow(name, handler)` form still works
   // for deployments that were built before Zod schemas were a thing.
@@ -232,6 +236,7 @@ export class LibrettoWorkflow<
 
 export type ExportedLibrettoWorkflow = {
   readonly [LIBRETTO_WORKFLOW_BRAND]: true;
+  readonly [LIBRETTO_WORKFLOW_RUNTIME_AUTH_BRAND]?: true;
   readonly name: string;
   readonly inputSchema?: z.ZodType;
   readonly outputSchema?: z.ZodType;

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -98,6 +98,53 @@ describe("createHostedDeployPackage", () => {
     return workspaceRoot;
   }
 
+  function installFixtureLibretto(args: {
+    runtimeAuth: boolean;
+    version: string;
+    workspaceRoot: string;
+  }): void {
+    const packageDir = join(args.workspaceRoot, "node_modules", "libretto");
+    rmSync(packageDir, { force: true, recursive: true });
+    mkdirSync(packageDir, { recursive: true });
+    writeJson(join(packageDir, "package.json"), {
+      name: "libretto",
+      version: args.version,
+      type: "module",
+      exports: "./index.js",
+    });
+    writeFileSync(
+      join(packageDir, "index.js"),
+      [
+        'const WORKFLOW_BRAND = Symbol.for("libretto.workflow");',
+        "",
+        "export function workflow(name, definitionOrHandler) {",
+        "  const definition = typeof definitionOrHandler === \"function\"",
+        "    ? { handler: definitionOrHandler }",
+        "    : definitionOrHandler;",
+        "  return {",
+        "    [WORKFLOW_BRAND]: true,",
+        "    name,",
+        "    credentialNames: [],",
+        "    async run(ctx, input) {",
+        ...(args.runtimeAuth
+          ? [
+              "      const { __libretto: runtime, ...handlerInput } = input;",
+              "      return definition.handler(ctx, handlerInput, runtime);",
+            ]
+          : [
+              "      if (definition.strictInput && Object.keys(input).some((key) => key !== \"value\")) {",
+              '        throw new Error(`Unknown input keys: ${Object.keys(input).join(",")}`);',
+              "      }",
+              "      return definition.handler(ctx, input);",
+            ]),
+        "    },",
+        "  };",
+        "}",
+        "",
+      ].join("\n"),
+    );
+  }
+
   function trackDeployPackage(
     deployPackage: Awaited<ReturnType<typeof createHostedDeployPackage>>,
   ): Awaited<ReturnType<typeof createHostedDeployPackage>> {
@@ -563,6 +610,134 @@ describe("createHostedDeployPackage", () => {
         }),
       }),
     );
+  });
+
+  it("strips hosted runtime auth before invoking a legacy Libretto runtime", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    installFixtureLibretto({
+      runtimeAuth: false,
+      version: "0.6.43",
+      workspaceRoot,
+    });
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    const entryPoint = join(sourceDir, "src", "workflow.ts");
+    const outfile = join(workspaceRoot, "legacy-deployment.cjs");
+
+    mkdirSync(join(sourceDir, "src"), { recursive: true });
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      type: "module",
+      dependencies: { libretto: "0.6.43" },
+    });
+    writeFileSync(
+      entryPoint,
+      [
+        'import { workflow } from "libretto";',
+        "",
+        'export const strictWorkflow = workflow("strictWorkflow", {',
+        "  strictInput: true,",
+        "  handler: async (_ctx, input) => ({",
+        "    value: input.value,",
+        '    hasRuntime: Object.hasOwn(input, "__libretto"),',
+        "  }),",
+        "});",
+        "",
+        'export const schemaLessWorkflow = workflow("schemaLessWorkflow", async (_ctx, input) => ({',
+        '  hasRuntime: Object.hasOwn(input, "__libretto"),',
+        "}));",
+        "",
+      ].join("\n"),
+    );
+
+    const deployPackage = trackDeployPackage(
+      await createHostedDeployPackage({
+        deploymentName: "legacy-worker",
+        entryPoint,
+        sourceDir,
+      }),
+    );
+    const deployed = await rebundleDeployEntrypointToCjs({
+      deployPackage,
+      outfile,
+    });
+    const workflowExport = (name: string) => {
+      const index = deployPackage.workflows.findIndex(
+        (workflow) => workflow.name === name,
+      );
+      return deployed[`workflow_${index}`];
+    };
+    const hostedInput = {
+      value: "accepted",
+      __libretto: {
+        job: {
+          apiUrl: "https://api.hosted.test",
+          jobId: "job-1",
+          token: "hosted-job-token",
+        },
+      },
+    };
+
+    await expect(
+      workflowExport("strictWorkflow")?.run?.({}, hostedInput),
+    ).resolves.toEqual({ value: "accepted", hasRuntime: false });
+    await expect(
+      workflowExport("schemaLessWorkflow")?.run?.({}, hostedInput),
+    ).resolves.toEqual({ hasRuntime: false });
+  });
+
+  it("forwards hosted runtime auth to released Libretto 0.6.44", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    installFixtureLibretto({
+      runtimeAuth: true,
+      version: "0.6.44",
+      workspaceRoot,
+    });
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    const entryPoint = join(sourceDir, "src", "workflow.ts");
+    const outfile = join(workspaceRoot, "released-auth-deployment.cjs");
+
+    mkdirSync(join(sourceDir, "src"), { recursive: true });
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      type: "module",
+      dependencies: { libretto: "0.6.44" },
+    });
+    writeFileSync(
+      entryPoint,
+      [
+        'import { workflow } from "libretto";',
+        "",
+        'export const authWorkflow = workflow("authWorkflow", async (_ctx, input, runtime) => ({',
+        '  hasRuntimeInput: Object.hasOwn(input, "__libretto"),',
+        "  token: runtime?.job?.token,",
+        "}));",
+        "",
+      ].join("\n"),
+    );
+
+    const deployPackage = trackDeployPackage(
+      await createHostedDeployPackage({
+        deploymentName: "released-auth-worker",
+        entryPoint,
+        sourceDir,
+      }),
+    );
+    const deployed = await rebundleDeployEntrypointToCjs({
+      deployPackage,
+      outfile,
+    });
+
+    await expect(
+      deployed.workflow_0?.run?.(
+        {},
+        { __libretto: { job: { token: "hosted-job-token" } } },
+      ),
+    ).resolves.toEqual({
+      hasRuntimeInput: false,
+      token: "hosted-job-token",
+    });
   });
 
   it("rejects externalizing the deployment-selected Libretto", async () => {

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -14,7 +14,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { build } from "esbuild";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHostedDeployPackage } from "../src/cli/core/deploy-artifact.js";
 
 function writeJson(path: string, value: unknown): void {
@@ -67,6 +67,7 @@ describe("createHostedDeployPackage", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     for (const cleanup of cleanups.splice(0)) {
       cleanup();
     }
@@ -269,7 +270,6 @@ describe("createHostedDeployPackage", () => {
       ),
     ).toContain("formatMessage");
     expect(bundle).toContain('createWorkflowProxy("testWorkflow", {"credentialNames":[]})');
-    expect(bundle).toContain("return workflow(workflowName, {");
     expect(implementation).toContain("bundled from workspace source");
     expect(implementation).toContain("formatted");
     expect(implementation).not.toContain("@repo/config/message");
@@ -476,6 +476,112 @@ describe("createHostedDeployPackage", () => {
     });
     expect(bundle).toContain('createWorkflowProxy("testWorkflow", {"credentialNames":[]})');
     expect(implementation).toContain("lodash");
+  });
+
+  it("passes hosted runtime auth to the deployment-selected Libretto", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    const entryPoint = join(sourceDir, "src", "workflow.ts");
+    const outfile = join(workspaceRoot, "hosted-deployment.cjs");
+
+    mkdirSync(join(sourceDir, "src"), { recursive: true });
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      type: "module",
+      dependencies: {
+        libretto: currentLibrettoManifest.version,
+      },
+    });
+    writeFileSync(
+      entryPoint,
+      [
+        'import { claimSmsOtp, workflow } from "libretto";',
+        "",
+        "export const otpWorkflow = workflow(",
+        '  "otpWorkflow",',
+        "  async () => {",
+        '    const claim = await claimSmsOtp({ phoneNumberLabel: "test" });',
+        "    return { claimId: claim.claimId };",
+        "  },",
+        ");",
+        "",
+      ].join("\n"),
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        json: {
+          success: true,
+          claim: {
+            claim_id: "claim-1",
+            status: "open",
+            phone_number: "+15551234567",
+            number_id: "number-1",
+            label: "test",
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+            code: null,
+          },
+          message: "ok",
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const deployPackage = trackDeployPackage(
+      await createHostedDeployPackage({
+        deploymentName: "hosted-auth-worker",
+        entryPoint,
+        sourceDir,
+      }),
+    );
+    const deployed = await rebundleDeployEntrypointToCjs({
+      deployPackage,
+      outfile,
+    });
+
+    await expect(
+      deployed.workflow_0?.run?.(
+        {},
+        {
+          __libretto: {
+            job: {
+              apiUrl: "https://api.hosted.test",
+              jobId: "job-1",
+              token: "hosted-job-token",
+            },
+          },
+        },
+      ),
+    ).resolves.toEqual({ claimId: "claim-1" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hosted.test/v1/smsOtp/claims/create",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-libretto-job-token": "hosted-job-token",
+        }),
+      }),
+    );
+  });
+
+  it("rejects externalizing the deployment-selected Libretto", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    mkdirSync(sourceDir, { recursive: true });
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      dependencies: { libretto: currentLibrettoManifest.version },
+    });
+
+    await expect(
+      createHostedDeployPackage({
+        additionalExternals: ["libretto"],
+        deploymentName: "external-libretto-worker",
+        sourceDir,
+      }),
+    ).rejects.toThrow('Remove "libretto" from --external and deploy again.');
   });
 
   it("preserves workflow auth profile and browser launch metadata without site metadata", async () => {


### PR DESCRIPTION
## Summary

- keep the workflow project's selected Libretto bundled into its deployment artifact
- replace the generated outer `workflow()` wrapper with a small branded proxy that forwards hosted input to auth-capable runtimes
- strip the reserved hosted field before invoking older or unknown runtimes, preserving strict schemas and keeping job tokens out of legacy handlers
- reject `--external libretto`, which would otherwise resolve the executor's copy instead of the project's version
- cover current hosted `claimSmsOtp`, released 0.6.44, and legacy 0.6.43 behavior

## Why

The generated outer Libretto workflow consumed and removed hosted runtime auth before the embedded workflow ran. The embedded, project-selected Libretto then saw no job token. The proxy now lets an auth-capable selected runtime process the token exactly once, while maintaining the pre-auth behavior of older selected runtimes.

## Verification

- `pnpm --dir packages/libretto -s type-check`
- `pnpm -s exec oxlint --type-aware packages/libretto/src/index.ts packages/libretto/src/shared/workflow/workflow.ts packages/libretto/src/cli/core/deploy-artifact.ts packages/libretto/test/deploy-artifact.spec.ts`
- `pnpm --dir packages/libretto -s test:vitest --run test/deploy-artifact.spec.ts test/claimSmsOtp.spec.ts` (18 passed)
