### PR TITLE
Document experimental npm publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ In `packages/browser-tools`, format caught errors with `errorMessage()` from `sr
 ## **FORBIDDEN** Actions
 
 - For stable releases on `main`: NEVER manually edit the `version` field in `packages/libretto/package.json`. Use `pnpm prepare-release` — that script opens a release PR, and CI publishes to npm under the `latest` dist-tag on merge.
-- For experimental pre-releases (e.g. validating a new API on a downstream consumer before promoting it to a stable release): manually edit `packages/libretto/package.json` `version` to a pre-release identifier like `0.6.16-experimental-<feature>.0`, then run `pnpm publish:experimental` from this repo root. That script derives the npm dist-tag from the pre-release identifier (between `-` and `.N`) and publishes locally — it does NOT touch `main` and does NOT use the GitHub Actions release workflow. Refuses to publish if the version isn't a pre-release.
+- For experimental pre-releases, make temporary edits to `packages/libretto/package.json`: set a pre-release version and replace every `workspace:` or `catalog:` dependency with its published range. Run `pnpm publish:experimental`, approve npm's browser passkey prompt, then verify the exact version installs in a clean project. Do not commit the temporary manifest edits.
 - NEVER hand-edit mirrored files in `.agents/skills/` or `.claude/skills/`. Edit the source in `packages/libretto/skills/` and run `pnpm sync:mirrors`.
 - NEVER run `pnpm build` just to type-check. Use `pnpm type-check` instead.
 - NEVER use `git add -A` or `git add .` — only stage the files you changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,16 @@ pnpm prepare-release [patch|minor|major]
 
 This bumps the version, updates all SKILL.md files, syncs mirrors, validates parity, commits, pushes a `release-v*` branch, and opens a PR. The release CI workflow triggers automatically when the PR merges to `main`.
 
+## Publishing an Experimental Version
+
+Temporarily set a pre-release version in `packages/libretto/package.json` and replace its `workspace:` and `catalog:` dependency ranges with published ranges. Then run:
+
+```bash
+pnpm publish:experimental
+```
+
+Approve npm's browser passkey prompt and verify the exact version installs in a clean project. Do not commit the temporary manifest edits.
+
 ## Mirror System
 
 Skill files and READMEs are mirrored across multiple locations. **Do not hand-edit the mirrored copies.** Edit source files only, then sync.


### PR DESCRIPTION
## Summary
- document the temporary manifest changes required for experimental npm packages
- note npm browser passkey approval and clean-project install verification
- clarify that temporary version and dependency edits must not be committed

## Validation
- `git diff --check`
