### PR TITLE
Include workflow schemas in CLI deploy metadata

### DIFF
--- a/packages/libretto/src/cli/core/deploy-artifact.ts
+++ b/packages/libretto/src/cli/core/deploy-artifact.ts
@@ -16,6 +16,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 import { build } from "esbuild";
+import { z } from "zod";
 import {
   getWorkflowFromModuleExports,
   getWorkflowsFromModuleExports,
@@ -59,6 +60,8 @@ type HostedDeployPackage = {
 export type WorkflowDeployMetadata = {
   name: string;
   credentialNames: string[];
+  inputSchema?: unknown;
+  outputSchema?: unknown;
   authProfileName?: string;
   authProfileRefresh?: boolean;
   startUrl?: string;
@@ -869,6 +872,7 @@ function createDiscoveryLibrettoModule(
       workflowsByName.set(name, {
         name,
         ...extractDiscoveryCredentialMetadata(definitionOrHandler),
+        ...extractDiscoverySchemaMetadata(name, definitionOrHandler),
         ...extractDiscoveryAuthProfileMetadata(definitionOrHandler),
         ...extractDiscoveryLaunchMetadata(definitionOrHandler),
       });
@@ -893,6 +897,43 @@ function createDiscoveryLibrettoModule(
       return createExternalDiscoveryStub();
     },
   });
+}
+
+function extractDiscoverySchemaMetadata(
+  workflowName: string,
+  definitionOrHandler: unknown,
+): Pick<WorkflowDeployMetadata, "inputSchema" | "outputSchema"> {
+  if (!definitionOrHandler || typeof definitionOrHandler !== "object") {
+    return {};
+  }
+
+  const definition = definitionOrHandler as {
+    input?: unknown;
+    output?: unknown;
+  };
+  const metadata: Pick<
+    WorkflowDeployMetadata,
+    "inputSchema" | "outputSchema"
+  > = {};
+
+  for (const [definitionKey, metadataKey] of [
+    ["input", "inputSchema"],
+    ["output", "outputSchema"],
+  ] as const) {
+    const schema = definition[definitionKey];
+    if (!schema) continue;
+
+    try {
+      metadata[metadataKey] = z.toJSONSchema(schema as z.ZodType);
+    } catch (error) {
+      console.warn(
+        `Failed to serialize ${metadataKey} for workflow "${workflowName}":`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  return metadata;
 }
 
 function extractDiscoveryLaunchMetadata(

--- a/packages/libretto/test/deploy-artifact.spec.ts
+++ b/packages/libretto/test/deploy-artifact.spec.ts
@@ -86,6 +86,10 @@ describe("createHostedDeployPackage", () => {
       join(nodeModulesDir, "libretto"),
       "dir",
     );
+    const zodPackageJsonPath = require.resolve("zod/package.json", {
+      paths: [currentLibrettoPackageDir],
+    });
+    symlinkSync(dirname(zodPackageJsonPath), join(nodeModulesDir, "zod"), "dir");
     for (const packageName of Object.keys(expectedRuntimeExternalDependencies)) {
       const packageJsonPath = require.resolve(`${packageName}/package.json`, {
         paths: [currentLibrettoPackageDir],
@@ -826,6 +830,80 @@ describe("createHostedDeployPackage", () => {
     );
     expect(bundle).not.toContain("authProfileSites");
     expect(bundle).not.toContain("sites:");
+  });
+
+  it("serializes workflow schemas into deployment metadata", async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const sourceDir = join(workspaceRoot, "apps", "worker");
+    const entryPoint = join(sourceDir, "src", "workflow.ts");
+
+    mkdirSync(join(sourceDir, "src"), { recursive: true });
+
+    writeJson(join(sourceDir, "package.json"), {
+      name: "@repo/worker",
+      private: true,
+      type: "module",
+      dependencies: {
+        libretto: currentLibrettoManifest.version,
+        zod: currentLibrettoManifest.dependencies?.zod,
+      },
+    });
+
+    writeFileSync(
+      entryPoint,
+      [
+        'import { workflow } from "libretto";',
+        'import { z } from "zod";',
+        "",
+        "export const testWorkflow = workflow(",
+        '  "testWorkflow",',
+        "  {",
+        "    input: z.object({ phone: z.string().min(1) }),",
+        "    output: z.object({ accepted: z.boolean() }),",
+        "  },",
+        "  async (_ctx, input) => ({ accepted: input.phone.length > 0 }),",
+        ");",
+        "",
+      ].join("\n"),
+    );
+
+    const deployPackage = trackDeployPackage(
+      await createHostedDeployPackage({
+        deploymentName: "schema-worker",
+        entryPoint,
+        sourceDir,
+      }),
+    );
+    const deployMetadata = JSON.parse(
+      readFileSync(
+        join(deployPackage.outputDir, ".libretto-workflows.json"),
+        "utf8",
+      ),
+    ) as {
+      workflows: Array<{
+        inputSchema?: unknown;
+        outputSchema?: unknown;
+      }>;
+    };
+
+    expect(deployMetadata.workflows[0]?.inputSchema).toEqual(
+      expect.objectContaining({
+        type: "object",
+        properties: {
+          phone: { type: "string", minLength: 1 },
+        },
+        required: ["phone"],
+      }),
+    );
+    expect(deployMetadata.workflows[0]?.outputSchema).toEqual(
+      expect.objectContaining({
+        type: "object",
+        properties: {
+          accepted: { type: "boolean" },
+        },
+        required: ["accepted"],
+      }),
+    );
   });
 
   it("vendors the current libretto package when the source manifest uses a local-only libretto spec", async () => {


### PR DESCRIPTION
## Summary

- serialize declared Zod input and output schemas during CLI deployment discovery
- include the JSON schemas in the existing `.libretto-workflows.json` artifact
- keep deployment working when a schema cannot be represented as JSON Schema, with a local warning

## Why

CLI deployment uses a safe generated proxy during hosted discovery. That proxy intentionally does not load the embedded workflow implementation, so the hosted build cannot read the original Zod schemas. Capturing them in the existing metadata artifact preserves the schemas without weakening proxy isolation.

## Validation

- `pnpm --filter affordance build`
- `pnpm --filter libretto build`
- `pnpm --filter libretto exec vitest run test/deploy-artifact.spec.ts` (15 tests)
- `pnpm --filter libretto type-check`
- `pnpm exec oxlint packages/libretto/src/cli/core/deploy-artifact.ts packages/libretto/test/deploy-artifact.spec.ts`

## Follow-up

Libretto Cloud must consume these optional metadata fields during hosted discovery. A linked Cloud PR follows.
