### PR TITLE
Resolve OAuth redirects against the API origin

### DIFF
--- a/apps/website/src/OAuthContinuePage.tsx
+++ b/apps/website/src/OAuthContinuePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { withReturnTo } from "./authRedirect";
-import { authPost, getAuthStatus } from "./cloudApi";
+import { authPost, cloudApiUrl, getAuthStatus } from "./cloudApi";
 import { Navbar } from "./components/Navbar";
 import {
   authResponseDestination,
@@ -36,7 +36,7 @@ export function OAuthContinuePage() {
         "/api/auth/oauth2/continue",
         { postLogin: true, oauth_query: oauthQuery },
       );
-      const destination = authResponseDestination(result);
+      const destination = authResponseDestination(result, cloudApiUrl);
       if (!destination) {
         throw new Error("Libretto did not return an authorization destination.");
       }

--- a/apps/website/src/SignInPage.tsx
+++ b/apps/website/src/SignInPage.tsx
@@ -218,7 +218,7 @@ export function SignInPage() {
           window.location.search,
         ),
       );
-      const destination = authResponseDestination(result);
+      const destination = authResponseDestination(result, cloudApiUrl);
       if (destination) {
         window.location.assign(destination);
         return;
@@ -255,7 +255,7 @@ export function SignInPage() {
           window.location.search,
         ),
       );
-      const destination = authResponseDestination(result);
+      const destination = authResponseDestination(result, cloudApiUrl);
       if (destination) {
         window.location.assign(destination);
         return;
@@ -293,7 +293,7 @@ export function SignInPage() {
           window.location.search,
         ),
       );
-      const destination = authResponseDestination(result);
+      const destination = authResponseDestination(result, cloudApiUrl);
       if (destination) {
         window.location.assign(destination);
         return;

--- a/apps/website/src/oauthFlow.spec.ts
+++ b/apps/website/src/oauthFlow.spec.ts
@@ -56,11 +56,26 @@ describe("OAuth authentication flow", () => {
   });
 
   it("accepts either Better Auth redirect response field", () => {
-    expect(authResponseDestination({ url: "https://accounts.google.com" })).toBe(
-      "https://accounts.google.com",
-    );
-    expect(authResponseDestination({ uri: "https://github.com/login" })).toBe(
-      "https://github.com/login",
-    );
+    expect(
+      authResponseDestination(
+        { url: "https://accounts.google.com" },
+        "https://api.libretto.sh",
+      ),
+    ).toBe("https://accounts.google.com/");
+    expect(
+      authResponseDestination(
+        { uri: "https://github.com/login" },
+        "https://api.libretto.sh",
+      ),
+    ).toBe("https://github.com/login");
+  });
+
+  it("resolves relative Better Auth destinations against the API", () => {
+    expect(
+      authResponseDestination(
+        { uri: "/oauth/consent?sig=signed-value" },
+        "https://api.libretto.sh",
+      ),
+    ).toBe("https://api.libretto.sh/oauth/consent?sig=signed-value");
   });
 });

--- a/apps/website/src/oauthFlow.ts
+++ b/apps/website/src/oauthFlow.ts
@@ -38,6 +38,8 @@ export function oauthAuthorizeUrl(apiUrl: string, oauthQuery: string): string {
 
 export function authResponseDestination(
   response: OAuthAuthResponse,
+  apiUrl: string,
 ): string | null {
-  return response.url ?? response.uri ?? null;
+  const destination = response.url ?? response.uri ?? null;
+  return destination ? new URL(destination, apiUrl).toString() : null;
 }


### PR DESCRIPTION
## Summary
- resolve relative Better Auth redirect destinations against the configured Libretto Cloud API origin
- apply the same destination handling to email, social, and post-onboarding OAuth flows
- cover the API-relative consent redirect that previously landed on the website's `/oauth/consent` 404

## Verification
- `pnpm --dir apps/website exec vitest run src/oauthFlow.spec.ts`
- `pnpm --dir apps/website type-check`
- Computer Use: private Safari flow from signed-out authorization through email sign-in and `/oauth/continue` to the API-hosted consent screen
