### PR TITLE
Fix public workflow detail routes

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -69,6 +69,14 @@
   ],
   "rewrites": [
     {
+      "source": "/hosted-workflows/:tenantSlug/:workflowName",
+      "destination": "/hosted-workflows"
+    },
+    {
+      "source": "/open-workflows/:id",
+      "destination": "/open-workflows"
+    },
+    {
       "source": "/dashboard/workflows/:workflow",
       "destination": "/dashboard/workflows"
     },


### PR DESCRIPTION
## Summary
- route direct requests for hosted workflow detail URLs to the prerendered hosted-workflows document
- route legacy open workflow detail URLs to the prerendered open-workflows document
- preserve each requested URL so TanStack Router can render the matching dynamic route

## Verification
- `pnpm --filter @libretto/website build`
- confirmed production currently returns Vercel `404: NOT_FOUND` for both dynamic URL shapes while the hosted workflow data endpoint returns `200`
