### PR TITLE
feat(website): deploy main to staging and production manually

### DIFF
--- a/.github/workflows/deploy-website-production.yml
+++ b/.github/workflows/deploy-website-production.yml
@@ -1,0 +1,35 @@
+name: Deploy Website to Production
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-website-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Deploy production website
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          npx --yes vercel@59.0.0 deploy
+          --yes
+          --prod
+          --build-env VITE_LIBRETTO_CLOUD_API_URL=https://api.libretto.sh
+          --build-env VITE_GITHUB_APP_INSTALL_URL=https://github.com/apps/libretto-agent/installations/new
+          --token="$VERCEL_TOKEN"

--- a/apps/website/DEPLOYMENTS.md
+++ b/apps/website/DEPLOYMENTS.md
@@ -1,0 +1,55 @@
+# Website deployments
+
+The website uses one Vercel project with two deployment targets:
+
+| Target | Domain | API | Trigger |
+|---|---|---|---|
+| Staging | `staging.libretto.sh` | `https://api.staging.libretto.sh` | Vercel branch rule for `main` |
+| Production | `libretto.sh` | `https://api.libretto.sh` | Manual GitHub workflow |
+
+Vercel's custom `staging` environment owns the `main` branch rule. The
+Production Branch is a protected release branch, not `main`, so merging `main`
+cannot deploy Production. The production GitHub workflow deploys the selected
+`main` commit manually. `vercel.json` disables Git deployments for every other
+branch, so the old PR previews are not part of this staging setup.
+
+## One-time setup
+
+1. In Vercel Project Settings, create a custom environment named `staging`.
+   Add a branch rule matching exactly `main`.
+2. Change the project's Production Branch from `main` to a protected branch
+   named `production`. `vercel.json` explicitly disables Git deployments for
+   that branch, so even an accidental push cannot bypass the manual workflow.
+3. Attach `staging.libretto.sh` to the staging environment and add the DNS record
+   Vercel requests.
+4. Enable Standard Deployment Protection with Vercel Authentication for
+   pre-production deployments. Grant project access only to Libretto team
+   members, do not create shareable-link bypasses, and verify the staging URL
+   while signed out.
+5. In Vercel's Environment Variables settings, enable **Automatically expose
+   System Environment Variables** so the build receives `VERCEL_TARGET_ENV`.
+   The build fails if its target and endpoint identities do not agree.
+6. In Vercel, set `VITE_LIBRETTO_CLOUD_API_URL` and
+   `VITE_GITHUB_APP_INSTALL_URL` separately for the staging and Production
+   environments. Staging uses `https://api.staging.libretto.sh` and the
+   separate staging GitHub App installation URL. Production uses
+   `https://api.libretto.sh` and
+   `https://github.com/apps/libretto-agent/installations/new`. The build
+   validates these values
+   against `VERCEL_TARGET_ENV` and stops rather than falling back to the wrong
+   API or GitHub App.
+7. In GitHub, create a `production` environment and require an approver. Add
+   `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` as its secrets. The
+   token and project id identify the existing production website project; no
+   Vercel token is exposed to the automatic staging build.
+8. Finish the staging API domain and OAuth setup documented in
+   `saffron-health/libretto-cloud/terraform/README.md` before the first staging
+   website deployment.
+
+The staging target receives its API URL from the Vercel environment. The
+manual production workflow also passes the production values explicitly, so a
+manual release does not depend on a generated hostname or inherited staging
+configuration.
+
+Run `Deploy Website to Production` from the Actions tab on the `main` branch
+to release the current `main` commit to `libretto.sh`.

--- a/apps/website/scripts/deployment-config.spec.ts
+++ b/apps/website/scripts/deployment-config.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { validateVercelDeploymentConfig } from "./deployment-config";
+
+const production = {
+  target: "production",
+  apiUrl: "https://api.libretto.sh",
+  githubAppInstallUrl:
+    "https://github.com/apps/libretto-agent/installations/new",
+};
+
+const staging = {
+  target: "staging",
+  apiUrl: "https://api.staging.libretto.sh",
+  githubAppInstallUrl:
+    "https://github.com/apps/libretto-agent-staging/installations/new",
+};
+
+describe("Vercel deployment configuration", () => {
+  it("accepts exact production and staging configuration", () => {
+    expect(() => validateVercelDeploymentConfig(production)).not.toThrow();
+    expect(() => validateVercelDeploymentConfig(staging)).not.toThrow();
+  });
+
+  it("rejects a staging build pointed at production", () => {
+    expect(() =>
+      validateVercelDeploymentConfig({
+        ...staging,
+        apiUrl: production.apiUrl,
+      }),
+    ).toThrow(/Staging builds require/);
+  });
+
+  it("rejects production credentials in staging", () => {
+    expect(() =>
+      validateVercelDeploymentConfig({
+        ...staging,
+        githubAppInstallUrl: production.githubAppInstallUrl,
+      }),
+    ).toThrow(/separate staging GitHub App/);
+  });
+
+  it("rejects missing and unsupported Vercel targets", () => {
+    expect(() =>
+      validateVercelDeploymentConfig({ target: "preview" }),
+    ).toThrow(/Unsupported/);
+    expect(() =>
+      validateVercelDeploymentConfig({ target: "staging" }),
+    ).toThrow(/Staging builds require/);
+    expect(() =>
+      validateVercelDeploymentConfig({ apiUrl: staging.apiUrl }),
+    ).toThrow(/deployment target is required/);
+  });
+
+  it("does not constrain local builds", () => {
+    expect(() => validateVercelDeploymentConfig({})).not.toThrow();
+  });
+});

--- a/apps/website/scripts/deployment-config.ts
+++ b/apps/website/scripts/deployment-config.ts
@@ -1,0 +1,61 @@
+const PRODUCTION_API_URL = "https://api.libretto.sh";
+const STAGING_API_URL = "https://api.staging.libretto.sh";
+const PRODUCTION_GITHUB_APP_INSTALL_URL =
+  "https://github.com/apps/libretto-agent/installations/new";
+
+type DeploymentConfig = {
+  target?: string;
+  apiUrl?: string;
+  githubAppInstallUrl?: string;
+};
+
+export function validateVercelDeploymentConfig({
+  target,
+  apiUrl,
+  githubAppInstallUrl,
+}: DeploymentConfig): void {
+  if (!target) {
+    if (apiUrl || githubAppInstallUrl) {
+      throw new Error(
+        "A Vercel deployment target is required when deployment URLs are configured.",
+      );
+    }
+    return;
+  }
+
+  if (target === "production") {
+    if (apiUrl !== PRODUCTION_API_URL) {
+      throw new Error(
+        `Production builds require VITE_LIBRETTO_CLOUD_API_URL=${PRODUCTION_API_URL}`,
+      );
+    }
+    if (githubAppInstallUrl !== PRODUCTION_GITHUB_APP_INSTALL_URL) {
+      throw new Error(
+        "Production builds require the production GitHub App install URL.",
+      );
+    }
+    return;
+  }
+
+  if (target === "staging") {
+    if (apiUrl !== STAGING_API_URL) {
+      throw new Error(
+        `Staging builds require VITE_LIBRETTO_CLOUD_API_URL=${STAGING_API_URL}`,
+      );
+    }
+    if (
+      !githubAppInstallUrl ||
+      githubAppInstallUrl === PRODUCTION_GITHUB_APP_INSTALL_URL ||
+      !/^https:\/\/github\.com\/apps\/[a-z0-9-]+\/installations\/new$/.test(
+        githubAppInstallUrl,
+      )
+    ) {
+      throw new Error(
+        "Staging builds require a separate staging GitHub App install URL.",
+      );
+    }
+    return;
+  }
+
+  throw new Error(`Unsupported Vercel deployment target: ${target}`);
+}

--- a/apps/website/src/prAgentSetup.ts
+++ b/apps/website/src/prAgentSetup.ts
@@ -1,4 +1,5 @@
 export const GITHUB_APP_INSTALL_URL =
+  import.meta.env.VITE_GITHUB_APP_INSTALL_URL?.trim() ||
   "https://github.com/apps/libretto-agent/installations/new";
 
 export const DEBUGGER_DOCS_URL = "/docs/reference/runtime/playwright-debugger";

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true,
+      "production": false
+    }
+  },
   "outputDirectory": "dist/client",
   "redirects": [
     {
@@ -35,7 +42,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.libretto.sh https://api.github.com https://cdn.usefathom.com https://api.usefathom.com; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.libretto.sh https://api.staging.libretto.sh https://api.github.com https://cdn.usefathom.com https://api.usefathom.com; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     },

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -5,6 +5,13 @@ import { comptime } from "comptime.ts/vite";
 import { defineConfig, type Plugin } from "vite";
 import { loadBlogPostInputs } from "./scripts/blog-posts.ts";
 import { dashboardPrerenderPaths } from "./src/dashboardSections.ts";
+import { validateVercelDeploymentConfig } from "./scripts/deployment-config.ts";
+
+validateVercelDeploymentConfig({
+  target: process.env.VERCEL_TARGET_ENV,
+  apiUrl: process.env.VITE_LIBRETTO_CLOUD_API_URL,
+  githubAppInstallUrl: process.env.VITE_GITHUB_APP_INSTALL_URL,
+});
 
 const comptimePlugin = await comptime();
 const blogPosts = await loadBlogPostInputs();


### PR DESCRIPTION
## Summary

Replaces preview-based staging with a stable Vercel custom environment.

- allows only `main` to trigger a Vercel Git deployment, routed by the Vercel branch rule to `staging`
- disables Git deployments for PR branches and the sentinel `production` branch
- adds a protected manual production workflow pinned to the dispatched `main` SHA
- validates Vercel target, API endpoint, and environment-specific GitHub App URL at build time
- points staging at `https://api.staging.libretto.sh` and production at `https://api.libretto.sh`
- documents Vercel domains, branch rules, environment variables, Deployment Protection, and GitHub environment secrets

## Dependencies

- cloud auth policy: https://github.com/saffron-health/libretto-cloud/pull/273
- staging domains/config: https://github.com/saffron-health/libretto-cloud/pull/274

## Verification

- website Vitest: 21 tests passed
- website TypeScript type-check
- staging build with staging API and staging GitHub App identities
- production build with production identities; no staging endpoint in application bundles
- mismatched staging-to-production build fails before compilation
- actionlint and `git diff --check`
- independent security review: no Critical, High, or Medium blockers

## Rollout prerequisites

Complete `apps/website/DEPLOYMENTS.md` before merging: create the Vercel `staging` custom environment and exact `main` branch rule; set Production Branch to `production`; expose system variables; set scoped endpoint/App variables; attach `staging.libretto.sh`; enable Vercel Authentication without bypass links; and create the approval-protected GitHub `production` environment.