### PR TITLE
Rename hosted workflows page to workflow catalogue

### DIFF
--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -84,7 +84,7 @@ function hostedKey(workflow: Pick<HostedWorkflowSummary, "tenant_slug" | "workfl
 }
 
 function hostedPath(workflow: Pick<HostedWorkflowSummary, "tenant_slug" | "workflow_name">) {
-  return `/hosted-workflows/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
+  return `/workflow-catalogue/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
 }
 
 function matchesQuery(workflow: HostedWorkflowSummary, query: string): boolean {
@@ -832,7 +832,7 @@ export function HostedWorkflowPage({
   return pageShell(
     <>
       <a
-        href="/hosted-workflows"
+        href="/workflow-catalogue"
         className="inline-flex pt-4 font-mono text-xs text-muted no-underline transition hover:text-ink"
       >
         ← Published workflows

--- a/apps/website/src/routeTree.gen.ts
+++ b/apps/website/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WorkflowCatalogueRouteImport } from './routes/workflow-catalogue'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as SigninRouteImport } from './routes/signin'
 import { Route as PrivacyRouteImport } from './routes/privacy'
@@ -16,7 +17,6 @@ import { Route as OpenWorkflowsRouteImport } from './routes/open-workflows'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as MarketplaceRouteImport } from './routes/marketplace'
 import { Route as InviteRouteImport } from './routes/invite'
-import { Route as HostedWorkflowsRouteImport } from './routes/hosted-workflows'
 import { Route as DebugAgentsRouteImport } from './routes/debug-agents'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as CliRouteImport } from './routes/cli'
@@ -38,9 +38,14 @@ import { Route as DashboardCloudBrowsersRouteImport } from './routes/dashboard_.
 import { Route as DashboardChromeExtensionRouteImport } from './routes/dashboard_.chrome-extension'
 import { Route as DashboardSectionRouteImport } from './routes/dashboard_.$section'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
-import { Route as HostedWorkflowsTenantSlugWorkflowNameRouteImport } from './routes/hosted-workflows_.$tenantSlug.$workflowName'
+import { Route as WorkflowCatalogueTenantSlugWorkflowNameRouteImport } from './routes/workflow-catalogue_.$tenantSlug.$workflowName'
 import { Route as DashboardWorkflowsWorkflowRouteImport } from './routes/dashboard_.workflows_.$workflow'
 
+const WorkflowCatalogueRoute = WorkflowCatalogueRouteImport.update({
+  id: '/workflow-catalogue',
+  path: '/workflow-catalogue',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const VerifyEmailRoute = VerifyEmailRouteImport.update({
   id: '/verify-email',
   path: '/verify-email',
@@ -74,11 +79,6 @@ const MarketplaceRoute = MarketplaceRouteImport.update({
 const InviteRoute = InviteRouteImport.update({
   id: '/invite',
   path: '/invite',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HostedWorkflowsRoute = HostedWorkflowsRouteImport.update({
-  id: '/hosted-workflows',
-  path: '/hosted-workflows',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DebugAgentsRoute = DebugAgentsRouteImport.update({
@@ -187,10 +187,10 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
   path: '/$slug',
   getParentRoute: () => BlogRouteRoute,
 } as any)
-const HostedWorkflowsTenantSlugWorkflowNameRoute =
-  HostedWorkflowsTenantSlugWorkflowNameRouteImport.update({
-    id: '/hosted-workflows_/$tenantSlug/$workflowName',
-    path: '/hosted-workflows/$tenantSlug/$workflowName',
+const WorkflowCatalogueTenantSlugWorkflowNameRoute =
+  WorkflowCatalogueTenantSlugWorkflowNameRouteImport.update({
+    id: '/workflow-catalogue_/$tenantSlug/$workflowName',
+    path: '/workflow-catalogue/$tenantSlug/$workflowName',
     getParentRoute: () => rootRouteImport,
   } as any)
 const DashboardWorkflowsWorkflowRoute =
@@ -209,7 +209,6 @@ export interface FileRoutesByFullPath {
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/debug-agents': typeof DebugAgentsRoute
-  '/hosted-workflows': typeof HostedWorkflowsRoute
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
@@ -217,6 +216,7 @@ export interface FileRoutesByFullPath {
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
+  '/workflow-catalogue': typeof WorkflowCatalogueRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/dashboard/$section': typeof DashboardSectionRoute
   '/dashboard/chrome-extension': typeof DashboardChromeExtensionRoute
@@ -231,7 +231,7 @@ export interface FileRoutesByFullPath {
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
   '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
-  '/hosted-workflows/$tenantSlug/$workflowName': typeof HostedWorkflowsTenantSlugWorkflowNameRoute
+  '/workflow-catalogue/$tenantSlug/$workflowName': typeof WorkflowCatalogueTenantSlugWorkflowNameRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -241,7 +241,6 @@ export interface FileRoutesByTo {
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/debug-agents': typeof DebugAgentsRoute
-  '/hosted-workflows': typeof HostedWorkflowsRoute
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
@@ -249,6 +248,7 @@ export interface FileRoutesByTo {
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
+  '/workflow-catalogue': typeof WorkflowCatalogueRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/dashboard/$section': typeof DashboardSectionRoute
   '/dashboard/chrome-extension': typeof DashboardChromeExtensionRoute
@@ -263,7 +263,7 @@ export interface FileRoutesByTo {
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog': typeof BlogIndexRoute
   '/dashboard/workflows/$workflow': typeof DashboardWorkflowsWorkflowRoute
-  '/hosted-workflows/$tenantSlug/$workflowName': typeof HostedWorkflowsTenantSlugWorkflowNameRoute
+  '/workflow-catalogue/$tenantSlug/$workflowName': typeof WorkflowCatalogueTenantSlugWorkflowNameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -275,7 +275,6 @@ export interface FileRoutesById {
   '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/debug-agents': typeof DebugAgentsRoute
-  '/hosted-workflows': typeof HostedWorkflowsRoute
   '/invite': typeof InviteRoute
   '/marketplace': typeof MarketplaceRoute
   '/onboarding': typeof OnboardingRoute
@@ -283,6 +282,7 @@ export interface FileRoutesById {
   '/privacy': typeof PrivacyRoute
   '/signin': typeof SigninRoute
   '/verify-email': typeof VerifyEmailRoute
+  '/workflow-catalogue': typeof WorkflowCatalogueRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/dashboard_/$section': typeof DashboardSectionRoute
   '/dashboard_/chrome-extension': typeof DashboardChromeExtensionRoute
@@ -297,7 +297,7 @@ export interface FileRoutesById {
   '/vs/stagehand': typeof VsStagehandRoute
   '/blog/': typeof BlogIndexRoute
   '/dashboard_/workflows_/$workflow': typeof DashboardWorkflowsWorkflowRoute
-  '/hosted-workflows_/$tenantSlug/$workflowName': typeof HostedWorkflowsTenantSlugWorkflowNameRoute
+  '/workflow-catalogue_/$tenantSlug/$workflowName': typeof WorkflowCatalogueTenantSlugWorkflowNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -310,7 +310,6 @@ export interface FileRouteTypes {
     | '/cli'
     | '/dashboard'
     | '/debug-agents'
-    | '/hosted-workflows'
     | '/invite'
     | '/marketplace'
     | '/onboarding'
@@ -318,6 +317,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/signin'
     | '/verify-email'
+    | '/workflow-catalogue'
     | '/blog/$slug'
     | '/dashboard/$section'
     | '/dashboard/chrome-extension'
@@ -332,7 +332,7 @@ export interface FileRouteTypes {
     | '/vs/stagehand'
     | '/blog/'
     | '/dashboard/workflows/$workflow'
-    | '/hosted-workflows/$tenantSlug/$workflowName'
+    | '/workflow-catalogue/$tenantSlug/$workflowName'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -342,7 +342,6 @@ export interface FileRouteTypes {
     | '/cli'
     | '/dashboard'
     | '/debug-agents'
-    | '/hosted-workflows'
     | '/invite'
     | '/marketplace'
     | '/onboarding'
@@ -350,6 +349,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/signin'
     | '/verify-email'
+    | '/workflow-catalogue'
     | '/blog/$slug'
     | '/dashboard/$section'
     | '/dashboard/chrome-extension'
@@ -364,7 +364,7 @@ export interface FileRouteTypes {
     | '/vs/stagehand'
     | '/blog'
     | '/dashboard/workflows/$workflow'
-    | '/hosted-workflows/$tenantSlug/$workflowName'
+    | '/workflow-catalogue/$tenantSlug/$workflowName'
   id:
     | '__root__'
     | '/'
@@ -375,7 +375,6 @@ export interface FileRouteTypes {
     | '/cli'
     | '/dashboard'
     | '/debug-agents'
-    | '/hosted-workflows'
     | '/invite'
     | '/marketplace'
     | '/onboarding'
@@ -383,6 +382,7 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/signin'
     | '/verify-email'
+    | '/workflow-catalogue'
     | '/blog/$slug'
     | '/dashboard_/$section'
     | '/dashboard_/chrome-extension'
@@ -397,7 +397,7 @@ export interface FileRouteTypes {
     | '/vs/stagehand'
     | '/blog/'
     | '/dashboard_/workflows_/$workflow'
-    | '/hosted-workflows_/$tenantSlug/$workflowName'
+    | '/workflow-catalogue_/$tenantSlug/$workflowName'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -409,7 +409,6 @@ export interface RootRouteChildren {
   CliRoute: typeof CliRoute
   DashboardRoute: typeof DashboardRoute
   DebugAgentsRoute: typeof DebugAgentsRoute
-  HostedWorkflowsRoute: typeof HostedWorkflowsRoute
   InviteRoute: typeof InviteRoute
   MarketplaceRoute: typeof MarketplaceRoute
   OnboardingRoute: typeof OnboardingRoute
@@ -417,6 +416,7 @@ export interface RootRouteChildren {
   PrivacyRoute: typeof PrivacyRoute
   SigninRoute: typeof SigninRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
+  WorkflowCatalogueRoute: typeof WorkflowCatalogueRoute
   DashboardSectionRoute: typeof DashboardSectionRoute
   DashboardChromeExtensionRoute: typeof DashboardChromeExtensionRoute
   DashboardCloudBrowsersRoute: typeof DashboardCloudBrowsersRoute
@@ -429,11 +429,18 @@ export interface RootRouteChildren {
   VsPlaywrightCodegenRoute: typeof VsPlaywrightCodegenRoute
   VsStagehandRoute: typeof VsStagehandRoute
   DashboardWorkflowsWorkflowRoute: typeof DashboardWorkflowsWorkflowRoute
-  HostedWorkflowsTenantSlugWorkflowNameRoute: typeof HostedWorkflowsTenantSlugWorkflowNameRoute
+  WorkflowCatalogueTenantSlugWorkflowNameRoute: typeof WorkflowCatalogueTenantSlugWorkflowNameRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/workflow-catalogue': {
+      id: '/workflow-catalogue'
+      path: '/workflow-catalogue'
+      fullPath: '/workflow-catalogue'
+      preLoaderRoute: typeof WorkflowCatalogueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/verify-email': {
       id: '/verify-email'
       path: '/verify-email'
@@ -481,13 +488,6 @@ declare module '@tanstack/react-router' {
       path: '/invite'
       fullPath: '/invite'
       preLoaderRoute: typeof InviteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/hosted-workflows': {
-      id: '/hosted-workflows'
-      path: '/hosted-workflows'
-      fullPath: '/hosted-workflows'
-      preLoaderRoute: typeof HostedWorkflowsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/debug-agents': {
@@ -637,11 +637,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof BlogRouteRoute
     }
-    '/hosted-workflows_/$tenantSlug/$workflowName': {
-      id: '/hosted-workflows_/$tenantSlug/$workflowName'
-      path: '/hosted-workflows/$tenantSlug/$workflowName'
-      fullPath: '/hosted-workflows/$tenantSlug/$workflowName'
-      preLoaderRoute: typeof HostedWorkflowsTenantSlugWorkflowNameRouteImport
+    '/workflow-catalogue_/$tenantSlug/$workflowName': {
+      id: '/workflow-catalogue_/$tenantSlug/$workflowName'
+      path: '/workflow-catalogue/$tenantSlug/$workflowName'
+      fullPath: '/workflow-catalogue/$tenantSlug/$workflowName'
+      preLoaderRoute: typeof WorkflowCatalogueTenantSlugWorkflowNameRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard_/workflows_/$workflow': {
@@ -677,7 +677,6 @@ const rootRouteChildren: RootRouteChildren = {
   CliRoute: CliRoute,
   DashboardRoute: DashboardRoute,
   DebugAgentsRoute: DebugAgentsRoute,
-  HostedWorkflowsRoute: HostedWorkflowsRoute,
   InviteRoute: InviteRoute,
   MarketplaceRoute: MarketplaceRoute,
   OnboardingRoute: OnboardingRoute,
@@ -685,6 +684,7 @@ const rootRouteChildren: RootRouteChildren = {
   PrivacyRoute: PrivacyRoute,
   SigninRoute: SigninRoute,
   VerifyEmailRoute: VerifyEmailRoute,
+  WorkflowCatalogueRoute: WorkflowCatalogueRoute,
   DashboardSectionRoute: DashboardSectionRoute,
   DashboardChromeExtensionRoute: DashboardChromeExtensionRoute,
   DashboardCloudBrowsersRoute: DashboardCloudBrowsersRoute,
@@ -697,8 +697,8 @@ const rootRouteChildren: RootRouteChildren = {
   VsPlaywrightCodegenRoute: VsPlaywrightCodegenRoute,
   VsStagehandRoute: VsStagehandRoute,
   DashboardWorkflowsWorkflowRoute: DashboardWorkflowsWorkflowRoute,
-  HostedWorkflowsTenantSlugWorkflowNameRoute:
-    HostedWorkflowsTenantSlugWorkflowNameRoute,
+  WorkflowCatalogueTenantSlugWorkflowNameRoute:
+    WorkflowCatalogueTenantSlugWorkflowNameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/website/src/routes/marketplace.tsx
+++ b/apps/website/src/routes/marketplace.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/marketplace")({
   beforeLoad: () => {
     throw redirect({
-      to: "/hosted-workflows",
+      to: "/workflow-catalogue",
     });
   },
 });

--- a/apps/website/src/routes/open-workflows.tsx
+++ b/apps/website/src/routes/open-workflows.tsx
@@ -2,6 +2,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/open-workflows")({
   beforeLoad: () => {
-    throw redirect({ to: "/hosted-workflows" });
+    throw redirect({ to: "/workflow-catalogue" });
   },
 });

--- a/apps/website/src/routes/open-workflows_.$id.tsx
+++ b/apps/website/src/routes/open-workflows_.$id.tsx
@@ -22,7 +22,7 @@ function OpenWorkflowRoute() {
           throw new Error("This workflow does not have a public publisher slug.");
         }
         window.location.replace(
-          `/hosted-workflows/${encodeURIComponent(workflow.publisher_slug)}/${encodeURIComponent(workflow.workflow_name)}`,
+          `/workflow-catalogue/${encodeURIComponent(workflow.publisher_slug)}/${encodeURIComponent(workflow.workflow_name)}`,
         );
       })
       .catch((cause) =>

--- a/apps/website/src/routes/workflow-catalogue.tsx
+++ b/apps/website/src/routes/workflow-catalogue.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { HostedWorkflowsPage } from "../HostedWorkflowsPage";
 
-export const Route = createFileRoute("/hosted-workflows")({
+export const Route = createFileRoute("/workflow-catalogue")({
   head: () => ({
     meta: [
       { title: "Hosted Workflow APIs | Libretto" },

--- a/apps/website/src/routes/workflow-catalogue_.$tenantSlug.$workflowName.tsx
+++ b/apps/website/src/routes/workflow-catalogue_.$tenantSlug.$workflowName.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { HostedWorkflowPage } from "../HostedWorkflowsPage";
 
 export const Route = createFileRoute(
-  "/hosted-workflows_/$tenantSlug/$workflowName",
+  "/workflow-catalogue_/$tenantSlug/$workflowName",
 )({
   head: () => ({
     meta: [{ title: "Hosted workflow | Libretto" }],

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -3,8 +3,18 @@
   "outputDirectory": "dist/client",
   "redirects": [
     {
+      "source": "/hosted-workflows",
+      "destination": "/workflow-catalogue",
+      "permanent": true
+    },
+    {
+      "source": "/hosted-workflows/:tenantSlug/:workflowName",
+      "destination": "/workflow-catalogue/:tenantSlug/:workflowName",
+      "permanent": true
+    },
+    {
       "source": "/marketplace",
-      "destination": "/open-workflows",
+      "destination": "/workflow-catalogue",
       "permanent": true
     },
     {
@@ -69,8 +79,8 @@
   ],
   "rewrites": [
     {
-      "source": "/hosted-workflows/:tenantSlug/:workflowName",
-      "destination": "/hosted-workflows"
+      "source": "/workflow-catalogue/:tenantSlug/:workflowName",
+      "destination": "/workflow-catalogue"
     },
     {
       "source": "/open-workflows/:id",

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         ...blogPostPaths,
         ...dashboardPaths,
         "/open-workflows",
-        "/hosted-workflows",
+        "/workflow-catalogue",
       ].map((path) => ({
         path,
         prerender: { enabled: true },


### PR DESCRIPTION
## Summary
- make `/workflow-catalogue` the canonical public workflow listing route
- serve workflow details at `/workflow-catalogue/:tenantSlug/:workflowName`
- permanently redirect the former `/hosted-workflows` URLs and preserve other legacy entry points
- prerender the new canonical catalogue page and rewrite direct detail requests to it

## Verification
- `pnpm website:build`
- confirmed `apps/website/dist/client/workflow-catalogue/index.html` is generated

## Deployment note
PR #579 already added the missing dynamic-route rewrite, but Vercel skipped both that PR and its merge commit with `Canceled by Ignored Build Step`. This PR changes website source as well as `vercel.json`; the resulting Vercel deployment should be checked explicitly.