### PR TITLE
Fix workflow catalogue layout overflow

### DIFF
--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -1044,7 +1044,7 @@ export function HostedWorkflowPage({
                     variant="outline"
                     onClick={startDeployingOwnCopy}
                     disabled={!workflow.import_available || busy}
-                    className="w-full"
+                    className="w-full !min-w-0"
                   >
                     {busy
                       ? "Deploying…"

--- a/apps/website/src/SourceBrowser.tsx
+++ b/apps/website/src/SourceBrowser.tsx
@@ -49,14 +49,15 @@ export function SourceBrowser({
               <button
                 key={file.file_name}
                 type="button"
+                title={file.file_name}
                 onClick={() => setActiveFile(file.file_name)}
-                className={`shrink-0 rounded-md px-3 py-1.5 text-left font-mono text-xs transition lg:w-full lg:py-2 ${
+                className={`shrink-0 rounded-md px-3 py-1.5 text-left font-mono text-xs transition lg:w-full lg:min-w-0 lg:max-w-full lg:overflow-hidden lg:py-2 ${
                   selected
                     ? "bg-accent/10 text-accent-bright shadow-[inset_0_0_0_1px_rgba(18,206,65,0.18)]"
                     : "text-muted hover:bg-white/4 hover:text-ink"
                 }`}
               >
-                <span className="truncate">{file.file_name}</span>
+                <span className="block truncate">{file.file_name}</span>
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
- keep catalogue action buttons within the same card width
- truncate long source filenames with an ellipsis
- expose the full source filename on hover

## Verification
- pnpm -s --filter @libretto/website type-check
- pnpm -s lint
- local browser layout check
