### PR TITLE
Clarify API response envelopes and debugger setup

### DIFF
--- a/docs/libretto-cloud-api/jobs-and-logs.mdx
+++ b/docs/libretto-cloud-api/jobs-and-logs.mdx
@@ -28,11 +28,13 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
 
 ```json
 {
-  "job_id": "<job-id>",
-  "workflow": "scrape-page",
-  "status": "completed",
-  "result": {
-    "title": "Example Domain"
+  "json": {
+    "job_id": "<job-id>",
+    "workflow": "scrape-page",
+    "status": "completed",
+    "result": {
+      "title": "Example Domain"
+    }
   }
 }
 ```

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -36,6 +36,50 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
   }'
 ```
 
+### Response format
+
+The RPC handler wraps successful responses in a top-level `json` field. The
+response fields listed on each endpoint page are inside that field. For
+example, a successful response has this shape:
+
+```json
+{
+  "json": {
+    "job_id": "<job-id>",
+    "status": "completed"
+  }
+}
+```
+
+Errors returned by the RPC handler use the same envelope. Validation details,
+when present, are in `json.data`:
+
+```json
+{
+  "json": {
+    "defined": false,
+    "code": "BAD_REQUEST",
+    "status": 400,
+    "message": "Input validation failed",
+    "data": {
+      "issues": [
+        {
+          "validation": "uuid",
+          "code": "invalid_string",
+          "message": "Invalid uuid",
+          "path": ["id"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Middleware or infrastructure can return a direct JSON error before a request
+reaches the RPC handler. Always check the HTTP status before reading the body.
+
+Catalogue routes return direct JSON responses without this RPC envelope.
+
 ### Authentication rules
 
 - `POST /v1/auth/*` routes are public and do not require `x-api-key`.

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -19,9 +19,9 @@ Authenticated routes use:
 - `Content-Type: application/json`
 - JSON request bodies for state-changing requests
 
-The RPC routes documented in this section wrap input as `{ "json": { ... } }`.
-Catalogue routes use direct JSON bodies as shown on the
-[Workflow catalogue](/libretto-cloud-api/catalogue) page.
+JSON request bodies documented in this section wrap input as
+`{ "json": { ... } }`, including catalogue `POST` routes. Catalogue `GET` and
+`DELETE` routes continue to receive input through query and path parameters.
 
 For example:
 
@@ -38,9 +38,10 @@ curl -X POST "https://api.libretto.sh/v1/jobs/get" \
 
 ### Response format
 
-The RPC handler wraps successful responses in a top-level `json` field. The
-response fields listed on each endpoint page are inside that field. For
-example, a successful response has this shape:
+Authenticated API routes, including catalogue routes, wrap successful
+responses in a top-level `json` field. The response fields listed on each
+endpoint page are inside that field. For example, a successful response has
+this shape:
 
 ```json
 {
@@ -51,8 +52,8 @@ example, a successful response has this shape:
 }
 ```
 
-Errors returned by the RPC handler use the same envelope. Validation details,
-when present, are in `json.data`:
+API errors use the same envelope. Validation details, when present, are in
+`json.data`:
 
 ```json
 {
@@ -76,9 +77,11 @@ when present, are in `json.data`:
 ```
 
 Middleware or infrastructure can return a direct JSON error before a request
-reaches the RPC handler. Always check the HTTP status before reading the body.
+reaches an API route handler. Always check the HTTP status before reading the
+body.
 
-Catalogue routes return direct JSON responses without this RPC envelope.
+The public `/catalogue/*` website routes are separate from the authenticated
+API and do not use this envelope.
 
 ### Authentication rules
 

--- a/docs/reference/runtime/playwright-debugger.mdx
+++ b/docs/reference/runtime/playwright-debugger.mdx
@@ -112,9 +112,10 @@ secrets manager.
 
 The debugger uses Libretto's public GitHub App through Libretto Cloud.
 
-First use the [Libretto setup flow](https://libretto.sh/setup) to connect the
-repository. The flow verifies the GitHub user can access the installed Libretto
-GitHub App and stores the tenant/repository link. Then provide:
+First use the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+to connect the repository. Libretto verifies that the GitHub user can access
+the installed Libretto GitHub App and stores the tenant/repository link. Then
+[create an API key](https://libretto.sh/dashboard/api_keys) and provide it as:
 
 ```bash
 export LIBRETTO_API_KEY=...

--- a/docs/reference/runtime/playwright-debugger.mdx
+++ b/docs/reference/runtime/playwright-debugger.mdx
@@ -112,14 +112,16 @@ secrets manager.
 
 The debugger uses Libretto's public GitHub App through Libretto Cloud.
 
-First use the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
-to connect the repository. Libretto verifies that the GitHub user can access
-the installed Libretto GitHub App and stores the tenant/repository link. Then
-[create an API key](https://libretto.sh/dashboard/api_keys) and provide it as:
+First [create an API key](https://libretto.sh/dashboard/api_keys) and provide
+it as:
 
 ```bash
 export LIBRETTO_API_KEY=...
 ```
+
+Then use the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+to connect the repository. Libretto verifies that the GitHub user can access
+the installed Libretto GitHub App and stores the tenant/repository link.
 
 With that setup, the debugger asks Libretto Cloud for a short-lived GitHub
 installation token scoped to the configured `owner/repo` and only the

--- a/docs/understand-libretto/autofix-debugging.mdx
+++ b/docs/understand-libretto/autofix-debugging.mdx
@@ -51,9 +51,10 @@ observed on the page.
   `playwrightDebugger.debugFailure(error, page)` in your automation's `catch`
   block before Playwright teardown.
 
-Use the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
-to connect GitHub, then [create an API key](https://libretto.sh/dashboard/api_keys).
-The dashboard provides a prompt for adding the debugger to an existing script.
+[Create an API key](https://libretto.sh/dashboard/api_keys), then use the
+[Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+to connect GitHub. The dashboard provides a prompt for adding the debugger to
+an existing script.
 
 ## Relationship to error recovery
 

--- a/docs/understand-libretto/autofix-debugging.mdx
+++ b/docs/understand-libretto/autofix-debugging.mdx
@@ -51,8 +51,9 @@ observed on the page.
   `playwrightDebugger.debugFailure(error, page)` in your automation's `catch`
   block before Playwright teardown.
 
-The [setup flow](https://libretto.sh/setup) walks through connecting GitHub,
-minting the API key, and adding the debugger to an existing script.
+Use the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+to connect GitHub, then [create an API key](https://libretto.sh/dashboard/api_keys).
+The dashboard provides a prompt for adding the debugger to an existing script.
 
 ## Relationship to error recovery
 

--- a/packages/playwright-debugger/README.md
+++ b/packages/playwright-debugger/README.md
@@ -18,10 +18,10 @@ The project must already depend on Playwright.
 
 ## Configure authentication
 
-1. Open the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+1. [Create a Libretto Cloud API key](https://libretto.sh/dashboard/api_keys).
+2. Set `LIBRETTO_API_KEY` in the environment that runs the automation.
+3. Open the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
    and install the Libretto GitHub App for the target repository.
-2. [Create a Libretto Cloud API key](https://libretto.sh/dashboard/api_keys).
-3. Set `LIBRETTO_API_KEY` in the environment that runs the automation.
 4. Set the API key for the configured model provider: `OPENAI_API_KEY` for an
    `openai/...` model or `ANTHROPIC_API_KEY` for an `anthropic/...` model.
 

--- a/packages/playwright-debugger/README.md
+++ b/packages/playwright-debugger/README.md
@@ -18,11 +18,11 @@ The project must already depend on Playwright.
 
 ## Configure authentication
 
-1. Open the [Libretto setup flow](https://libretto.sh/setup), install the
-   Libretto GitHub App for the target repository, and create a Libretto Cloud
-   API key.
-2. Set `LIBRETTO_API_KEY` in the environment that runs the automation.
-3. Set the API key for the configured model provider: `OPENAI_API_KEY` for an
+1. Open the [Self-Healing Playwright dashboard](https://libretto.sh/dashboard/connected_repos)
+   and install the Libretto GitHub App for the target repository.
+2. [Create a Libretto Cloud API key](https://libretto.sh/dashboard/api_keys).
+3. Set `LIBRETTO_API_KEY` in the environment that runs the automation.
+4. Set the API key for the configured model provider: `OPENAI_API_KEY` for an
    `openai/...` model or `ANTHROPIC_API_KEY` for an `anthropic/...` model.
 
 Store both keys in the project's existing secret-management system.


### PR DESCRIPTION
## Summary
- document the top-level `json` envelope used by authenticated Libretto Cloud API responses, including catalogue routes
- add success and validation-error response examples
- correct the `jobs/get` example and distinguish API responses from middleware and public website responses
- replace the removed debugger setup page with the current API Keys and Self-Healing Playwright dashboard links
- document the actual setup order: create the API key before connecting GitHub

## Validation
- `git diff --check`
- confirmed no documentation references remain for `https://libretto.sh/setup`
- verified the API Keys and Connected Repositories destinations return HTTP 200
- `pnpm docs:build` with Node 24
- `pnpm --filter @libretto/website test:vitest`
- `pnpm --filter @libretto/website build`

## Stack
- #585 adds the catalogue-specific examples and client transport changes
- paired API implementation: saffron-health/libretto-cloud#279
