### PR TITLE
Preserve catalogue REST routes with JSON envelopes

### DIFF
--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -283,7 +283,7 @@ function highlightJson(value: unknown): string {
 }
 
 function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
-  const runUrl = `${cloudApiUrl}/v1/catalogue/run`;
+  const runUrl = `${cloudApiUrl}/v1/catalogue/run/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
   const credLines =
     workflow.credential_requirements.length === 0
       ? ["- (none)"]
@@ -311,13 +311,12 @@ function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
     `Run endpoint: POST ${runUrl}`,
     "",
     "Authenticate with your Libretto API key in the `x-api-key` header.",
-    `Wrap the request fields in \`json\`, including \`publisher: "${workflow.tenant_slug}"\` and \`workflow: "${workflow.workflow_name}"\`.`,
-    "Pass credentials under `json.credentials`: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
+    "Wrap the run input in a top-level `json` field. Pass credentials under `json.credentials`: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
     ...credLines,
     "",
     schemaBlock,
     "",
-    "Or poll instead of a callback by setting `\"skip_callbacks\": true` and calling `POST /v1/jobs/get` with the returned `job_id`.",
+    "Or poll instead of a callback by setting `json.skip_callbacks` to `true` and calling `POST /v1/jobs/get` with the returned `job_id`.",
     "Jobs and credentials stay in your tenant. The publisher cannot see your identity, inputs, credentials, outputs, errors, or job details.",
   ]
     .filter((line): line is string => line !== null)
@@ -825,7 +824,7 @@ export function HostedWorkflowPage({
   }
 
   const prompt = buildHostedAgentPrompt(workflow);
-  const runUrl = `${cloudApiUrl}/v1/catalogue/run`;
+  const runUrl = `${cloudApiUrl}/v1/catalogue/run/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
   const returnTo = hostedPath(workflow);
   const canViewSource = workflow.source_access === "granted";
   const showSource = canViewSource && activeView === "source";
@@ -910,22 +909,12 @@ export function HostedWorkflowPage({
                   <h2 className="text-2xl font-medium tracking-tight text-ink">
                     Request envelope
                   </h2>
-                  <Text as="p" size="sm" className="mt-2 leading-6 text-muted">
-                    Wrap all request fields in the top-level json object.
-                  </Text>
                 </div>
                 <ParamRow
-                  name="json.publisher"
-                  typeLabel="string"
+                  name="json"
+                  typeLabel="object"
                   required
-                  description={`Use ${workflow.tenant_slug}.`}
-                  extras={[]}
-                />
-                <ParamRow
-                  name="json.workflow"
-                  typeLabel="string"
-                  required
-                  description={`Use ${workflow.workflow_name}.`}
+                  description="Wrap params, credentials, and run options in this top-level field."
                   extras={[]}
                 />
               </section>

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -283,7 +283,7 @@ function highlightJson(value: unknown): string {
 }
 
 function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
-  const runUrl = `${cloudApiUrl}/v1/hosted-workflows/run/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
+  const runUrl = `${cloudApiUrl}/v1/catalogue/run`;
   const credLines =
     workflow.credential_requirements.length === 0
       ? ["- (none)"]
@@ -311,7 +311,8 @@ function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
     `Run endpoint: POST ${runUrl}`,
     "",
     "Authenticate with your Libretto API key in the `x-api-key` header.",
-    "Pass a `credentials` map in the run body: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
+    `Wrap the request fields in \`json\`, including \`publisher: "${workflow.tenant_slug}"\` and \`workflow: "${workflow.workflow_name}"\`.`,
+    "Pass credentials under `json.credentials`: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
     ...credLines,
     "",
     schemaBlock,
@@ -535,7 +536,7 @@ function CredentialsReference({
           Credentials
         </h2>
         <Text as="p" size="sm" className="mt-2 leading-6 text-muted">
-          Pass these values under <code className="text-ink">credentials</code>{" "}
+          Pass these values under <code className="text-ink">json.credentials</code>{" "}
           in the request body.
         </Text>
       </div>
@@ -824,7 +825,7 @@ export function HostedWorkflowPage({
   }
 
   const prompt = buildHostedAgentPrompt(workflow);
-  const runUrl = `${cloudApiUrl}/v1/hosted-workflows/run/${encodeURIComponent(workflow.tenant_slug)}/${encodeURIComponent(workflow.workflow_name)}`;
+  const runUrl = `${cloudApiUrl}/v1/catalogue/run`;
   const returnTo = hostedPath(workflow);
   const canViewSource = workflow.source_access === "granted";
   const showSource = canViewSource && activeView === "source";
@@ -910,7 +911,7 @@ export function HostedWorkflowPage({
 
               <SchemaReference
                 title="Request fields"
-                description="Pass these fields under params in the JSON request body."
+                description="Pass these fields under json.params in the request body."
                 schema={workflow.input_schema}
                 emptyLabel="This workflow has no declared request fields."
               />

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -311,7 +311,7 @@ function buildHostedAgentPrompt(workflow: HostedWorkflowDetail): string {
     `Run endpoint: POST ${runUrl}`,
     "",
     "Authenticate with your Libretto API key in the `x-api-key` header.",
-    "Wrap the run input in a top-level `json` field. Pass credentials under `json.credentials`: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
+    "Wrap the run input in a top-level `json` field. Put workflow input fields under `json.params`. Pass credentials under `json.credentials`: each key is a required name below, and each value is either a credential id or a secret name from YOUR tenant:",
     ...credLines,
     "",
     schemaBlock,

--- a/apps/website/src/HostedWorkflowsPage.tsx
+++ b/apps/website/src/HostedWorkflowsPage.tsx
@@ -905,6 +905,31 @@ export function HostedWorkflowPage({
                 />
               </section>
 
+              <section>
+                <div className="border-b border-rule pb-4">
+                  <h2 className="text-2xl font-medium tracking-tight text-ink">
+                    Request envelope
+                  </h2>
+                  <Text as="p" size="sm" className="mt-2 leading-6 text-muted">
+                    Wrap all request fields in the top-level json object.
+                  </Text>
+                </div>
+                <ParamRow
+                  name="json.publisher"
+                  typeLabel="string"
+                  required
+                  description={`Use ${workflow.tenant_slug}.`}
+                  extras={[]}
+                />
+                <ParamRow
+                  name="json.workflow"
+                  typeLabel="string"
+                  required
+                  description={`Use ${workflow.workflow_name}.`}
+                  extras={[]}
+                />
+              </section>
+
               <CredentialsReference
                 requirements={workflow.credential_requirements}
               />

--- a/docs/libretto-cloud-api/catalogue.mdx
+++ b/docs/libretto-cloud-api/catalogue.mdx
@@ -66,12 +66,16 @@ All routes require `x-api-key`.
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `GET` | `/v1/catalogue?q=<query>&limit=<limit>` | Search the catalogue. |
-| `GET` | `/v1/catalogue/:publisher/:workflow` | Inspect one workflow. |
-| `POST` | `/v1/catalogue/run/:publisher/:workflow` | Queue a run. |
-| `GET` | `/v1/catalogue/bookmarks` | List tenant bookmarks. |
-| `POST` | `/v1/catalogue/bookmarks` | Save or update a bookmark. |
-| `DELETE` | `/v1/catalogue/bookmarks/:id` | Remove a bookmark. |
+| `POST` | `/v1/catalogue/search` | Search the catalogue. |
+| `POST` | `/v1/catalogue/get` | Inspect one workflow. |
+| `POST` | `/v1/catalogue/run` | Queue a run. |
+| `POST` | `/v1/catalogue/bookmarks/list` | List tenant bookmarks. |
+| `POST` | `/v1/catalogue/bookmarks/save` | Save or update a bookmark. |
+| `POST` | `/v1/catalogue/bookmarks/remove` | Remove a bookmark. |
+
+Each route uses the shared RPC request and response envelope described in the
+[API overview](/libretto-cloud-api/overview). Pass `publisher` and `workflow`
+in the `json` input for `get` and `run`.
 
 Poll run results with `POST /v1/jobs/get`. See
 [Jobs and logs](/libretto-cloud-api/jobs-and-logs) for the response fields.
@@ -80,11 +84,13 @@ The bookmark save body uses this shape:
 
 ```json
 {
-  "workflow": "acme/check-eligibility",
-  "alias": "eligibility",
-  "notes": "Default west region",
-  "default_params": {
-    "region": "west"
+  "json": {
+    "workflow": "acme/check-eligibility",
+    "alias": "eligibility",
+    "notes": "Default west region",
+    "default_params": {
+      "region": "west"
+    }
   }
 }
 ```

--- a/docs/libretto-cloud-api/catalogue.mdx
+++ b/docs/libretto-cloud-api/catalogue.mdx
@@ -66,33 +66,30 @@ All routes require `x-api-key`.
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `POST` | `/v1/catalogue/search` | Search the catalogue. |
-| `POST` | `/v1/catalogue/get` | Inspect one workflow. |
-| `POST` | `/v1/catalogue/run` | Queue a run. |
-| `POST` | `/v1/catalogue/bookmarks/list` | List tenant bookmarks. |
-| `POST` | `/v1/catalogue/bookmarks/save` | Save or update a bookmark. |
-| `POST` | `/v1/catalogue/bookmarks/remove` | Remove a bookmark. |
+| `GET` | `/v1/catalogue?q=<query>&limit=<limit>` | Search the catalogue. |
+| `GET` | `/v1/catalogue/:publisher/:workflow` | Inspect one workflow. |
+| `POST` | `/v1/catalogue/run/:publisher/:workflow` | Queue a run. |
+| `GET` | `/v1/catalogue/bookmarks` | List tenant bookmarks. |
+| `POST` | `/v1/catalogue/bookmarks` | Save or update a bookmark. |
+| `DELETE` | `/v1/catalogue/bookmarks/:id` | Remove a bookmark. |
 
-Each route uses the shared RPC request and response envelope described in the
-[API overview](/libretto-cloud-api/overview). Pass `publisher` and `workflow`
-in the `json` input for `get` and `run`.
+All success and error responses use the top-level `json` envelope described in
+the [API overview](/libretto-cloud-api/overview). The two POST routes also wrap
+their request bodies in `json`; GET query/path parameters and DELETE path
+parameters remain unchanged.
 
 Poll run results with `POST /v1/jobs/get`. See
 [Jobs and logs](/libretto-cloud-api/jobs-and-logs) for the response fields.
 
 ### Queue a run
 
-The run route is shared by every catalogue workflow. Identify the publication
-with `publisher` and `workflow` inside the RPC input:
-
 ```bash
-curl -sS -X POST https://api.libretto.sh/v1/catalogue/run \
+curl -sS -X POST \
+  https://api.libretto.sh/v1/catalogue/run/acme/check-eligibility \
   -H "x-api-key: $LIBRETTO_API_KEY" \
   -H "content-type: application/json" \
   -d '{
     "json": {
-      "publisher": "acme",
-      "workflow": "check-eligibility",
       "params": { "member_id": "member-123" },
       "skip_callbacks": true
     }

--- a/docs/libretto-cloud-api/catalogue.mdx
+++ b/docs/libretto-cloud-api/catalogue.mdx
@@ -80,6 +80,37 @@ in the `json` input for `get` and `run`.
 Poll run results with `POST /v1/jobs/get`. See
 [Jobs and logs](/libretto-cloud-api/jobs-and-logs) for the response fields.
 
+### Queue a run
+
+The run route is shared by every catalogue workflow. Identify the publication
+with `publisher` and `workflow` inside the RPC input:
+
+```bash
+curl -sS -X POST https://api.libretto.sh/v1/catalogue/run \
+  -H "x-api-key: $LIBRETTO_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "json": {
+      "publisher": "acme",
+      "workflow": "check-eligibility",
+      "params": { "member_id": "member-123" },
+      "skip_callbacks": true
+    }
+  }'
+```
+
+```json
+{
+  "json": {
+    "success": true,
+    "job_id": "f7dcbb42-282b-49d7-b9eb-7c349a0c9e35",
+    "status": "queued",
+    "catalogue_workflow": "acme/check-eligibility",
+    "message": "Job queued — waiting for browser capacity"
+  }
+}
+```
+
 The bookmark save body uses this shape:
 
 ```json

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -10,7 +10,8 @@ The Libretto Cloud API base URL is `https://api.libretto.sh`.
 
 ### Request format
 
-Libretto Cloud API routes in this section are `POST` requests.
+Most Libretto Cloud API routes in this section are `POST` requests. Published
+workflow catalogue and bookmark routes also use `GET` and `DELETE`.
 
 Authenticated routes use:
 

--- a/docs/libretto-cloud-api/overview.mdx
+++ b/docs/libretto-cloud-api/overview.mdx
@@ -10,8 +10,7 @@ The Libretto Cloud API base URL is `https://api.libretto.sh`.
 
 ### Request format
 
-Most Libretto Cloud API routes in this section are `POST` requests. Published
-workflow catalogue and bookmark routes also use `GET` and `DELETE`.
+Libretto Cloud API routes in this section are `POST` requests.
 
 Authenticated routes use:
 

--- a/packages/libretto/src/cli/commands/cloud-catalogue.ts
+++ b/packages/libretto/src/cli/commands/cloud-catalogue.ts
@@ -1,9 +1,6 @@
 import { SimpleCLI } from "affordance";
 import { z } from "zod";
-import {
-  ApiCallError,
-  authFetch,
-} from "../core/auth-fetch.js";
+import { orpcCall } from "../core/auth-fetch.js";
 import { createCloudJobStatusCommand } from "./cloud-job-status.js";
 import { jsonObjectInput } from "./cloud-json-input.js";
 import { withCloudApiKey, type CloudApiKeyContext } from "./shared.js";
@@ -23,44 +20,17 @@ type RunJobResponse = {
   status: string;
 };
 
-async function cloudRestCall<TResult>(opts: {
+async function catalogueCall<TResult>(opts: {
   ctx: CloudApiKeyContext;
-  method?: "GET" | "POST" | "DELETE";
   path: string;
-  body?: unknown;
+  input?: Record<string, unknown>;
 }): Promise<TResult> {
-  const response = await authFetch({
+  return orpcCall<TResult>({
     apiUrl: opts.ctx.apiUrl,
     credential: opts.ctx.credential,
-    method: opts.method ?? "GET",
     path: opts.path,
-    body: opts.body,
+    input: opts.input,
   });
-  const text = await response.text();
-  let data: unknown;
-  try {
-    data = text ? JSON.parse(text) : {};
-  } catch {
-    throw new Error(
-      `Unexpected response from ${opts.path} (${response.status}). Try the command again.`,
-    );
-  }
-  if (!response.ok) {
-    const body = data as { error?: unknown; message?: unknown; code?: unknown };
-    throw new ApiCallError({
-      message:
-        typeof body.error === "string"
-          ? body.error
-          : typeof body.message === "string"
-            ? body.message
-            : `${opts.path} failed (${response.status})`,
-      status: response.status,
-      code: typeof body.code === "string" ? body.code : null,
-      data,
-      path: opts.path,
-    });
-  }
-  return data as TResult;
 }
 
 function printJsonOrLines(
@@ -78,9 +48,9 @@ function printJsonOrLines(
 async function savedWorkflows(
   ctx: CloudApiKeyContext,
 ): Promise<WorkflowSummary[]> {
-  const response = await cloudRestCall<{ workflows: WorkflowSummary[] }>({
+  const response = await catalogueCall<{ workflows: WorkflowSummary[] }>({
     ctx,
-    path: "/v1/catalogue/bookmarks",
+    path: "/v1/catalogue/bookmarks/list",
   });
   return response.workflows;
 }
@@ -149,12 +119,10 @@ export const searchCatalogueCommand = SimpleCLI.command({
   )
   .use(withCloudApiKey("search the workflow catalogue"))
   .handle(async ({ input, ctx }) => {
-    const query = new URLSearchParams();
-    if (input.query) query.set("q", input.query);
-    query.set("limit", String(input.limit ?? 20));
-    const response = await cloudRestCall<{ workflows: WorkflowSummary[] }>({
+    const response = await catalogueCall<{ workflows: WorkflowSummary[] }>({
       ctx,
-      path: `/v1/catalogue?${query}`,
+      path: "/v1/catalogue/search",
+      input: { q: input.query, limit: input.limit ?? 20 },
     });
     printJsonOrLines(
       response,
@@ -184,9 +152,13 @@ export const getCatalogueWorkflowCommand = SimpleCLI.command({
   .use(withCloudApiKey("inspect catalogue workflows"))
   .handle(async ({ input, ctx }) => {
     const workflow = await resolveWorkflow(ctx, input.workflow!);
-    const response = await cloudRestCall<Record<string, unknown>>({
+    const response = await catalogueCall<Record<string, unknown>>({
       ctx,
-      path: `/v1/catalogue/${encodeURIComponent(workflow.tenantSlug)}/${encodeURIComponent(workflow.workflowName)}`,
+      path: "/v1/catalogue/get",
+      input: {
+        publisher: workflow.tenantSlug,
+        workflow: workflow.workflowName,
+      },
     });
     const output = { workflow: response, default_params: workflow.defaultParams };
     printJsonOrLines(output, input.json, [
@@ -246,11 +218,12 @@ export const runCatalogueWorkflowCommand = SimpleCLI.command({
       "--credentials-file",
       input.credentialsFile,
     );
-    const response = await cloudRestCall<RunJobResponse>({
+    const response = await catalogueCall<RunJobResponse>({
       ctx,
-      method: "POST",
-      path: `/v1/catalogue/run/${encodeURIComponent(workflow.tenantSlug)}/${encodeURIComponent(workflow.workflowName)}`,
-      body: {
+      path: "/v1/catalogue/run",
+      input: {
+        publisher: workflow.tenantSlug,
+        workflow: workflow.workflowName,
         params: { ...workflow.defaultParams, ...params },
         ...(Object.keys(credentials).length > 0 ? { credentials } : {}),
         ...(input.timeoutSeconds !== undefined
@@ -305,13 +278,12 @@ export const saveCatalogueWorkflowCommand = SimpleCLI.command({
       "--defaults-file",
       input.defaultsFile,
     );
-    const response = await cloudRestCall<{
+    const response = await catalogueCall<{
       bookmark: { id: string; workflow: string; alias: string | null };
     }>({
       ctx,
-      method: "POST",
-      path: "/v1/catalogue/bookmarks",
-      body: {
+      path: "/v1/catalogue/bookmarks/save",
+      input: {
         workflow: input.workflow,
         alias: input.alias,
         notes: input.notes,
@@ -373,10 +345,10 @@ export const removeSavedCatalogueWorkflowCommand = SimpleCLI.command({
   )
   .use(withCloudApiKey("remove saved catalogue workflows"))
   .handle(async ({ input, ctx }) => {
-    const response = await cloudRestCall<{ removed: boolean; id: string }>({
+    const response = await catalogueCall<{ removed: boolean; id: string }>({
       ctx,
-      method: "DELETE",
-      path: `/v1/catalogue/bookmarks/${input.id}`,
+      path: "/v1/catalogue/bookmarks/remove",
+      input: { id: input.id },
     });
     printJsonOrLines(response, input.json, [
       response.removed

--- a/packages/libretto/src/cli/commands/cloud-catalogue.ts
+++ b/packages/libretto/src/cli/commands/cloud-catalogue.ts
@@ -1,6 +1,9 @@
 import { SimpleCLI } from "affordance";
 import { z } from "zod";
-import { orpcCall } from "../core/auth-fetch.js";
+import {
+  ApiCallError,
+  authFetch,
+} from "../core/auth-fetch.js";
 import { createCloudJobStatusCommand } from "./cloud-job-status.js";
 import { jsonObjectInput } from "./cloud-json-input.js";
 import { withCloudApiKey, type CloudApiKeyContext } from "./shared.js";
@@ -20,17 +23,56 @@ type RunJobResponse = {
   status: string;
 };
 
-async function catalogueCall<TResult>(opts: {
+async function cloudRestCall<TResult>(opts: {
   ctx: CloudApiKeyContext;
+  method?: "GET" | "POST" | "DELETE";
   path: string;
-  input?: Record<string, unknown>;
+  body?: unknown;
 }): Promise<TResult> {
-  return orpcCall<TResult>({
+  const response = await authFetch({
     apiUrl: opts.ctx.apiUrl,
     credential: opts.ctx.credential,
+    method: opts.method ?? "GET",
     path: opts.path,
-    input: opts.input,
+    body: opts.body === undefined ? undefined : { json: opts.body },
   });
+  const text = await response.text();
+  let data: unknown;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(
+      `Unexpected response from ${opts.path} (${response.status}). Try the command again.`,
+    );
+  }
+  const envelope =
+    data && typeof data === "object" ? (data as { json?: unknown }) : null;
+  const result = envelope?.json;
+  if (!response.ok) {
+    const body = (result ?? data) as {
+      error?: unknown;
+      message?: unknown;
+      code?: unknown;
+    };
+    throw new ApiCallError({
+      message:
+        typeof body.error === "string"
+          ? body.error
+          : typeof body.message === "string"
+            ? body.message
+            : `${opts.path} failed (${response.status})`,
+      status: response.status,
+      code: typeof body.code === "string" ? body.code : null,
+      data,
+      path: opts.path,
+    });
+  }
+  if (!envelope || !("json" in envelope)) {
+    throw new Error(
+      `Unexpected response from ${opts.path} (${response.status}). Try the command again.`,
+    );
+  }
+  return result as TResult;
 }
 
 function printJsonOrLines(
@@ -48,9 +90,9 @@ function printJsonOrLines(
 async function savedWorkflows(
   ctx: CloudApiKeyContext,
 ): Promise<WorkflowSummary[]> {
-  const response = await catalogueCall<{ workflows: WorkflowSummary[] }>({
+  const response = await cloudRestCall<{ workflows: WorkflowSummary[] }>({
     ctx,
-    path: "/v1/catalogue/bookmarks/list",
+    path: "/v1/catalogue/bookmarks",
   });
   return response.workflows;
 }
@@ -119,10 +161,12 @@ export const searchCatalogueCommand = SimpleCLI.command({
   )
   .use(withCloudApiKey("search the workflow catalogue"))
   .handle(async ({ input, ctx }) => {
-    const response = await catalogueCall<{ workflows: WorkflowSummary[] }>({
+    const query = new URLSearchParams();
+    if (input.query) query.set("q", input.query);
+    query.set("limit", String(input.limit ?? 20));
+    const response = await cloudRestCall<{ workflows: WorkflowSummary[] }>({
       ctx,
-      path: "/v1/catalogue/search",
-      input: { q: input.query, limit: input.limit ?? 20 },
+      path: `/v1/catalogue?${query}`,
     });
     printJsonOrLines(
       response,
@@ -152,13 +196,9 @@ export const getCatalogueWorkflowCommand = SimpleCLI.command({
   .use(withCloudApiKey("inspect catalogue workflows"))
   .handle(async ({ input, ctx }) => {
     const workflow = await resolveWorkflow(ctx, input.workflow!);
-    const response = await catalogueCall<Record<string, unknown>>({
+    const response = await cloudRestCall<Record<string, unknown>>({
       ctx,
-      path: "/v1/catalogue/get",
-      input: {
-        publisher: workflow.tenantSlug,
-        workflow: workflow.workflowName,
-      },
+      path: `/v1/catalogue/${encodeURIComponent(workflow.tenantSlug)}/${encodeURIComponent(workflow.workflowName)}`,
     });
     const output = { workflow: response, default_params: workflow.defaultParams };
     printJsonOrLines(output, input.json, [
@@ -218,12 +258,11 @@ export const runCatalogueWorkflowCommand = SimpleCLI.command({
       "--credentials-file",
       input.credentialsFile,
     );
-    const response = await catalogueCall<RunJobResponse>({
+    const response = await cloudRestCall<RunJobResponse>({
       ctx,
-      path: "/v1/catalogue/run",
-      input: {
-        publisher: workflow.tenantSlug,
-        workflow: workflow.workflowName,
+      method: "POST",
+      path: `/v1/catalogue/run/${encodeURIComponent(workflow.tenantSlug)}/${encodeURIComponent(workflow.workflowName)}`,
+      body: {
         params: { ...workflow.defaultParams, ...params },
         ...(Object.keys(credentials).length > 0 ? { credentials } : {}),
         ...(input.timeoutSeconds !== undefined
@@ -278,12 +317,13 @@ export const saveCatalogueWorkflowCommand = SimpleCLI.command({
       "--defaults-file",
       input.defaultsFile,
     );
-    const response = await catalogueCall<{
+    const response = await cloudRestCall<{
       bookmark: { id: string; workflow: string; alias: string | null };
     }>({
       ctx,
-      path: "/v1/catalogue/bookmarks/save",
-      input: {
+      method: "POST",
+      path: "/v1/catalogue/bookmarks",
+      body: {
         workflow: input.workflow,
         alias: input.alias,
         notes: input.notes,
@@ -345,10 +385,10 @@ export const removeSavedCatalogueWorkflowCommand = SimpleCLI.command({
   )
   .use(withCloudApiKey("remove saved catalogue workflows"))
   .handle(async ({ input, ctx }) => {
-    const response = await catalogueCall<{ removed: boolean; id: string }>({
+    const response = await cloudRestCall<{ removed: boolean; id: string }>({
       ctx,
-      path: "/v1/catalogue/bookmarks/remove",
-      input: { id: input.id },
+      method: "DELETE",
+      path: `/v1/catalogue/bookmarks/${input.id}`,
     });
     printJsonOrLines(response, input.json, [
       response.removed

--- a/packages/libretto/test/cloud-catalogue.spec.ts
+++ b/packages/libretto/test/cloud-catalogue.spec.ts
@@ -36,7 +36,7 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
     });
 
     let body: unknown;
-    if (path === "/v1/catalogue/search") {
+    if (path.startsWith("/v1/catalogue?q=")) {
       body = {
         json: {
           workflows: [
@@ -48,7 +48,7 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           ],
         },
       };
-    } else if (path === "/v1/catalogue/get") {
+    } else if (path === "/v1/catalogue/acme/patient-lookup") {
       body = {
         json: {
           tenant_slug: "acme",
@@ -57,7 +57,10 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           credential_requirements: [],
         },
       };
-    } else if (path === "/v1/catalogue/bookmarks/save") {
+    } else if (
+      path === "/v1/catalogue/bookmarks" &&
+      request.method === "POST"
+    ) {
       body = {
         json: {
           bookmark: {
@@ -67,7 +70,10 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           },
         },
       };
-    } else if (path === "/v1/catalogue/bookmarks/list") {
+    } else if (
+      path === "/v1/catalogue/bookmarks" &&
+      request.method === "GET"
+    ) {
       body = {
         json: {
           workflows: [
@@ -89,7 +95,9 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           ],
         },
       };
-    } else if (path === "/v1/catalogue/run") {
+    } else if (
+      path === "/v1/catalogue/run/acme/patient-lookup"
+    ) {
       body = { json: { job_id: jobId, status: "queued" } };
     } else if (path === "/v1/jobs/get") {
       statusCalls += 1;
@@ -101,7 +109,7 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           ...(statusCalls === 1 ? {} : { result: { patient_id: "p-1" } }),
         },
       };
-    } else if (path === "/v1/catalogue/bookmarks/remove") {
+    } else if (path === `/v1/catalogue/bookmarks/${bookmarkId}`) {
       body = { json: { id: bookmarkId, removed: true } };
     } else {
       response.writeHead(404, { "Content-Type": "application/json" });
@@ -187,22 +195,15 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
   expect(
     requests.find(
       (request) =>
-        request.path === "/v1/catalogue/run",
+        request.path === "/v1/catalogue/run/acme/patient-lookup",
     )?.body,
   ).toEqual({
     json: {
-      publisher: "acme",
-      workflow: "patient-lookup",
       params: { region: "west", patient_id: "p-1" },
       credentials: { portal: "credential-1" },
       skip_callbacks: true,
     },
   });
-  expect(
-    requests
-      .filter((request) => request.path.startsWith("/v1/catalogue"))
-      .every((request) => request.method === "POST" && request.body !== null),
-  ).toBe(true);
 });
 
 test("cloud workflow commands require an API key", async ({ librettoCli }) => {

--- a/packages/libretto/test/cloud-catalogue.spec.ts
+++ b/packages/libretto/test/cloud-catalogue.spec.ts
@@ -36,61 +36,61 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
     });
 
     let body: unknown;
-    if (path.startsWith("/v1/catalogue?q=")) {
+    if (path === "/v1/catalogue/search") {
       body = {
-        workflows: [
-          {
-            tenant_slug: "acme",
-            workflow_name: "patient-lookup",
-            description: "Find a patient",
-          },
-        ],
-      };
-    } else if (path === "/v1/catalogue/acme/patient-lookup") {
-      body = {
-        tenant_slug: "acme",
-        workflow_name: "patient-lookup",
-        input_schema: { type: "object" },
-        credential_requirements: [],
-      };
-    } else if (
-      path === "/v1/catalogue/bookmarks" &&
-      request.method === "POST"
-    ) {
-      body = {
-        bookmark: {
-          id: bookmarkId,
-          workflow: "acme/patient-lookup",
-          alias: "patient",
+        json: {
+          workflows: [
+            {
+              tenant_slug: "acme",
+              workflow_name: "patient-lookup",
+              description: "Find a patient",
+            },
+          ],
         },
       };
-    } else if (
-      path === "/v1/catalogue/bookmarks" &&
-      request.method === "GET"
-    ) {
+    } else if (path === "/v1/catalogue/get") {
       body = {
-        workflows: [
-          {
-            id: bookmarkId,
-            alias: "patient",
-            tenant_slug: "acme",
-            workflow_name: "patient-lookup",
-            default_params: { region: "west" },
-            available: true,
-          },
-          {
-            id: unavailableBookmarkId,
-            alias: "retired",
-            tenant_slug: null,
-            workflow_name: null,
-            available: false,
-          },
-        ],
+        json: {
+          tenant_slug: "acme",
+          workflow_name: "patient-lookup",
+          input_schema: { type: "object" },
+          credential_requirements: [],
+        },
       };
-    } else if (
-      path === "/v1/catalogue/run/acme/patient-lookup"
-    ) {
-      body = { job_id: jobId, status: "queued" };
+    } else if (path === "/v1/catalogue/bookmarks/save") {
+      body = {
+        json: {
+          bookmark: {
+            id: bookmarkId,
+            workflow: "acme/patient-lookup",
+            alias: "patient",
+          },
+        },
+      };
+    } else if (path === "/v1/catalogue/bookmarks/list") {
+      body = {
+        json: {
+          workflows: [
+            {
+              id: bookmarkId,
+              alias: "patient",
+              tenant_slug: "acme",
+              workflow_name: "patient-lookup",
+              default_params: { region: "west" },
+              available: true,
+            },
+            {
+              id: unavailableBookmarkId,
+              alias: "retired",
+              tenant_slug: null,
+              workflow_name: null,
+              available: false,
+            },
+          ],
+        },
+      };
+    } else if (path === "/v1/catalogue/run") {
+      body = { json: { job_id: jobId, status: "queued" } };
     } else if (path === "/v1/jobs/get") {
       statusCalls += 1;
       body = {
@@ -101,8 +101,8 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
           ...(statusCalls === 1 ? {} : { result: { patient_id: "p-1" } }),
         },
       };
-    } else if (path === `/v1/catalogue/bookmarks/${bookmarkId}`) {
-      body = { id: bookmarkId, removed: true };
+    } else if (path === "/v1/catalogue/bookmarks/remove") {
+      body = { json: { id: bookmarkId, removed: true } };
     } else {
       response.writeHead(404, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ error: `Unexpected path ${path}` }));
@@ -187,13 +187,22 @@ test("cloud workflow commands cover catalogue, runs, and saved workflows", async
   expect(
     requests.find(
       (request) =>
-        request.path === "/v1/catalogue/run/acme/patient-lookup",
+        request.path === "/v1/catalogue/run",
     )?.body,
   ).toEqual({
-    params: { region: "west", patient_id: "p-1" },
-    credentials: { portal: "credential-1" },
-    skip_callbacks: true,
+    json: {
+      publisher: "acme",
+      workflow: "patient-lookup",
+      params: { region: "west", patient_id: "p-1" },
+      credentials: { portal: "credential-1" },
+      skip_callbacks: true,
+    },
   });
+  expect(
+    requests
+      .filter((request) => request.path.startsWith("/v1/catalogue"))
+      .every((request) => request.method === "POST" && request.body !== null),
+  ).toBe(true);
 });
 
 test("cloud workflow commands require an API key", async ({ librettoCli }) => {


### PR DESCRIPTION
## Summary
- preserve the deployed catalogue GET, POST, and DELETE methods and dynamic workflow URLs
- wrap catalogue POST inputs and all authenticated catalogue responses in the top-level `json` field
- update the CLI transport, docs, and website API panel for the shared envelope
- correct stale website run URLs while keeping publisher and workflow in the endpoint path

## Validation
- `pnpm -s --filter libretto type-check`
- `pnpm -s --filter libretto build`
- `pnpm -s --filter libretto exec vitest run test/cloud-catalogue.spec.ts`
- `pnpm -s --filter @libretto/website type-check`
- docs production build with Node 24

## Stack
- builds on #584, which clarifies the general API response envelope
- paired API implementation: saffron-health/libretto-cloud#279
