### PR TITLE
Polish Chrome extension and product navigation

### DIFF
--- a/apps/website/src/BrowserToolsPage.tsx
+++ b/apps/website/src/BrowserToolsPage.tsx
@@ -6,6 +6,7 @@ import { Kicker } from "./components/Kicker";
 import { SectionDivider } from "./components/SectionDivider";
 import { ShellCommand } from "./components/ShellCommand";
 import { CanvasAsciihedron } from "./components/CanvasAsciihedron";
+import { HeroResourceLinks } from "./components/HeroResourceLinks";
 
 const INSTALL_COMMAND = "npm i libretto-browser-tools";
 
@@ -94,12 +95,19 @@ function BrowserToolsHero() {
             Six tools let any AI agent open a real browser, read the page, and
             act with Playwright.
           </Text>
-          <ShellCommand
-            ariaLabel="Copy browser tools install command"
-            command={INSTALL_COMMAND}
-            fathomEvent="Browser tools hero install copy"
-            className="max-w-[390px]"
-          />
+          <div className="flex w-fit flex-col items-center gap-3">
+            <ShellCommand
+              ariaLabel="Copy browser tools install command"
+              command={INSTALL_COMMAND}
+              fathomEvent="Browser tools hero install copy"
+              className="max-w-[390px]"
+            />
+            <HeroResourceLinks
+              docsHref="/docs/browser-tools/quickstart"
+              docsFathomEvent="Browser tools hero docs click"
+              talkFathomEvent="Browser tools hero talk to dev click"
+            />
+          </div>
         </div>
         <CodeWindow />
       </div>

--- a/apps/website/src/ChromeExtensionPage.tsx
+++ b/apps/website/src/ChromeExtensionPage.tsx
@@ -8,60 +8,8 @@ import { SectionDivider } from "./components/SectionDivider";
 import { Text } from "./components/Text";
 import { CanvasAsciihedron } from "./components/CanvasAsciihedron";
 
-interface Example {
-  site: string;
-  siteTone: string;
-  task: string;
-}
-
 const CHROME_EXTENSION_URL =
   "https://chromewebstore.google.com/detail/libretto/ddjagimknfjnkaefgfjpcnanflaipbmn";
-
-const oneTimeExamples: Example[] = [
-  {
-    site: "Google Maps",
-    siteTone: "text-blue-300",
-    task: "Find ten dentists within five miles that are open on Saturdays, then put their names, ratings, and phone numbers in a Google Sheet.",
-  },
-  {
-    site: "Zillow",
-    siteTone: "text-blue-300",
-    task: "Make me a shortlist of two-bedroom apartments in Oakland under $3,500 with parking and in-unit laundry.",
-  },
-  {
-    site: "Amazon",
-    siteTone: "text-amber-bright",
-    task: "Compare the five highest-rated standing desks under $400 and summarize the differences in size, warranty, and delivery time.",
-  },
-  {
-    site: "Salesforce",
-    siteTone: "text-sky-300",
-    task: "Update these 32 customer accounts using the names, titles, and phone numbers in this spreadsheet.",
-  },
-];
-
-const repeatableExamples: Example[] = [
-  {
-    site: "Shopify → Google Sheets",
-    siteTone: "text-green-300",
-    task: "Every Monday at 8 AM, export last week's orders and add them to the team sales tracker.",
-  },
-  {
-    site: "Stripe → Email",
-    siteTone: "text-violet-300",
-    task: "Every weekday, download yesterday's payouts and email the finance team a summary.",
-  },
-  {
-    site: "Salesforce",
-    siteTone: "text-sky-300",
-    task: "Check for new enterprise leads every morning and send the account owner a prioritized list.",
-  },
-  {
-    site: "Vendor portal → Slack",
-    siteTone: "text-fuchsia-300",
-    task: "Check open orders twice a day and notify the operations channel whenever a delivery date changes.",
-  },
-];
 
 function ArrowIcon() {
   return (
@@ -179,35 +127,149 @@ function BrowserDemo() {
   );
 }
 
-function ExampleCard({ example, index }: { example: Example; index: number }) {
+function OneOffTaskGraphic() {
   return (
-    <Panel
-      padding="none"
-      radius="lg"
-      className="group flex min-h-[200px] flex-col overflow-hidden transition-colors hover:border-accent/30"
-    >
-      <div className="flex items-center justify-between border-b border-rule px-5 py-3">
-        <span className={`text-xs font-medium ${example.siteTone}`}>
-          {example.site}
+    <Panel padding="none" radius="lg" className="overflow-hidden">
+      <div className="flex items-center justify-between border-b border-rule bg-panel-hi/45 px-5 py-3.5">
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">
+          One-off task
         </span>
-        <span className="text-[10px] text-muted/35">0{index + 1}</span>
+        <span className="flex items-center gap-2 font-mono text-[10px] text-accent-bright">
+          <span className="size-1.5 rounded-full bg-accent" /> Complete
+        </span>
       </div>
-      <div className="flex flex-1 items-start p-5">
-        <Text as="p" size="sm" className="leading-relaxed text-ink/85">
-          “{example.task}”
-        </Text>
+      <div className="grid gap-0 md:grid-cols-[0.92fr_1.08fr]">
+        <div className="border-b border-rule p-5 md:border-r md:border-b-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+            Request
+          </div>
+          <p className="mt-3 text-sm leading-6 text-ink">
+            Find ten dentists nearby that are open Saturdays and add their
+            details to a Google Sheet.
+          </p>
+          <div className="mt-6 space-y-3 border-t border-rule pt-5 font-mono text-[11px] text-muted">
+            {[
+              "Searched Google Maps",
+              "Checked hours and ratings",
+              "Created the spreadsheet",
+            ].map((step) => (
+              <div key={step} className="flex items-center gap-3">
+                <span className="text-accent">✓</span>
+                <span>{step}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bg-bg/35 p-5">
+          <div className="flex items-end justify-between border-b border-rule pb-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+                Result
+              </div>
+              <div className="mt-1 text-sm text-ink">Saturday dentists</div>
+            </div>
+            <div className="font-mono text-[10px] text-muted">10 rows</div>
+          </div>
+          <div className="font-mono text-[10px] text-muted">
+            {[
+              ["Lake Dental", "4.9", "9–2"],
+              ["Grand Avenue", "4.8", "8–1"],
+              ["Temescal Smiles", "4.7", "9–3"],
+            ].map(([name, rating, hours]) => (
+              <div
+                key={name}
+                className="grid grid-cols-[1fr_38px_42px] gap-3 border-b border-rule/70 py-3 last:border-0"
+              >
+                <span className="text-ink/80">{name}</span>
+                <span>{rating}</span>
+                <span>{hours}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex items-center justify-between rounded border border-accent/20 bg-green-3/20 px-3 py-2.5 font-mono text-[10px] text-accent-bright">
+            <span>Google Sheet ready</span>
+            <ArrowIcon />
+          </div>
+        </div>
       </div>
     </Panel>
   );
 }
 
-function ExampleGrid({ examples }: { examples: Example[] }) {
+function WorkflowGraphic() {
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {examples.map((example, index) => (
-        <ExampleCard key={example.site} example={example} index={index} />
-      ))}
-    </div>
+    <Panel padding="none" radius="lg" className="overflow-hidden">
+      <div className="flex items-center justify-between border-b border-rule bg-panel-hi/45 px-5 py-3.5">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">
+            Saved workflow
+          </div>
+          <div className="mt-1 text-sm text-ink">Weekly sales tracker</div>
+        </div>
+        <span className="rounded border border-accent/20 bg-green-3/20 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-accent-bright">
+          Active
+        </span>
+      </div>
+      <div className="p-5">
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+          <div className="rounded-md border border-rule bg-bg/45 p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+              Source
+            </div>
+            <div className="mt-2 text-sm text-ink">Shopify orders</div>
+          </div>
+          <ArrowIcon />
+          <div className="rounded-md border border-rule bg-bg/45 p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+              Destination
+            </div>
+            <div className="mt-2 text-sm text-ink">Google Sheets</div>
+          </div>
+        </div>
+        <div className="mt-4 flex items-center justify-between rounded-md border border-rule bg-bg/45 px-4 py-3">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+              Schedule
+            </div>
+            <div className="mt-1 text-sm text-ink">Every Monday at 8:00 AM</div>
+          </div>
+          <div className="grid grid-cols-7 gap-1" aria-label="Runs every Monday">
+            {["M", "T", "W", "T", "F", "S", "S"].map((day, index) => (
+              <span
+                key={`${day}-${index}`}
+                className={`grid size-6 place-items-center rounded-sm font-mono text-[9px] ${
+                  index === 0
+                    ? "bg-accent text-bg"
+                    : "border border-rule text-faint"
+                }`}
+              >
+                {day}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="border-t border-rule bg-bg/35 px-5 py-4">
+        <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
+          Recent runs
+        </div>
+        <div className="space-y-2 font-mono text-[10px]">
+          {[
+            ["Aug 17", "128 orders", "Completed"],
+            ["Aug 10", "116 orders", "Completed"],
+          ].map(([date, result, status]) => (
+            <div
+              key={date}
+              className="grid grid-cols-[62px_1fr_auto] items-center gap-3 border-t border-rule/70 pt-2 text-muted"
+            >
+              <span>{date}</span>
+              <span className="text-ink/75">{result}</span>
+              <span className="text-accent-bright">✓ {status}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Panel>
   );
 }
 
@@ -215,13 +277,11 @@ function StorySection({
   kicker,
   title,
   description,
-  examples,
   children,
 }: {
   kicker: string;
   title: string;
   description: string;
-  examples: Example[];
   children: ReactNode;
 }) {
   return (
@@ -243,9 +303,8 @@ function StorySection({
         >
           {description}
         </Text>
-        {children}
       </div>
-      <ExampleGrid examples={examples} />
+      <div>{children}</div>
     </section>
   );
 }
@@ -300,17 +359,6 @@ function Hero() {
         <BrowserDemo />
       </div>
     </section>
-  );
-}
-
-function CloudCallout() {
-  return (
-    <div className="mt-8 rounded-lg border border-accent/20 bg-green-3/20 p-4">
-      <Text as="p" size="xs" className="leading-relaxed text-muted">
-        Workflows run securely in the cloud. Close your laptop and Libretto
-        keeps going.
-      </Text>
-    </div>
   );
 }
 
@@ -395,24 +443,19 @@ export function ChromeExtensionPage() {
         >
           <SectionDivider />
           <StorySection
-            kicker="// GET A TASK DONE --"
-            title="Ask once. Get it done."
-            description="Tell the Libretto agent what you need in everyday language. It works across websites to complete the task while you focus on something else."
-            examples={oneTimeExamples}
+            kicker="// ONE-OFF TASKS --"
+            title="Delegate a browser task."
+            description="Describe the result you need. Libretto navigates the sites, handles the repetitive steps, and returns the finished work."
           >
-            <div className="mt-7 flex items-center gap-2 text-xs text-accent-bright">
-              Great for research, data entry, comparisons, and one-off admin
-              work
-            </div>
+            <OneOffTaskGraphic />
           </StorySection>
           <SectionDivider />
           <StorySection
-            kicker="// MAKE IT A WORKFLOW --"
-            title="Save it once. Run it anytime."
-            description="Turn any useful task into a dependable workflow. Run it with one click or choose a schedule and let Libretto take care of it in the cloud."
-            examples={repeatableExamples}
+            kicker="// REPEATABLE WORKFLOWS --"
+            title="Automate the tasks you repeat."
+            description="Save a completed task as a workflow. Run it on demand or put it on a schedule; cloud execution keeps it moving when your computer is closed."
           >
-            <CloudCallout />
+            <WorkflowGraphic />
           </StorySection>
           <SectionDivider />
           <PrivacyStrip />

--- a/apps/website/src/ChromeExtensionPage.tsx
+++ b/apps/website/src/ChromeExtensionPage.tsx
@@ -127,68 +127,80 @@ function BrowserDemo() {
   );
 }
 
+function ExtensionPanelHeader({ status }: { status: string }) {
+  return (
+    <div className="flex items-center justify-between border-b border-rule bg-panel-hi/45 px-5 py-3.5">
+      <div>
+        <div className="text-sm font-medium text-ink">Libretto</div>
+        <div className="mt-0.5 font-mono text-[9px] text-accent-bright">
+          {status}
+        </div>
+      </div>
+      <span className="rounded border border-accent/20 bg-green-3/20 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-accent-bright">
+        Chrome
+      </span>
+    </div>
+  );
+}
+
 function OneOffTaskGraphic() {
   return (
     <Panel padding="none" radius="lg" className="overflow-hidden">
-      <div className="flex items-center justify-between border-b border-rule bg-panel-hi/45 px-5 py-3.5">
-        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">
-          One-off task
-        </span>
-        <span className="flex items-center gap-2 font-mono text-[10px] text-accent-bright">
-          <span className="size-1.5 rounded-full bg-accent" /> Complete
-        </span>
-      </div>
-      <div className="grid gap-0 md:grid-cols-[0.92fr_1.08fr]">
-        <div className="border-b border-rule p-5 md:border-r md:border-b-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-            Request
+      <ExtensionPanelHeader status="Task complete" />
+      <div className="space-y-4 bg-[#121512] p-5">
+        <div className="ml-10 rounded-lg rounded-tr-sm border border-rule bg-panel-hi p-4 text-xs leading-5 text-ink">
+          Find ten dentists nearby that are open Saturdays and add their
+          details to a Google Sheet.
+        </div>
+        <div className="mr-3 rounded-lg rounded-tl-sm border border-accent/20 bg-green-3/20 p-4">
+          <div className="flex items-center gap-2 text-xs text-accent-bright">
+            <span className="grid size-4 place-items-center rounded-full bg-accent text-[10px] text-bg">
+              ✓
+            </span>
+            Done — I created the sheet
           </div>
-          <p className="mt-3 text-sm leading-6 text-ink">
-            Find ten dentists nearby that are open Saturdays and add their
-            details to a Google Sheet.
-          </p>
-          <div className="mt-6 space-y-3 border-t border-rule pt-5 font-mono text-[11px] text-muted">
+          <div className="mt-4 grid gap-4 sm:grid-cols-[0.84fr_1.16fr]">
+            <div className="space-y-2.5 font-mono text-[10px] text-muted">
             {[
               "Searched Google Maps",
               "Checked hours and ratings",
               "Created the spreadsheet",
             ].map((step) => (
-              <div key={step} className="flex items-center gap-3">
+              <div key={step} className="flex items-center gap-2">
                 <span className="text-accent">✓</span>
                 <span>{step}</span>
               </div>
             ))}
-          </div>
-        </div>
-        <div className="bg-bg/35 p-5">
-          <div className="flex items-end justify-between border-b border-rule pb-3">
-            <div>
-              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-                Result
-              </div>
-              <div className="mt-1 text-sm text-ink">Saturday dentists</div>
             </div>
-            <div className="font-mono text-[10px] text-muted">10 rows</div>
-          </div>
-          <div className="font-mono text-[10px] text-muted">
-            {[
-              ["Lake Dental", "4.9", "9–2"],
-              ["Grand Avenue", "4.8", "8–1"],
-              ["Temescal Smiles", "4.7", "9–3"],
-            ].map(([name, rating, hours]) => (
-              <div
-                key={name}
-                className="grid grid-cols-[1fr_38px_42px] gap-3 border-b border-rule/70 py-3 last:border-0"
-              >
-                <span className="text-ink/80">{name}</span>
-                <span>{rating}</span>
-                <span>{hours}</span>
+            <div className="overflow-hidden rounded-md border border-rule bg-bg/55">
+              <div className="flex items-end justify-between border-b border-rule px-3 py-2.5">
+                <div>
+                  <div className="font-mono text-[8px] uppercase tracking-[0.12em] text-faint">
+                    Google Sheets
+                  </div>
+                  <div className="mt-1 text-[11px] text-ink">
+                    Saturday dentists
+                  </div>
+                </div>
+                <div className="font-mono text-[9px] text-muted">10 rows</div>
               </div>
-            ))}
-          </div>
-          <div className="mt-3 flex items-center justify-between rounded border border-accent/20 bg-green-3/20 px-3 py-2.5 font-mono text-[10px] text-accent-bright">
-            <span>Google Sheet ready</span>
-            <ArrowIcon />
+              <div className="px-3 font-mono text-[9px] text-muted">
+                {[
+                  ["Lake Dental", "4.9", "9–2"],
+                  ["Grand Avenue", "4.8", "8–1"],
+                  ["Temescal Smiles", "4.7", "9–3"],
+                ].map(([name, rating, hours]) => (
+                  <div
+                    key={name}
+                    className="grid grid-cols-[1fr_28px_30px] gap-2 border-b border-rule/70 py-2 last:border-0"
+                  >
+                    <span className="text-ink/80">{name}</span>
+                    <span>{rating}</span>
+                    <span>{hours}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -199,74 +211,70 @@ function OneOffTaskGraphic() {
 function WorkflowGraphic() {
   return (
     <Panel padding="none" radius="lg" className="overflow-hidden">
-      <div className="flex items-center justify-between border-b border-rule bg-panel-hi/45 px-5 py-3.5">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted">
-            Saved workflow
-          </div>
-          <div className="mt-1 text-sm text-ink">Weekly sales tracker</div>
+      <ExtensionPanelHeader status="Workflow ready" />
+      <div className="space-y-4 bg-[#121512] p-5">
+        <div className="ml-10 rounded-lg rounded-tr-sm border border-rule bg-panel-hi p-4 text-xs leading-5 text-ink">
+          Save this task and run it every Monday at 8 AM.
         </div>
-        <span className="rounded border border-accent/20 bg-green-3/20 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-accent-bright">
-          Active
-        </span>
-      </div>
-      <div className="p-5">
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
-          <div className="rounded-md border border-rule bg-bg/45 p-4">
-            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-              Source
-            </div>
-            <div className="mt-2 text-sm text-ink">Shopify orders</div>
-          </div>
-          <ArrowIcon />
-          <div className="rounded-md border border-rule bg-bg/45 p-4">
-            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-              Destination
-            </div>
-            <div className="mt-2 text-sm text-ink">Google Sheets</div>
-          </div>
-        </div>
-        <div className="mt-4 flex items-center justify-between rounded-md border border-rule bg-bg/45 px-4 py-3">
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-              Schedule
-            </div>
-            <div className="mt-1 text-sm text-ink">Every Monday at 8:00 AM</div>
-          </div>
-          <div className="grid grid-cols-7 gap-1" aria-label="Runs every Monday">
-            {["M", "T", "W", "T", "F", "S", "S"].map((day, index) => (
-              <span
-                key={`${day}-${index}`}
-                className={`grid size-6 place-items-center rounded-sm font-mono text-[9px] ${
-                  index === 0
-                    ? "bg-accent text-bg"
-                    : "border border-rule text-faint"
-                }`}
-              >
-                {day}
+        <div className="mr-3 rounded-lg rounded-tl-sm border border-accent/20 bg-green-3/20 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-xs text-accent-bright">
+              <span className="grid size-4 place-items-center rounded-full bg-accent text-[10px] text-bg">
+                ✓
               </span>
-            ))}
-          </div>
-        </div>
-      </div>
-      <div className="border-t border-rule bg-bg/35 px-5 py-4">
-        <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.12em] text-faint">
-          Recent runs
-        </div>
-        <div className="space-y-2 font-mono text-[10px]">
-          {[
-            ["Aug 17", "128 orders", "Completed"],
-            ["Aug 10", "116 orders", "Completed"],
-          ].map(([date, result, status]) => (
-            <div
-              key={date}
-              className="grid grid-cols-[62px_1fr_auto] items-center gap-3 border-t border-rule/70 pt-2 text-muted"
-            >
-              <span>{date}</span>
-              <span className="text-ink/75">{result}</span>
-              <span className="text-accent-bright">✓ {status}</span>
+              Weekly sales tracker saved
             </div>
-          ))}
+            <span className="font-mono text-[9px] uppercase tracking-[0.1em] text-accent-bright">
+              Active
+            </span>
+          </div>
+          <div className="mt-4 rounded-md border border-rule bg-bg/55 p-3">
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+              <div>
+                <div className="font-mono text-[8px] uppercase tracking-[0.12em] text-faint">
+                  Source
+                </div>
+                <div className="mt-1 text-[11px] text-ink">Shopify orders</div>
+              </div>
+              <ArrowIcon />
+              <div>
+                <div className="font-mono text-[8px] uppercase tracking-[0.12em] text-faint">
+                  Destination
+                </div>
+                <div className="mt-1 text-[11px] text-ink">Google Sheets</div>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center justify-between border-t border-rule pt-3">
+              <div>
+                <div className="font-mono text-[8px] uppercase tracking-[0.12em] text-faint">
+                  Schedule
+                </div>
+                <div className="mt-1 text-[11px] text-ink">
+                  Mondays at 8:00 AM
+                </div>
+              </div>
+              <div className="grid grid-cols-7 gap-1" aria-label="Runs every Monday">
+                {["M", "T", "W", "T", "F", "S", "S"].map((day, index) => (
+                  <span
+                    key={`${day}-${index}`}
+                    className={`grid size-5 place-items-center rounded-sm font-mono text-[8px] ${
+                      index === 0
+                        ? "bg-accent text-bg"
+                        : "border border-rule text-faint"
+                    }`}
+                  >
+                    {day}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 grid grid-cols-[1fr_auto] gap-x-4 gap-y-2 border-t border-rule pt-3 font-mono text-[9px] text-muted">
+            <span>Last run · 128 orders</span>
+            <span className="text-accent-bright">✓ Completed</span>
+            <span>Previous · 116 orders</span>
+            <span className="text-accent-bright">✓ Completed</span>
+          </div>
         </div>
       </div>
     </Panel>

--- a/apps/website/src/CliProductPage.tsx
+++ b/apps/website/src/CliProductPage.tsx
@@ -12,6 +12,7 @@ import { Text } from "./components/Text";
 import { InstallSnippet } from "./components/InstallSnippet";
 import { Kicker } from "./components/Kicker";
 import { CanvasAsciihedron } from "./components/CanvasAsciihedron";
+import { HeroResourceLinks } from "./components/HeroResourceLinks";
 
 const DEMO_VIDEO_SRC = "/demos/cli-demo.mp4";
 const DEMO_VIDEO_SOURCE =
@@ -55,18 +56,13 @@ function CliHero() {
             An open-source CLI that records live browser workflows and compiles
             them into fast, reusable scripts in your codebase.
           </Text>
-          <div className="flex flex-col items-start gap-3">
+          <div className="flex w-fit flex-col items-center gap-3">
             <InstallSnippet />
-            <div className="text-xs text-muted">
-              or{" "}
-              <a
-                href="https://cal.com/team/libretto/demo"
-                className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
-                data-fathom-event="CLI hero demo click"
-              >
-                TALK TO A DEV
-              </a>
-            </div>
+            <HeroResourceLinks
+              docsHref="/docs/get-started/quickstart"
+              docsFathomEvent="CLI hero docs click"
+              talkFathomEvent="CLI hero demo click"
+            />
           </div>
         </div>
         <div className="w-full overflow-hidden rounded-xl border border-rule bg-panel/50 shadow-lg shadow-black/30">

--- a/apps/website/src/DebugAgentsPage.tsx
+++ b/apps/website/src/DebugAgentsPage.tsx
@@ -9,9 +9,9 @@ import { SectionIntro } from "./components/SectionIntro";
 import { SiteSection } from "./components/SiteSection";
 import { SectionDivider } from "./components/SectionDivider.js";
 import { CanvasAsciihedron } from "./components/CanvasAsciihedron";
+import { HeroResourceLinks } from "./components/HeroResourceLinks";
 
 const GET_STARTED_URL = "/signin?mode=signup";
-const TALK_TO_A_DEV_URL = "https://cal.com/team/libretto/demo";
 
 const SECTION_POINTS = [
   {
@@ -83,21 +83,6 @@ const PR_AGENT_FAQS: FAQItem[] = [
   },
 ];
 
-function TalkToADevLink({ fathomEvent }: { fathomEvent: string }) {
-  return (
-    <div className="text-xs text-muted">
-      or{" "}
-      <a
-        href={TALK_TO_A_DEV_URL}
-        className="text-muted underline decoration-muted decoration-1 underline-offset-4 transition-colors duration-100 hover:text-ink hover:decoration-accent"
-        data-fathom-event={fathomEvent}
-      >
-        TALK TO A DEV
-      </a>
-    </div>
-  );
-}
-
 function DebugAgentsHero() {
   return (
     <section className="relative overflow-hidden px-6 pt-16 pb-20 md:px-8 md:pt-24 md:pb-28">
@@ -137,7 +122,7 @@ function DebugAgentsHero() {
             Libretto investigates the live page and opens a GitHub pull request
             with a proposed code fix.
           </Text>
-          <div className="flex flex-col items-start gap-3">
+          <div className="flex w-fit flex-col items-center gap-3">
             <Button
               href={GET_STARTED_URL}
               className="h-12 min-w-[240px] px-8 text-sm"
@@ -145,7 +130,11 @@ function DebugAgentsHero() {
             >
               Get started
             </Button>
-            <TalkToADevLink fathomEvent="Debug agents hero talk to dev click" />
+            <HeroResourceLinks
+              docsHref="/docs/understand-libretto/autofix-debugging"
+              docsFathomEvent="Debug agents hero docs click"
+              talkFathomEvent="Debug agents hero talk to dev click"
+            />
           </div>
         </div>
         <GitHubPRMock className="w-full text-left" />

--- a/apps/website/src/components/HeroResourceLinks.tsx
+++ b/apps/website/src/components/HeroResourceLinks.tsx
@@ -1,0 +1,43 @@
+const TALK_TO_A_DEV_URL = "https://cal.com/team/libretto/demo";
+
+interface HeroResourceLinksProps {
+  docsHref: string;
+  docsFathomEvent: string;
+  talkFathomEvent: string;
+}
+
+const linkClass =
+  "text-muted underline decoration-muted/60 underline-offset-4 transition-colors hover:text-accent-bright hover:decoration-accent/60";
+
+export function HeroResourceLinks({
+  docsHref,
+  docsFathomEvent,
+  talkFathomEvent,
+}: HeroResourceLinksProps) {
+  const resolvedDocsHref =
+    import.meta.env.DEV && docsHref.startsWith("/docs/")
+      ? `http://localhost:3000${docsHref}`
+      : docsHref;
+
+  return (
+    <div className="flex w-full items-center justify-center gap-2 font-mono text-[11px]">
+      <a
+        href={resolvedDocsHref}
+        className={linkClass}
+        data-fathom-event={docsFathomEvent}
+      >
+        Docs
+      </a>
+      <span aria-hidden="true" className="text-faint">
+        ·
+      </span>
+      <a
+        href={TALK_TO_A_DEV_URL}
+        className={linkClass}
+        data-fathom-event={talkFathomEvent}
+      >
+        Talk to a dev
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the repeated example-card grids with two purpose-built Chrome extension graphics
- give both graphics the visual language of the Chrome side panel while keeping their one-off and reusable-workflow outcomes distinct
- replace slogan-like headings and inconsistent supporting callouts with clearer, consistently formatted copy
- add specific Docs and Talk to a dev links beneath the primary actions on the Debug Agents, Browser Tools SDK, and CLI pages
- route product docs links to the local port 3000 docs preview during development while preserving same-origin `/docs/*` paths in production

## Validation
- `pnpm --filter @libretto/website test:vitest` (16 tests)
- `pnpm --filter @libretto/website type-check`
- `pnpm --filter @libretto/website build`
- verified all local docs targets and production dashboard/contact destinations return HTTP 200
- visually inspected the Chrome extension page and all three product heroes at desktop and 390px mobile widths

## Stack
- builds on #585
